### PR TITLE
fix(ci): add retry for Python install and suppress hypothesis flaky test warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        run: uv python install 3.11
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -94,7 +99,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        run: uv python install 3.11
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -140,7 +150,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        run: uv python install 3.11
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -162,7 +177,12 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
-        run: uv python install 3.11
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install 3.11
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from io import StringIO
 
 import pytest
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from portolan_cli.output import detail, error, info, success, warn
@@ -242,6 +242,7 @@ class TestDryRunMode:
         result = output.getvalue()
         assert "[DRY RUN]" not in result
 
+    @settings(suppress_health_check=[HealthCheck.differing_executors])
     @given(st.text(min_size=1))
     @pytest.mark.unit
     def test_dry_run_preserves_message_content(self, message: str) -> None:


### PR DESCRIPTION
## Summary

Fixes two CI failures observed in the nightly workflow:

- **Python 3.13 install failure**: Transient 502 Bad Gateway from GitHub CDN when downloading Python 3.13 from `python-build-standalone`. Added `nick-fields/retry@v3` with 3 attempts and 10-second wait between retries to handle transient network issues.

- **Hypothesis flaky test**: `test_dry_run_preserves_message_content` was failing with `HealthCheck.differing_executors` during mutation testing. This occurs because mutmut runs pytest in a way that hypothesis detects as multiple executors. Suppressed this specific health check as it's a false positive for our use case.

## Test plan

- [x] Run the hypothesis test locally - passes
- [x] Pre-commit hooks pass
- [x] CI workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability by implementing automatic retry logic for Python environment setup across continuous integration workflows (up to 3 attempts with 5-minute timeout)
  * Improved test stability with updated health check handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->