### PR TITLE
Remove non-existent --bundle flag reference from scan suggestion

### DIFF
--- a/portolan_cli/scan.py
+++ b/portolan_cli/scan.py
@@ -775,7 +775,7 @@ def _finalize_multi_asset_checks(ctx: _ScanContext) -> None:
                     issue_type=IssueType.MULTIPLE_PRIMARIES,
                     severity=Severity.WARNING,
                     message=f"Directory has {len(primaries)} primary assets: {names}",
-                    suggestion="Split into separate directories or use --bundle flag during import",
+                    suggestion="Split into separate directories, or track each asset as a separate item",
                 )
             )
 

--- a/tests/integration/test_scan_cli.py
+++ b/tests/integration/test_scan_cli.py
@@ -182,6 +182,36 @@ class TestScanCLI:
             assert "severity" in issue
             assert "message" in issue
 
+    def test_multiple_primaries_suggestion_text(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Multiple primaries suggestion should not mention --bundle flag."""
+        # Create multiple primary files in same directory
+        (tmp_path / "data1.geojson").write_text('{"type": "FeatureCollection", "features": []}')
+        (tmp_path / "data2.geojson").write_text('{"type": "FeatureCollection", "features": []}')
+
+        result = runner.invoke(cli, ["scan", str(tmp_path), "--json"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+
+        # Find the multiple_primaries issue (lowercase in JSON output)
+        issues = data.get("data", {}).get("issues", [])
+        multi_prim_issues = [i for i in issues if i.get("type") == "multiple_primaries"]
+
+        assert len(multi_prim_issues) >= 1, "Should detect multiple primary assets"
+        suggestion = multi_prim_issues[0].get("suggestion", "")
+
+        # Verify suggestion doesn't mention --bundle flag
+        assert "--bundle" not in suggestion, (
+            f"Suggestion should not mention --bundle flag: {suggestion}"
+        )
+        # Verify suggestion mentions both recommended approaches
+        assert "Split into separate directories" in suggestion, (
+            f"Suggestion should mention splitting into directories: {suggestion}"
+        )
+        assert "separate item" in suggestion, (
+            f"Suggestion should mention tracking as separate items: {suggestion}"
+        )
+
 
 # =============================================================================
 # Phase 12: Output Truncation Tests (US10)

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -865,6 +865,19 @@ class TestIssueDetection:
         assert len(multi_issues) >= 1
         assert multi_issues[0].severity == Severity.WARNING
 
+    def test_multiple_primaries_suggestion_no_bundle_flag(self, fixtures_dir: Path) -> None:
+        """Multiple primaries suggestion should not mention --bundle flag."""
+        from portolan_cli.scan import IssueType, scan_directory
+
+        result = scan_directory(fixtures_dir / "multiple_primaries")
+
+        multi_issues = [i for i in result.issues if i.issue_type == IssueType.MULTIPLE_PRIMARIES]
+        assert len(multi_issues) >= 1
+        assert multi_issues[0].suggestion is not None
+        assert "--bundle" not in multi_issues[0].suggestion
+        assert "Split into separate directories" in multi_issues[0].suggestion
+        assert "separate item" in multi_issues[0].suggestion
+
     def test_detect_long_path(self, tmp_path: Path) -> None:
         """scan_directory detects very long paths (200+ chars)."""
         from portolan_cli.scan import IssueType, Severity, scan_directory


### PR DESCRIPTION
## Summary
- Removes reference to non-existent `--bundle` flag from scan output suggestion
- Updated suggestion to recommend splitting into separate directories or tracking each asset as a separate item

## Test plan
- [x] Unit test verifies suggestion text doesn't mention --bundle
- [x] Integration test with multiple primary assets in same directory
- [x] All pre-commit checks pass
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated suggestion text for multiple primary assets to recommend splitting into separate directories or tracking as separate items instead of using a deprecated flag.

* **Tests**
  * Added integration and unit tests to verify correct behavior when multiple primary assets are detected.

* **Chores**
  * Added STAC catalog files and configuration for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->