### PR TITLE
fix(add): treat FileGDB directories as data assets for collection ID inference

### DIFF
--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -1409,22 +1409,28 @@ def resolve_collection_id(path: Path, catalog_root: Path) -> str:
 
 
 def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
-    """Infer nested collection ID from a file path (ADR-0032).
+    """Infer nested collection ID from a file or directory-based data asset (ADR-0032).
 
     Unlike resolve_collection_id() which returns only the first component,
     this returns the full nested path representing the leaf collection.
 
     Per ADR-0032: Nested catalogs with flat collections means:
     - Intermediate directories become catalogs (organizational)
-    - The parent directory of the data file is the collection
+    - The parent directory of the data asset is the collection
+
+    Directory-based formats like FileGDB (*.gdb) are treated as data assets,
+    not organizational directories. Detection uses both content inspection
+    (internal .gdbtable files or 'gdb' marker) and suffix fallback for
+    incomplete/corrupted FileGDB directories.
 
     Examples:
         climate/hittekaart/data.parquet -> "climate/hittekaart"
         env/air/quality/pm25.parquet -> "env/air/quality"
         demographics/data.parquet -> "demographics"
+        ocha/my_data.gdb -> "ocha"  (FileGDB directory)
 
     Args:
-        path: Path to the file.
+        path: Path to the file or directory-based data asset (e.g., FileGDB).
         catalog_root: Root directory of the catalog.
 
     Returns:
@@ -1447,16 +1453,25 @@ def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
     # A path is treated as a "data asset" (not a collection) if it's a file
     # OR a FileGDB directory. FileGDB directories (*.gdb) contain the actual
     # data - they're assets, not organizational collections (Issue #259).
-    is_asset = path.is_file() or is_filegdb(path)
+    #
+    # For FileGDB detection, we use:
+    # 1. is_filegdb() - content inspection (internal .gdbtable files or 'gdb' marker)
+    # 2. Suffix fallback - handles empty/incomplete/corrupted FileGDB directories
+    #
+    # The suffix fallback ensures directories named *.gdb are always treated as
+    # data assets, even if they lack proper internal structure (e.g., partial
+    # download, corruption, or manual folder creation).
+    is_gdb_suffix = path.is_dir() and path.name.lower().endswith(".gdb")
+    is_asset = path.is_file() or is_filegdb(path) or is_gdb_suffix
 
     # Data asset must be in at least one subdirectory (collection)
     if is_asset and len(parts) == 1:
-        raise ValueError(f"File {path} must be in a subdirectory (collection)")
+        raise ValueError(f"Data asset {path} must be in a subdirectory (collection)")
 
     # Return parent directory path as collection ID (all but last component)
     parent_parts = parts[:-1] if is_asset else parts
     if not parent_parts:
-        raise ValueError(f"File {path} must be in a subdirectory (collection)")
+        raise ValueError(f"Data asset {path} must be in a subdirectory (collection)")
 
     return "/".join(parent_parts)
 

--- a/tests/unit/test_nested_catalog_inference.py
+++ b/tests/unit/test_nested_catalog_inference.py
@@ -121,6 +121,65 @@ class TestInferNestedCollectionId:
         result = infer_nested_collection_id(gdb_path, catalog_root)
         assert result == "theme/subtheme"
 
+    def test_filegdb_with_gdbtable_files(self, tmp_path: Path) -> None:
+        """FileGDB detected via .gdbtable files (alternate detection path).
+
+        is_filegdb() accepts either 'gdb' marker OR .gdbtable files.
+        This test covers the .gdbtable detection path.
+        """
+        from portolan_cli.dataset import infer_nested_collection_id
+
+        catalog_root = tmp_path
+        gdb_path = tmp_path / "ocha" / "boundaries.gdb"
+        gdb_path.mkdir(parents=True)
+        # Create .gdbtable files instead of 'gdb' marker
+        (gdb_path / "a00000001.gdbtable").touch()
+        (gdb_path / "a00000002.gdbtable").touch()
+
+        result = infer_nested_collection_id(gdb_path, catalog_root)
+        assert result == "ocha"
+
+    def test_empty_gdb_directory_uses_suffix_fallback(self, tmp_path: Path) -> None:
+        """Empty .gdb directory still infers parent via suffix fallback.
+
+        A directory named *.gdb without proper internal structure (no 'gdb'
+        marker, no .gdbtable files) should still be treated as a data asset
+        using the suffix fallback. This handles:
+        - Corrupted FileGDB
+        - Partial downloads
+        - Manually created .gdb folders
+        """
+        from portolan_cli.dataset import infer_nested_collection_id
+        from portolan_cli.scan_detect import is_filegdb
+
+        catalog_root = tmp_path
+        gdb_path = tmp_path / "ocha" / "incomplete.gdb"
+        gdb_path.mkdir(parents=True)
+        # Intentionally NOT creating any internal structure
+
+        # Verify is_filegdb returns False (no internal structure)
+        assert is_filegdb(gdb_path) is False
+
+        # But infer_nested_collection_id should still work via suffix fallback
+        result = infer_nested_collection_id(gdb_path, catalog_root)
+        assert result == "ocha"
+
+    def test_empty_gdb_at_root_raises_error(self, tmp_path: Path) -> None:
+        """Empty .gdb directory at root should raise ValueError.
+
+        Even with suffix fallback, a .gdb directory at catalog root must
+        be in a collection subdirectory.
+        """
+        from portolan_cli.dataset import infer_nested_collection_id
+
+        catalog_root = tmp_path
+        gdb_path = tmp_path / "empty.gdb"
+        gdb_path.mkdir()
+        # Intentionally NOT creating any internal structure
+
+        with pytest.raises(ValueError, match="must be in a subdirectory"):
+            infer_nested_collection_id(gdb_path, catalog_root)
+
 
 class TestCreateIntermediateCatalogs:
     """Test create_intermediate_catalogs() function."""


### PR DESCRIPTION
## Summary

- Fixes #259: `portolan add` fails for `.gdb` folders with "Invalid collection ID contains invalid character: '.'"
- FileGDB directories (*.gdb) were incorrectly treated as organizational collections rather than data assets
- The `.gdb` folder name was included in the collection ID, causing the invalid character error

## Root Cause

In `infer_nested_collection_id()`, the function uses `path.is_file()` to determine whether to strip the last path component from the collection ID. Since FileGDB directories are technically directories, `is_file()` returns `False`, and the `.gdb` folder name was included in the collection ID.

## Fix

Treat FileGDB directories like files for collection ID inference:
- `.gdb` in collection: `ocha/my_data.gdb` → collection `ocha` ✓
- `.gdb` at root: skips with warning (consistent with `.gpkg` at root) ✓

## Test plan

- [x] Added 3 unit tests for FileGDB collection ID inference
- [x] All 2663 unit tests pass
- [x] All 497 integration tests pass
- [x] Verified end-to-end with real OCHA `.gdb` data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* FileGDB directories placed at the catalog root will now raise a validation error and must be positioned in subdirectories instead. Collection ID inference for nested FileGDB directories now correctly excludes the FileGDB directory name from the computed identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->