### PR TITLE
bump: version 0.4.4 → 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-## Unreleased
+## v0.5.0 (2026-03-08)
 
-### BREAKING CHANGE
+### Feat
 
-- **cli**: remove deprecated `portolan dataset` command group (#214)
-  - `portolan dataset list` removed → use `portolan list`
-  - `portolan dataset info` removed → use `portolan info`
+- **cli**: unify list and status commands (#215)
+- **cli**: remove deprecated dataset command group (#214)
+- **cli**: add file-level progress output for add and check --fix (#213)
+- **check**: add --remove-legacy flag to delete source files after conversion (#212)
+
+### Fix
+
+- **scan**: normalize filenames to lowercase with dashes (#211)
 
 ## v0.4.4 (2026-03-07)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "portolan-cli"
-version = "0.4.4"
+version = "0.5.0"
 description = "A CLI tool for managing cloud-native geospatial data"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -81,7 +81,7 @@ packages = ["portolan_cli"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.4.4"
+version = "0.5.0"
 version_files = ["pyproject.toml:^version"]
 tag_format = "v$version"
 update_changelog_on_bump = true


### PR DESCRIPTION
## Release v0.5.0

Bumps version from 0.4.4 to 0.5.0.

### Key changes in this release:
- **feat(cli)**: Unified `list` and `status` commands (#210, #215)
  - `list` now shows ALL files with status indicators (✓ tracked, + untracked, ~ modified, ! deleted)
  - Added `--tracked-only` and `--untracked-only` filter flags
  - **BREAKING**: Removed `status` command (functionality merged into `list`)
- **fix**: Spaces in file extensions now sanitized during `scan --fix`
- **fix**: CPG sidecar files correctly detected as GeoParquet format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI command unifications for improved usability
  * Enhanced progress output display
* **Bug Fixes**
  * Improved scan filename normalization

**Version**: v0.5.0 released March 8, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->