### PR TITLE
feat(catalog): track collections in catalog-level versions.json

### DIFF
--- a/context/shared/adr/0005-versions-json-source-of-truth.md
+++ b/context/shared/adr/0005-versions-json-source-of-truth.md
@@ -46,7 +46,7 @@ catalog-root/                              # Same structure locally and on remot
 
 ```json
 {
-  "spec_version": "1.0.0",
+  "schema_version": "1.0.0",
   "current_version": "2.1.0",
   "versions": [
     {

--- a/portolan_cli/catalog_versions.py
+++ b/portolan_cli/catalog_versions.py
@@ -211,14 +211,9 @@ def update_catalog_versions_collection(
         item_count: Number of items in the collection.
         current_version: Optional version string for the collection.
     """
-    versions_path = catalog_root / "versions.json"
-
-    # Read existing data
-    if versions_path.exists():
-        data = json.loads(versions_path.read_text(encoding="utf-8"))
-        catalog_versions = _parse_catalog_versions(data)
-    else:
-        raise FileNotFoundError(f"versions.json not found: {versions_path}")
+    # Read existing data (reuses read_catalog_versions for DRY)
+    data = read_catalog_versions(catalog_root)
+    catalog_versions = _parse_catalog_versions(data)
 
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -272,12 +267,11 @@ def remove_collection_from_catalog_versions(catalog_root: Path, collection_id: s
         catalog_root: Root directory of the catalog.
         collection_id: Unique identifier for the collection to remove.
     """
-    versions_path = catalog_root / "versions.json"
-
-    if not versions_path.exists():
+    try:
+        data = read_catalog_versions(catalog_root)
+    except FileNotFoundError:
         return
 
-    data = json.loads(versions_path.read_text(encoding="utf-8"))
     catalog_versions = _parse_catalog_versions(data)
 
     if collection_id in catalog_versions.collections:

--- a/tests/unit/test_catalog_versions_collections.py
+++ b/tests/unit/test_catalog_versions_collections.py
@@ -372,8 +372,6 @@ class TestCatalogVersionsHypothesis:
     ) -> None:
         """All added collections should be tracked in catalog versions."""
         # Create a fresh catalog for each test run using uuid for uniqueness
-        import uuid
-
         from portolan_cli.catalog_versions import (
             read_catalog_versions,
             update_catalog_versions_collection,


### PR DESCRIPTION
## Summary

Per ADR-0005, the catalog-level versions.json now tracks:
- Which collections exist
- When each was created/modified
- Summary metadata (item count, current_version)

## Changes

Adds new module `portolan_cli/catalog_versions.py` with:
- `CollectionEntry` and `CatalogVersionsFile` dataclasses
- `read_catalog_versions()` and `write_catalog_versions()` (atomic writes)
- `update_catalog_versions_collection()` for adding/updating collections
- `get_collection_info()` for reading collection metadata
- `remove_collection_from_catalog_versions()` for cleanup

## Test plan

- [x] 11 unit tests for core CRUD operations
- [x] 3 dataclass structure tests
- [x] 2 atomic write tests
- [x] 2 Hypothesis property-based tests
- [x] 2 remove collection tests
- [x] All 20 tests passing
- [x] mypy type checking passes
- [x] All pre-commit hooks pass

Closes #142

---
🤖 Generated with [Claude Code](https://claude.ai/code)