### PR TITLE
fix(list): add guidance when no items found

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -403,7 +403,11 @@ def list_cmd(
         output_json_envelope(envelope)
     else:
         if not datasets:
-            info_output("No items found")
+            info_output("No tracked items")
+            info_output("")
+            detail("To get started:")
+            detail("  portolan scan .      Discover files in this directory")
+            detail("  portolan add <path>  Track a specific file or directory")
             return
 
         _list_tree_output(datasets, catalog_path)

--- a/tests/unit/test_cli_dataset.py
+++ b/tests/unit/test_cli_dataset.py
@@ -337,7 +337,109 @@ class TestTopLevelList:
             result = runner.invoke(cli, ["list"])
 
             assert result.exit_code == 0
-            assert "no items" in result.output.lower() or "empty" in result.output.lower()
+            assert "no tracked items" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_list_empty_shows_guidance_scan(self, runner: CliRunner) -> None:
+        """portolan list shows guidance about scan command when empty."""
+        with runner.isolated_filesystem():
+            # Create catalog structure per ADR-0023
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+
+            result = runner.invoke(cli, ["list"])
+
+            assert result.exit_code == 0
+            # Check for scan guidance
+            assert "scan" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_list_empty_shows_guidance_add(self, runner: CliRunner) -> None:
+        """portolan list shows guidance about add command when empty."""
+        with runner.isolated_filesystem():
+            # Create catalog structure per ADR-0023
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+
+            result = runner.invoke(cli, ["list"])
+
+            assert result.exit_code == 0
+            # Check for add guidance
+            assert "add" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_list_empty_guidance_not_shown_in_json_mode(self, runner: CliRunner) -> None:
+        """portolan list --json returns valid empty envelope without guidance text."""
+        with runner.isolated_filesystem():
+            # Create catalog structure per ADR-0023
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+
+            result = runner.invoke(cli, ["list", "--json"])
+
+            assert result.exit_code == 0
+            # Parse JSON and verify it's a valid empty response
+            envelope = json.loads(result.output)
+            assert envelope["success"] is True
+            assert envelope["command"] == "list"
+            # Items should be empty list, not contain guidance text
+            assert envelope["data"]["count"] == 0
+            assert envelope["data"]["items"] == []
+
+    @pytest.mark.unit
+    def test_list_empty_guidance_mentions_portolan_commands(self, runner: CliRunner) -> None:
+        """portolan list empty guidance mentions full portolan commands."""
+        with runner.isolated_filesystem():
+            # Create catalog structure per ADR-0023
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+
+            result = runner.invoke(cli, ["list"])
+
+            assert result.exit_code == 0
+            # Check for command references
+            assert "portolan scan" in result.output or "scan ." in result.output
+            assert "portolan add" in result.output or "add <path>" in result.output
 
     @pytest.mark.unit
     def test_list_shows_tree_view_format(self, runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary

When running `portolan list` on an empty catalog, users now receive helpful guidance on next steps instead of just seeing \"No items found\".

The empty state message now shows:
- \"No tracked items\" message
- Helpful prompts for getting started:
  - `portolan scan .` to discover files in the current directory
  - `portolan add <path>` to track a specific file or directory

This guidance only appears in human-readable output. JSON mode (`--json`) continues to return a valid empty envelope without guidance text.

## Changes

- Updated `list_cmd` in `portolan_cli/cli.py` to show contextual guidance
- Added 4 new unit tests to verify guidance behavior
- All 2570 tests pass with 91% code coverage (exceeds 90% minimum)

## Addresses

Fixes #137

## Test Plan

1. Run unit tests: `uv run pytest tests/unit/test_cli_dataset.py::TestTopLevelList -v`
2. Verify guidance is shown for empty catalog:
   ```
   portolan list
   # Output should show \"No tracked items\" and next steps
   ```
3. Verify JSON mode is unchanged:
   ```
   portolan list --json
   # Output should be valid JSON envelope with empty items list
   ```
4. Run full test suite: `uv run pytest tests/ -q`
5. Verify code quality: `uv run ruff check . && uv run mypy portolan_cli`

Generated with Claude Code