### PR TITLE
fix(ci): use mutmut junitxml instead of non-existent --json flag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,13 +34,14 @@ jobs:
 
       - name: Check mutation score
         run: |
-          # Get mutation results as JSON and check score
-          uv run mutmut results --json > mutation-results.json
+          # Generate JUnit XML report (mutmut's supported output format)
+          uv run mutmut junitxml > mutation-results.xml
 
-          # Calculate survival rate (lower is better)
-          SURVIVED=$(jq '.survived // 0' mutation-results.json)
-          KILLED=$(jq '.killed // 0' mutation-results.json)
-          TOTAL=$((SURVIVED + KILLED))
+          # Parse JUnit XML to count killed (failures) vs survived (passed) mutants
+          # In JUnit XML: failures = killed mutants, passes = survived mutants
+          TOTAL=$(grep -c '<testcase' mutation-results.xml || echo 0)
+          KILLED=$(grep -c '<failure' mutation-results.xml || echo 0)
+          SURVIVED=$((TOTAL - KILLED))
 
           if [ "$TOTAL" -eq 0 ]; then
             echo "No mutations generated - check if source code is testable"
@@ -68,7 +69,9 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: mutation-report
-          path: html/
+          path: |
+            html/
+            mutation-results.xml
           retention-days: 30
         if: always()
 


### PR DESCRIPTION
## Summary

- Fixes CI failure where `mutmut results --json` was used, but that flag doesn't exist
- Uses `mutmut junitxml` to generate JUnit XML report (a supported output format per [mutmut docs](https://mutmut.readthedocs.io/))
- Parses the XML to count killed/survived mutants for the kill rate calculation
- Includes `mutation-results.xml` in uploaded artifacts for debugging

## Root Cause

The nightly workflow assumed `mutmut results --json` existed, but mutmut only supports:
- Text output (`mutmut results`)
- HTML report (`mutmut html`)  
- JUnit XML (`mutmut junitxml`)

## Test plan

- [ ] Manually trigger the nightly workflow to verify mutation testing completes
- [ ] Check that kill rate calculation works correctly from JUnit XML parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated mutation testing metrics collection in the nightly workflow for improved result reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->