### PR TITLE
fix(scan): add .parquet to GEO_ASSET_EXTENSIONS

### DIFF
--- a/portolan_cli/scan_classify.py
+++ b/portolan_cli/scan_classify.py
@@ -34,6 +34,7 @@ GEO_ASSET_EXTENSIONS: frozenset[str] = frozenset(
         ".shp",
         ".gpkg",
         ".fgb",
+        ".parquet",
         ".tif",
         ".tiff",
         ".jp2",


### PR DESCRIPTION
## Summary

- Adds `.parquet` to `GEO_ASSET_EXTENSIONS` in `scan_classify.py`
- GeoParquet is our primary vector format but `portolan scan` didn't recognize it

## Changes

- **`portolan_cli/scan_classify.py`**: Added `".parquet"` to the `GEO_ASSET_EXTENSIONS` frozenset
- **`tests/unit/test_scan_classify.py`**: Added 2 tests (written first per TDD)
  - `test_parquet_in_geo_asset_extensions`: Direct membership check
  - `test_parquet_classified_as_geo_asset`: End-to-end classification test

## Test plan

- [x] New tests verify `.parquet` is in extensions and classifies correctly
- [x] Full unit suite passes (1628 passed, 2 skipped)
- [x] Pre-commit hooks pass

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)