### PR TITLE
feat(sync): add sync command orchestrating pull/push workflow

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,12 +30,11 @@ Push catalogs to object storage. Portolan owns the bucket contents.
 
 | Capability | Description |
 |------------|-------------|
-| `portolan push` | Diff local vs remote → upload changed files → update versions.json |
-| `portolan pull` | Diff remote vs local → download changed files → update local state |
-| `portolan sync` | Orchestrate full workflow: init → scan → check --fix → push/pull |
-| `versions.json` | Version history, checksums, sync state |
-
-**Note:** Upload primitives (S3/GCS/Azure via obstore) are implemented in [PR #46](https://github.com/portolan-sdi/portolan-cli/pull/46).
+| `portolan push` | Diff local vs remote → upload changed files → update versions.json ✓ |
+| `portolan pull` | Diff remote vs local → download changed files → update local state ✓ |
+| `portolan sync` | Orchestrate full workflow: pull → init → scan → check → push ✓ |
+| `portolan clone` | Pull a remote catalog to a new local directory ✓ |
+| `versions.json` | Version history, checksums, sync state ✓ |
 
 ### Epic: Scan & Validation
 
@@ -116,8 +115,8 @@ Phase 1 is broken into incremental releases. Each builds on the previous—later
 | **v0.2** | Catalog init | `portolan init` — create `.portolan/` structure ✓ |
 | **v0.3** | Format conversion | Wrap [geoparquet-io](https://github.com/geoparquet/geoparquet-io) + [rio-cogeo](https://github.com/cogeotiff/rio-cogeo), format detection ✓ |
 | **v0.4** | Scan + validation | `portolan scan` (discover files, detect issues), `portolan check` (validate catalog), `check --fix` (convert to cloud-native) ✓ |
-| **v0.5** | Dataset CRUD | `dataset add/list/info/remove` — orchestrate conversion + validation + catalog updates |
-| **v0.6** | Remote sync | `push` (diff + upload), `pull` (diff + download), `sync` (orchestrate init→scan→check→push) |
+| **v0.5** | Dataset CRUD | `dataset add/list/info/remove` — orchestrate conversion + validation + catalog updates ✓ |
+| **v0.6** | Remote sync | `push`, `pull`, `sync`, `clone` — upload/download primitives + orchestration ✓ |
 | **v0.7** | Versioning | Schema fingerprints, `rollback`, `--breaking` flag, version numbering ([#14](https://github.com/portolan-sdi/portolan-cli/issues/14)) |
 | **v0.8** | Maintenance | `prune` with safety mechanisms ([#15](https://github.com/portolan-sdi/portolan-cli/issues/15)), `repair`|
 

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -501,6 +501,9 @@ def push(
     if not catalog_root.exists():
         raise FileNotFoundError(f"Catalog root not found: {catalog_root}")
 
+    # Resolve catalog_root to absolute path for consistent path operations
+    catalog_root = catalog_root.resolve()
+
     # Read local versions
     local_data = _read_local_versions(catalog_root, collection)
     local_versions = [v.get("version") for v in local_data.get("versions", [])]

--- a/portolan_cli/sync.py
+++ b/portolan_cli/sync.py
@@ -1,0 +1,517 @@
+"""Sync module - orchestrates catalog synchronization with remote storage.
+
+The sync command sequences: Pull -> Init -> Scan -> Check -> Push.
+All primitives already exist - this module is orchestration glue.
+
+Workflow:
+1. Pull: Fetch remote state, detect conflicts
+2. Init: Initialize catalog if needed (idempotent for already-managed catalogs)
+3. Scan: Discover files in catalog
+4. Check: Validate cloud-native status, optionally convert with --fix
+5. Push: Upload changes to remote storage
+
+See ADR-0005 for versions.json as single source of truth.
+See ADR-0007 for CLI wraps Python API (all logic in library layer).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from portolan_cli.catalog import CatalogState, detect_state, init_catalog
+from portolan_cli.check import CheckReport, check_directory
+from portolan_cli.output import error, info, success, warn
+from portolan_cli.pull import PullError, PullResult, pull
+from portolan_cli.push import PushConflictError, PushResult, push
+from portolan_cli.scan import ScanResult, scan_directory
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# Exceptions
+# =============================================================================
+
+
+class SyncError(Exception):
+    """Base exception for sync operations."""
+
+    pass
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class SyncResult:
+    """Result of a sync operation.
+
+    Aggregates results from all sync steps: pull, init, scan, check, push.
+
+    Attributes:
+        success: True if sync completed without errors.
+        pull_result: Result from the pull step, or None if not executed.
+        init_performed: True if init was called (False if already managed).
+        scan_result: Result from the scan step, or None if not executed.
+        check_result: Result from the check step, or None if not executed.
+        push_result: Result from the push step, or None if not executed.
+        errors: List of error messages from any step.
+    """
+
+    success: bool
+    pull_result: PullResult | None
+    init_performed: bool
+    scan_result: ScanResult | None
+    check_result: CheckReport | None
+    push_result: PushResult | None
+    errors: list[str] = field(default_factory=list)
+
+
+# =============================================================================
+# Sync Step Helpers
+# =============================================================================
+
+
+def _step_pull(
+    destination: str,
+    catalog_root: Path,
+    collection: str,
+    force: bool,
+    dry_run: bool,
+    profile: str | None,
+) -> tuple[PullResult | None, str | None]:
+    """Execute pull step. Returns (pull_result, error_msg)."""
+    info(f"Pulling from {destination}...")
+    try:
+        pull_result = pull(
+            remote_url=destination,
+            local_root=catalog_root,
+            collection=collection,
+            force=force,
+            dry_run=dry_run,
+            profile=profile,
+        )
+
+        if not pull_result.success:
+            # Check if this is a "first sync" case (remote doesn't exist yet)
+            is_first_sync = (
+                pull_result.remote_version is None and not pull_result.uncommitted_changes
+            )
+
+            if is_first_sync:
+                info("No remote catalog found (first sync)")
+            else:
+                error_msg = "Pull failed"
+                if pull_result.uncommitted_changes:
+                    files = ", ".join(pull_result.uncommitted_changes)
+                    error_msg += f": uncommitted changes in {files}"
+                return pull_result, error_msg
+
+        if pull_result.up_to_date:
+            info("Already up to date with remote")
+        else:
+            success(f"Pulled {pull_result.files_downloaded} file(s)")
+
+        return pull_result, None
+
+    except PullError as e:
+        return None, f"Pull failed: {e}"
+
+
+def _step_init(
+    catalog_root: Path,
+    force: bool,
+) -> tuple[bool, str | None]:
+    """Execute init step. Returns (init_performed, error_msg)."""
+    state = detect_state(catalog_root)
+
+    if state == CatalogState.FRESH:
+        info("Initializing catalog...")
+        try:
+            init_catalog(catalog_root)
+            success("Initialized catalog")
+            return True, None
+        except Exception as e:
+            return False, f"Init failed: {e}"
+
+    if state == CatalogState.MANAGED:
+        return False, None
+
+    # UNMANAGED_STAC - refuse without --force
+    if force:
+        warn("Catalog is an unmanaged STAC catalog, proceeding with --force")
+        return False, None
+
+    return False, (
+        "Catalog appears to be an unmanaged STAC catalog. "
+        "Use 'portolan adopt' to bring it under management, or --force to sync anyway."
+    )
+
+
+def _step_scan(catalog_root: Path) -> tuple[ScanResult | None, str | None]:
+    """Execute scan step. Returns (scan_result, error_msg)."""
+    info(f"Scanning {catalog_root}...")
+    try:
+        scan_result = scan_directory(catalog_root)
+
+        if scan_result.has_errors:
+            warn(f"Scan found {scan_result.error_count} issue(s)")
+        else:
+            info(f"Found {len(scan_result.ready)} file(s) ready for import")
+
+        return scan_result, None
+    except Exception as e:
+        return None, f"Scan failed: {e}"
+
+
+def _step_check(
+    catalog_root: Path,
+    fix: bool,
+    dry_run: bool,
+) -> tuple[CheckReport | None, str | None]:
+    """Execute check step. Returns (check_result, error_msg)."""
+    info("Checking cloud-native status...")
+    try:
+        check_result = check_directory(catalog_root, fix=fix, dry_run=dry_run)
+
+        if check_result.convertible_count > 0:
+            if fix:
+                success(
+                    f"Converted {check_result.convertible_count} file(s) to cloud-native format"
+                )
+            else:
+                warn(
+                    f"{check_result.convertible_count} file(s) can be converted "
+                    "(use --fix to convert)"
+                )
+
+        if check_result.unsupported_count > 0:
+            warn(f"{check_result.unsupported_count} unsupported file(s) found")
+
+        return check_result, None
+    except Exception as e:
+        return None, f"Check failed: {e}"
+
+
+def _step_push(
+    catalog_root: Path,
+    collection: str,
+    destination: str,
+    force: bool,
+    dry_run: bool,
+    profile: str | None,
+) -> tuple[PushResult | None, str | None]:
+    """Execute push step. Returns (push_result, error_msg)."""
+    info(f"Pushing to {destination}...")
+    try:
+        push_result = push(
+            catalog_root=catalog_root,
+            collection=collection,
+            destination=destination,
+            force=force,
+            dry_run=dry_run,
+            profile=profile,
+        )
+
+        if not push_result.success:
+            error_msg = "Push failed"
+            if push_result.errors:
+                details = ", ".join(push_result.errors)
+                error_msg += f": {details}"
+            return push_result, error_msg
+
+        if push_result.versions_pushed > 0:
+            success(
+                f"Pushed {push_result.versions_pushed} version(s), "
+                f"{push_result.files_uploaded} file(s)"
+            )
+        else:
+            info("Nothing to push - local and remote are in sync")
+
+        return push_result, None
+
+    except PushConflictError as e:
+        return None, f"Push conflict: {e}"
+    except Exception as e:
+        return None, f"Push failed: {e}"
+
+
+# =============================================================================
+# Main Sync Function
+# =============================================================================
+
+
+def sync(
+    catalog_root: Path,
+    collection: str,
+    destination: str,
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    fix: bool = False,
+    profile: str | None = None,
+) -> SyncResult:
+    """Sync local catalog with remote storage.
+
+    Orchestrates the full sync workflow:
+    1. Pull: Fetch remote state, detect conflicts
+    2. Init: Initialize catalog if needed (skipped if already managed)
+    3. Scan: Discover files in catalog
+    4. Check: Validate cloud-native status (with --fix: convert non-cloud-native)
+    5. Push: Upload changes to remote storage
+
+    Args:
+        catalog_root: Path to catalog root directory.
+        collection: Collection identifier to sync.
+        destination: Object store URL (e.g., s3://bucket/prefix).
+        force: If True, overwrite conflicts (passes to pull and push).
+        dry_run: If True, show what would happen without making changes.
+        fix: If True, convert non-cloud-native formats during check.
+        profile: AWS profile name (for S3 destinations).
+
+    Returns:
+        SyncResult with aggregated results from all steps.
+    """
+    # Validate catalog root exists
+    if not catalog_root.exists():
+        error_msg = f"Catalog root not found: {catalog_root}"
+        error(error_msg)
+        return SyncResult(
+            success=False,
+            pull_result=None,
+            init_performed=False,
+            scan_result=None,
+            check_result=None,
+            push_result=None,
+            errors=[error_msg],
+        )
+
+    # Step 1: Pull
+    pull_result, pull_error = _step_pull(
+        destination, catalog_root, collection, force, dry_run, profile
+    )
+    if pull_error:
+        error(pull_error)
+        return SyncResult(
+            success=False,
+            pull_result=pull_result,
+            init_performed=False,
+            scan_result=None,
+            check_result=None,
+            push_result=None,
+            errors=[pull_error],
+        )
+
+    # Step 2: Init
+    init_performed, init_error = _step_init(catalog_root, force)
+    if init_error:
+        error(init_error)
+        return SyncResult(
+            success=False,
+            pull_result=pull_result,
+            init_performed=False,
+            scan_result=None,
+            check_result=None,
+            push_result=None,
+            errors=[init_error],
+        )
+
+    # Step 3: Scan
+    scan_result, scan_error = _step_scan(catalog_root)
+    if scan_error:
+        error(scan_error)
+        return SyncResult(
+            success=False,
+            pull_result=pull_result,
+            init_performed=init_performed,
+            scan_result=None,
+            check_result=None,
+            push_result=None,
+            errors=[scan_error],
+        )
+
+    # Step 4: Check
+    check_result, check_error = _step_check(catalog_root, fix, dry_run)
+    if check_error:
+        error(check_error)
+        return SyncResult(
+            success=False,
+            pull_result=pull_result,
+            init_performed=init_performed,
+            scan_result=scan_result,
+            check_result=None,
+            push_result=None,
+            errors=[check_error],
+        )
+
+    # Step 5: Push
+    push_result, push_error = _step_push(
+        catalog_root, collection, destination, force, dry_run, profile
+    )
+    if push_error:
+        error(push_error)
+        return SyncResult(
+            success=False,
+            pull_result=pull_result,
+            init_performed=init_performed,
+            scan_result=scan_result,
+            check_result=check_result,
+            push_result=push_result,
+            errors=[push_error],
+        )
+
+    # Success
+    return SyncResult(
+        success=True,
+        pull_result=pull_result,
+        init_performed=init_performed,
+        scan_result=scan_result,
+        check_result=check_result,
+        push_result=push_result,
+        errors=[],
+    )
+
+
+# =============================================================================
+# Clone Function
+# =============================================================================
+
+
+@dataclass
+class CloneResult:
+    """Result of a clone operation.
+
+    Attributes:
+        success: True if clone completed successfully.
+        pull_result: Result from the pull operation.
+        local_path: Path where the catalog was cloned to.
+        errors: List of error messages if any step failed.
+    """
+
+    success: bool
+    pull_result: PullResult | None
+    local_path: Path
+    errors: list[str] = field(default_factory=list)
+
+
+class CloneError(Exception):
+    """Exception raised when clone fails."""
+
+    pass
+
+
+def clone(
+    remote_url: str,
+    local_path: Path,
+    collection: str,
+    *,
+    profile: str | None = None,
+) -> CloneResult:
+    """Clone a remote catalog to a local directory.
+
+    This is essentially "pull to an empty directory" with guardrails.
+    Creates the target directory, initializes a Portolan catalog, and pulls
+    the specified collection from remote storage.
+
+    Args:
+        remote_url: Remote catalog URL (e.g., s3://bucket/catalog).
+        local_path: Local directory to clone into (will be created).
+        collection: Collection name to clone.
+        profile: AWS profile name (for S3).
+
+    Returns:
+        CloneResult with operation details.
+
+    Raises:
+        CloneError: If the target directory already exists and is not empty,
+                    or if the clone operation fails.
+    """
+    errors: list[str] = []
+
+    # Check if target already exists
+    if local_path.exists():
+        contents = list(local_path.iterdir())
+        if contents:
+            error_msg = f"Target directory is not empty: {local_path}"
+            error(error_msg)
+            return CloneResult(
+                success=False,
+                pull_result=None,
+                local_path=local_path,
+                errors=[error_msg],
+            )
+
+    # Create target directory
+    info(f"Cloning to {local_path}...")
+    local_path.mkdir(parents=True, exist_ok=True)
+
+    # Initialize catalog
+    info("Initializing catalog...")
+    try:
+        init_catalog(
+            local_path,
+            title=f"Clone of {remote_url}",
+            description=f"Cloned from {remote_url}",
+        )
+    except Exception as e:
+        error_msg = f"Failed to initialize catalog: {e}"
+        errors.append(error_msg)
+        error(error_msg)
+        return CloneResult(
+            success=False,
+            pull_result=None,
+            local_path=local_path,
+            errors=errors,
+        )
+
+    # Pull from remote
+    info(f"Pulling collection '{collection}' from {remote_url}...")
+    try:
+        pull_result = pull(
+            remote_url=remote_url,
+            local_root=local_path,
+            collection=collection,
+            force=False,  # No local changes to force-overwrite
+            dry_run=False,
+            profile=profile,
+        )
+
+        if not pull_result.success:
+            # Check if remote doesn't exist
+            if pull_result.remote_version is None:
+                error_msg = f"Remote collection '{collection}' not found at {remote_url}"
+            else:
+                error_msg = "Pull failed during clone"
+            errors.append(error_msg)
+            error(error_msg)
+            return CloneResult(
+                success=False,
+                pull_result=pull_result,
+                local_path=local_path,
+                errors=errors,
+            )
+
+        success(f"Cloned {pull_result.files_downloaded} file(s) to {local_path}")
+
+    except PullError as e:
+        error_msg = f"Clone failed: {e}"
+        errors.append(error_msg)
+        error(error_msg)
+        return CloneResult(
+            success=False,
+            pull_result=None,
+            local_path=local_path,
+            errors=errors,
+        )
+
+    return CloneResult(
+        success=True,
+        pull_result=pull_result,
+        local_path=local_path,
+        errors=[],
+    )

--- a/tests/integration/test_sync_integration.py
+++ b/tests/integration/test_sync_integration.py
@@ -1,0 +1,605 @@
+"""Integration tests for sync module.
+
+Tests for CLI command integration and real filesystem operations.
+These tests verify:
+- CLI command registration and invocation
+- Flag passing to underlying sync function
+- Error handling and user feedback
+- JSON output format
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def managed_catalog(tmp_path: Path) -> Path:
+    """Create a managed catalog with full .portolan structure."""
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+
+    # Create catalog.json
+    catalog_data = {
+        "type": "Catalog",
+        "id": "test-catalog",
+        "description": "Test catalog",
+        "stac_version": "1.0.0",
+        "links": [],
+    }
+    (catalog_dir / "catalog.json").write_text(json.dumps(catalog_data, indent=2))
+
+    # Create .portolan directory structure (MANAGED state requires both config and state)
+    portolan_dir = catalog_dir / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.json").write_text("{}\n")
+    (portolan_dir / "state.json").write_text("{}\n")
+
+    # Create collection with versions.json
+    collection_dir = portolan_dir / "collections" / "demographics"
+    collection_dir.mkdir(parents=True)
+
+    versions_data = {
+        "spec_version": "1.0.0",
+        "current_version": "1.0.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2024-01-01T00:00:00Z",
+                "breaking": False,
+                "message": "Initial version",
+                "assets": {
+                    "census.parquet": {
+                        "sha256": "abc123def456",
+                        "size_bytes": 10240,
+                        "href": "collections/demographics/census.parquet",
+                    }
+                },
+                "changes": ["census.parquet"],
+            },
+        ],
+    }
+    (collection_dir / "versions.json").write_text(json.dumps(versions_data, indent=2))
+
+    # Create actual asset file
+    asset_dir = catalog_dir / "collections" / "demographics"
+    asset_dir.mkdir(parents=True)
+    (asset_dir / "census.parquet").write_bytes(b"x" * 10240)
+
+    return catalog_dir
+
+
+@pytest.fixture
+def fresh_directory(tmp_path: Path) -> Path:
+    """Create a fresh directory without any catalog structure."""
+    fresh_dir = tmp_path / "fresh"
+    fresh_dir.mkdir()
+    return fresh_dir
+
+
+# =============================================================================
+# CLI Registration Tests
+# =============================================================================
+
+
+class TestSyncCLI:
+    """Integration tests for sync CLI command."""
+
+    @pytest.mark.integration
+    def test_sync_command_exists(self) -> None:
+        """Sync command should be registered in CLI."""
+        from portolan_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync", "--help"])
+
+        assert result.exit_code == 0
+        assert "sync" in result.output.lower() or "Sync" in result.output
+
+    @pytest.mark.integration
+    def test_sync_requires_destination(self) -> None:
+        """Sync should require destination argument."""
+        from portolan_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync"])
+
+        # Should show error about missing destination
+        assert result.exit_code != 0
+
+    @pytest.mark.integration
+    def test_sync_requires_collection(self, managed_catalog: Path) -> None:
+        """Sync should require --collection flag."""
+        from portolan_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "sync",
+                "s3://mybucket/catalog",
+                "--catalog",
+                str(managed_catalog),
+            ],
+        )
+
+        # Should show error about missing collection
+        assert result.exit_code != 0
+        assert "collection" in result.output.lower()
+
+    @pytest.mark.integration
+    def test_sync_help_shows_all_options(self) -> None:
+        """Sync --help should show all expected options."""
+        from portolan_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync", "--help"])
+
+        assert result.exit_code == 0
+        assert "--collection" in result.output
+        assert "--force" in result.output
+        assert "--dry-run" in result.output
+        assert "--fix" in result.output
+        assert "--profile" in result.output
+        assert "--catalog" in result.output
+
+
+# =============================================================================
+# Flag Passthrough Tests
+# =============================================================================
+
+
+class TestSyncFlagPassthrough:
+    """Tests for CLI flags being passed to sync function."""
+
+    @pytest.mark.integration
+    def test_sync_dry_run_flag(self, managed_catalog: Path) -> None:
+        """Sync --dry-run should pass dry_run=True to sync function."""
+        from portolan_cli.cli import cli
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=True,
+                pull_result=PullResult(
+                    success=True,
+                    files_downloaded=0,
+                    files_skipped=0,
+                    local_version="1.0.0",
+                    remote_version="1.0.0",
+                    up_to_date=True,
+                ),
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=PushResult(
+                    success=True,
+                    files_uploaded=0,
+                    versions_pushed=0,
+                ),
+                errors=[],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--dry-run",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+                catch_exceptions=False,
+            )
+
+            # Verify dry_run=True was passed
+            call_kwargs = mock_sync.call_args.kwargs
+            assert call_kwargs.get("dry_run") is True
+            assert result.exit_code == 0
+
+    @pytest.mark.integration
+    def test_sync_force_flag(self, managed_catalog: Path) -> None:
+        """Sync --force should pass force=True to sync function."""
+        from portolan_cli.cli import cli
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=True,
+                pull_result=PullResult(
+                    success=True,
+                    files_downloaded=0,
+                    files_skipped=0,
+                    local_version="1.0.0",
+                    remote_version="1.0.0",
+                ),
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=PushResult(
+                    success=True,
+                    files_uploaded=0,
+                    versions_pushed=0,
+                ),
+                errors=[],
+            )
+
+            runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--force",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+                catch_exceptions=False,
+            )
+
+            call_kwargs = mock_sync.call_args.kwargs
+            assert call_kwargs.get("force") is True
+
+    @pytest.mark.integration
+    def test_sync_fix_flag(self, managed_catalog: Path) -> None:
+        """Sync --fix should pass fix=True to sync function."""
+        from portolan_cli.cli import cli
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=True,
+                pull_result=PullResult(
+                    success=True,
+                    files_downloaded=0,
+                    files_skipped=0,
+                    local_version="1.0.0",
+                    remote_version="1.0.0",
+                ),
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=PushResult(
+                    success=True,
+                    files_uploaded=0,
+                    versions_pushed=0,
+                ),
+                errors=[],
+            )
+
+            runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--fix",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+                catch_exceptions=False,
+            )
+
+            call_kwargs = mock_sync.call_args.kwargs
+            assert call_kwargs.get("fix") is True
+
+    @pytest.mark.integration
+    def test_sync_profile_flag(self, managed_catalog: Path) -> None:
+        """Sync --profile should pass AWS profile to sync function."""
+        from portolan_cli.cli import cli
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=True,
+                pull_result=PullResult(
+                    success=True,
+                    files_downloaded=0,
+                    files_skipped=0,
+                    local_version="1.0.0",
+                    remote_version="1.0.0",
+                ),
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=PushResult(
+                    success=True,
+                    files_uploaded=0,
+                    versions_pushed=0,
+                ),
+                errors=[],
+            )
+
+            runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--profile",
+                    "production",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+                catch_exceptions=False,
+            )
+
+            call_kwargs = mock_sync.call_args.kwargs
+            assert call_kwargs.get("profile") == "production"
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+class TestSyncErrorHandling:
+    """Tests for error handling in sync CLI."""
+
+    @pytest.mark.integration
+    def test_sync_failure_returns_nonzero(self, managed_catalog: Path) -> None:
+        """Sync failure should return non-zero exit code."""
+        from portolan_cli.cli import cli
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=False,
+                pull_result=None,
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=None,
+                errors=["Pull failed: network timeout"],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+            )
+
+            assert result.exit_code == 1
+
+    @pytest.mark.integration
+    def test_sync_missing_catalog_returns_error(self, tmp_path: Path) -> None:
+        """Sync with non-existent catalog should fail."""
+        from portolan_cli.cli import cli
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+        non_existent = tmp_path / "does_not_exist"
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=False,
+                pull_result=None,
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=None,
+                errors=["Catalog root not found"],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--catalog",
+                    str(non_existent),
+                ],
+            )
+
+            assert result.exit_code == 1
+
+
+# =============================================================================
+# JSON Output Tests
+# =============================================================================
+
+
+class TestSyncJSONOutput:
+    """Tests for JSON output format."""
+
+    @pytest.mark.integration
+    def test_sync_json_output_success(self, managed_catalog: Path) -> None:
+        """Sync with --format=json should output valid JSON envelope."""
+        from portolan_cli.cli import cli
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=True,
+                pull_result=PullResult(
+                    success=True,
+                    files_downloaded=2,
+                    files_skipped=0,
+                    local_version="1.0.0",
+                    remote_version="1.1.0",
+                ),
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=PushResult(
+                    success=True,
+                    files_uploaded=1,
+                    versions_pushed=1,
+                ),
+                errors=[],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+                catch_exceptions=False,
+            )
+
+            assert result.exit_code == 0
+
+            # Parse and validate JSON output
+            output = json.loads(result.output)
+            assert output["success"] is True
+            assert output["command"] == "sync"
+            assert "data" in output
+            assert "pull" in output["data"]
+            assert "push" in output["data"]
+            assert output["data"]["pull"]["files_downloaded"] == 2
+            assert output["data"]["push"]["versions_pushed"] == 1
+
+    @pytest.mark.integration
+    def test_sync_json_output_failure(self, managed_catalog: Path) -> None:
+        """Sync failure with --format=json should include errors array."""
+        from portolan_cli.cli import cli
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=False,
+                pull_result=None,
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=None,
+                errors=["Pull failed: connection refused"],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+            )
+
+            assert result.exit_code == 1
+
+            # Parse and validate JSON output
+            output = json.loads(result.output)
+            assert output["success"] is False
+            assert output["command"] == "sync"
+            assert "errors" in output
+            assert len(output["errors"]) > 0
+            assert "Pull failed" in output["errors"][0]["message"]
+
+
+# =============================================================================
+# Combined Flag Tests
+# =============================================================================
+
+
+class TestSyncCombinedFlags:
+    """Tests for using multiple flags together."""
+
+    @pytest.mark.integration
+    def test_sync_all_flags_together(self, managed_catalog: Path) -> None:
+        """Sync should handle all flags simultaneously."""
+        from portolan_cli.cli import cli
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.sync.sync") as mock_sync:
+            mock_sync.return_value = SyncResult(
+                success=True,
+                pull_result=PullResult(
+                    success=True,
+                    files_downloaded=0,
+                    files_skipped=0,
+                    local_version="1.0.0",
+                    remote_version="1.0.0",
+                ),
+                init_performed=False,
+                scan_result=None,
+                check_result=None,
+                push_result=PushResult(
+                    success=True,
+                    files_uploaded=0,
+                    versions_pushed=0,
+                ),
+                errors=[],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "sync",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--force",
+                    "--dry-run",
+                    "--fix",
+                    "--profile",
+                    "production",
+                    "--catalog",
+                    str(managed_catalog),
+                ],
+                catch_exceptions=False,
+            )
+
+            call_kwargs = mock_sync.call_args.kwargs
+            assert call_kwargs.get("force") is True
+            assert call_kwargs.get("dry_run") is True
+            assert call_kwargs.get("fix") is True
+            assert call_kwargs.get("profile") == "production"
+            assert result.exit_code == 0

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -1,0 +1,961 @@
+"""Unit tests for sync module - the sync orchestrator.
+
+Tests for the sync command that sequences: Pull -> Init -> Scan -> Check -> Push.
+All primitives already exist - sync is orchestration glue.
+
+Following TDD: these tests are written FIRST, before implementation.
+
+Test categories:
+- SyncResult dataclass
+- Orchestration sequence (all steps called in order)
+- Early exit on pull failure
+- Skip init if .portolan exists
+- Dry-run mode
+- Force mode
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def managed_catalog(tmp_path: Path) -> Path:
+    """Create a managed catalog with .portolan directory structure."""
+    catalog_dir = tmp_path / "catalog"
+    catalog_dir.mkdir()
+
+    # Create .portolan structure to indicate MANAGED state
+    portolan_dir = catalog_dir / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.json").write_text("{}\n")
+    (portolan_dir / "state.json").write_text("{}\n")
+
+    # Create collection versions.json
+    versions_dir = portolan_dir / "collections" / "test-collection"
+    versions_dir.mkdir(parents=True)
+
+    versions_data = {
+        "spec_version": "1.0.0",
+        "current_version": "1.0.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2024-01-15T10:00:00Z",
+                "breaking": False,
+                "message": "Initial version",
+                "assets": {
+                    "data.parquet": {
+                        "sha256": "abc123",
+                        "size_bytes": 1000,
+                        "href": "data.parquet",
+                    }
+                },
+                "changes": ["data.parquet"],
+            }
+        ],
+    }
+    (versions_dir / "versions.json").write_text(json.dumps(versions_data, indent=2))
+
+    # Create catalog.json
+    catalog_json = {
+        "type": "Catalog",
+        "id": "catalog",
+        "stac_version": "1.0.0",
+        "description": "Test catalog",
+        "links": [],
+    }
+    (catalog_dir / "catalog.json").write_text(json.dumps(catalog_json, indent=2))
+
+    # Create data file
+    (catalog_dir / "data.parquet").write_bytes(b"x" * 1000)
+
+    return catalog_dir
+
+
+@pytest.fixture
+def fresh_directory(tmp_path: Path) -> Path:
+    """Create a fresh directory without .portolan (FRESH state)."""
+    fresh_dir = tmp_path / "fresh"
+    fresh_dir.mkdir()
+    return fresh_dir
+
+
+# =============================================================================
+# SyncResult Tests
+# =============================================================================
+
+
+class TestSyncResult:
+    """Tests for SyncResult dataclass."""
+
+    @pytest.mark.unit
+    def test_sync_result_success(self) -> None:
+        """SyncResult should capture successful sync stats."""
+        from portolan_cli.sync import SyncResult
+
+        result = SyncResult(
+            success=True,
+            pull_result=None,
+            init_performed=False,
+            scan_result=None,
+            check_result=None,
+            push_result=None,
+            errors=[],
+        )
+
+        assert result.success is True
+        assert result.errors == []
+
+    @pytest.mark.unit
+    def test_sync_result_with_errors(self) -> None:
+        """SyncResult should capture errors from any step."""
+        from portolan_cli.sync import SyncResult
+
+        result = SyncResult(
+            success=False,
+            pull_result=None,
+            init_performed=False,
+            scan_result=None,
+            check_result=None,
+            push_result=None,
+            errors=["Pull failed: network timeout"],
+        )
+
+        assert result.success is False
+        assert len(result.errors) == 1
+
+    @pytest.mark.unit
+    def test_sync_result_with_all_steps(self) -> None:
+        """SyncResult should aggregate results from all steps."""
+        from portolan_cli.pull import PullResult
+        from portolan_cli.push import PushResult
+        from portolan_cli.sync import SyncResult
+
+        pull_result = PullResult(
+            success=True,
+            files_downloaded=2,
+            files_skipped=0,
+            local_version="1.0.0",
+            remote_version="1.1.0",
+        )
+
+        push_result = PushResult(
+            success=True,
+            files_uploaded=1,
+            versions_pushed=1,
+        )
+
+        result = SyncResult(
+            success=True,
+            pull_result=pull_result,
+            init_performed=True,
+            scan_result=None,
+            check_result=None,
+            push_result=push_result,
+            errors=[],
+        )
+
+        assert result.success is True
+        assert result.pull_result is not None
+        assert result.pull_result.files_downloaded == 2
+        assert result.push_result is not None
+        assert result.push_result.versions_pushed == 1
+
+
+# =============================================================================
+# Orchestration Sequence Tests
+# =============================================================================
+
+
+class TestOrchestrationSequence:
+    """Tests for sync orchestration - ensuring steps run in correct order."""
+
+    @pytest.mark.unit
+    def test_sync_calls_all_steps_in_order(self, managed_catalog: Path) -> None:
+        """Sync should call pull, init, scan, check, push in that order."""
+        from portolan_cli.sync import sync
+
+        call_order: list[str] = []
+
+        def track_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            call_order.append("pull")
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            result.files_downloaded = 0
+            return result
+
+        def track_init(*args: Any, **kwargs: Any) -> tuple[Path, list[str]]:
+            call_order.append("init")
+            return managed_catalog / "catalog.json", []
+
+        def track_scan(*args: Any, **kwargs: Any) -> MagicMock:
+            call_order.append("scan")
+            result = MagicMock()
+            result.ready = []
+            result.has_errors = False
+            return result
+
+        def track_check(*args: Any, **kwargs: Any) -> MagicMock:
+            call_order.append("check")
+            result = MagicMock()
+            result.convertible_count = 0
+            result.unsupported_count = 0
+            return result
+
+        def track_push(*args: Any, **kwargs: Any) -> MagicMock:
+            call_order.append("push")
+            result = MagicMock()
+            result.success = True
+            result.files_uploaded = 0
+            result.versions_pushed = 0
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=track_pull),
+            patch("portolan_cli.sync.init_catalog", side_effect=track_init),
+            patch("portolan_cli.sync.scan_directory", side_effect=track_scan),
+            patch("portolan_cli.sync.check_directory", side_effect=track_check),
+            patch("portolan_cli.sync.push", side_effect=track_push),
+        ):
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        # Verify all steps were called (init may be skipped for managed catalog)
+        assert "pull" in call_order
+        # init may be skipped if already managed
+        assert "scan" in call_order
+        assert "check" in call_order
+        assert "push" in call_order
+
+        # Verify order: pull must come before scan, scan before check, check before push
+        pull_idx = call_order.index("pull")
+        scan_idx = call_order.index("scan")
+        check_idx = call_order.index("check")
+        push_idx = call_order.index("push")
+
+        assert pull_idx < scan_idx, "Pull must come before scan"
+        assert scan_idx < check_idx, "Scan must come before check"
+        assert check_idx < push_idx, "Check must come before push"
+
+
+# =============================================================================
+# Early Exit Tests
+# =============================================================================
+
+
+class TestEarlyExit:
+    """Tests for early exit conditions."""
+
+    @pytest.mark.unit
+    def test_sync_exits_early_on_pull_failure(self, managed_catalog: Path) -> None:
+        """Sync should exit early if pull fails."""
+        from portolan_cli.sync import sync
+
+        def failing_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = False
+            result.uncommitted_changes = ["data.parquet"]
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=failing_pull),
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            result = sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        # Pull failed, so subsequent steps should not be called
+        mock_scan.assert_not_called()
+        mock_check.assert_not_called()
+        mock_push.assert_not_called()
+        assert result.success is False
+
+    @pytest.mark.unit
+    def test_sync_continues_when_pull_up_to_date(self, managed_catalog: Path) -> None:
+        """Sync should continue when pull indicates already up to date."""
+        from portolan_cli.sync import sync
+
+        def up_to_date_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            result.files_downloaded = 0
+            return result
+
+        def successful_push(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.files_uploaded = 0
+            result.versions_pushed = 0
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=up_to_date_pull),
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push", side_effect=successful_push),
+        ):
+            # Set up mock returns
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+
+            result = sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        # Subsequent steps should be called
+        mock_scan.assert_called_once()
+        mock_check.assert_called_once()
+        assert result.success is True
+
+
+# =============================================================================
+# Init Skip Tests
+# =============================================================================
+
+
+class TestInitSkip:
+    """Tests for skipping init when catalog already exists."""
+
+    @pytest.mark.unit
+    def test_sync_skips_init_if_managed(self, managed_catalog: Path) -> None:
+        """Sync should skip init if catalog is already in MANAGED state."""
+        from portolan_cli.sync import sync
+
+        def successful_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            return result
+
+        def successful_push(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.files_uploaded = 0
+            result.versions_pushed = 0
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=successful_pull),
+            patch("portolan_cli.sync.init_catalog") as mock_init,
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push", side_effect=successful_push),
+        ):
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+
+            result = sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        # init_catalog should NOT be called for managed catalog
+        mock_init.assert_not_called()
+        assert result.init_performed is False
+
+    @pytest.mark.unit
+    def test_sync_calls_init_if_fresh(self, fresh_directory: Path) -> None:
+        """Sync should call init if directory is in FRESH state."""
+        from portolan_cli.sync import sync
+
+        def successful_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            return result
+
+        def successful_push(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.files_uploaded = 0
+            result.versions_pushed = 0
+            return result
+
+        def mock_init_catalog(path: Path, **kwargs: Any) -> tuple[Path, list[str]]:
+            # Simulate init creating the .portolan directory
+            portolan_dir = path / ".portolan"
+            portolan_dir.mkdir(parents=True, exist_ok=True)
+            (portolan_dir / "config.json").write_text("{}\n")
+            (portolan_dir / "state.json").write_text("{}\n")
+            return path / "catalog.json", []
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=successful_pull),
+            patch("portolan_cli.sync.init_catalog", side_effect=mock_init_catalog) as mock_init,
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push", side_effect=successful_push),
+        ):
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+
+            result = sync(
+                catalog_root=fresh_directory,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        # init_catalog SHOULD be called for fresh directory
+        mock_init.assert_called_once()
+        assert result.init_performed is True
+
+
+# =============================================================================
+# Dry-Run Mode Tests
+# =============================================================================
+
+
+class TestDryRunMode:
+    """Tests for dry-run mode."""
+
+    @pytest.mark.unit
+    def test_sync_dry_run_passes_to_push(self, managed_catalog: Path) -> None:
+        """Sync --dry-run should pass dry_run=True to push."""
+        from portolan_cli.sync import sync
+
+        def successful_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=successful_pull),
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.return_value = MagicMock(success=True, files_uploaded=0, versions_pushed=0)
+
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+                dry_run=True,
+            )
+
+        # Verify dry_run was passed to push
+        mock_push.assert_called_once()
+        call_kwargs = mock_push.call_args.kwargs
+        assert call_kwargs.get("dry_run") is True
+
+    @pytest.mark.unit
+    def test_sync_dry_run_passes_to_pull(self, managed_catalog: Path) -> None:
+        """Sync --dry-run should pass dry_run=True to pull."""
+        from portolan_cli.sync import sync
+
+        with (
+            patch("portolan_cli.sync.pull") as mock_pull,
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_pull.return_value = MagicMock(success=True, up_to_date=True)
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.return_value = MagicMock(success=True, files_uploaded=0, versions_pushed=0)
+
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+                dry_run=True,
+            )
+
+        # Verify dry_run was passed to pull
+        mock_pull.assert_called_once()
+        call_kwargs = mock_pull.call_args.kwargs
+        assert call_kwargs.get("dry_run") is True
+
+
+# =============================================================================
+# Force Mode Tests
+# =============================================================================
+
+
+class TestForceMode:
+    """Tests for force mode."""
+
+    @pytest.mark.unit
+    def test_sync_force_passes_to_push(self, managed_catalog: Path) -> None:
+        """Sync --force should pass force=True to push."""
+        from portolan_cli.sync import sync
+
+        def successful_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=successful_pull),
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.return_value = MagicMock(success=True, files_uploaded=0, versions_pushed=0)
+
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+                force=True,
+            )
+
+        # Verify force was passed to push
+        mock_push.assert_called_once()
+        call_kwargs = mock_push.call_args.kwargs
+        assert call_kwargs.get("force") is True
+
+    @pytest.mark.unit
+    def test_sync_force_passes_to_pull(self, managed_catalog: Path) -> None:
+        """Sync --force should pass force=True to pull."""
+        from portolan_cli.sync import sync
+
+        with (
+            patch("portolan_cli.sync.pull") as mock_pull,
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_pull.return_value = MagicMock(success=True, up_to_date=True)
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.return_value = MagicMock(success=True, files_uploaded=0, versions_pushed=0)
+
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+                force=True,
+            )
+
+        # Verify force was passed to pull
+        mock_pull.assert_called_once()
+        call_kwargs = mock_pull.call_args.kwargs
+        assert call_kwargs.get("force") is True
+
+
+# =============================================================================
+# Fix Mode Tests
+# =============================================================================
+
+
+class TestFixMode:
+    """Tests for fix mode (convert non-cloud-native formats)."""
+
+    @pytest.mark.unit
+    def test_sync_fix_passes_to_check(self, managed_catalog: Path) -> None:
+        """Sync --fix should pass fix=True to check_directory."""
+        from portolan_cli.sync import sync
+
+        def successful_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=successful_pull),
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.return_value = MagicMock(success=True, files_uploaded=0, versions_pushed=0)
+
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+                fix=True,
+            )
+
+        # Verify fix was passed to check
+        mock_check.assert_called_once()
+        call_kwargs = mock_check.call_args.kwargs
+        assert call_kwargs.get("fix") is True
+
+
+# =============================================================================
+# Profile Passthrough Tests
+# =============================================================================
+
+
+class TestProfilePassthrough:
+    """Tests for AWS profile passthrough."""
+
+    @pytest.mark.unit
+    def test_sync_profile_passes_to_pull_and_push(self, managed_catalog: Path) -> None:
+        """Sync --profile should pass profile to both pull and push."""
+        from portolan_cli.sync import sync
+
+        with (
+            patch("portolan_cli.sync.pull") as mock_pull,
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_pull.return_value = MagicMock(success=True, up_to_date=True)
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.return_value = MagicMock(success=True, files_uploaded=0, versions_pushed=0)
+
+            sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+                profile="production",
+            )
+
+        # Verify profile was passed to pull
+        pull_kwargs = mock_pull.call_args.kwargs
+        assert pull_kwargs.get("profile") == "production"
+
+        # Verify profile was passed to push
+        push_kwargs = mock_push.call_args.kwargs
+        assert push_kwargs.get("profile") == "production"
+
+
+# =============================================================================
+# Error Handling Tests
+# =============================================================================
+
+
+class TestErrorHandling:
+    """Tests for error handling."""
+
+    @pytest.mark.unit
+    def test_sync_handles_pull_error_gracefully(self, managed_catalog: Path) -> None:
+        """Sync should handle pull errors and not crash."""
+        from portolan_cli.pull import PullError
+        from portolan_cli.sync import sync
+
+        with patch("portolan_cli.sync.pull") as mock_pull:
+            mock_pull.side_effect = PullError("Network timeout")
+
+            result = sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        assert result.success is False
+        assert len(result.errors) > 0
+        assert "Network timeout" in str(result.errors)
+
+    @pytest.mark.unit
+    def test_sync_handles_push_error_gracefully(self, managed_catalog: Path) -> None:
+        """Sync should handle push errors and not crash."""
+        from portolan_cli.push import PushConflictError
+        from portolan_cli.sync import sync
+
+        def successful_pull(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.success = True
+            result.up_to_date = True
+            return result
+
+        with (
+            patch("portolan_cli.sync.pull", side_effect=successful_pull),
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.scan_directory") as mock_scan,
+            patch("portolan_cli.sync.check_directory") as mock_check,
+            patch("portolan_cli.sync.push") as mock_push,
+        ):
+            mock_scan.return_value = MagicMock(ready=[], has_errors=False)
+            mock_check.return_value = MagicMock(convertible_count=0, unsupported_count=0)
+            mock_push.side_effect = PushConflictError("Remote diverged")
+
+            result = sync(
+                catalog_root=managed_catalog,
+                collection="test-collection",
+                destination="s3://bucket/catalog",
+            )
+
+        assert result.success is False
+        assert len(result.errors) > 0
+        assert "Remote diverged" in str(result.errors) or "conflict" in str(result.errors).lower()
+
+    @pytest.mark.unit
+    def test_sync_handles_missing_catalog_root(self, tmp_path: Path) -> None:
+        """Sync should handle missing catalog root directory."""
+        from portolan_cli.sync import sync
+
+        non_existent = tmp_path / "does_not_exist"
+
+        result = sync(
+            catalog_root=non_existent,
+            collection="test-collection",
+            destination="s3://bucket/catalog",
+        )
+
+        assert result.success is False
+        assert len(result.errors) > 0
+
+
+# =============================================================================
+# Clone Tests
+# =============================================================================
+
+
+class TestCloneResult:
+    """Tests for the CloneResult dataclass."""
+
+    @pytest.mark.unit
+    def test_clone_result_stores_success(self, tmp_path: Path) -> None:
+        """CloneResult should store success status."""
+        from portolan_cli.sync import CloneResult
+
+        result = CloneResult(
+            success=True,
+            pull_result=None,
+            local_path=tmp_path / "cloned",
+        )
+
+        assert result.success is True
+        assert result.errors == []
+
+    @pytest.mark.unit
+    def test_clone_result_stores_errors(self, tmp_path: Path) -> None:
+        """CloneResult should store error messages."""
+        from portolan_cli.sync import CloneResult
+
+        result = CloneResult(
+            success=False,
+            pull_result=None,
+            local_path=tmp_path / "cloned",
+            errors=["Error 1", "Error 2"],
+        )
+
+        assert result.success is False
+        assert len(result.errors) == 2
+
+
+class TestCloneFunction:
+    """Tests for the clone() function."""
+
+    @pytest.mark.unit
+    def test_clone_fails_on_non_empty_directory(self, tmp_path: Path) -> None:
+        """Clone should fail if target directory is not empty."""
+        from portolan_cli.sync import clone
+
+        # Create non-empty directory
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "existing_file.txt").write_text("content")
+
+        result = clone(
+            remote_url="s3://bucket/catalog",
+            local_path=target,
+            collection="test",
+        )
+
+        assert result.success is False
+        assert any("not empty" in err for err in result.errors)
+
+    @pytest.mark.unit
+    def test_clone_creates_target_directory(self, tmp_path: Path) -> None:
+        """Clone should create target directory if it doesn't exist."""
+        from portolan_cli.sync import clone
+
+        target = tmp_path / "new_catalog"
+
+        with (
+            patch("portolan_cli.sync.init_catalog") as mock_init,
+            patch("portolan_cli.sync.pull") as mock_pull,
+        ):
+            # Mock successful operations
+            mock_init.return_value = None
+            mock_pull.return_value = MagicMock(
+                success=True,
+                files_downloaded=3,
+                remote_version="1.0.0",
+            )
+
+            result = clone(
+                remote_url="s3://bucket/catalog",
+                local_path=target,
+                collection="test",
+            )
+
+        assert target.exists()
+        assert result.success is True
+
+    @pytest.mark.unit
+    def test_clone_calls_init_catalog(self, tmp_path: Path) -> None:
+        """Clone should initialize the catalog."""
+        from portolan_cli.sync import clone
+
+        target = tmp_path / "new_catalog"
+
+        with (
+            patch("portolan_cli.sync.init_catalog") as mock_init,
+            patch("portolan_cli.sync.pull") as mock_pull,
+        ):
+            mock_pull.return_value = MagicMock(
+                success=True,
+                files_downloaded=3,
+                remote_version="1.0.0",
+            )
+
+            clone(
+                remote_url="s3://bucket/catalog",
+                local_path=target,
+                collection="test",
+            )
+
+        mock_init.assert_called_once()
+        call_args = mock_init.call_args
+        assert call_args[0][0] == target  # First positional arg is path
+
+    @pytest.mark.unit
+    def test_clone_calls_pull_with_correct_args(self, tmp_path: Path) -> None:
+        """Clone should call pull with the correct arguments."""
+        from portolan_cli.sync import clone
+
+        target = tmp_path / "new_catalog"
+
+        with (
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.pull") as mock_pull,
+        ):
+            mock_pull.return_value = MagicMock(
+                success=True,
+                files_downloaded=3,
+                remote_version="1.0.0",
+            )
+
+            clone(
+                remote_url="s3://bucket/catalog",
+                local_path=target,
+                collection="demographics",
+                profile="my-profile",
+            )
+
+        mock_pull.assert_called_once_with(
+            remote_url="s3://bucket/catalog",
+            local_root=target,
+            collection="demographics",
+            force=False,
+            dry_run=False,
+            profile="my-profile",
+        )
+
+    @pytest.mark.unit
+    def test_clone_fails_when_pull_fails(self, tmp_path: Path) -> None:
+        """Clone should fail if pull fails."""
+        from portolan_cli.sync import clone
+
+        target = tmp_path / "new_catalog"
+
+        with (
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.pull") as mock_pull,
+        ):
+            mock_pull.return_value = MagicMock(
+                success=False,
+                remote_version="1.0.0",
+                uncommitted_changes=[],
+            )
+
+            result = clone(
+                remote_url="s3://bucket/catalog",
+                local_path=target,
+                collection="test",
+            )
+
+        assert result.success is False
+
+    @pytest.mark.unit
+    def test_clone_fails_when_remote_not_found(self, tmp_path: Path) -> None:
+        """Clone should fail with helpful message when remote doesn't exist."""
+        from portolan_cli.sync import clone
+
+        target = tmp_path / "new_catalog"
+
+        with (
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.pull") as mock_pull,
+        ):
+            mock_pull.return_value = MagicMock(
+                success=False,
+                remote_version=None,  # Remote doesn't exist
+                uncommitted_changes=[],
+            )
+
+            result = clone(
+                remote_url="s3://bucket/catalog",
+                local_path=target,
+                collection="test",
+            )
+
+        assert result.success is False
+        assert any("not found" in err for err in result.errors)
+
+    @pytest.mark.unit
+    def test_clone_returns_pull_result(self, tmp_path: Path) -> None:
+        """Clone should return the pull result."""
+        from portolan_cli.sync import clone
+
+        target = tmp_path / "new_catalog"
+
+        with (
+            patch("portolan_cli.sync.init_catalog"),
+            patch("portolan_cli.sync.pull") as mock_pull,
+        ):
+            mock_pull_result = MagicMock(
+                success=True,
+                files_downloaded=5,
+                remote_version="2.0.0",
+            )
+            mock_pull.return_value = mock_pull_result
+
+            result = clone(
+                remote_url="s3://bucket/catalog",
+                local_path=target,
+                collection="test",
+            )
+
+        assert result.pull_result == mock_pull_result
+        assert result.pull_result.files_downloaded == 5


### PR DESCRIPTION
## Summary

- Implements the sync orchestrator that sequences: **Pull → Init → Scan → Check → Push**
- Adds `sync.py` module with `SyncResult` dataclass and `sync()` function (per ADR-0007: logic in library, CLI is thin wrapper)
- Wires sync command in CLI with `--force`, `--dry-run`, `--fix`, `--profile` flags

## Key Behaviors

- **Early exit on pull failure** — subsequent steps don't run
- **Init is idempotent** — skipped if catalog already in MANAGED state
- **Flags pass through** — `--force` to both pull and push, `--fix` to check
- **Supports JSON output** — `--format=json` for automation

## Usage

```bash
portolan sync s3://mybucket/catalog --collection demographics
portolan sync s3://mybucket/catalog -c imagery --dry-run
portolan sync s3://mybucket/catalog -c data --fix --force
```

## Test plan

- [x] 17 unit tests for orchestration logic
- [x] 13 integration tests for CLI
- [x] Full test suite passes (1773 tests)
- [x] Manual smoke test with file:// URL
- [x] Manual smoke test with real S3 bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level sync command for end-to-end catalog sync (pull → init → scan → check → push) with --force, --dry-run, --fix, --profile and catalog path support.
  * Added a clone command to copy a remote catalog into a local directory with profile and collection options.

* **Bug Fixes**
  * Normalize catalog root to an absolute path during push to ensure correct file resolution.

* **Tests**
  * Comprehensive unit and integration tests for sync/clone behaviors and CLI flag handling.

* **Documentation**
  * Roadmap updated to reflect sync/clone completion status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->