### PR TITLE
feat(ci): add duplicate code detection with pylint R0801

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           slug: portolan-sdi/portolan-cli
 
   dead-code:
-    name: Dead Code & Complexity
+    name: Dead Code, Complexity & Duplication
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -129,6 +129,9 @@ jobs:
 
       - name: Check code complexity
         run: uv run xenon --max-absolute=C --max-modules=B --max-average=A portolan_cli tests
+
+      - name: Check for duplicate code
+        run: uv run pylint --disable=all --enable=duplicate-code --fail-under=9.5 portolan_cli/
 
   docs:
     name: Documentation Build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ uv run ruff format .                    # Format
 uv run mypy portolan_cli                # Type check
 uv run vulture portolan_cli tests       # Dead code
 uv run xenon --max-absolute=C portolan_cli  # Complexity
+uv run pylint --disable=all --enable=duplicate-code portolan_cli/  # Duplicate code
 
 # Commits (use commitizen for conventional commits)
 uv run cz commit                        # Interactive commit
@@ -227,6 +228,7 @@ Install: `uv run pre-commit install`. All hooks block—no `--no-verify`. See `.
 - **mypy** — Type checking (`strict = true`)
 - **vulture** — Dead code detection
 - **xenon** — Complexity monitoring (max C function, B module, A average)
+- **pylint** — Duplicate code detection (R0801 only, `--fail-under=9.5`)
 - **bandit** — Security scanning
 - **pip-audit** — Dependency vulnerabilities
 
@@ -370,7 +372,7 @@ error("No geometry column (required)")     # ✗ Red X
 detail("Processing chunk 3/10...")         # Dimmed text
 ```
 
-<!-- freshness: last-verified: 2026-02-27 -->
+<!-- freshness: last-verified: 2026-03-03 -->
 ## Design Principles
 
 | Principle | Meaning | ADR |

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -67,10 +67,11 @@ Workflow: `.github/workflows/ci.yml`
 - Excludes network, slow, and benchmark tests
 - Coverage reporting to Codecov
 
-#### `dead-code` — Dead Code & Complexity
+#### `dead-code` — Dead Code, Complexity & Duplication
 
 - `vulture` — Unused code detection (min confidence 80%)
 - `xenon` — Complexity thresholds (max C absolute, B modules, A average)
+- `pylint` — Duplicate code detection (R0801 only, `--fail-under=9.5`)
 
 #### `docs` — Documentation Build
 

--- a/portolan_cli/constants.py
+++ b/portolan_cli/constants.py
@@ -39,3 +39,33 @@ MTIME_TOLERANCE_SECONDS: float = 2.0
 
 # Maximum depth for catalog root discovery (prevent traversing to filesystem root)
 MAX_CATALOG_SEARCH_DEPTH: int = 20
+
+# Windows reserved device names (case-insensitive)
+# Files with these names (with any extension) are problematic on Windows.
+# Used by scan.py and scan_fix.py for cross-platform compatibility checks.
+WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset(
+    {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        "com1",
+        "com2",
+        "com3",
+        "com4",
+        "com5",
+        "com6",
+        "com7",
+        "com8",
+        "com9",
+        "lpt1",
+        "lpt2",
+        "lpt3",
+        "lpt4",
+        "lpt5",
+        "lpt6",
+        "lpt7",
+        "lpt8",
+        "lpt9",
+    }
+)

--- a/portolan_cli/scan.py
+++ b/portolan_cli/scan.py
@@ -33,7 +33,7 @@ from enum import Enum
 from pathlib import Path
 
 # Import new types from scan modules
-from portolan_cli.constants import PARQUET_EXTENSION
+from portolan_cli.constants import PARQUET_EXTENSION, WINDOWS_RESERVED_NAMES
 from portolan_cli.scan_classify import (
     FileCategory,
     SkippedFile,
@@ -74,34 +74,7 @@ LONG_PATH_THRESHOLD: int = 200
 # Matches: spaces, parentheses, brackets, control chars (0x00-0x1F, 0x7F), and non-ASCII
 INVALID_CHAR_PATTERN: re.Pattern[str] = re.compile(r"[\s()\[\]\x00-\x1f\x7f]|[^\x00-\x7f]")
 
-# Windows reserved device names (case-insensitive)
-# Files with these names (with any extension) are problematic on Windows
-WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset(
-    {
-        "con",
-        "prn",
-        "aux",
-        "nul",
-        "com1",
-        "com2",
-        "com3",
-        "com4",
-        "com5",
-        "com6",
-        "com7",
-        "com8",
-        "com9",
-        "lpt1",
-        "lpt2",
-        "lpt3",
-        "lpt4",
-        "lpt5",
-        "lpt6",
-        "lpt7",
-        "lpt8",
-        "lpt9",
-    }
-)
+# WINDOWS_RESERVED_NAMES imported from portolan_cli.constants
 
 
 # =============================================================================

--- a/portolan_cli/scan_fix.py
+++ b/portolan_cli/scan_fix.py
@@ -27,11 +27,10 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from portolan_cli.constants import WINDOWS_RESERVED_NAMES
+
 if TYPE_CHECKING:
     from portolan_cli.scan import ScanIssue
-
-# Define constants locally to avoid circular imports with scan.py
-# These must match the values in scan.py
 
 # Pattern for invalid filename characters
 # Matches: spaces, parentheses, brackets, braces, control chars (0x00-0x1F, 0x7F), and non-ASCII
@@ -45,33 +44,7 @@ INVALID_CHAR_PATTERN: re.Pattern[str] = re.compile(r"[\s()\[\]{}/\\\x00-\x1f\x7f
 # This threshold is for the FULL path, not just filename
 LONG_PATH_THRESHOLD: int = 200
 
-# Windows reserved device names (case-insensitive)
-WINDOWS_RESERVED_NAMES: frozenset[str] = frozenset(
-    {
-        "con",
-        "prn",
-        "aux",
-        "nul",
-        "com1",
-        "com2",
-        "com3",
-        "com4",
-        "com5",
-        "com6",
-        "com7",
-        "com8",
-        "com9",
-        "lpt1",
-        "lpt2",
-        "lpt3",
-        "lpt4",
-        "lpt5",
-        "lpt6",
-        "lpt7",
-        "lpt8",
-        "lpt9",
-    }
-)
+# WINDOWS_RESERVED_NAMES imported from portolan_cli.constants
 
 # Shapefile sidecar extensions
 # Comprehensive list including all known sidecar types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,5 +219,6 @@ modules = [
 
 [dependency-groups]
 dev = [
+    "pylint>=4.0.5",
     "types-pyyaml>=6.0.12.20250915",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -238,6 +238,18 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445 },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +679,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298 },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019 },
 ]
 
 [[package]]
@@ -1256,6 +1277,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733 },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1602,6 +1632,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819 },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426 },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146 },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350 },
 ]
 
 [[package]]
@@ -2645,6 +2684,7 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pylint" },
     { name = "types-pyyaml" },
 ]
 
@@ -2685,7 +2725,10 @@ requires-dist = [
 provides-extras = ["dev", "docs"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
+dev = [
+    { name = "pylint", specifier = ">=4.0.5" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
+]
 
 [[package]]
 name = "pre-commit"
@@ -3061,6 +3104,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds pylint to CI pipeline for detecting cross-file code duplication (R0801 rule)
- Fills a gap in quality gates: we had complexity (xenon), dead code (vulture), security (bandit), but no duplication detection
- Fixes the `WINDOWS_RESERVED_NAMES` duplication by moving it to `constants.py`

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Add `pylint>=4.0.5` to dev dependencies |
| `.github/workflows/ci.yml` | Add duplicate-code check to dead-code job |
| `portolan_cli/constants.py` | Add `WINDOWS_RESERVED_NAMES` constant |
| `portolan_cli/scan.py` | Import from `constants.py` instead of local definition |
| `portolan_cli/scan_fix.py` | Import from `constants.py` instead of local definition |
| `CLAUDE.md` | Document pylint in code quality section |
| `context/shared/documentation/ci.md` | Update CI documentation |

## Rationale

This was inspired by [this article on SonarQube in AI-assisted workflows](https://dev.to/camptocamp-geo/adding-sonarqube-to-an-ai-assisted-development-workflow-3k0h). After analysis, we determined that SonarQube would be largely redundant with our existing toolchain (mypy, bandit, xenon, vulture, mutmut), but **duplication detection was a genuine gap**.

pylint's R0801 (duplicate-code) provides this capability without adding infrastructure (no Java server needed).

## Threshold

`--fail-under=9.5` is intentionally lenient:
- Current score: 9.98/10
- Catches *new* duplications while allowing time to address existing ones
- Remaining duplications (model serialization, upload/download patterns) should be addressed in separate refactoring PRs

## Test plan

- [x] Pre-commit hooks pass
- [x] All tests pass (1982 passed)
- [x] pylint duplicate-code check passes threshold
- [x] `WINDOWS_RESERVED_NAMES` no longer appears in duplication report

🤖 Generated with [Claude Code](https://claude.com/claude-code)