### PR TITLE
bump: version 0.2.0 → 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.3.0 (2026-02-07)
+
+### Feat
+
+- **dataset**: implement dataset CRUD operations (#39)
+- v0.4 - Metadata extraction and validation framework (#37)
+- v0.3 format conversion foundation (#36)
+- **output**: add dry-run and verbose modes to output functions (#32)
+- **test**: add geospatial test fixtures for vector and raster formats (#31)
+
+### Fix
+
+- **ci**: add retry for Python install and suppress hypothesis flaky test warning (#40)
+- **ci**: update codecov configuration with token and slug (#28)
+- **ci**: update nightly workflow for mutmut 3.x API (#25)
+- **ci**: use mutmut junitxml instead of non-existent --json flag (#23)
+- **ci**: repair failing workflows with tag-based releases and placeholder tests (#22)
+- **docs**: update GitHub organization from portolan to portolan-sdi (#21)
+
 ## v0.2.0 (2026-02-05)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "portolan-cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "A CLI tool for managing cloud-native geospatial data"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -75,7 +75,7 @@ packages = ["portolan_cli"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.0"
+version = "0.3.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true


### PR DESCRIPTION
## Release v0.3.0

This PR bumps the version from 0.2.0 to 0.3.0 and updates the CHANGELOG.

### New Features

- **dataset**: implement dataset CRUD operations (#39)
- **format conversion**: v0.3 format conversion foundation (#36)
- **metadata**: v0.4 metadata extraction and validation framework (#37)
- **output**: add dry-run and verbose modes to output functions (#32)
- **test**: add geospatial test fixtures for vector and raster formats (#31)

### Bug Fixes

- **ci**: add retry for Python install and suppress hypothesis flaky test warning (#40)
- **ci**: update codecov configuration with token and slug (#28)
- **ci**: update nightly workflow for mutmut 3.x API (#25)
- **ci**: use mutmut junitxml instead of non-existent --json flag (#23)
- **ci**: repair failing workflows with tag-based releases and placeholder tests (#22)
- **docs**: update GitHub organization from portolan to portolan-sdi (#21)

### Release Process

After this PR is merged:
1. The release workflow will detect the bump commit
2. Create git tag `v0.3.0`
3. Build and publish to PyPI
4. Create GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)