### PR TITLE
docs: add MVP versioning strategy and two-tier architecture ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0012](context/shared/adr/0012-flat-catalog-hierarchy.md) | Flat catalog hierarchy (no nested collections) |
 | [0013](context/shared/adr/0013-gitingest-auto-fetch.md) | Auto-fetch dependency docs via gitingest |
 | [0014](context/shared/adr/0014-accept-non-cloud-native-formats.md) | Accept non-cloud-native formats with warnings |
-| [0015](context/shared/adr/0015-two-tier-versioning-architecture.md) | Two-tier versioning: simple MVP + Iceberg plugin for enterprise |
+| [0015](context/shared/adr/0015-two-tier-versioning-architecture.md) | Two-tier versioning: simple MVP + [portolake](https://github.com/portolan-sdi/portolake) plugin for enterprise |
 
 ## Common Commands
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,7 +115,10 @@ Phase 1 is broken into incremental releases. Each builds on the previous—later
 | **v0.7** | Versioning | Schema fingerprints, `rollback`, `--breaking` flag, version numbering ([#14](https://github.com/portolan-sdi/portolan-cli/issues/14)) |
 | **v0.8** | Maintenance | `prune` with safety mechanisms ([#15](https://github.com/portolan-sdi/portolan-cli/issues/15)), `repair`|
 
-**Note on multi-user:** Per [ADR-0015](context/shared/adr/0015-two-tier-versioning-architecture.md), multi-user/concurrent access is deferred to the `portolan-iceberg` plugin. The core CLI assumes single-writer access.
+**Note on multi-user:** Per [ADR-0015][adr-0015], multi-user/concurrent access is deferred to the [portolake][] plugin. The core CLI assumes single-writer access.
+
+[adr-0015]: https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0015-two-tier-versioning-architecture.md
+[portolake]: https://github.com/portolan-sdi/portolake
 
 **Why this order?**
 
@@ -135,23 +138,23 @@ init → conversion → validation → add → sync → multi-user → maintenan
 - **v0.7**: [#14 (Schema evolution)](https://github.com/portolan-sdi/portolan-cli/issues/14) — schema fingerprints and breaking change detection
 - **v0.8**: [#15 (Prune safety)](https://github.com/portolan-sdi/portolan-cli/issues/15) — `--dry-run`, confirmation
 
-**Deferred to plugin:** [#33 (Multi-user ADR)](https://github.com/portolan-sdi/portolan-cli/issues/33), [#18 (Concurrent access)](https://github.com/portolan-sdi/portolan-cli/issues/18) — see [ADR-0015](context/shared/adr/0015-two-tier-versioning-architecture.md)
+**Deferred to plugin:** [#33 (Multi-user ADR)](https://github.com/portolan-sdi/portolan-cli/issues/33), [#18 (Concurrent access)](https://github.com/portolan-sdi/portolan-cli/issues/18) — see [ADR-0015][adr-0015]
 
 ---
 
-## Parallel: Iceberg + Icechunk Plugin
+## Parallel: Portolake (Iceberg + Icechunk Plugin)
 
 Multi-user versioning and tabular analytics. Developed by Javier alongside Phase 1.
 
 | Capability | Description |
 |------------|-------------|
-| `portolan-iceberg` | Apache Iceberg + Icechunk backend for versioning |
+| [portolake][] | Apache Iceberg + Icechunk backend for versioning |
 | **Multi-writer ACID** | Concurrent access with optimistic locking |
 | **Native time travel** | Branch, tag, and query historical versions |
 | **Schema evolution** | Automatic breaking change detection |
 | Query integration | SQL/DataFrame access to versioned data |
 
-**Architecture:** The plugin implements the same `VersioningBackend` protocol as the MVP's `versions.json` backend, allowing seamless upgrade. See [ADR-0015](context/shared/adr/0015-two-tier-versioning-architecture.md) for details.
+**Architecture:** The plugin implements the same `VersioningBackend` protocol as the MVP's `versions.json` backend, allowing seamless upgrade. See [ADR-0015][adr-0015] for details.
 
 **Target users:** Organizations needing concurrent access (Carto, HDX, multi-user teams).
 

--- a/context/shared/adr/0003-plugin-architecture.md
+++ b/context/shared/adr/0003-plugin-architecture.md
@@ -26,7 +26,7 @@ We use a **plugin architecture** with Python entry points:
 - PMTiles → `portolan-pmtiles`
 - COPC → `portolan-copc`
 - 3D Tiles → `portolan-3dtiles`
-- Iceberg → `portolan-iceberg`
+- Iceberg + Icechunk → [portolake](https://github.com/portolan-sdi/portolake)
 
 ### Entry point registration
 

--- a/context/shared/adr/0004-iceberg-as-plugin.md
+++ b/context/shared/adr/0004-iceberg-as-plugin.md
@@ -41,7 +41,7 @@ GeoParquet and COG files are the same regardless of catalog layer. If someone wa
 
 ### Plugin path
 
-A `portolan-iceberg` plugin could:
+The [portolake](https://github.com/portolan-sdi/portolake) plugin could:
 - Export Portolan catalogs to Iceberg format
 - Register GeoParquet files in an existing Iceberg catalog
 - Sync Iceberg metadata alongside STAC

--- a/context/shared/adr/0005-versions-json-source-of-truth.md
+++ b/context/shared/adr/0005-versions-json-source-of-truth.md
@@ -151,7 +151,7 @@ Adding columns or bands is NOT breaking (additive change).
 
 ### Trade-offs
 - We accept file growth for simplicity
-- We accept single-writer constraint for consistency (multi-user deferred to Iceberg plugin)
+- We accept single-writer constraint for consistency (multi-user deferred to portolake plugin)
 
 ## Alternatives Considered
 
@@ -170,7 +170,7 @@ Adding columns or bands is NOT breaking (additive change).
 ## Related ADRs
 
 - [ADR-0006: Remote Ownership Model](0006-remote-ownership-model.md) — Portolan owns bucket contents
-- [ADR-0015: Two-Tier Versioning Architecture](0015-two-tier-versioning-architecture.md) — MVP vs Iceberg plugin
+- [ADR-0015: Two-Tier Versioning Architecture](0015-two-tier-versioning-architecture.md) — MVP vs portolake plugin
 
 ## References
 

--- a/context/shared/adr/0015-two-tier-versioning-architecture.md
+++ b/context/shared/adr/0015-two-tier-versioning-architecture.md
@@ -33,9 +33,14 @@ A file-based versioning system that:
 
 **Target users:** Municipalities, small teams, individual publishers. Anyone who doesn't need concurrent access.
 
-### Tier 2: Iceberg Plugin (`portolan-iceberg`)
+### Tier 2: Portolake Plugin
 
-A plugin that replaces the versioning backend with Iceberg + Icechunk:
+[Portolake](https://github.com/portolan-sdi/portolake) is a plugin that replaces the versioning backend with:
+
+- **Apache Iceberg** — For tabular/vector data (GeoParquet) with ACID transactions
+- **Icechunk** — For array/raster data (COG, NetCDF, HDF, Zarr) via VirtualiZarr
+
+Features:
 - ACID transactions for concurrent writes
 - Native time travel and version branching
 - Schema evolution with automatic detection
@@ -75,7 +80,7 @@ This allows the CLI to remain unchanged regardless of backend.
 Via Python entry points (consistent with [ADR-0003](0003-plugin-architecture.md)):
 
 ```toml
-# portolan-iceberg/pyproject.toml
+# portolake/pyproject.toml
 [project.entry-points."portolan.backends"]
 iceberg = "portolan_iceberg:IcebergBackend"
 ```
@@ -125,7 +130,7 @@ The single-writer assumption must be prominently documented:
 ```
 Note: Portolan MVP assumes single-writer access. Do not run concurrent
 publish, sync, or prune operations on the same catalog. For multi-user
-support, see the portolan-iceberg plugin.
+support, see the portolake plugin.
 ```
 
 ### Drift Detection
@@ -147,7 +152,7 @@ This catches accidental concurrent access even without true locking.
 
 When users outgrow MVP:
 
-1. Install `portolan-iceberg` plugin
+1. Install `portolake` plugin
 2. Configure Iceberg catalog connection
 3. Run `portolan migrate --to iceberg` (future command)
 4. Existing version history preserved in Iceberg format
@@ -162,5 +167,7 @@ When users outgrow MVP:
 ## References
 
 - [MVP Versioning Strategy](../plans/mvp-versioning-strategy.md) — Detailed implementation plan
-- [Icechunk](https://github.com/earth-mover/icechunk) — Versioned cloud-native array storage
+- [Portolake](https://github.com/portolan-sdi/portolake) — Enterprise versioning plugin for Portolan
 - [Apache Iceberg](https://iceberg.apache.org/) — Table format for huge analytic datasets
+- [Icechunk](https://github.com/earth-mover/icechunk) — Versioned cloud-native array storage
+- [VirtualiZarr](https://github.com/zarr-developers/VirtualiZarr) — Virtual Zarr stores for legacy formats

--- a/context/shared/plans/mvp-versioning-strategy.md
+++ b/context/shared/plans/mvp-versioning-strategy.md
@@ -5,7 +5,7 @@
 
 ## Executive Summary
 
-Portolan will ship an MVP with simple, file-based versioning (`versions.json`) that assumes single-writer access. Advanced features (concurrency, ACID writes, multi-user collaboration) will be provided via an **Iceberg + Icechunk plugin** that Javier will develop in parallel.
+Portolan will ship an MVP with simple, file-based versioning (`versions.json`) that assumes single-writer access. Advanced features (concurrency, ACID writes, multi-user collaboration) will be provided via **[portolake](https://github.com/portolan-sdi/portolake)**, a plugin combining Apache Iceberg (for tabular/vector data) and Icechunk (for raster/array data via VirtualiZarr) that Javier will develop in parallel.
 
 This approach:
 1. Gets a working product to entry-level users (municipalities, small orgs) quickly
@@ -25,8 +25,8 @@ This approach:
               ┌───────────────────────┴───────────────────────┐
               │                                               │
      ┌────────▼────────┐                          ┌──────────▼──────────┐
-     │  MVP Backend    │                          │  Plugin: icechunk   │
-     │  (versions.json)│                          │  + iceberg          │
+     │  MVP Backend    │                          │  Plugin: portolake  │
+     │  (versions.json)│                          │  (Iceberg+Icechunk) │
      ├─────────────────┤                          ├─────────────────────┤
      │ • Single writer │                          │ • Multi-writer ACID │
      │ • File-based    │                          │ • Native versioning │
@@ -434,7 +434,7 @@ class IcebergBackend(VersioningBackend):
 Plugins register via Python entry points:
 
 ```toml
-# portolan-iceberg/pyproject.toml
+# portolake/pyproject.toml
 [project.entry-points."portolan.backends"]
 iceberg = "portolan_iceberg:IcebergBackend"
 ```
@@ -450,7 +450,7 @@ The MVP must clearly document the single-writer assumption:
 ```
 Note: Portolan MVP assumes single-writer access. Do not run concurrent
 publish, sync, or prune operations on the same catalog. For multi-user
-support, see the portolan-iceberg plugin.
+support, see the portolake plugin.
 ```
 
 ### In docs:
@@ -460,7 +460,7 @@ support, see the portolan-iceberg plugin.
 > The MVP versioning system (`versions.json`) does not support concurrent writes.
 > If two users publish to the same catalog simultaneously, data corruption may occur.
 >
-> For multi-user environments, install the `portolan-iceberg` plugin which provides
+> For multi-user environments, install the `portolake` plugin which provides
 > ACID transactions and optimistic concurrency control.
 
 ### In code (fail loudly):
@@ -514,6 +514,8 @@ def sync(self, collection: str, force: bool = False) -> None:
 - [Issue #15: Prune safety](https://github.com/portolan-sdi/portolan-cli/issues/15)
 - [Issue #18: Concurrent access](https://github.com/portolan-sdi/portolan-cli/issues/18)
 - [Issue #33: Multi-user ADR](https://github.com/portolan-sdi/portolan-cli/issues/33)
-- [Icechunk](https://github.com/earth-mover/icechunk) — Versioned cloud-native array storage
+- [Portolake](https://github.com/portolan-sdi/portolake) — Enterprise versioning plugin for Portolan
 - [Apache Iceberg](https://iceberg.apache.org/) — Table format for huge analytic datasets
+- [Icechunk](https://github.com/earth-mover/icechunk) — Versioned cloud-native array storage
+- [VirtualiZarr](https://github.com/zarr-developers/VirtualiZarr) — Virtual Zarr stores for legacy formats
 - [STAC Spec](https://github.com/radiantearth/stac-spec) — SpatioTemporal Asset Catalog specification

--- a/scripts/orchestrate-issue.sh
+++ b/scripts/orchestrate-issue.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+#
+# Orchestrates autonomous issue implementation:
+#   1. Create worktree + planning agent (speckit)
+#   2. Implementation agent (commit, push, PR)
+#   3. Review agent (roborev loop until passing)
+#
+# Usage: ./scripts/orchestrate-issue.sh <issue-url>
+# Example: ./scripts/orchestrate-issue.sh https://github.com/portolan-sdi/portolan-cli/issues/10#issuecomment-3871537791
+
+set -euo pipefail
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Configuration
+# ─────────────────────────────────────────────────────────────────────────────
+
+ISSUE_URL="${1:-}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKTREE_BASE="${REPO_ROOT}/../worktrees"
+LOG_DIR="${REPO_ROOT}/logs/orchestration"
+MAX_REVIEW_LOOPS=5
+
+# Notification helpers
+ping_user() { echo -e "\a"; echo "✓ $1"; }
+gong_user() { echo -e "\a\a\a"; echo "✗ ERROR: $1"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+if [[ -z "$ISSUE_URL" ]]; then
+    echo "Usage: $0 <github-issue-url>"
+    echo "Example: $0 https://github.com/portolan-sdi/portolan-cli/issues/10#issuecomment-3871537791"
+    exit 1
+fi
+
+# Extract issue number from URL
+if [[ "$ISSUE_URL" =~ issues/([0-9]+) ]]; then
+    ISSUE_NUM="${BASH_REMATCH[1]}"
+else
+    gong_user "Could not parse issue number from URL: $ISSUE_URL"
+    exit 1
+fi
+
+# Extract repo from URL
+if [[ "$ISSUE_URL" =~ github\.com/([^/]+/[^/]+)/issues ]]; then
+    REPO="${BASH_REMATCH[1]}"
+else
+    gong_user "Could not parse repo from URL: $ISSUE_URL"
+    exit 1
+fi
+
+echo "───────────────────────────────────────────────────────────────────────"
+echo "Orchestrating issue #${ISSUE_NUM} from ${REPO}"
+echo "───────────────────────────────────────────────────────────────────────"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Setup
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Fetch issue title for branch name
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json title --jq '.title')
+# Convert to branch name: lowercase, replace spaces/special chars with hyphens
+BRANCH_NAME="feature/$(echo "$ISSUE_TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//' | cut -c1-50)"
+
+WORKTREE_PATH="${WORKTREE_BASE}/${BRANCH_NAME}"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+mkdir -p "$LOG_DIR"
+
+echo "Branch: $BRANCH_NAME"
+echo "Worktree: $WORKTREE_PATH"
+echo "Logs: $LOG_DIR"
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 1: Planning Agent
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "╔═══════════════════════════════════════════════════════════════════════╗"
+echo "║ PHASE 1: Planning                                                      ║"
+echo "╚═══════════════════════════════════════════════════════════════════════╝"
+
+# Create worktree
+if [[ -d "$WORKTREE_PATH" ]]; then
+    echo "Worktree already exists, reusing: $WORKTREE_PATH"
+else
+    echo "Creating worktree..."
+    git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" main 2>/dev/null || \
+    git worktree add "$WORKTREE_PATH" "$BRANCH_NAME" 2>/dev/null || \
+    { gong_user "Failed to create worktree"; exit 1; }
+fi
+
+# Fetch issue body and comment for context
+ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json body --jq '.body')
+COMMENT_BODY=""
+if [[ "$ISSUE_URL" =~ issuecomment-([0-9]+) ]]; then
+    COMMENT_ID="${BASH_REMATCH[1]}"
+    COMMENT_BODY=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}/comments" --jq ".[] | select(.id == ${COMMENT_ID}) | .body" 2>/dev/null || echo "")
+fi
+
+PLAN_LOG="${LOG_DIR}/${TIMESTAMP}-phase1-plan.log"
+
+# Build the planning prompt
+PLAN_PROMPT="You are a planning agent. Your job is to create a speckit plan for implementing this GitHub issue.
+
+## Issue #${ISSUE_NUM}: ${ISSUE_TITLE}
+
+### Issue Body:
+${ISSUE_BODY}
+
+### Design Comment (if present):
+${COMMENT_BODY}
+
+## Your Task:
+1. Run /speckit.specify to create the feature specification based on the issue
+2. Run /speckit.clarify if there are ambiguities (auto-answer based on the design comment above)
+3. Run /speckit.plan to generate the implementation plan
+4. Run /speckit.tasks to generate the task list
+
+When all speckit artifacts are complete (.specify/features/ should have spec.md, plan.md, tasks.md),
+commit them with message 'docs: add speckit plan for issue #${ISSUE_NUM}'
+
+Signal completion by creating a file: .planning-complete
+
+DO NOT implement any code. Only create the plan."
+
+echo "Launching planning agent..."
+echo "Logging to: $PLAN_LOG"
+
+# Run claude in the worktree
+cd "$WORKTREE_PATH"
+claude --print "$PLAN_PROMPT" 2>&1 | tee "$PLAN_LOG"
+
+# Check for completion
+if [[ -f "$WORKTREE_PATH/.planning-complete" ]]; then
+    echo "✓ Planning phase complete"
+    rm -f "$WORKTREE_PATH/.planning-complete"
+else
+    # Check if speckit files exist as alternative completion signal
+    if [[ -d "$WORKTREE_PATH/.specify/features" ]] && \
+       find "$WORKTREE_PATH/.specify/features" -name "plan.md" -o -name "tasks.md" 2>/dev/null | grep -q .; then
+        echo "✓ Planning phase complete (speckit artifacts found)"
+    else
+        gong_user "Planning phase did not complete successfully. Check log: $PLAN_LOG"
+        exit 1
+    fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 2: Implementation Agent
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "╔═══════════════════════════════════════════════════════════════════════╗"
+echo "║ PHASE 2: Implementation                                                ║"
+echo "╚═══════════════════════════════════════════════════════════════════════╝"
+
+IMPL_LOG="${LOG_DIR}/${TIMESTAMP}-phase2-implement.log"
+
+IMPL_PROMPT="You are an implementation agent. Your job is to implement the plan created by the planning agent.
+
+## Context
+- Issue #${ISSUE_NUM}: ${ISSUE_TITLE}
+- Branch: ${BRANCH_NAME}
+- The speckit plan is in .specify/features/
+
+## Your Task:
+1. Read the plan and tasks from .specify/features/
+2. Run /speckit.implement to execute all tasks
+3. Follow TDD: write tests first, then implementation
+4. After implementation is complete:
+   - Run all tests: uv run pytest
+   - Run linting: uv run ruff check . && uv run ruff format .
+   - Run type checking: uv run mypy portolan_cli
+5. Commit all changes with conventional commit messages
+6. Push the branch: git push -u origin ${BRANCH_NAME}
+7. Open a PR: gh pr create --title 'feat: implement issue #${ISSUE_NUM}' --body 'Implements #${ISSUE_NUM}'
+
+When the PR is created, output the PR URL and create a file: .implementation-complete with the PR URL inside.
+
+DO NOT skip tests. TDD is mandatory per CLAUDE.md."
+
+echo "Launching implementation agent..."
+echo "Logging to: $IMPL_LOG"
+
+cd "$WORKTREE_PATH"
+claude --print "$IMPL_PROMPT" 2>&1 | tee "$IMPL_LOG"
+
+# Extract PR URL
+PR_URL=""
+if [[ -f "$WORKTREE_PATH/.implementation-complete" ]]; then
+    PR_URL=$(cat "$WORKTREE_PATH/.implementation-complete")
+    rm -f "$WORKTREE_PATH/.implementation-complete"
+fi
+
+# Fallback: try to get PR URL from git
+if [[ -z "$PR_URL" ]]; then
+    PR_URL=$(gh pr view --json url --jq '.url' 2>/dev/null || echo "")
+fi
+
+if [[ -z "$PR_URL" ]]; then
+    gong_user "Implementation phase did not create a PR. Check log: $IMPL_LOG"
+    exit 1
+fi
+
+echo "✓ Implementation phase complete"
+echo "PR URL: $PR_URL"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 3: Review Loop
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "╔═══════════════════════════════════════════════════════════════════════╗"
+echo "║ PHASE 3: Review Loop                                                   ║"
+echo "╚═══════════════════════════════════════════════════════════════════════╝"
+
+# Extract PR number from URL
+if [[ "$PR_URL" =~ /pull/([0-9]+) ]]; then
+    PR_NUM="${BASH_REMATCH[1]}"
+else
+    gong_user "Could not parse PR number from URL: $PR_URL"
+    exit 1
+fi
+
+review_loop=0
+review_passed=false
+
+while [[ $review_loop -lt $MAX_REVIEW_LOOPS ]]; do
+    review_loop=$((review_loop + 1))
+    REVIEW_LOG="${LOG_DIR}/${TIMESTAMP}-phase3-review-${review_loop}.log"
+
+    echo ""
+    echo "─── Review iteration ${review_loop}/${MAX_REVIEW_LOOPS} ───"
+    echo "Logging to: $REVIEW_LOG"
+
+    # Run roborev
+    echo "Running roborev..."
+    if roborev "$PR_URL" 2>&1 | tee "${REVIEW_LOG}.roborev"; then
+        ROBOREV_OUTPUT=$(cat "${REVIEW_LOG}.roborev")
+    else
+        ROBOREV_OUTPUT=$(cat "${REVIEW_LOG}.roborev")
+    fi
+
+    # Check if review passed (no findings)
+    if echo "$ROBOREV_OUTPUT" | grep -qi "no issues\|passed\|approved\|lgtm\|no findings"; then
+        echo "✓ Review passed!"
+        review_passed=true
+        break
+    fi
+
+    # If there are findings, launch agent to fix them
+    echo "Review found issues. Launching fix agent..."
+
+    FIX_PROMPT="You are a review-fix agent. Roborev found issues in PR #${PR_NUM}.
+
+## Roborev Output:
+${ROBOREV_OUTPUT}
+
+## Your Task:
+1. Read and understand each finding
+2. Fix each issue in the code
+3. Run tests to ensure fixes don't break anything: uv run pytest
+4. Commit fixes with message: 'fix: address review feedback (iteration ${review_loop})'
+5. Push changes: git push
+
+After pushing, create file: .fixes-complete"
+
+    cd "$WORKTREE_PATH"
+    claude --print "$FIX_PROMPT" 2>&1 | tee "$REVIEW_LOG"
+
+    if [[ -f "$WORKTREE_PATH/.fixes-complete" ]]; then
+        rm -f "$WORKTREE_PATH/.fixes-complete"
+        echo "✓ Fixes applied, re-running review..."
+    else
+        echo "⚠ Fix agent may not have completed successfully"
+    fi
+done
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Completion
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════════════"
+
+if [[ "$review_passed" == "true" ]]; then
+    ping_user "PR is ready for merge: $PR_URL"
+    echo ""
+    echo "Summary:"
+    echo "  - Issue: #${ISSUE_NUM}"
+    echo "  - Branch: ${BRANCH_NAME}"
+    echo "  - PR: ${PR_URL}"
+    echo "  - Review iterations: ${review_loop}"
+    echo "  - Logs: ${LOG_DIR}/${TIMESTAMP}-*"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Review the PR: $PR_URL"
+    echo "  2. Merge when satisfied"
+    echo "  3. Clean up worktree: git worktree remove $WORKTREE_PATH"
+else
+    gong_user "Review loop exhausted after ${MAX_REVIEW_LOOPS} iterations. Manual intervention required."
+    echo ""
+    echo "PR: $PR_URL"
+    echo "Worktree: $WORKTREE_PATH"
+    echo "Logs: ${LOG_DIR}/${TIMESTAMP}-*"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds **ADR-0015**: Two-tier versioning architecture documenting the decision to ship a simple MVP backend (`versions.json`) with multi-user support deferred to the `portolan-iceberg` plugin
- Adds comprehensive **MVP versioning strategy** document with all design decisions resolved
- Updates **ADR-0005** with schema fingerprints for breaking change detection
- Updates **ROADMAP** to clarify MVP vs plugin scope for milestones v0.6-v0.8

## Key Decisions Documented

| Decision | Choice |
|----------|--------|
| Version numbering | Semantic + timestamp (both) |
| Asset storage | Version prefixes (`v1.0.0/asset.parquet`) |
| `versions.json` location | At each level (catalog, collection) |
| Schema fingerprints | GeoParquet columns/types, COG bands/resolution/CRS |
| Breaking changes | Column/band removal, type changes, CRS changes, resolution changes |
| Multi-user | Deferred to `portolan-iceberg` plugin |
| Prune behavior | Keep metadata, delete files (audit trail preserved) |
| Rollback behavior | Creates new version (append-only history) |

## Related Issues

Clarifies scope for:
- #14 (Schema evolution) → MVP: fingerprints + manual `--breaking`; Plugin: automatic detection
- #15 (Prune safety) → MVP: `--dry-run`, confirmation, `--yes`
- #18 (Concurrent access) → Plugin scope
- #33 (Multi-user ADR) → Resolved: single-writer MVP, plugin for multi

## Test plan

- [x] Review ADR-0015 for architectural clarity
- [x] Review MVP strategy document for completeness
- [x] Verify ADR-0005 schema fingerprint examples are correct
- [x] Verify ROADMAP milestones accurately reflect new scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap: v0.7 emphasizes schema fingerprints and rollback capabilities
  * Introduced Portolake plugin for multi-user versioning with ACID compliance and time travel support
  * Documented two-tier architecture: single-writer core with enterprise-ready plugin extension for concurrent access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->