### PR TITLE
bump: version 0.3.0 → 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v0.4.0 (2026-02-09)
+
+### Feat
+
+- **validation**: PMTiles recommended, not required (#49)
+- warn on non-cloud-native formats (#48)
+- **workflow**: add speckit for specification-driven development (#47)
+- **hooks**: add auto-fetch for core dependency docs via gitingest (#44)
+
+### Fix
+
+- **ci**: extract only project version from pyproject.toml (#45)
+
 ## v0.3.0 (2026-02-07)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "portolan-cli"
-version = "0.3.0"
+version = "0.4.0"
 description = "A CLI tool for managing cloud-native geospatial data"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -76,7 +76,7 @@ packages = ["portolan_cli"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.3.0"
+version = "0.4.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true


### PR DESCRIPTION
## Summary

- Bump version from 0.3.0 to 0.4.0 using commitizen
- Updates CHANGELOG.md with all changes since v0.3.0

## Changes included in v0.4.0

- **feat(validation)**: PMTiles recommended, not required (#49)
- **feat**: warn on non-cloud-native formats (#48)
- **feat(workflow)**: add speckit for specification-driven development (#47)
- **feat(hooks)**: add auto-fetch for core dependency docs via gitingest (#44)
- **fix(ci)**: extract only project version from pyproject.toml (#45)

## Context

Previous releases were blocked due to CI issues with version extraction. The CI fix in #45 resolved the parsing problem. This PR triggers a proper release via commitizen bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)