### PR TITLE
fix(docs): update GitHub organization from portolan to portolan-sdi

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: portolan-cli
 site_description: A CLI tool for managing cloud-native geospatial data
 site_author: Nissim Lebovits
 site_url: https://portolan.github.io/portolan-cli/
-repo_name: portolan/portolan-cli
-repo_url: https://github.com/portolan/portolan-cli
+repo_name: portolan-sdi/portolan-cli
+repo_url: https://github.com/portolan-sdi/portolan-cli
 edit_uri: edit/main/docs/
 
 theme:
@@ -38,7 +38,7 @@ extra_css:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/portolan/portolan-cli
+      link: https://github.com/portolan-sdi/portolan-cli
       name: Portolan CLI on GitHub
 
 plugins:


### PR DESCRIPTION
## Summary
- Updated mkdocs configuration to point to correct GitHub organization (portolan-sdi)
- Fixed repo_name, repo_url, and social media link references

## Changes
- `repo_name`: portolan/portolan-cli → portolan-sdi/portolan-cli
- `repo_url`: https://github.com/portolan/portolan-cli → https://github.com/portolan-sdi/portolan-cli
- Social link: Updated to use correct organization

## Test Plan
- [x] Pre-commit hooks passed (YAML validation, formatting checks)
- [x] mkdocs.yml is syntactically valid YAML
- [ ] Build docs locally to verify: `uv run mkdocs build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration to reflect current repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->