### PR TITLE
docs(catalog): clarify v1/v2 API in module docstring

### DIFF
--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -1,13 +1,13 @@
 """Catalog management for Portolan.
 
-The Catalog class is the primary interface for working with Portolan catalogs.
-It wraps all catalog operations as methods, following ADR-0007 (CLI wraps API).
+Primary API (v2, per ADR-0023):
+- init_catalog(): Initialize catalog with STAC catalog.json at root level
+- detect_state(): Detect catalog state (MANAGED, UNMANAGED_STAC, FRESH)
 
-This module also provides library functions for catalog creation:
+Legacy API (v1, unused — candidates for removal):
 - create_catalog(): Create a CatalogModel with auto-extracted fields
 - write_catalog_json(): Serialize CatalogModel to .portolan/catalog.json
 - read_catalog_json(): Load CatalogModel from .portolan/catalog.json
-- detect_state(): Detect the catalog state of a directory (MANAGED, UNMANAGED_STAC, FRESH)
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Surface `init_catalog()` and `detect_state()` as the primary API (v2, per ADR-0023)
- Label legacy functions (`create_catalog`, `write_catalog_json`, `read_catalog_json`) as unused candidates for removal — they have zero production callers (only tests)

**Why:** The previous docstring only listed v1 functions, omitting `init_catalog()` entirely. A developer reading the module header would assume `catalog.json` belongs inside `.portolan/` and miss the current API.

Follows up on the review of PR #102 (fix for #94).

## Test plan
- [x] `ruff check` passes
- [x] `mypy` passes
- [x] Docstring-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new v2 catalog initialization interface with support for optional title and description metadata.

* **Deprecated**
  * Legacy catalog management API marked as deprecated and identified as candidates for removal in future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->