### PR TITLE
fix(push): recursive collection discovery for nested catalogs

### DIFF
--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -751,12 +751,24 @@ def discover_collections(catalog_root: Path) -> list[str]:
     collections: list[str] = []
     visited_paths: set[Path] = set()
 
-    for versions_file in catalog_root.rglob("versions.json"):
+    # Use rglob to find all versions.json files recursively
+    # Wrap in try/except to handle permission errors gracefully
+    try:
+        versions_files = list(catalog_root.rglob("versions.json"))
+    except PermissionError as e:
+        warn(f"Permission denied during catalog scan: {e}")
+        versions_files = []
+
+    for versions_file in versions_files:
         # Get the collection directory (parent of versions.json)
         collection_dir = versions_file.parent
 
         # Get path relative to catalog root for checking
         rel_path = collection_dir.relative_to(catalog_root)
+
+        # Skip versions.json at catalog root (not a valid collection location)
+        if not rel_path.parts:
+            continue
 
         # Skip hidden directories (starting with '.') at any level in relative path
         # This includes .portolan, .git, .hidden, etc.

--- a/tests/unit/test_discover_nested_collections.py
+++ b/tests/unit/test_discover_nested_collections.py
@@ -198,3 +198,83 @@ def test_subcatalog_without_collections_ignored(catalog_with_config: Path) -> No
     result = discover_collections(catalog_with_config)
 
     assert result == ["real-collection"]
+
+
+@pytest.mark.unit
+def test_root_level_versions_json_ignored(catalog_with_config: Path) -> None:
+    """versions.json at catalog root should be ignored (not a valid collection).
+
+    Structure:
+        catalog_root/
+            versions.json  # Should be ignored (at root level)
+            real-collection/
+                versions.json  # Should be included
+
+    Expected: ["real-collection"] (root-level versions.json excluded)
+    """
+    # Create versions.json at root (should be ignored)
+    (catalog_with_config / "versions.json").write_text("{}")
+
+    # Create real collection in subdirectory
+    real = catalog_with_config / "real-collection"
+    real.mkdir()
+    (real / "versions.json").write_text("{}")
+
+    result = discover_collections(catalog_with_config)
+
+    assert result == ["real-collection"]
+
+
+@pytest.mark.unit
+def test_symlink_cycle_detection(catalog_with_config: Path) -> None:
+    """Symlink cycles should be detected and deduplicated.
+
+    Structure:
+        catalog_root/
+            real-collection/
+                versions.json
+            loop -> catalog_root  # Symlink back to root (cycle)
+
+    Expected: ["real-collection"] (cycle doesn't cause duplicates or hangs)
+    """
+    # Create real collection
+    real = catalog_with_config / "real-collection"
+    real.mkdir()
+    (real / "versions.json").write_text("{}")
+
+    # Create symlink that points back to catalog root (creates cycle)
+    loop = catalog_with_config / "loop"
+    loop.symlink_to(catalog_with_config)
+
+    # Should not hang, should detect the cycle and deduplicate
+    result = discover_collections(catalog_with_config)
+
+    # The real collection should appear exactly once
+    assert result == ["real-collection"]
+
+
+@pytest.mark.unit
+def test_empty_nested_directory_structure(catalog_with_config: Path) -> None:
+    """Empty nested directories should not affect discovery.
+
+    Structure:
+        catalog_root/
+            empty-sub/
+                another-empty/  # No versions.json anywhere
+            real-collection/
+                versions.json
+
+    Expected: ["real-collection"]
+    """
+    # Create empty nested structure
+    empty = catalog_with_config / "empty-sub" / "another-empty"
+    empty.mkdir(parents=True)
+
+    # Create real collection
+    real = catalog_with_config / "real-collection"
+    real.mkdir()
+    (real / "versions.json").write_text("{}")
+
+    result = discover_collections(catalog_with_config)
+
+    assert result == ["real-collection"]


### PR DESCRIPTION
## Summary

- Changes `discover_collections()` to use `rglob("versions.json")` instead of `iterdir()`, enabling discovery of collections at any depth
- Returns POSIX-style relative paths (e.g., `"sub-catalog/collection"`) instead of just directory names
- Preserves existing behavior: skips hidden directories (`.portolan`, `.git`, etc.), detects symlink cycles

This implements ADR-0032 (Nested Catalogs with Flat Collections) support for `push` and `pull` commands.

## Test plan

- [x] New tests for nested collection discovery (`tests/unit/test_discover_nested_collections.py`)
- [x] All existing tests pass (2558 passed)
- [x] Linting clean
- [x] Pre-commit hooks pass

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Catalog discovery now searches nested directories at any depth and excludes hidden directories at any nesting level.
  * Root-level metadata files are ignored; permission errors during scanning now emit warnings instead of failing.
  * Symlink cycles are detected and handled to avoid duplicate or infinite discovery.

* **Tests**
  * Added comprehensive tests covering nested discovery, exclusion rules, symlink cycles, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->