### PR TITLE
refactor(catalog): unify config.json and config.yaml as sentinel (ADR-0027)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 specs/
+.worktrees

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0024](context/shared/adr/0024-hierarchical-config-system.md) | Hierarchical config system (YAML) |
 | [0025](context/shared/adr/0025-architecture-as-code.md) | Architecture as code with import-linter |
 | [0026](context/shared/adr/0026-conversion-config-design.md) | Conversion config: extension/path overrides, precedence rules |
+| [0027](context/shared/adr/0027-unified-config-yaml-sentinel.md) | Unified config.yaml as sentinel and user config (eliminates config.json) |
 
 ## Common Commands
 

--- a/context/shared/adr/0023-stac-structure-separation.md
+++ b/context/shared/adr/0023-stac-structure-separation.md
@@ -48,7 +48,7 @@ This violates STAC conventions and makes catalogs unusable with standard STAC to
 | `collection.json` | `./{collection}/` | STAC standard |
 | `item.json` | `./{collection}/{item}/` | STAC standard |
 | `versions.json` | Alongside STAC files | Consumer-visible metadata (version history, checksums) |
-| `config.json` | `.portolan/` | Internal tooling configuration |
+| `config.yaml` | `.portolan/` | Internal tooling configuration |
 | `state.json` | `.portolan/` | Internal local state (not synced? TBD) |
 
 ### Local = Remote

--- a/context/shared/adr/0027-unified-config-yaml-sentinel.md
+++ b/context/shared/adr/0027-unified-config-yaml-sentinel.md
@@ -1,0 +1,77 @@
+# ADR-0027: Unified config.yaml as Sentinel and User Config
+
+## Status
+Accepted
+
+## Context
+
+Portolan has two configuration files in `.portolan/` with confusingly similar names:
+
+- **`config.json`** - Empty sentinel file (`{}`) used only for MANAGED state detection
+- **`config.yaml`** - User configuration (remote URLs, AWS profile, conversion settings per ADR-0024)
+
+The `detect_state()` function checks for the existence of both `config.json` AND `state.json` to determine MANAGED state. It never reads `config.json` contents—just uses filesystem presence as a signal.
+
+### Problems
+
+1. **Naming confusion**: Both files are called "config" but serve entirely different purposes
+2. **Undocumented pattern**: The sentinel pattern isn't documented in any ADR
+3. **Redundant file**: `config.json` contains only `{}` and will never be written to
+4. **Developer confusion**: New contributors must learn this non-obvious convention
+
+### Forces
+
+- ADR-0024 established `config.yaml` for user settings
+- PR #128 expands `config.yaml` with conversion overrides, making it the clear "real" config file
+- We're pre-v1.0 with minimal users, so breaking changes are acceptable
+
+## Decision
+
+**Eliminate `config.json`. Use `config.yaml` as both the sentinel file and user configuration.**
+
+### New Behavior
+
+| State | Condition |
+|-------|-----------|
+| MANAGED | `.portolan/config.yaml` AND `.portolan/state.json` both exist |
+| UNMANAGED_STAC | `catalog.json` exists at root, but not MANAGED |
+| FRESH | Everything else |
+
+### Implementation
+
+1. `detect_state()` checks for `config.yaml` instead of `config.json`
+2. `init_catalog()` creates an empty `config.yaml` (with optional comment header)
+3. All documentation updated to reference `config.yaml` only
+
+### Migration
+
+None required. Pre-v1.0 with minimal users. Existing catalogs with old-style `config.json` will be detected as FRESH and can re-init.
+
+## Consequences
+
+### Benefits
+
+- **Clearer mental model**: One config file, two purposes (sentinel + settings)
+- **Reduced confusion**: No more "why are there two config files?"
+- **Simpler `.portolan/`**: One fewer file to explain
+
+### Trade-offs
+
+- **Existing catalogs break**: Old catalogs with `config.json` will no longer be recognized as MANAGED
+  - Mitigation: Pre-v1.0, acceptable. Users can re-init.
+- **Empty YAML looks different**: An empty `config.yaml` still needs to exist
+  - Mitigation: Use a comment header like `# Portolan configuration` to indicate it's intentional
+
+## Alternatives Considered
+
+### Option A: Rename config.json to managed.json or sentinel.json
+**Rejected**: Still requires two files. The sentinel pattern itself is the problem—it's an empty file that exists only to be checked for existence.
+
+### Option B: Document current behavior in ADR-0024
+**Rejected**: Documentation doesn't solve the underlying design issue. New contributors would still be confused by the pattern.
+
+## References
+
+- [ADR-0024: Hierarchical Config System](0024-hierarchical-config-system.md)
+- [ADR-0023: STAC Structure Separation](0023-stac-structure-separation.md)
+- [GitHub Issue #107](https://github.com/portolan-sdi/portolan-cli/issues/107)

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -33,8 +33,9 @@ class CatalogState(Enum):
     """The state of a directory with respect to Portolan catalog management.
 
     States:
-        MANAGED: A fully managed Portolan catalog exists. Both .portolan/config.json
+        MANAGED: A fully managed Portolan catalog exists. Both .portolan/config.yaml
             AND .portolan/state.json exist. This is the target state after `portolan init`.
+            Per ADR-0027, config.yaml serves as both the sentinel file and user config.
 
         UNMANAGED_STAC: An existing STAC catalog (catalog.json) exists but is not
             managed by Portolan. This happens when someone has a pre-existing STAC
@@ -42,7 +43,7 @@ class CatalogState(Enum):
 
         FRESH: No catalog exists. This is a clean directory suitable for `portolan init`.
             Note: An empty .portolan directory or partial .portolan (only one of
-            config.json/state.json) is also considered FRESH.
+            config.yaml/state.json) is also considered FRESH.
     """
 
     MANAGED = "managed"
@@ -56,8 +57,8 @@ def detect_state(path: Path) -> CatalogState:
     Checks only file/directory existence - does NOT read file contents.
     This ensures fast detection without I/O overhead.
 
-    The detection logic:
-    1. If .portolan/config.json AND .portolan/state.json both exist -> MANAGED
+    The detection logic (per ADR-0027):
+    1. If .portolan/config.yaml AND .portolan/state.json both exist -> MANAGED
     2. If catalog.json exists at root (and not MANAGED) -> UNMANAGED_STAC
     3. Otherwise -> FRESH
 
@@ -71,14 +72,14 @@ def detect_state(path: Path) -> CatalogState:
         >>> detect_state(Path("/empty/dir"))
         CatalogState.FRESH
 
-        >>> detect_state(Path("/my-catalog"))  # where .portolan/config.json and state.json exist
+        >>> detect_state(Path("/my-catalog"))  # where .portolan/config.yaml and state.json exist
         CatalogState.MANAGED
 
         >>> detect_state(Path("/with/only/catalog.json"))
         CatalogState.UNMANAGED_STAC
     """
     portolan_dir = path / ".portolan"
-    config_file = portolan_dir / "config.json"
+    config_file = portolan_dir / "config.yaml"
     state_file = portolan_dir / "state.json"
     root_catalog = path / "catalog.json"
 
@@ -270,7 +271,7 @@ def init_catalog(
 
     Creates (in order for partial failure recovery):
     1. .portolan/ directory
-    2. .portolan/config.json (empty {} for now)
+    2. .portolan/config.yaml (empty with comment header, per ADR-0027)
     3. versions.json at ROOT level (consumer-visible per ADR-0023)
     4. catalog.json at ROOT level (valid STAC catalog via pystac)
     5. .portolan/state.json (empty {} for now) - LAST
@@ -325,9 +326,9 @@ def init_catalog(
 
     # ─────────────────────────────────────────────────────────────────────────
     # WRITE ORDER: state.json LAST to ensure atomic MANAGED transition
-    # detect_state() checks for BOTH config.json AND state.json to determine
-    # MANAGED state. Writing state.json last ensures that if init fails
-    # partway through, the directory stays in FRESH state (retry-safe).
+    # detect_state() checks for BOTH config.yaml AND state.json to determine
+    # MANAGED state (per ADR-0027). Writing state.json last ensures that if
+    # init fails partway through, the directory stays in FRESH state (retry-safe).
     # ─────────────────────────────────────────────────────────────────────────
 
     # Step 1: Create .portolan directory
@@ -337,11 +338,12 @@ def init_catalog(
     except OSError as e:
         raise CatalogInitError(f"Cannot create .portolan directory: {e}") from e
 
-    # Step 2: config.json - empty for now (first sentinel, not enough for MANAGED)
+    # Step 2: config.yaml - sentinel file per ADR-0027 (not enough for MANAGED alone)
+    # Also serves as user configuration file for settings like remote, aws_profile, etc.
     try:
-        (portolan_dir / "config.json").write_text("{}\n")
+        (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
     except OSError as e:
-        raise CatalogInitError(f"Cannot write config.json: {e}") from e
+        raise CatalogInitError(f"Cannot write config.yaml: {e}") from e
 
     # Step 3: versions.json - minimal catalog-level versioning
     # Per ADR-0023: versions.json is consumer-visible metadata and must live at
@@ -391,9 +393,9 @@ def init_catalog(
     except OSError as e:
         raise CatalogInitError(f"Cannot update catalog.json with self link: {e}") from e
 
-    # Step 6: state.json - LAST (second sentinel, flips to MANAGED state)
-    # This MUST be the final write. Once state.json exists alongside config.json,
-    # detect_state() will report MANAGED. All other files must be in place first.
+    # Step 6: state.json - LAST (flips to MANAGED state)
+    # This MUST be the final write. Once state.json exists alongside config.yaml,
+    # detect_state() will report MANAGED (per ADR-0027). All files must be in place first.
     try:
         (portolan_dir / "state.json").write_text("{}\n")
     except OSError as e:

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -127,7 +127,7 @@ def init(
     """Initialize a new Portolan catalog.
 
     Creates a catalog.json at the root level and a .portolan directory with
-    management files (config.json, state.json, versions.json).
+    management files (config.yaml, state.json, versions.json).
 
     Auto-extracts the catalog ID from the directory name.
 

--- a/portolan_cli/errors.py
+++ b/portolan_cli/errors.py
@@ -91,7 +91,7 @@ class UnmanagedStacCatalogError(CatalogError):
     Error code: PRTLN-CAT003
 
     This occurs when a directory has a catalog.json file but is not managed
-    by Portolan (missing .portolan/config.json and .portolan/state.json).
+    by Portolan (missing .portolan/config.yaml and .portolan/state.json).
     Use `portolan adopt` to bring an existing STAC catalog under management.
     """
 

--- a/tests/benchmark/test_validation_benchmark.py
+++ b/tests/benchmark/test_validation_benchmark.py
@@ -22,7 +22,7 @@ def valid_catalog(tmp_path: Path) -> Path:
     # v2 structure: .portolan directory with config, state, and versions
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
-    (portolan_dir / "config.json").write_text("{}")
+    (portolan_dir / "config.yaml").write_text("{}")
     (portolan_dir / "versions.json").write_text(
         json.dumps(
             {

--- a/tests/integration/test_cli_json.py
+++ b/tests/integration/test_cli_json.py
@@ -27,7 +27,7 @@ def valid_catalog(tmp_path: Path) -> Path:
 
     Creates the v2 structure with:
     - catalog.json at root
-    - .portolan/config.json (required for MANAGED state)
+    - .portolan/config.yaml (required for MANAGED state)
     - .portolan/state.json (required for MANAGED state)
     """
     # Root catalog.json
@@ -46,7 +46,7 @@ def valid_catalog(tmp_path: Path) -> Path:
     # .portolan directory with management files
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
-    (portolan_dir / "config.json").write_text("{}")
+    (portolan_dir / "config.yaml").write_text("{}")
     (portolan_dir / "state.json").write_text("{}")
     return tmp_path
 

--- a/tests/integration/test_init_command.py
+++ b/tests/integration/test_init_command.py
@@ -86,14 +86,14 @@ class TestInitCommandAutoMode:
         """portolan init --auto should create management files in correct locations.
 
         Per ADR-0023: versions.json is consumer-visible metadata at catalog root.
-        Internal state (config.json, state.json) lives in .portolan/.
+        Internal state (config.yaml, state.json) lives in .portolan/.
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
             result = runner.invoke(cli, ["init", "--auto"])
 
             assert result.exit_code == 0
             # Internal tooling state: lives in .portolan/
-            assert Path(".portolan/config.json").exists()
+            assert Path(".portolan/config.yaml").exists()
             assert Path(".portolan/state.json").exists()
             # Consumer-visible metadata: lives at catalog root (ADR-0023)
             assert Path("versions.json").exists()
@@ -115,7 +115,7 @@ class TestInitCommandErrors:
             # Create managed catalog (both config and state required)
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("{}")
             (portolan / "state.json").write_text("{}")
 
             # Use --auto to skip interactive prompts and test error path
@@ -145,7 +145,7 @@ class TestInitCommandErrors:
             # Create managed catalog
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("{}")
             (portolan / "state.json").write_text("{}")
 
             result = runner.invoke(cli, ["--format", "json", "init"])
@@ -184,7 +184,7 @@ class TestInitCommandJsonOutput:
             # Create managed catalog
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("{}")
             (portolan / "state.json").write_text("{}")
 
             result = runner.invoke(cli, ["--format", "json", "init"])

--- a/tests/integration/test_init_v2.py
+++ b/tests/integration/test_init_v2.py
@@ -3,7 +3,7 @@
 The new init command creates (per ADR-0023):
 - catalog.json at ROOT level (valid STAC catalog via pystac)
 - versions.json at ROOT level (consumer-visible catalog-level versioning)
-- .portolan/config.json (empty {} for now) -- internal tooling state
+- .portolan/config.yaml (empty {} for now) -- internal tooling state
 - .portolan/state.json (empty {} for now) -- internal tooling state
 
 Error cases:
@@ -42,14 +42,18 @@ class TestInitCreatesRequiredFiles:
 
     @pytest.mark.integration
     def test_init_creates_portolan_config(self, runner: CliRunner, tmp_path: Path) -> None:
-        """Init should create .portolan/config.json (empty {} for now)."""
+        """Init should create .portolan/config.yaml (per ADR-0027, serves as sentinel and user config)."""
+        import yaml
+
         with runner.isolated_filesystem(temp_dir=tmp_path):
             result = runner.invoke(cli, ["init", "--auto"])
 
             assert result.exit_code == 0
-            config_file = Path(".portolan/config.json")
+            config_file = Path(".portolan/config.yaml")
             assert config_file.exists()
-            assert json.loads(config_file.read_text()) == {}
+            # Config starts as a comment-only file (empty dict when parsed as YAML)
+            content = yaml.safe_load(config_file.read_text())
+            assert content is None or content == {}  # Empty YAML or comment-only
 
     @pytest.mark.integration
     def test_init_creates_portolan_state(self, runner: CliRunner, tmp_path: Path) -> None:
@@ -92,7 +96,7 @@ class TestInitCreatesRequiredFiles:
           - versions.json
 
         .portolan/ (internal tooling state only):
-          - config.json
+          - config.yaml
           - state.json
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -103,7 +107,7 @@ class TestInitCreatesRequiredFiles:
             assert Path("catalog.json").exists()
             assert Path("versions.json").exists()
             # .portolan/ directory: internal tooling state only
-            assert Path(".portolan/config.json").exists()
+            assert Path(".portolan/config.yaml").exists()
             assert Path(".portolan/state.json").exists()
             # versions.json must NOT be inside .portolan/ (ADR-0023)
             assert not Path(".portolan/versions.json").exists()
@@ -172,7 +176,7 @@ class TestInitErrorCases:
             # Create managed catalog structure
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("{}")
             (portolan / "state.json").write_text("{}")
 
             # Use --auto to skip interactive prompts and test error path
@@ -231,12 +235,12 @@ class TestInitPartialState:
     def test_init_succeeds_with_partial_portolan(self, runner: CliRunner, tmp_path: Path) -> None:
         """Partial .portolan (only config, no state) should allow init.
 
-        Both config.json AND state.json are required for MANAGED state.
+        Both config.yaml AND state.json are required for MANAGED state.
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("{}")
             # Note: state.json is missing
 
             result = runner.invoke(cli, ["init", "--auto"])
@@ -333,7 +337,7 @@ class TestInitJsonOutput:
         with runner.isolated_filesystem(temp_dir=tmp_path):
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("{}")
             (portolan / "state.json").write_text("{}")
 
             result = runner.invoke(cli, ["--format", "json", "init"])

--- a/tests/integration/test_push_integration.py
+++ b/tests/integration/test_push_integration.py
@@ -23,7 +23,7 @@ def catalog_with_versions(tmp_path: Path) -> Path:
     """Create a catalog with versions.json for integration tests.
 
     Per ADR-0023: STAC files (catalog.json, collection.json, versions.json)
-    live at root level, only config.json goes in .portolan/.
+    live at root level; config.yaml and state.json go in .portolan/.
     """
     catalog_dir = tmp_path / "catalog"
     catalog_dir.mkdir()

--- a/tests/integration/test_sync_integration.py
+++ b/tests/integration/test_sync_integration.py
@@ -37,7 +37,7 @@ def managed_catalog(tmp_path: Path) -> Path:
     # Create .portolan directory structure (MANAGED state requires both config and state)
     portolan_dir = catalog_dir / ".portolan"
     portolan_dir.mkdir()
-    (portolan_dir / "config.json").write_text("{}\n")
+    (portolan_dir / "config.yaml").write_text("{}\n")
     (portolan_dir / "state.json").write_text("{}\n")
 
     # Create collection with versions.json

--- a/tests/unit/test_catalog_model_init.py
+++ b/tests/unit/test_catalog_model_init.py
@@ -411,7 +411,7 @@ class TestInitCatalogFilesystemErrors:
 
     @pytest.mark.unit
     def test_init_catalog_raises_on_config_write_failure(self, tmp_path: Path) -> None:
-        """CatalogInitError raised when config.json write fails."""
+        """CatalogInitError raised when config.yaml write fails."""
         from unittest.mock import patch
 
         from portolan_cli.catalog import CatalogInitError, init_catalog
@@ -422,14 +422,14 @@ class TestInitCatalogFilesystemErrors:
         original_write_text = Path.write_text
 
         def failing_write_text(self: Path, *args: Any, **kwargs: Any) -> int:
-            if "config.json" in str(self):
+            if "config.yaml" in str(self):
                 raise OSError("Disk full")
             return original_write_text(self, *args, **kwargs)
 
         with patch.object(Path, "write_text", failing_write_text):
             with pytest.raises(CatalogInitError) as exc_info:
                 init_catalog(catalog_dir)
-            assert "Cannot write config.json" in exc_info.value.message
+            assert "Cannot write config.yaml" in exc_info.value.message
 
     @pytest.mark.unit
     def test_init_catalog_raises_on_state_write_failure(self, tmp_path: Path) -> None:

--- a/tests/unit/test_cli_check.py
+++ b/tests/unit/test_cli_check.py
@@ -96,7 +96,7 @@ class TestCheckCommand:
         # .portolan with management files (required for MANAGED state)
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         (portolan_dir / "state.json").write_text("{}")
         return tmp_path
 
@@ -419,7 +419,7 @@ class TestCheckMetadataGeoAssetsFlags:
         # .portolan with management files (required for MANAGED state)
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         (portolan_dir / "state.json").write_text("{}")
         return tmp_path
 

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -33,9 +33,9 @@ class TestCliInit:
             assert result.exit_code == 0, f"Failed: {result.output}"
             # New structure: catalog.json at root
             assert Path("catalog.json").exists()
-            # .portolan directory with management files
+            # .portolan directory with management files (config.yaml per ADR-0027)
             assert Path(".portolan").exists()
-            assert Path(".portolan/config.json").exists()
+            assert Path(".portolan/config.yaml").exists()
             assert Path(".portolan/state.json").exists()
 
     @pytest.mark.unit
@@ -51,10 +51,10 @@ class TestCliInit:
     def test_init_fails_if_managed_catalog_exists(self, runner: CliRunner, tmp_path: Path) -> None:
         """portolan init should fail if MANAGED catalog exists."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            # Create managed catalog (both config and state)
+            # Create managed catalog (config.yaml + state.json per ADR-0027)
             portolan = Path(".portolan")
             portolan.mkdir()
-            (portolan / "config.json").write_text("{}")
+            (portolan / "config.yaml").write_text("# Portolan config\n")
             (portolan / "state.json").write_text("{}")
 
             # Use --auto to skip interactive prompts and test error path

--- a/tests/unit/test_state_detection.py
+++ b/tests/unit/test_state_detection.py
@@ -1,7 +1,7 @@
 """Tests for catalog state detection.
 
 The detect_state() function determines the current state of a directory:
-- MANAGED: A full Portolan catalog (.portolan/config.json AND .portolan/state.json exist)
+- MANAGED: A full Portolan catalog (.portolan/config.yaml AND .portolan/state.json exist)
 - UNMANAGED_STAC: An existing STAC catalog (catalog.json exists but not managed)
 - FRESH: No catalog exists (neither .portolan nor catalog.json)
 """
@@ -70,22 +70,22 @@ class TestDetectStateFresh:
 
     @pytest.mark.unit
     def test_portolan_with_only_config_is_fresh(self, tmp_path: Path) -> None:
-        """Partial .portolan (only config.json, no state.json) is FRESH.
+        """Partial .portolan (only config.yaml, no state.json) is FRESH.
 
-        Both config.json AND state.json are required for MANAGED state.
+        Both config.yaml AND state.json are required for MANAGED state.
         """
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
 
         state = detect_state(tmp_path)
         assert state == CatalogState.FRESH
 
     @pytest.mark.unit
     def test_portolan_with_only_state_is_fresh(self, tmp_path: Path) -> None:
-        """Partial .portolan (only state.json, no config.json) is FRESH.
+        """Partial .portolan (only state.json, no config.yaml) is FRESH.
 
-        Both config.json AND state.json are required for MANAGED state.
+        Both config.yaml AND state.json are required for MANAGED state.
         """
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
@@ -100,10 +100,10 @@ class TestDetectStateManaged:
 
     @pytest.mark.unit
     def test_full_portolan_structure_is_managed(self, tmp_path: Path) -> None:
-        """Directory with .portolan/config.json AND .portolan/state.json is MANAGED."""
+        """Directory with .portolan/config.yaml AND .portolan/state.json is MANAGED."""
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         (portolan_dir / "state.json").write_text("{}")
 
         state = detect_state(tmp_path)
@@ -114,7 +114,7 @@ class TestDetectStateManaged:
         """MANAGED state should work even with extra files in .portolan."""
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         (portolan_dir / "state.json").write_text("{}")
         (portolan_dir / "versions.json").write_text("{}")
         (portolan_dir / "catalog.json").write_text("{}")
@@ -132,7 +132,7 @@ class TestDetectStateManaged:
         # .portolan with both required files
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         (portolan_dir / "state.json").write_text("{}")
 
         state = detect_state(tmp_path)
@@ -190,7 +190,7 @@ class TestDetectStateUnmanagedStac:
         (tmp_path / "catalog.json").write_text(json.dumps(catalog_data))
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         # Note: state.json is missing, so not fully managed
 
         state = detect_state(tmp_path)
@@ -202,6 +202,61 @@ def is_case_sensitive_fs(tmp_path: Path) -> bool:
     test_file = tmp_path / "CaseSensitivityTest"
     test_file.touch()
     return not (tmp_path / "casesensitivitytest").exists()
+
+
+class TestDetectStateConfigYamlSentinel:
+    """Tests for config.yaml as the sentinel file (ADR-0027).
+
+    Per ADR-0027, we use config.yaml (not config.yaml) as the sentinel file.
+    MANAGED state requires: .portolan/config.yaml AND .portolan/state.json
+    """
+
+    @pytest.mark.unit
+    def test_config_yaml_with_state_json_is_managed(self, tmp_path: Path) -> None:
+        """config.yaml + state.json should be MANAGED (new behavior per ADR-0027)."""
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
+        (portolan_dir / "state.json").write_text("{}")
+
+        state = detect_state(tmp_path)
+        assert state == CatalogState.MANAGED
+
+    @pytest.mark.unit
+    def test_config_yaml_only_is_fresh(self, tmp_path: Path) -> None:
+        """config.yaml without state.json should be FRESH."""
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
+
+        state = detect_state(tmp_path)
+        assert state == CatalogState.FRESH
+
+    @pytest.mark.unit
+    def test_config_yaml_empty_is_valid_sentinel(self, tmp_path: Path) -> None:
+        """Empty config.yaml should still work as sentinel."""
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("")
+        (portolan_dir / "state.json").write_text("{}")
+
+        state = detect_state(tmp_path)
+        assert state == CatalogState.MANAGED
+
+    @pytest.mark.unit
+    def test_old_config_json_not_recognized(self, tmp_path: Path) -> None:
+        """Old config.json (without config.yaml) should NOT be MANAGED.
+
+        Per ADR-0027, we no longer recognize config.json as the sentinel.
+        """
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.json").write_text("{}")  # Old pattern
+        (portolan_dir / "state.json").write_text("{}")
+
+        state = detect_state(tmp_path)
+        # Old pattern is no longer recognized - should be FRESH
+        assert state == CatalogState.FRESH
 
 
 class TestDetectStateEdgeCases:
@@ -216,7 +271,7 @@ class TestDetectStateEdgeCases:
         # Create files with invalid JSON (would error if read)
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("not valid json {{{")
+        (portolan_dir / "config.yaml").write_text("not valid json {{{")
         (portolan_dir / "state.json").write_text("also invalid!!!")
 
         # Should still detect as MANAGED (existence check only)
@@ -259,7 +314,7 @@ class TestDetectStateEdgeCases:
         # Create real portolan dir elsewhere
         real_portolan = tmp_path / "real-portolan"
         real_portolan.mkdir()
-        (real_portolan / "config.json").write_text("{}")
+        (real_portolan / "config.yaml").write_text("{}")
         (real_portolan / "state.json").write_text("{}")
 
         # Create workspace with symlink

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -41,7 +41,7 @@ def managed_catalog(tmp_path: Path) -> Path:
     # Create .portolan structure to indicate MANAGED state
     portolan_dir = catalog_dir / ".portolan"
     portolan_dir.mkdir()
-    (portolan_dir / "config.json").write_text("{}\n")
+    (portolan_dir / "config.yaml").write_text("{}\n")
     (portolan_dir / "state.json").write_text("{}\n")
 
     # Create collection versions.json
@@ -404,7 +404,7 @@ class TestInitSkip:
             # Simulate init creating the .portolan directory
             portolan_dir = path / ".portolan"
             portolan_dir.mkdir(parents=True, exist_ok=True)
-            (portolan_dir / "config.json").write_text("{}\n")
+            (portolan_dir / "config.yaml").write_text("{}\n")
             (portolan_dir / "state.json").write_text("{}\n")
             return path / "catalog.json", []
 

--- a/tests/unit/test_validation_runner.py
+++ b/tests/unit/test_validation_runner.py
@@ -32,7 +32,7 @@ class TestCheck:
         # .portolan with management files (required for MANAGED state)
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
-        (portolan_dir / "config.json").write_text("{}")
+        (portolan_dir / "config.yaml").write_text("{}")
         (portolan_dir / "state.json").write_text("{}")
         return tmp_path
 


### PR DESCRIPTION
## Summary

Eliminates the confusing dual config file pattern per GitHub issue #107:

- **Before**: `config.json` was an empty sentinel file (`{}`), `config.yaml` was user config
- **After**: `config.yaml` serves both purposes (sentinel + user config)

## Changes

- `detect_state()` now checks for `config.yaml` instead of `config.json`
- `init_catalog()` creates `config.yaml` with comment header (`# Portolan configuration`)
- Updated all tests and documentation references
- Added ADR-0027 documenting this decision

## Detection Logic (per ADR-0027)

| State | Condition |
|-------|-----------|
| MANAGED | `.portolan/config.yaml` AND `.portolan/state.json` both exist |
| UNMANAGED_STAC | `catalog.json` exists at root, but not MANAGED |
| FRESH | Everything else |

## Test plan

- [x] Unit tests for `detect_state()` with new sentinel
- [x] Test that old `config.json` pattern is NOT recognized as MANAGED
- [x] Integration tests for `init_catalog()` creating `config.yaml`
- [x] All 1976 existing tests pass
- [x] Pre-commit hooks pass (including Xenon complexity check)

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated internal catalog configuration format from JSON to YAML.
  * Updated state detection logic for managed catalogs.
  * Enhanced internal configuration handling to unify sentinel and user configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->