### PR TITLE
fix(status): detect and skip symlink cycles

### DIFF
--- a/portolan_cli/status.py
+++ b/portolan_cli/status.py
@@ -337,17 +337,27 @@ def _scan_item_dir_status(
     collection_id: str,
     versions_path: Path,
     tracked_assets: set[str],
+    _visited: set[Path] | None = None,
 ) -> tuple[list[FileStatus], list[FileStatus], set[str]]:
     """Scan a single item directory for status changes.
 
     Recursively scans the item directory to support hive-partitioned
     datasets where geo files are nested in subdirectories.
 
+    Symlink cycles are detected by tracking resolved paths passed via
+    _visited. When a symlink points to an already-visited directory it
+    is skipped with a warning log.
+
     Args:
         item_dir: Path to the item directory.
         collection_id: ID of the containing collection.
         versions_path: Path to versions.json.
         tracked_assets: Set of tracked asset keys.
+        _visited: Set of already-resolved paths used for cycle detection.
+            Shared across item scans within the same collection so that
+            two items symlinking to the same physical directory are both
+            reported correctly (the second traversal re-enters via a
+            *different* item_dir path, which is not yet in _visited).
 
     Returns:
         Tuple of (untracked, modified, seen_keys).
@@ -368,6 +378,7 @@ def _scan_item_dir_status(
         untracked=untracked,
         modified=modified,
         seen_keys=seen_keys,
+        _visited=_visited,
     )
 
     return untracked, modified, seen_keys
@@ -386,9 +397,15 @@ def get_catalog_status(catalog_root: Path) -> StatusResult:
     Per ADR-0023, versions.json lives at the collection root
     (collection/versions.json), NOT inside .portolan/.
 
-    Symlink cycles are detected at collection and item directory levels by
-    tracking resolved paths. When a symlink points to an already-visited
-    directory, it is skipped with a warning log.
+    Collection-level symlink cycles are detected by tracking resolved paths
+    in a catalog-wide set; when a collection symlink resolves to a directory
+    already processed, it is skipped with a warning log.
+
+    Item-level symlink cycles (self-referential, mutual, deep) are detected
+    per-item by _scan_item_dir_recursive using a fresh visited set for each
+    item scan.  This ensures that two item symlinks pointing to the same
+    physical directory are both reported (they are distinct catalog items)
+    while internal cycles within a single item traversal are still caught.
 
     Args:
         catalog_root: Root directory of the catalog (contains catalog.json).
@@ -407,8 +424,12 @@ def get_catalog_status(catalog_root: Path) -> StatusResult:
     modified: list[FileStatus] = []
     deleted: list[FileStatus] = []
 
-    # Track visited directories to detect symlink cycles at collection/item level
-    visited_dirs: set[Path] = set()
+    # Track visited collection directories to detect collection-level symlink
+    # cycles (e.g. catalog_root/linked-col -> catalog_root/real-col).
+    # This set is global across the entire catalog scan so that a collection
+    # symlink that resolves to a directory already visited as a real collection
+    # is correctly skipped.
+    visited_col_dirs: set[Path] = set()
 
     for col_dir in sorted(catalog_root.iterdir()):
         if not col_dir.is_dir() or col_dir.name.startswith("."):
@@ -421,10 +442,10 @@ def get_catalog_status(catalog_root: Path) -> StatusResult:
             logger.debug("Cannot resolve %s: %s", col_dir, e)
             continue
 
-        if col_resolved in visited_dirs:
+        if col_resolved in visited_col_dirs:
             logger.warning("Skipping symlink cycle: %s -> %s", col_dir, col_resolved)
             continue
-        visited_dirs.add(col_resolved)
+        visited_col_dirs.add(col_resolved)
 
         # Include directories that have collection.json (initialized collections)
         # OR directories that contain geo-assets (uninitialized potential collections).
@@ -444,20 +465,29 @@ def get_catalog_status(catalog_root: Path) -> StatusResult:
             if not item_dir.is_dir() or item_dir.name.startswith("."):
                 continue
 
-            # Check for symlink cycle at item level
+            # Skip any item directory that is itself a symlink to a known
+            # collection root.  This catches the pattern ocha/ocha -> ocha
+            # where a self-referential symlink inside a collection points back
+            # to the collection directory, which is already in visited_col_dirs.
             try:
                 item_resolved = item_dir.resolve()
             except OSError as e:
                 logger.debug("Cannot resolve %s: %s", item_dir, e)
                 continue
 
-            if item_resolved in visited_dirs:
-                logger.warning("Skipping symlink cycle: %s -> %s", item_dir, item_resolved)
+            if item_resolved in visited_col_dirs:
+                logger.warning(
+                    "Skipping item symlink that points to a collection root: %s -> %s",
+                    item_dir,
+                    item_resolved,
+                )
                 continue
-            visited_dirs.add(item_resolved)
 
             item_untracked, item_modified, item_seen = _scan_item_dir_status(
-                item_dir, collection_id, versions_path, tracked_assets
+                item_dir,
+                collection_id,
+                versions_path,
+                tracked_assets,
             )
             untracked.extend(item_untracked)
             modified.extend(item_modified)

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1737,3 +1737,71 @@ class TestSymlinkCycleDetection:
         # Should find the file and not hang
         assert len(result.untracked) == 1
         assert "year=2024/month=01/data.parquet" in result.untracked[0].filename
+
+    @pytest.mark.unit
+    def test_collection_symlink_to_sibling_collection_skipped(self, tmp_path: Path) -> None:
+        """A collection-level symlink pointing to a sibling collection is skipped.
+
+        True collection-level cycle: catalog_root/zzz-link -> catalog_root/aaa-real.
+        The real collection is sorted first (aaa-real < zzz-link), processed, added to
+        visited_col_dirs; when zzz-link resolves to the same physical directory it is
+        detected and skipped so files are never double-counted.
+        """
+        # Use names that guarantee sort order: aaa-real processed before zzz-link
+        make_catalog(tmp_path, ["aaa-real"])
+        real_col = tmp_path / "aaa-real"
+        make_collection(real_col)
+
+        item_dir = real_col / "boundaries"
+        item_dir.mkdir()
+        (item_dir / "data.parquet").write_bytes(b"parquet data")
+
+        # Create a peer symlink that sorts AFTER the real collection
+        link_col = tmp_path / "zzz-link"
+        link_col.symlink_to(real_col)
+
+        result = get_catalog_status(tmp_path)
+
+        # Files should appear exactly once under the first-processed name (aaa-real).
+        # zzz-link resolves to the same dir and must be skipped.
+        untracked_paths = [f.path for f in result.untracked]
+        assert len(result.untracked) == 1, (
+            f"Expected 1 untracked file, got {len(result.untracked)}: {untracked_paths}"
+        )
+        assert result.untracked[0].collection_id == "aaa-real"
+        assert result.untracked[0].filename == "data.parquet"
+
+    @pytest.mark.unit
+    def test_two_items_symlinking_to_same_physical_dir_both_reported(self, tmp_path: Path) -> None:
+        """Two item symlinks pointing to the same physical directory are both reported.
+
+        Regression for the silent data-loss bug where visited_dirs was global across
+        all collections/items.  If item-a and item-b both symlink to the same real
+        directory, both items must be reported as untracked - not just the first.
+        """
+        make_catalog(tmp_path, ["col"])
+        col_dir = tmp_path / "col"
+        make_collection(col_dir)
+
+        # A real data directory outside the collection
+        real_data = tmp_path / "shared-data"
+        real_data.mkdir()
+        (real_data / "data.parquet").write_bytes(b"shared parquet data")
+
+        # Two item directories that are both symlinks to the same real_data dir
+        item_a = col_dir / "item-a"
+        item_b = col_dir / "item-b"
+        item_a.symlink_to(real_data)
+        item_b.symlink_to(real_data)
+
+        result = get_catalog_status(tmp_path)
+
+        # Both items must be visible - neither should be silently skipped
+        collection_ids = {f.collection_id for f in result.untracked}
+        item_ids = {f.item_id for f in result.untracked}
+        assert "col" in collection_ids
+        assert "item-a" in item_ids, "item-a was silently skipped"
+        assert "item-b" in item_ids, "item-b was silently skipped"
+        assert len(result.untracked) == 2, (
+            f"Expected 2 untracked files (one per item), got {len(result.untracked)}"
+        )


### PR DESCRIPTION
## Summary

- Adds symlink cycle detection to `portolan status` scanning functions
- Tracks visited directories using `Path.resolve()` to detect cycles
- Logs a warning when skipping a cycle instead of erroring
- Prevents path explosion from self-referential symlinks (e.g., `ocha/ocha -> /path/to/ocha`)

## Implementation

Added `_visited: set[Path]` parameter to track resolved paths in:
- `_has_geo_assets()` - Checks for geospatial files in directories
- `_scan_item_dir_recursive()` - Scans item directories for status changes  
- `get_catalog_status()` - Main entry point for catalog status

When a symlink resolves to an already-visited path, it is skipped with a warning log.

## Test plan

- [x] Test self-referential symlinks in item directories
- [x] Test symlink cycles at collection level
- [x] Test mutual symlink cycles (A -> B -> A)
- [x] Test deep symlink cycles (A -> B -> C -> A)
- [x] Test valid (non-cyclic) symlinks still work
- [x] Test broken symlinks are handled gracefully
- [x] All existing status tests pass

Closes #178

---
Generated with [Claude Code](https://claude.com/claude-code)