### PR TITLE
chore(cli): deprecate dataset info command (#148)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -79,7 +79,7 @@ hide:
 
     ---
 
-    Track datasets with checksums and full history
+    Track items with checksums and full history
 
 - :material-cloud-sync-outline:{ .lg .middle } **Sync**
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -2056,17 +2056,22 @@ def dataset_list(ctx: click.Context, collection: str | None, catalog_path: Path)
 def dataset_info(
     ctx: click.Context, dataset_id: str, catalog_path: Path, json_output: bool
 ) -> None:
-    """Show information about a dataset.
+    """Show information about a dataset (DEPRECATED).
+
+    This command is deprecated. Use 'portolan info' instead.
 
     DATASET_ID is in the format 'collection/item'.
 
     Examples:
 
-        portolan dataset info demographics/census
-
-        portolan dataset info imagery/satellite-2024 --json
+        portolan info demographics/census          # New command
+        portolan info imagery/satellite-2024 --json
     """
     use_json = should_output_json(ctx, json_output)
+
+    # Show deprecation warning (unless JSON output)
+    if not use_json:
+        warn("'portolan dataset info' is deprecated. Use 'portolan info' instead.")
 
     try:
         ds = get_dataset_info(catalog_path, dataset_id)

--- a/tests/integration/test_dataset_integration.py
+++ b/tests/integration/test_dataset_integration.py
@@ -472,3 +472,116 @@ class TestMultiAssetIntegration:
         assert "data.parquet" in untracked_filenames
         assert ".DS_Store" not in untracked_filenames
         assert ".hidden" not in untracked_filenames
+
+
+# =============================================================================
+# Deprecation Warning Integration Tests (Issue #148)
+# =============================================================================
+
+
+class TestDatasetInfoDeprecationIntegration:
+    """Integration tests verifying 'portolan dataset info' deprecation behavior.
+
+    These tests exercise the full CLI path to ensure the deprecation warning
+    is emitted at the right point and doesn't break the command output.
+    """
+
+    @pytest.mark.integration
+    def test_dataset_info_cli_shows_deprecation_warning(
+        self, initialized_catalog: Path, valid_points_geojson: Path
+    ) -> None:
+        """dataset info CLI emits deprecation warning with real catalog data."""
+        from click.testing import CliRunner
+
+        from portolan_cli.cli import cli
+
+        # Add a real dataset first
+        add_result = add_dataset(
+            path=valid_points_geojson,
+            catalog_root=initialized_catalog,
+            collection_id="test-col",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "dataset",
+                "info",
+                f"test-col/{add_result.item_id}",
+                "--catalog",
+                str(initialized_catalog),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "deprecated" in result.output.lower()
+        assert "portolan info" in result.output
+
+    @pytest.mark.integration
+    def test_dataset_info_cli_still_returns_correct_data_after_warning(
+        self, initialized_catalog: Path, valid_points_geojson: Path
+    ) -> None:
+        """dataset info CLI still returns item data after emitting deprecation warning."""
+        from click.testing import CliRunner
+
+        from portolan_cli.cli import cli
+
+        add_result = add_dataset(
+            path=valid_points_geojson,
+            catalog_root=initialized_catalog,
+            collection_id="test-col",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "dataset",
+                "info",
+                f"test-col/{add_result.item_id}",
+                "--catalog",
+                str(initialized_catalog),
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Deprecation warning is present
+        assert "deprecated" in result.output.lower()
+        # Item data is also present
+        assert add_result.item_id in result.output
+        assert "test-col" in result.output
+
+    @pytest.mark.integration
+    def test_dataset_info_cli_json_mode_no_deprecation_warning(
+        self, initialized_catalog: Path, valid_points_geojson: Path
+    ) -> None:
+        """dataset info CLI in JSON mode does not contaminate output with warning."""
+        from click.testing import CliRunner
+
+        from portolan_cli.cli import cli
+
+        add_result = add_dataset(
+            path=valid_points_geojson,
+            catalog_root=initialized_catalog,
+            collection_id="test-col",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "dataset",
+                "info",
+                f"test-col/{add_result.item_id}",
+                "--catalog",
+                str(initialized_catalog),
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # Output must be valid JSON (warning would break this)
+        parsed = json.loads(result.output)
+        assert parsed["success"] is True
+        assert "deprecated" not in result.output.lower()

--- a/tests/unit/test_cli_dataset.py
+++ b/tests/unit/test_cli_dataset.py
@@ -17,6 +17,8 @@ from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from portolan_cli.cli import cli
 from portolan_cli.dataset import DatasetInfo
@@ -558,6 +560,136 @@ class TestDatasetListDeprecation:
                 assert result.exit_code == 0
                 # Should still show items (after deprecation warning)
                 assert "col1" in result.output
+
+
+class TestDatasetInfoDeprecation:
+    """Tests for deprecated 'portolan dataset info' command."""
+
+    @pytest.mark.unit
+    def test_dataset_info_shows_deprecation_warning(self, runner: CliRunner) -> None:
+        """dataset info shows deprecation warning."""
+        with patch("portolan_cli.cli.get_dataset_info") as mock_info:
+            mock_info.return_value = DatasetInfo(
+                item_id="my-item",
+                collection_id="my-collection",
+                format_type=FormatType.VECTOR,
+                bbox=[-122.5, 37.5, -122.0, 38.0],
+                asset_paths=["data.parquet"],
+            )
+
+            with runner.isolated_filesystem():
+                Path(".portolan").mkdir()
+                (Path(".portolan") / "catalog.json").write_text("{}")
+
+                result = runner.invoke(cli, ["dataset", "info", "my-collection/my-item"])
+
+                assert result.exit_code == 0
+                assert "deprecated" in result.output.lower()
+                assert "portolan info" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_dataset_info_still_works_after_deprecation_warning(self, runner: CliRunner) -> None:
+        """dataset info still returns correct information despite deprecation warning."""
+        with patch("portolan_cli.cli.get_dataset_info") as mock_info:
+            mock_info.return_value = DatasetInfo(
+                item_id="census",
+                collection_id="demographics",
+                format_type=FormatType.VECTOR,
+                bbox=[-122.5, 37.5, -122.0, 38.0],
+                asset_paths=["data.parquet"],
+                title="Census 2020",
+            )
+
+            with runner.isolated_filesystem():
+                Path(".portolan").mkdir()
+                (Path(".portolan") / "catalog.json").write_text("{}")
+
+                result = runner.invoke(cli, ["dataset", "info", "demographics/census"])
+
+                assert result.exit_code == 0
+                # Warning present
+                assert "deprecated" in result.output.lower()
+                # But data also present
+                assert "census" in result.output
+                assert "demographics" in result.output
+
+    @pytest.mark.unit
+    def test_dataset_info_deprecation_warning_not_in_json_mode(self, runner: CliRunner) -> None:
+        """dataset info does not show deprecation warning in JSON mode."""
+        with patch("portolan_cli.cli.get_dataset_info") as mock_info:
+            mock_info.return_value = DatasetInfo(
+                item_id="my-item",
+                collection_id="my-collection",
+                format_type=FormatType.VECTOR,
+                bbox=[-122.5, 37.5, -122.0, 38.0],
+                asset_paths=["data.parquet"],
+            )
+
+            with runner.isolated_filesystem():
+                Path(".portolan").mkdir()
+                (Path(".portolan") / "catalog.json").write_text("{}")
+
+                result = runner.invoke(cli, ["dataset", "info", "my-collection/my-item", "--json"])
+
+                assert result.exit_code == 0
+                # JSON output should be parseable without the warning contaminating it
+                data = json.loads(result.output)
+                assert data["success"] is True
+                assert "deprecated" not in result.output.lower()
+
+    @pytest.mark.unit
+    def test_dataset_info_deprecation_warning_points_to_info_command(
+        self, runner: CliRunner
+    ) -> None:
+        """dataset info deprecation warning points users to 'portolan info' specifically."""
+        with patch("portolan_cli.cli.get_dataset_info") as mock_info:
+            mock_info.return_value = DatasetInfo(
+                item_id="my-item",
+                collection_id="my-collection",
+                format_type=FormatType.VECTOR,
+                bbox=[-122.5, 37.5, -122.0, 38.0],
+                asset_paths=["data.parquet"],
+            )
+
+            with runner.isolated_filesystem():
+                Path(".portolan").mkdir()
+                (Path(".portolan") / "catalog.json").write_text("{}")
+
+                result = runner.invoke(cli, ["dataset", "info", "my-collection/my-item"])
+
+                assert result.exit_code == 0
+                # Must specifically mention 'portolan info' (not just any info)
+                assert "portolan info" in result.output
+
+    @pytest.mark.unit
+    @given(
+        item_id=st.from_regex(r"[a-zA-Z0-9][a-zA-Z0-9_-]{0,39}", fullmatch=True),
+        collection_id=st.from_regex(r"[a-zA-Z0-9][a-zA-Z0-9_-]{0,39}", fullmatch=True),
+    )
+    @settings(max_examples=20)
+    def test_dataset_info_deprecation_warning_always_present_for_any_dataset_id(
+        self, item_id: str, collection_id: str
+    ) -> None:
+        """dataset info deprecation warning is always shown regardless of dataset_id value."""
+        runner = CliRunner()
+        with patch("portolan_cli.cli.get_dataset_info") as mock_info:
+            mock_info.return_value = DatasetInfo(
+                item_id=item_id,
+                collection_id=collection_id,
+                format_type=FormatType.VECTOR,
+                bbox=[-180.0, -90.0, 180.0, 90.0],
+                asset_paths=["data.parquet"],
+            )
+
+            with runner.isolated_filesystem():
+                Path(".portolan").mkdir()
+                (Path(".portolan") / "catalog.json").write_text("{}")
+
+                result = runner.invoke(cli, ["dataset", "info", f"{collection_id}/{item_id}"])
+
+                assert result.exit_code == 0
+                assert "deprecated" in result.output.lower()
+                assert "portolan info" in result.output
 
 
 class TestListFormatSize:


### PR DESCRIPTION
## Summary

- Adds deprecation warning to `portolan dataset info`, matching the existing pattern on `portolan dataset list`
- Both `dataset` subcommands now warn users to migrate to modern STAC equivalents: `portolan info` and `portolan list`
- Deprecation warning is suppressed in `--json` mode to avoid contaminating machine-readable output
- Updates `docs/index.md` to use STAC terminology ("items" instead of "datasets") per project terminology rules

## Changes

- `portolan_cli/cli.py`: Updated `dataset_info` docstring to mark as `(DEPRECATED)` and added `warn()` call before execution (skipped in JSON mode) — mirrors the exact pattern used in `dataset_list`
- `docs/index.md`: Changed "Track datasets with checksums" to "Track items with checksums"
- `tests/unit/test_cli_dataset.py`: Added `TestDatasetInfoDeprecation` class with 5 tests (4 regular unit tests + 1 Hypothesis property test)
- `tests/integration/test_dataset_integration.py`: Added `TestDatasetInfoDeprecationIntegration` class with 3 integration tests using real catalog fixtures

## Test plan

- [x] `portolan dataset info <id>` shows deprecation warning in human output
- [x] `portolan dataset info <id> --json` does NOT show warning (JSON remains valid/parseable)
- [x] `portolan dataset info` still returns correct item data after warning
- [x] Warning always says `portolan info` (not a generic message)
- [x] Hypothesis property test: deprecation warning present for any valid dataset ID
- [x] Integration tests with real GeoJSON fixtures verify full CLI path
- [x] All 2437 existing tests continue to pass
- [x] Test coverage at 91% (exceeds required 90%)
- [x] All pre-commit hooks pass (ruff, mypy, vulture, xenon, architecture rules, fast tests)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation terminology.

* **Deprecations**
  * The `dataset_info` command now emits a deprecation warning directing users to use `portolan info` instead. Deprecation warnings do not appear in JSON output mode, preserving machine-readable output.

* **Tests**
  * Added integration and unit tests for deprecation warning behavior across different output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->