### PR TITLE
chore(hooks): add pre-commit check to forbid worktree commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,16 @@ repos:
 
   - repo: local
     hooks:
+      # === SAFETY HOOKS ===
+      # Prevent accidental commits of temporary/generated content
+
+      - id: forbid-worktrees
+        name: forbid worktree files
+        entry: "bash -c 'echo ERROR - Worktree files should not be committed. Remove .claude/worktrees/ from staging. && exit 1'"
+        language: system
+        files: ^\.claude/worktrees/
+        pass_filenames: false
+
       # === AUTO-UPDATE HOOKS ===
       # These regenerate content from code - keeps docs in sync automatically
 


### PR DESCRIPTION
## Summary
- Adds a safety pre-commit hook that prevents accidentally committing files from `.claude/worktrees/`
- These are temporary development environments that should never be in version control

## Test plan
- [x] Pre-commit config validates successfully
- [x] Hook is skipped when no worktree files staged (expected behavior)
- [ ] Hook blocks commit when worktree files are staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)