### PR TITLE
fix(catalog): write versions.json to root per ADR-0023

### DIFF
--- a/tests/integration/test_init_command.py
+++ b/tests/integration/test_init_command.py
@@ -83,15 +83,21 @@ class TestInitCommandAutoMode:
 
     @pytest.mark.integration
     def test_init_creates_all_management_files(self, runner: CliRunner, tmp_path: Path) -> None:
-        """portolan init --auto should create all management files in .portolan."""
+        """portolan init --auto should create management files in correct locations.
+
+        Per ADR-0023: versions.json is consumer-visible metadata at catalog root.
+        Internal state (config.json, state.json) lives in .portolan/.
+        """
         with runner.isolated_filesystem(temp_dir=tmp_path):
             result = runner.invoke(cli, ["init", "--auto"])
 
             assert result.exit_code == 0
-            # Verify all management files exist
+            # Internal tooling state: lives in .portolan/
             assert Path(".portolan/config.json").exists()
             assert Path(".portolan/state.json").exists()
-            assert Path(".portolan/versions.json").exists()
+            # Consumer-visible metadata: lives at catalog root (ADR-0023)
+            assert Path("versions.json").exists()
+            assert not Path(".portolan/versions.json").exists()
 
 
 class TestInitCommandErrors:


### PR DESCRIPTION
## Summary

- Fixes `init_catalog()` to write `versions.json` to catalog root instead of `.portolan/`
- Per ADR-0023, `versions.json` is user-visible metadata and belongs alongside STAC files
- Updated existing integration tests that had incorrect path expectations

## Changes

- **`portolan_cli/catalog.py`**: Changed write path from `portolan_dir / "versions.json"` to `path / "versions.json"`
- **`tests/unit/test_catalog_init.py`**: Added 2 new tests (written first per TDD)
- **`tests/integration/test_init_v2.py`**: Updated stale path assertions
- **`tests/integration/test_init_command.py`**: Updated stale path assertions

## Test plan

- [x] New unit tests verify `versions.json` at root, not in `.portolan/`
- [x] Full test suite passes (1981 passed, 2 skipped)
- [x] Pre-commit hooks pass

Fixes #111

🤖 Generated with [Claude Code](https://claude.ai/code)