### PR TITLE
docs: extract ADRs 0017-0020 from implementation plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0014](context/shared/adr/0014-accept-non-cloud-native-formats.md) | Accept non-cloud-native formats with warnings |
 | [0015](context/shared/adr/0015-two-tier-versioning-architecture.md) | Two-tier versioning: simple MVP + [portolake](https://github.com/portolan-sdi/portolake) plugin for enterprise |
 | [0016](context/shared/adr/0016-scan-before-import.md) | Scan-before-import: separate validation from import (like ruff check/fix) |
+| [0017](context/shared/adr/0017-mtime-heuristics-change-detection.md) | MTIME + heuristics for change detection (fast gate, O(1) metadata check) |
+| [0018](context/shared/adr/0018-metadata-generation-tiers.md) | Metadata generation tiers: auto-extractable → derivable → defaults → human-enrichable |
+| [0019](context/shared/adr/0019-cog-optimization-defaults.md) | COG defaults: DEFLATE, predictor=2, 512×512 tiles, nearest resampling |
+| [0020](context/shared/adr/0020-conversion-output-location.md) | Conversion output: side-by-side for vectors, in-place for rasters |
 
 ## Common Commands
 

--- a/context/shared/adr/0017-mtime-heuristics-change-detection.md
+++ b/context/shared/adr/0017-mtime-heuristics-change-detection.md
@@ -1,0 +1,50 @@
+# ADR-0017: MTIME + Heuristics for Change Detection
+
+## Status
+Accepted
+
+## Context
+
+Portolan needs to detect when local files have changed so metadata can be regenerated. Options considered:
+
+1. **MTIME only** — Fast (µs) but unreliable (touch, git checkout, S3 sync all affect mtime)
+2. **Content hash (SHA256)** — Reliable but slow (100GB file = 200s at 500MB/s)
+3. **MTIME + heuristics** — Fast gate, then O(1) metadata check
+4. **Git-style object store** — Overkill for MVP
+
+## Decision
+
+Use **MTIME + heuristic fallback**:
+
+```
+stat() → mtime changed?
+    NO  → skip (fast path)
+    YES → extract metadata → heuristics changed?
+              NO  → warn "file touched, metadata unchanged"
+              YES → flag for update
+```
+
+Heuristics checked (all O(1) reads from file headers):
+- bbox
+- feature_count (vector) / dimensions (raster)
+- schema fingerprint
+
+## Consequences
+
+### Benefits
+- **Fast**: 1µs for unchanged files, 5-50ms for changed files
+- **Scales**: Works on 100GB+ files without reading content
+- **Practical**: Catches real data changes in typical workflows
+
+### Trade-offs
+- **False negatives**: Attribute-only edits (same bbox/count) are missed
+- **Escape hatch**: `--force-rehash` flag for full SHA256 verification when needed
+- **S3 uncertainty**: ETags aren't always content hashes (multipart uploads differ)
+
+## Alternatives Considered
+
+**MTIME only**: Too unreliable for S3 sync scenarios.
+
+**Pure hash**: Too slow for interactive use (hours for large catalogs).
+
+**Git-style object store**: Major architectural change; deferred to portolake plugin.

--- a/context/shared/adr/0018-metadata-generation-tiers.md
+++ b/context/shared/adr/0018-metadata-generation-tiers.md
@@ -1,0 +1,36 @@
+# ADR-0018: Metadata Generation Tiers
+
+## Status
+Accepted
+
+## Context
+
+STAC metadata has many fields. Some can be extracted automatically, others require human input. We need clarity on what `check --fix` regenerates vs what users must provide.
+
+## Decision
+
+Metadata is categorized into four tiers:
+
+| Tier | Fields | Source |
+|------|--------|--------|
+| **1: Auto-extractable** | bbox, crs, geometry_type, feature_count, schema, sha256, size_bytes | File headers (O(1) read) |
+| **2: Derivable** | datetime, title, extent.spatial, extent.temporal | Heuristics (mtime, filename, child aggregation) |
+| **3: Auto with defaults** | description, license | Sensible defaults provided |
+| **4: Human-enrichable** | semantic_type, unit, providers, custom titles | Optional; user adds if desired |
+
+**Key decision: No human-required fields.** All metadata can be auto-generated with sensible defaults. Users may enrich but are never blocked.
+
+## Consequences
+
+### What `--fix` regenerates
+- All Tier 1 fields (re-extracted from file)
+- All Tier 2 fields (re-derived)
+- Tier 3 fields only if missing (won't overwrite user customization)
+
+### What `--fix` preserves
+- Tier 4 fields (user enrichments)
+- Tier 3 fields if already set
+
+### Trade-offs
+- Defaults may be generic ("A Portolan-managed dataset")
+- Users wanting rich descriptions must add them manually or use LLM-assisted tooling (future)

--- a/context/shared/adr/0019-cog-optimization-defaults.md
+++ b/context/shared/adr/0019-cog-optimization-defaults.md
@@ -1,0 +1,38 @@
+# ADR-0019: COG Optimization Defaults
+
+## Status
+Accepted
+
+## Context
+
+Cloud-Optimized GeoTIFFs have many tunable parameters (compression, tile size, predictor, resampling). Different settings suit different data types (imagery vs elevation vs categorical).
+
+## Decision
+
+**Single opinionated default** for all COG conversions:
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| Compression | DEFLATE | Lossless, universal compatibility |
+| Predictor | 2 (horizontal differencing) | Improves compression for all types |
+| Tile size | 512×512 | Matches rio-cogeo default; fewer HTTP requests |
+| Overview resampling | nearest | Safe for categorical, elevation, and imagery |
+
+**Power users** who need fine-tuned control (WEBP for imagery, LERC for elevation) should use `rio_cogeo.cog_translate()` directly. Portolan is for batch workflows, not per-file optimization.
+
+## Consequences
+
+### Benefits
+- Zero configuration for typical users
+- Consistent output across all conversions
+- Works acceptably for all data types
+
+### Trade-offs
+- Not optimal for any specific use case
+- Larger file sizes than WEBP/JPEG for RGB imagery
+- Slower compression than LZW
+
+## References
+
+- [Cloud Native Geo Guide](https://guide.cloudnativegeo.org/cloud-optimized-geotiffs/cogs-details.html)
+- [Koko Alberti's compression guide](https://kokoalberti.com/articles/geotiff-compression-optimization-guide/)

--- a/context/shared/adr/0020-conversion-output-location.md
+++ b/context/shared/adr/0020-conversion-output-location.md
@@ -1,0 +1,40 @@
+# ADR-0020: Conversion Output Location Strategy
+
+## Status
+Accepted
+
+## Context
+
+When converting files to cloud-native formats, where should output go? Options:
+1. Side-by-side (new file next to original)
+2. In-place (overwrite original)
+3. Separate output directory
+
+## Decision
+
+**Format-dependent strategy:**
+
+| Format | Strategy | Example |
+|--------|----------|---------|
+| Vector | Side-by-side | `roads.shp` → `roads.parquet` (both exist) |
+| Raster | In-place | `elevation.tif` → `elevation.tif` (COG replaces original) |
+
+**Flags:**
+- `--replace` — Delete original vector files after successful conversion
+- Default behavior preserves originals for vectors
+
+## Consequences
+
+### Why in-place for rasters
+- Same `.tif` extension for COG and non-COG
+- Users expect TIFF files; changing extension breaks workflows
+- COG is strictly better; no reason to keep non-COG version
+
+### Why side-by-side for vectors
+- Different extensions (`.shp` vs `.parquet`)
+- Users may need originals for legacy tools
+- Explicit `--replace` makes deletion intentional
+
+### Safety
+- Conversion must succeed AND validate before any deletion
+- Original never deleted on failure


### PR DESCRIPTION
## Summary
- Extract 4 key architectural decisions from implementation plans into formal ADRs
- Update CLAUDE.md ADR index to include new entries

## New ADRs

| ADR | Decision |
|-----|----------|
| **0017** | MTIME + heuristics for change detection |
| **0018** | Metadata generation tiers (auto → derivable → defaults → human) |
| **0019** | COG optimization defaults (DEFLATE, 512×512, nearest) |
| **0020** | Conversion output location (side-by-side vectors, in-place rasters) |

## Why

These decisions were made during `check-metadata-handling` and `convert-command` scoping but weren't captured as ADRs. They're important architectural choices that should be:
- Discoverable (in the ADR index)
- Referenceable (by future code and docs)
- Succinct (the plans remain as detailed reasoning in git history)

## Test plan
- [x] Pre-commit hooks pass (including `validate CLAUDE.md references`)
- [x] All 21 ADRs now listed in CLAUDE.md index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added change detection optimization with `--force-rehash` override for manual verification
  * Documented STAC metadata generation tiers and regeneration behavior
  * Established standard Cloud Optimized GeoTIFF conversion defaults for consistent output
  * Defined output location strategy: vectors create separate files, rasters convert in-place with optional `--replace` flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->