### PR TITLE
feat: add GitHub PR and issue templates from geoparquet-io

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please provide details to help us reproduce and fix it.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: Clear description of what went wrong
+      placeholder: "When I run `portolan init`, it crashes with..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the issue
+      placeholder: |
+        1. Install portolan with `pipx install portolan-cli`
+        2. Run `portolan init`
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include error messages/stack traces.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: System details
+      value: |
+        - OS: [e.g., Ubuntu 22.04, macOS 14, Windows 11]
+        - Python version: [e.g., 3.11.5]
+        - portolan version: [run `portolan --version`]
+        - Installation method: [pipx, pip, uv tool, from source]
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: sample-data
+    attributes:
+      label: Sample Data (Optional)
+      description: |
+        Link to sample data that reproduces the issue.
+        Use a public URL (S3, GitHub gist, etc.) if possible.
+      placeholder: "https://example.com/sample.parquet"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs (Optional)
+      description: Full command output with `--verbose` flag
+      render: shell
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Would you like to submit a PR?
+      options:
+        - "No"
+        - "Yes, I'd like to try"
+        - "Yes, already working on it"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/portolan-sdi/portolan-cli/discussions
+    about: Ask questions or discuss ideas before opening an issue
+  - name: Security Issue
+    url: https://github.com/portolan-sdi/portolan-cli/security/advisories/new
+    about: Report security vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,43 @@
+name: Documentation Issue
+description: Report unclear, incorrect, or missing documentation
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: dropdown
+    id: docs-type
+    attributes:
+      label: Documentation Type
+      options:
+        - "README"
+        - "CLI Reference"
+        - "Python API"
+        - "User Guide"
+        - "Installation"
+        - "Contributing"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Link to the problematic documentation
+      placeholder: "https://portolan-sdi.github.io/portolan-cli/guide/..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What's Wrong?
+      description: Describe the problem with the current docs
+      placeholder: "The example shows X, but it should show Y because..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Improvement
+      description: How should it be fixed?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Help us understand your use case.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this solve? What's your use case?
+      placeholder: "I'm trying to [use case], but portolan doesn't support..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work? What should the CLI/API look like?
+      placeholder: |
+        CLI: `portolan convert --format pmtiles input.parquet`
+        Python: `catalog.publish(remote='s3://bucket/path')`
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've considered or current workarounds
+      placeholder: "Currently I'm using [workaround], but it's slow/cumbersome because..."
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this to your workflow?
+      options:
+        - "Nice to have"
+        - "Important"
+        - "Critical blocker"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I'm willing to submit a PR for this feature
+        - label: I can help test this feature

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## PR Title
 Write a clear, action-oriented title. This will be used for changelog and release notes.
+Examples: "Add `portolan publish` command for S3 sync" or "Fix collection asset path resolution"
 
 ## Description
 <!-- Concise summary of what changed and why. This may be used in release notes. -->
@@ -7,9 +8,15 @@ Write a clear, action-oriented title. This will be used for changelog and releas
 ## Technical Details
 <!-- Implementation notes, breaking changes, migration steps. For reviewers. -->
 
+## Breaking Changes
+**Does this PR introduce breaking changes?** No / Yes
+
+<!-- If yes, describe what breaks and how users should migrate -->
+
 ## Related Issue(s)
 - #
 
 ## Checklist
-- [ ] Code is formatted
-- [ ] Tests pass
+- [ ] Tests added/updated
+- [ ] All tests pass (`uv run pytest`)
+- [ ] Documentation updated (README, guides, CLI reference)


### PR DESCRIPTION
## Description
Adds comprehensive GitHub templates to improve issue and PR quality, adapted from geoparquet-io.

## What's Added

**Pull Request Template:**
- Clear action-oriented title guidance
- Breaking changes section
- Updated checklist with test and documentation requirements

**Issue Templates:**
1. **Bug Report** - Structured template with environment details, reproduction steps, and contribution options
2. **Documentation Issue** - Template for reporting doc problems with location and suggestions
3. **Feature Request** - Comprehensive template with problem statement, solution, alternatives, and priority
4. **Config** - Links to discussions and security reporting

## Technical Details
- All templates adapted from geoparquet-io repository
- Updated references from `gpio` to `portolan`
- Updated repository URLs to portolan-sdi organization
- Maintained YAML form structure for better UX

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
N/A - Infrastructure improvement

## Checklist
- [x] Tests added/updated (N/A - template files only)
- [x] All tests pass (`uv run pytest`) (N/A)
- [x] Documentation updated (templates are self-documenting)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub issue templates for bug reports, documentation issues, and feature requests with structured forms and required fields.
  * Updated pull request template to include breaking changes section and enhanced testing/documentation checklist items.
  * Added GitHub issue configuration for support channels and security reporting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->