### PR TITLE
feat(check): add --metadata and --geo-assets flags

### DIFF
--- a/tests/integration/test_check_command.py
+++ b/tests/integration/test_check_command.py
@@ -311,13 +311,16 @@ class TestCheckFixUnsupportedFiles:
         envelope = json.loads(result.output)
         data = envelope["data"]
 
-        # Only the GeoJSON should be in the report - .nc is ignored
-        assert data["summary"]["total"] == 1
-        assert data["summary"]["convertible"] == 1
+        # With --fix, format data is nested under "conversion" key
+        conversion_data = data.get("conversion", data)
 
-        # Conversion should only process the GeoJSON
-        if "conversion" in data:
-            conversion = data["conversion"]
+        # Only the GeoJSON should be in the report - .nc is ignored
+        assert conversion_data["summary"]["total"] == 1
+        assert conversion_data["summary"]["convertible"] == 1
+
+        # Conversion results should show only the GeoJSON was converted
+        if "conversion" in conversion_data:
+            conversion = conversion_data["conversion"]
             # No failures
             assert conversion["summary"]["failed"] == 0
             # Only the GeoJSON was converted


### PR DESCRIPTION
## Summary

Implements #99: Add selective validation flags to the `check` command.

- **`--metadata`**: Only validate STAC catalog structure and metadata
- **`--geo-assets`**: Only check geospatial assets for cloud-native compliance

## Usage

```bash
portolan check                           # Validate metadata (backward compatible)
portolan check --fix                     # Convert files (backward compatible)
portolan check --metadata                # Validate metadata only
portolan check --geo-assets              # Check geo-assets only
portolan check --metadata --geo-assets   # Run both validations
portolan check --geo-assets --fix        # Convert only (no metadata validation)
```

## Test plan

- [x] 16 unit tests for flag behavior
- [x] 13 integration tests with real files
- [x] 4 hypothesis (property-based) tests for flag combinations
- [x] All 65 check command tests pass
- [x] Linting clean

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--metadata` flag to validate catalog metadata independently.
  * Added `--geo-assets` flag to validate geographic assets separately.
  * Enhanced JSON output to report combined validation results with mode information.
  * Added format status reporting (cloud-native, convertible, unsupported).
  * Maintained backward compatibility with existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->