### PR TITLE
fix(dataset): use actual relative path for asset href in versions.json

### DIFF
--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -658,6 +658,7 @@ def add_dataset(
     _update_versions(
         collection_dir=collection_dir,
         item_id=item_id,
+        catalog_root=catalog_root,
         asset_files=asset_files,
     )
 
@@ -910,6 +911,7 @@ def _update_catalog_links(catalog_root: Path, collection_id: str) -> None:
 def _update_versions(
     collection_dir: Path,
     item_id: str,
+    catalog_root: Path,
     output_path: Path | None = None,
     checksum: str | None = None,
     *,
@@ -922,6 +924,7 @@ def _update_versions(
     Args:
         collection_dir: Path to collection directory.
         item_id: Item identifier.
+        catalog_root: Root directory of the catalog (for computing relative hrefs).
         output_path: Path to single output file (legacy mode).
         checksum: SHA-256 checksum for single file (legacy mode).
         asset_files: Dict mapping filename to (path, checksum) tuples.
@@ -955,7 +958,9 @@ def _update_versions(
         # Multi-asset mode (per issue #133)
         # Use item-scoped keys ({item_id}/{filename}) for multi-asset tracking
         for filename, (file_path, file_checksum) in asset_files.items():
-            href = f"{collection_id}/{item_id}/{filename}"
+            # Compute href as actual relative path from catalog_root (ADR-0031 fix)
+            # This handles both collection-level assets (vector) and item-level assets (raster)
+            href = str(file_path.relative_to(catalog_root))
             asset_key = f"{item_id}/{filename}"
             stat = file_path.stat()
             # For directory-format assets (e.g., FileGDB), size_bytes is the inode
@@ -970,7 +975,8 @@ def _update_versions(
             )
     elif output_path is not None and checksum is not None:
         # Legacy single-file mode (backward compatibility)
-        href = f"{collection_id}/{item_id}/{output_path.name}"
+        # Compute href as actual relative path from catalog_root (ADR-0031 fix)
+        href = str(output_path.relative_to(catalog_root))
         assets[output_path.name] = Asset(
             sha256=checksum,
             size_bytes=output_path.stat().st_size,
@@ -1882,6 +1888,7 @@ def _update_item_with_asset(
     _update_versions(
         collection_dir=collection_dir,
         item_id=item_id,
+        catalog_root=catalog_root,
         asset_files=asset_files,
     )
 

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1024,6 +1024,7 @@ class TestUpdateVersionsHref:
         _update_versions(
             collection_dir=collection_dir,
             item_id="census-2020",
+            catalog_root=catalog_root,
             asset_files={
                 "census-2020.parquet": (output_file, "abc123"),
             },
@@ -1049,6 +1050,7 @@ class TestUpdateVersionsHref:
         _update_versions(
             collection_dir=collection_dir,
             item_id="pop-data",
+            catalog_root=catalog_root,
             asset_files={
                 "pop-data.parquet": (output_file, "def456"),
             },
@@ -1461,6 +1463,7 @@ class TestMultiAssetUpdateVersions:
         _update_versions(
             collection_dir=collection_dir,
             item_id="my-item",
+            catalog_root=catalog_root,
             asset_files={
                 "my-item.parquet": (parquet_file, "hash1"),
                 "thumbnail.png": (thumbnail, "hash2"),
@@ -1501,6 +1504,7 @@ class TestMultiAssetUpdateVersions:
         _update_versions(
             collection_dir=collection_dir,
             item_id="census-2020",
+            catalog_root=catalog_root,
             asset_files={
                 "census-2020.parquet": (output_file, "abc123"),
             },
@@ -1511,6 +1515,46 @@ class TestMultiAssetUpdateVersions:
         asset = versions.versions[0].assets["census-2020/census-2020.parquet"]
         assert asset.href == "agriculture/census-2020/census-2020.parquet"
         assert asset.sha256 == "abc123"
+
+    @pytest.mark.unit
+    def test_update_versions_collection_level_asset_no_doubled_path(
+        self, tmp_path: Path
+    ) -> None:
+        """Collection-level assets (ADR-0031) should not double the path.
+
+        When item_id == collection_id (file is at collection level, not in
+        subdirectory), the href should NOT be collection/collection/file.
+        This is a regression test for the bug where vector data at collection
+        level got doubled paths in versions.json.
+        """
+        catalog_root = tmp_path / "catalog"
+        # Vector data at collection level: parks/parks_datasd.parquet
+        collection_dir = catalog_root / "parks"
+        collection_dir.mkdir(parents=True)
+
+        # File is directly in collection dir (not in item subdir)
+        parquet_file = collection_dir / "parks_datasd.parquet"
+        parquet_file.write_bytes(b"fake parquet")
+
+        # item_id == collection_id (both are "parks")
+        _update_versions(
+            collection_dir=collection_dir,
+            item_id="parks",
+            catalog_root=catalog_root,
+            asset_files={
+                "parks_datasd.parquet": (parquet_file, "abc123"),
+            },
+        )
+
+        versions = read_versions(collection_dir / "versions.json")
+        asset = versions.versions[0].assets["parks/parks_datasd.parquet"]
+
+        # href should be parks/parks_datasd.parquet, NOT parks/parks/parks_datasd.parquet
+        assert asset.href == "parks/parks_datasd.parquet"
+        # Verify it resolves to the actual file
+        resolved = catalog_root / asset.href
+        assert resolved == parquet_file
+        assert resolved.exists()
 
 
 class TestMultiAssetListAndInfo:


### PR DESCRIPTION
## Summary

- Fixes doubled path bug when pushing collection-level vector assets (ADR-0031)
- When `item_id == collection_id` (files at collection level), href was incorrectly `parks/parks/file.parquet` instead of `parks/file.parquet`
- Push failed with `FileNotFoundError: Asset referenced in version 1.0.0 not found`

## Changes

- Add `catalog_root` parameter to `_update_versions` function
- Compute href as actual relative path: `file_path.relative_to(catalog_root)`
- Add regression test for collection-level asset scenario

## Test plan

- [x] All 2620 unit tests pass
- [x] New regression test `test_update_versions_collection_level_asset_no_doubled_path` verifies fix
- [x] Manual test: `portolan init` + `portolan add` + `portolan push` works for collection-level vector data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset paths in dataset version records are now correctly computed as catalog-relative paths, eliminating instances of path duplication and ensuring reliable asset location resolution for both collection-level and item-level assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->