### PR TITLE
fix(ci): enable workflow_dispatch for release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,22 @@
 # 1. Accumulate changes via normal PR merges
 # 2. When ready to release, create a PR running: uv run cz bump --changelog
 # 3. Merge bump PR → this workflow creates tag and publishes
+#
+# Recovery workflow (when release fails after bump merge):
+# 1. Delete orphan tag if exists: git push origin :refs/tags/vX.Y.Z
+# 2. Trigger manually: gh workflow run release.yml --ref main
 name: Release
 on:
   push:
     branches: [main]
-  workflow_dispatch:  # Allow manual triggering
+  workflow_dispatch:  # Manual trigger for recovery scenarios
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # Only run if the commit message starts with "bump:" (from cz bump)
-    if: startsWith(github.event.head_commit.message, 'bump:')
+    # Run if: push with bump commit OR manual trigger (workflow_dispatch)
+    if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write  # Required for creating tags and releases
       id-token: write  # Required for trusted PyPI publishing
@@ -50,20 +54,32 @@ jobs:
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION (tag: v$VERSION)"
 
-      - name: Check if tag already exists
-        id: tag_check
+      - name: Check release status
+        id: release_check
         run: |
           TAG="v${{ steps.version.outputs.version }}"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping release"
-            echo "exists=true" >> $GITHUB_OUTPUT
+
+          # Check if GitHub Release exists (the real indicator of a completed release)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, nothing to do"
+            echo "release_exists=true" >> $GITHUB_OUTPUT
+            echo "tag_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "Tag $TAG does not exist, proceeding with release"
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "release_exists=false" >> $GITHUB_OUTPUT
+            # Check if tag exists (may need to skip tag creation but still publish)
+            if git rev-parse "$TAG" >/dev/null 2>&1; then
+              echo "Tag $TAG exists but no release - recovery mode"
+              echo "tag_exists=true" >> $GITHUB_OUTPUT
+            else
+              echo "Tag $TAG does not exist, full release"
+              echo "tag_exists=false" >> $GITHUB_OUTPUT
+            fi
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create git tag
-        if: steps.tag_check.outputs.exists == 'false'
+        if: steps.release_check.outputs.tag_exists == 'false'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -71,17 +87,17 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Build package
-        if: steps.tag_check.outputs.exists == 'false'
+        if: steps.release_check.outputs.release_exists == 'false'
         run: uv build
 
       - name: Publish to PyPI
-        if: steps.tag_check.outputs.exists == 'false'
+        if: steps.release_check.outputs.release_exists == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
 
       - name: Create GitHub Release
-        if: steps.tag_check.outputs.exists == 'false'
+        if: steps.release_check.outputs.release_exists == 'false'
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \


### PR DESCRIPTION
## Summary

- Allow `workflow_dispatch` to trigger the release job (for recovery scenarios)
- Check GitHub Release existence instead of just tag existence
- Support recovery mode: if tag exists but release doesn't, skip tag creation but still build/publish/release

## Problem

When the v0.4.0 bump PR was merged, the release workflow failed partway through:
- Tag v0.4.0 was created
- But PyPI publish and GitHub Release never happened

Attempting `workflow_dispatch` failed because:
1. `github.event.head_commit.message` is empty for manual triggers
2. The workflow only checked tag existence, not release existence

## Solution

1. **Job condition**: Accept `bump:` commit message OR `workflow_dispatch` event
2. **Release check**: Look at GitHub Release (the real completion indicator), not just tag
3. **Recovery mode**: Tag exists + no release → skip tag creation, proceed with build/publish/release

## After merging

1. Delete orphan tags: `git push origin :refs/tags/v0.3.0 :refs/tags/v0.4.0`
2. Trigger release: `gh workflow run release.yml --ref main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now supports manual recovery triggers in addition to automatic commits.
  * Release gating broadened to allow either bump commits or manual trigger to proceed.
  * Improved release verification with a two-step check for existing releases and tags to avoid duplicate releases.
  * Environment handling and status messages updated for clearer, more reliable release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->