### PR TITLE
bump: version 0.4.2 → 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## v0.4.3 (2026-03-07)
+
+### BREAKING CHANGE
+
+- Removes --fix-metadata flag; use --metadata --fix instead.
+
+### Feat
+
+- **cli**: add portolan clean command to remove metadata (#172)
+- **cli**: add --item-id flag to portolan add command (#171)
+- **check**: redesign --fix to work orthogonally with --metadata/--geo-assets (#164)
+
+### Fix
+
+- **dataset**: make add_dataset atomic and track files in-place (#170)
+- **catalog**: unify catalog root detection (#162) (#169)
+- **status**: detect untracked files in uninitialized collections (#167)
+- **dry-run**: prevent network calls in dry-run mode (#168)
+- **add**: support recursive add at catalog root (#166)
+- **list**: add guidance when no items found (#165)
+
 ## v0.4.2 (2026-03-06)
 
 ### Feat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "portolan-cli"
-version = "0.4.2"
+version = "0.4.3"
 description = "A CLI tool for managing cloud-native geospatial data"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -81,7 +81,7 @@ packages = ["portolan_cli"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.4.2"
+version = "0.4.3"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true

--- a/uv.lock
+++ b/uv.lock
@@ -2639,7 +2639,7 @@ wheels = [
 
 [[package]]
 name = "portolan-cli"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Version bump to 0.4.3 with changelog update.

## Changes in v0.4.3

### Features
- **cli**: add portolan clean command to remove metadata (#172)
- **cli**: add --item-id flag to portolan add command (#171)
- **check**: redesign --fix to work orthogonally with --metadata/--geo-assets (#164)

### Fixes
- **dataset**: make add_dataset atomic and track files in-place (#170)
- **catalog**: unify catalog root detection (#162) (#169)
- **status**: detect untracked files in uninitialized collections (#167)
- **dry-run**: prevent network calls in dry-run mode (#168)
- **add**: support recursive add at catalog root (#166)
- **list**: add guidance when no items found (#165)

### Breaking Change
- Removes `--fix-metadata` flag; use `--metadata --fix` instead

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.4.3

* **Breaking Changes**
  * Removed `--fix-metadata` flag; use `--metadata --fix` instead

* **New Features**
  * Added `clean` command to remove metadata
  * Added `--item-id` flag for the `add` command
  * Redesigned `--fix` flag to work with `--metadata` and `--geo-assets` options

* **Bug Fixes**
  * Multiple improvements to atomic, dataset, catalog, status, dry-run, add, and list operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->