### PR TITLE
docs: document ESRI GDB raster limitation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0030](context/shared/adr/0030-agent-native-cli-design.md) | Agent-native CLI design with JSON output and input hardening |
 | [0031](context/shared/adr/0031-collection-level-assets-for-vector-data.md) | Collection-level assets for vector data (GeoParquet, Shapefile, GeoPackage) |
 | [0032](context/shared/adr/0032-nested-catalogs-with-flat-collections.md) | Nested catalogs with flat collections (supersedes ADR-0012) |
+| [0033](context/shared/adr/0033-esri-gdb-raster-gdal-requirement.md) | ESRI GDB rasters require external GDAL (no bundled support) |
 
 ## Common Commands
 

--- a/context/shared/adr/0033-esri-gdb-raster-gdal-requirement.md
+++ b/context/shared/adr/0033-esri-gdb-raster-gdal-requirement.md
@@ -1,0 +1,46 @@
+# ADR-0033: ESRI GDB Rasters Require External GDAL
+
+## Status
+Accepted
+
+## Context
+ESRI File Geodatabase (.gdb) rasters cannot be read by any pure Python library. The format was reverse-engineered exclusively for GDAL's OpenFileGDB driver—no alternative implementations exist.
+
+Supporting GDB rasters in Portolan would require:
+- System GDAL installation, or
+- conda-forge rasterio (which bundles GDAL)
+
+Neither option is acceptable:
+- **System GDAL** creates installation friction and platform-specific issues
+- **conda-forge** breaks our `pipx install portolan` story (per ADR-0008)
+
+This affects a narrow use case: raster data stored in ESRI geodatabases. Vector GDB support is unaffected (pyogrio handles it).
+
+## Decision
+**Do not support ESRI GDB rasters.** Users must pre-convert to COG using GDAL before cataloging:
+
+```bash
+gdal_translate input.gdb/raster_name output.tif -of COG
+```
+
+Portolan will:
+1. Detect GDB rasters during `scan`
+2. Report them as requiring manual conversion
+3. Document the workaround in user-facing docs
+
+## Consequences
+- ✅ No GDAL dependency—keeps installation simple
+- ✅ Core remains pip-installable via pipx
+- ⚠️ GDB raster users need extra step before import
+- ⚠️ Cannot auto-convert GDB rasters with `--convert`
+
+## Alternatives Considered
+
+### Add GDAL as optional dependency
+Rejected: GDAL is notoriously difficult to package. Even as optional, it creates support burden and confuses the installation story.
+
+### Create portolan-gdb plugin
+Rejected for MVP: Adds maintenance burden for a niche format. Can revisit if demand materializes.
+
+### Bundle GDAL via conda
+Rejected: Breaks pipx installation model (ADR-0008). Users expect `pipx install portolan` to work.

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -1,0 +1,38 @@
+# Format Support
+
+Portolan converts data to cloud-native formats (GeoParquet, COG) for efficient cloud storage and querying.
+
+## Supported Formats
+
+| Input Format | Output Format | Notes |
+|--------------|---------------|-------|
+| Shapefile | GeoParquet | Auto-converted |
+| GeoJSON | GeoParquet | Auto-converted |
+| GeoPackage | GeoParquet | Auto-converted |
+| CSV (with geometry) | GeoParquet | Auto-converted |
+| TIFF/GeoTIFF | COG | Auto-converted |
+| JPEG2000 | COG | Auto-converted |
+| GeoParquet | GeoParquet | Already cloud-native |
+| COG | COG | Already cloud-native |
+| FlatGeobuf | — | Accepted as-is (cloud-native) |
+
+## Limitations
+
+### ESRI File Geodatabase Rasters
+
+Raster data stored in ESRI File Geodatabases (`.gdb`) **cannot be converted by Portolan**. The format was reverse-engineered exclusively for GDAL—no pure Python library can read it.
+
+**Workaround:** Pre-convert to COG using GDAL before adding to your catalog:
+
+```bash
+# List rasters in the geodatabase
+gdalinfo input.gdb
+
+# Convert to COG
+gdal_translate input.gdb/raster_name output.tif -of COG
+```
+
+Then add the resulting COG to your catalog as usual.
+
+!!! note "Vector GDB data is supported"
+    This limitation applies only to **raster** data in geodatabases. Vector layers in `.gdb` files work normally.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
   - Reference:
     - CLI: reference/cli.md
     - Configuration: reference/configuration.md
+    - Format Support: reference/formats.md
   - Contributing: contributing.md
   - Changelog: changelog.md
 


### PR DESCRIPTION
## Summary
- Add ADR-0033: ESRI GDB rasters require external GDAL
- Add `docs/reference/formats.md` with format support table and limitation note
- Users must pre-convert GDB rasters to COG with `gdal_translate`

Closes #82

## Test plan
- [ ] `mkdocs serve` renders the new formats page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive format support documentation detailing input formats, output conversion behavior, and cloud-native target formats.
  * Documented ESRI GDB raster limitations with recommended GDAL-based conversion workaround.
  * Clarified that vector layers within GDB files remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->