### PR TITLE
fix(ci): add pythonpath to pytest config for scripts imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ update_changelog_on_bump = true
 # ---------- testing ----------
 
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 python_files = "test_*.py"
 python_classes = "Test*"

--- a/uv.lock
+++ b/uv.lock
@@ -2429,7 +2429,7 @@ wheels = [
 
 [[package]]
 name = "portolan-cli"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Adds `pythonpath = ["."]` to pytest configuration in pyproject.toml
- Enables `scripts.*` imports during test execution
- Fixes nightly workflow failure where `ModuleNotFoundError: No module named 'scripts'` occurred

## Test Plan
- [x] Ran `uv run pytest tests/integration/test_fetch_lib_docs_integration.py tests/unit/test_fetch_lib_docs.py` - all 31 tests pass
- [x] Verified no ModuleNotFoundError
- [x] Ruff linting passes
- [x] mypy type checking passes

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)