### PR TITLE
fix(scan): make PATH argument optional, default to current directory

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -132,10 +132,10 @@ portolan rm -f vectors/                     # Force remove entire directory
 Scan a directory for geospatial files and potential issues.
 
 ```bash
+portolan scan                         # Scan current directory
+portolan scan --json                  # JSON output in current directory
 portolan scan /data/geospatial
-portolan scan . --json
 portolan scan /large/tree --max-depth=2
-portolan scan /data --no-recursive
 ```
 
 ### `portolan status`

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -1357,9 +1357,11 @@ def scan(
 
     Examples:
 
-        portolan scan /data/geospatial
+        portolan scan                         # Scan current directory
 
-        portolan scan . --json
+        portolan scan --json                  # JSON output in current directory
+
+        portolan scan /data/geospatial
 
         portolan scan /large/tree --max-depth=2
 

--- a/tests/integration/test_scan_cli.py
+++ b/tests/integration/test_scan_cli.py
@@ -1034,35 +1034,36 @@ class TestScanDefaultPath:
             assert total_files >= 1
 
     def test_scan_default_path_permission_error_handled(
-        self, runner: CliRunner, tmp_path: Path
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """portolan scan handles permission errors gracefully when scanning default path."""
         import os
-        import stat
 
-        # Create a directory that we'll make unreadable
+        # Create a directory structure
         unreadable = tmp_path / "unreadable"
         unreadable.mkdir()
-        (unreadable / "data.geojson").write_text('{"type": "FeatureCollection", "features": []}')
 
-        # Remove read permissions
-        original_mode = unreadable.stat().st_mode
-        try:
-            os.chmod(unreadable, stat.S_IWUSR)  # Write only, no read
+        # Store original scandir to call for other directories
+        original_scandir = os.scandir
 
-            # Scan the parent directory (should handle permission error gracefully)
-            result = runner.invoke(cli, ["scan", str(tmp_path), "--json"])
+        def mock_scandir(path: str):
+            """Raise PermissionError for the 'unreadable' directory."""
+            if Path(path).name == "unreadable":
+                raise PermissionError("Permission denied")
+            return original_scandir(path)
 
-            # Should not crash - exit code 0 even with permission issues
-            assert result.exit_code == 0
-            output = json.loads(result.output)
-            # Permission errors are reported as issues, not crashes
-            # success is False because there are errors in the scan
-            assert "data" in output
-            # Verify permission_denied issue is reported
-            issues = output["data"].get("issues", [])
-            permission_issues = [i for i in issues if i.get("type") == "permission_denied"]
-            assert len(permission_issues) == 1
-        finally:
-            # Restore permissions for cleanup
-            os.chmod(unreadable, original_mode)
+        # Patch os.scandir to simulate permission error (works cross-platform)
+        monkeypatch.setattr(os, "scandir", mock_scandir)
+
+        # Scan the parent directory (should handle permission error gracefully)
+        result = runner.invoke(cli, ["scan", str(tmp_path), "--json"])
+
+        # Should not crash - exit code 0 even with permission issues
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        # Permission errors are reported as issues, not crashes
+        assert "data" in output
+        # Verify permission_denied issue is reported
+        issues = output["data"].get("issues", [])
+        permission_issues = [i for i in issues if i.get("type") == "permission_denied"]
+        assert len(permission_issues) == 1


### PR DESCRIPTION
## Summary
- Makes PATH argument optional in `portolan scan`, defaulting to current directory (Issue #182)
- Brings scan command in line with similar commands like `portolan check` and `portolan init`
- Improves UX by eliminating need to explicitly type `.` when scanning current directory

## Test plan
- [x] Test scan with no arguments defaults to current directory
- [x] Test scan with explicit path `.` still works
- [x] Test scan with explicit path still works
- [x] Test scan with no PATH but with --json option works
- [x] Test scan with no PATH and no geo-assets exits with 0
- [x] Verified all 61 existing integration tests pass
- [x] Pre-commit checks pass (ruff, mypy, vulture, xenon, etc.)

## Changes
- Modified `portolan_cli/cli.py` line 1269: Changed `@click.argument("path", type=click.Path(path_type=Path))` to `@click.argument("path", type=click.Path(path_type=Path), default=".", required=False)`
- Added 5 comprehensive integration tests in `tests/integration/test_scan_cli.py` covering all scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PATH arguments are now optional for the `init` and `scan` commands. When omitted, the current directory is used by default.

* **Tests**
  * Added integration tests to verify default path handling and various CLI scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->