### PR TITLE
fix(add): format-aware collection inference and JSON/GeoJSON detection

### DIFF
--- a/portolan_cli/catalog_list.py
+++ b/portolan_cli/catalog_list.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from portolan_cli.config import get_ignored_files
-from portolan_cli.formats import FORMAT_DISPLAY_NAMES
+from portolan_cli.formats import FORMAT_DISPLAY_NAMES, FormatType, _detect_json_type
 from portolan_cli.versions import read_versions
 
 if TYPE_CHECKING:
@@ -130,6 +130,7 @@ _STAC_METADATA_FILES: frozenset[str] = frozenset(
         "item.json",
         "collection.json",
         "catalog.json",
+        "versions.json",  # Portolan internal version tracking
     }
 )
 
@@ -153,10 +154,13 @@ def _is_ignored(filename: str, item_id: str, ignored_patterns: list[str]) -> boo
     if filename.startswith("."):
         return True
 
-    # Ignore STAC metadata files
+    # Ignore STAC metadata files (by name)
     if filename in _STAC_METADATA_FILES:
         return True
-    if filename == f"{item_id}.json":
+
+    # Ignore STAC item JSON files named {item_id}.json
+    # These are STAC metadata, not user data files
+    if item_id and filename == f"{item_id}.json":
         return True
 
     # Check against ignored patterns
@@ -167,16 +171,29 @@ def _is_ignored(filename: str, item_id: str, ignored_patterns: list[str]) -> boo
     return False
 
 
-def _get_format_display_name(filename: str) -> str:
-    """Get human-readable format name for a file based on extension.
+def _get_format_display_name(filename: str, file_path: Path | None = None) -> str:
+    """Get human-readable format name for a file.
+
+    Uses extension-based detection by default, with content inspection
+    for ambiguous formats like .json (which may be GeoJSON or plain JSON).
 
     Args:
         filename: The filename to check.
+        file_path: Optional full path for content inspection. If provided and
+            the file exists, content inspection is used for .json files.
 
     Returns:
-        Human-readable format name (e.g., "GeoParquet", "PNG").
+        Human-readable format name (e.g., "GeoParquet", "GeoJSON", "JSON").
     """
     ext = Path(filename).suffix.lower()
+
+    # Special case: .json files need content inspection to distinguish
+    # GeoJSON from plain JSON (PR #261)
+    if ext == ".json" and file_path is not None and file_path.exists():
+        if _detect_json_type(file_path) == FormatType.VECTOR:
+            return "GeoJSON"
+        return "JSON"
+
     if ext in FORMAT_DISPLAY_NAMES:
         return FORMAT_DISPLAY_NAMES[ext]
     if ext:
@@ -264,7 +281,7 @@ def _scan_item_directory(
                     path=filename,
                     status=status,
                     size_bytes=size_bytes,
-                    format_name=_get_format_display_name(filename),
+                    format_name=_get_format_display_name(filename, file_path=entry),
                 )
             )
     except OSError as e:

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -27,6 +27,7 @@ from typing import Any
 
 import click
 import pystac
+from pystac.layout import AsIsLayoutStrategy
 
 from portolan_cli.collection_id import normalize_collection_id, validate_collection_id
 from portolan_cli.constants import (
@@ -680,6 +681,11 @@ def add_dataset(
         assets=stac_assets,
     )
 
+    # Set item href explicitly to prevent PySTAC from creating a nested subdirectory.
+    # By default, PySTAC's normalize_hrefs() + save() creates {item_id}/{item_id}.json
+    # but we want the item JSON in the existing item_dir (same as data files).
+    item.set_self_href(str(item_dir / f"{item_id}.json"))
+
     # Step 7: Load or create collection
     collection = _get_or_create_collection(
         catalog_root=catalog_root,
@@ -693,8 +699,13 @@ def add_dataset(
     # Step 8: De-duplicate item links before saving
     _deduplicate_collection_item_links(collection)
 
-    # Save collection (normalize_hrefs sets self link and relative paths)
-    collection.normalize_hrefs(str(collection_dir))
+    # Set collection href explicitly
+    collection.set_self_href(str(collection_dir / "collection.json"))
+
+    # Save collection using AsIsLayoutStrategy to preserve our explicit item hrefs.
+    # The default BestPracticesLayoutStrategy would create {item_id}/{item_id}.json
+    # subdirectories, but we want items flat in item_dir (same as data files).
+    collection.normalize_hrefs(str(collection_dir), strategy=AsIsLayoutStrategy())
     collection.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
 
     # Step 8b: Fix root/parent links in saved JSON
@@ -1409,35 +1420,41 @@ def resolve_collection_id(path: Path, catalog_root: Path) -> str:
 
 
 def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
-    """Infer nested collection ID from a file or directory-based data asset (ADR-0032).
+    """Infer nested collection ID from a file or directory-based data asset.
 
-    Unlike resolve_collection_id() which returns only the first component,
-    this returns the full nested path representing the leaf collection.
+    Per ADR-0031 (Collection-Level Assets for Vector Data) and ADR-0032
+    (Nested Catalogs with Flat Collections), the collection depth depends
+    on the format type:
 
-    Per ADR-0032: Nested catalogs with flat collections means:
-    - Intermediate directories become catalogs (organizational)
-    - The parent directory of the data asset is the collection
+    - **Vector data**: Parent directory = collection (collection-level asset)
+      Example: demographics/boundaries.parquet -> collection = "demographics"
 
-    Directory-based formats like FileGDB (*.gdb) are treated as data assets,
-    not organizational directories. Detection uses both content inspection
-    (internal .gdbtable files or 'gdb' marker) and suffix fallback for
-    incomplete/corrupted FileGDB directories.
+    - **Raster data**: Grandparent directory = collection, parent = item
+      Example: 2025/tile1/scene.tif -> collection = "2025", item = "tile1"
+
+    Directory-based formats like FileGDB (*.gdb) are treated as vector data
+    (collection-level assets).
 
     Examples:
+        # Vector (collection-level)
         climate/hittekaart/data.parquet -> "climate/hittekaart"
-        env/air/quality/pm25.parquet -> "env/air/quality"
-        demographics/data.parquet -> "demographics"
+        demographics/boundaries.geojson -> "demographics"
         ocha/my_data.gdb -> "ocha"  (FileGDB directory)
+
+        # Raster (item-level, needs subdirectory)
+        imagery/2025/tile1/scene.tif -> "imagery/2025"
+        satellite/scene-001/B04.tif -> "satellite"
 
     Args:
         path: Path to the file or directory-based data asset (e.g., FileGDB).
         catalog_root: Root directory of the catalog.
 
     Returns:
-        Collection ID (full path of parent directory relative to catalog root).
+        Collection ID (nested path relative to catalog root).
 
     Raises:
-        ValueError: If path is not inside catalog root or at root level.
+        ValueError: If path is not inside catalog root, at root level, or
+            if raster data lacks required item subdirectory structure.
     """
     # Get path relative to catalog root
     try:
@@ -1457,10 +1474,6 @@ def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
     # For FileGDB detection, we use:
     # 1. is_filegdb() - content inspection (internal .gdbtable files or 'gdb' marker)
     # 2. Suffix fallback - handles empty/incomplete/corrupted FileGDB directories
-    #
-    # The suffix fallback ensures directories named *.gdb are always treated as
-    # data assets, even if they lack proper internal structure (e.g., partial
-    # download, corruption, or manual folder creation).
     is_gdb_suffix = path.is_dir() and path.name.lower().endswith(".gdb")
     is_asset = path.is_file() or is_filegdb(path) or is_gdb_suffix
 
@@ -1468,12 +1481,31 @@ def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
     if is_asset and len(parts) == 1:
         raise ValueError(f"Data asset {path} must be in a subdirectory (collection)")
 
-    # Return parent directory path as collection ID (all but last component)
-    parent_parts = parts[:-1] if is_asset else parts
-    if not parent_parts:
+    # Detect format type to determine collection depth (ADR-0031)
+    # - Vector: parent directory = collection (collection-level asset)
+    # - Raster: grandparent = collection, parent = item (item-level asset)
+    format_type = detect_format(path)
+    is_raster = format_type == FormatType.RASTER
+
+    if is_raster:
+        # Raster files need item subdirectory: collection/item/data.tif
+        # Minimum depth: 3 parts (collection, item_dir, filename)
+        if len(parts) < 3:
+            raise ValueError(
+                f"Raster file {path} must be in a subdirectory (collection/item/). "
+                f"Per ADR-0031, raster data requires item-level organization."
+            )
+        # Return grandparent as collection (all but last 2 components)
+        collection_parts = parts[:-2]
+    else:
+        # Vector files: parent directory = collection
+        # Return parent as collection (all but last component)
+        collection_parts = parts[:-1] if is_asset else parts
+
+    if not collection_parts:
         raise ValueError(f"Data asset {path} must be in a subdirectory (collection)")
 
-    return "/".join(parent_parts)
+    return "/".join(collection_parts)
 
 
 def is_current(

--- a/portolan_cli/formats.py
+++ b/portolan_cli/formats.py
@@ -134,7 +134,7 @@ FORMAT_DISPLAY_NAMES: dict[str, str] = {
     ".gpkg": "GPKG",
     ".csv": "CSV",
     ".tsv": "TSV",
-    ".json": "GeoJSON",
+    ".json": "JSON",  # Plain JSON; use content inspection to detect GeoJSON
     # Convertible raster
     ".jp2": "JP2",
     # Unsupported
@@ -584,6 +584,9 @@ def _detect_json_type(path: Path) -> FormatType:
     Uses prefix reading (first 8KB) to avoid OOM on large files.
     Searches for GeoJSON type tokens without full JSON parsing.
 
+    STAC items/collections/catalogs are NOT GeoJSON even though they have
+    "type": "Feature". They are identified by "stac_version".
+
     Args:
         path: Path to JSON file.
 
@@ -615,6 +618,9 @@ def _detect_json_type(path: Path) -> FormatType:
         # Read only first 8KB to avoid OOM on large files
         with open(path, encoding="utf-8") as f:
             prefix = f.read(8192)
+            # STAC metadata has stac_version - NOT GeoJSON
+            if "stac_version" in prefix:
+                return FormatType.UNKNOWN
             if any(token in prefix for token in geojson_tokens):
                 return FormatType.VECTOR
     except (OSError, UnicodeDecodeError):

--- a/tests/integration/test_add_no_duplicate_nesting.py
+++ b/tests/integration/test_add_no_duplicate_nesting.py
@@ -1,0 +1,248 @@
+"""Integration tests for preventing duplicate directory nesting in add command.
+
+Tests that `portolan add collection/item_dir/FILE.tif` does NOT create
+an additional `collection/item_dir/FILE/` subdirectory for the STAC item.
+
+Uses real COG fixtures to exercise the full add pipeline including
+metadata extraction and STAC item creation.
+
+Related issue: portolan add creates duplicate nested subdirectories
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def cog_fixture() -> Path:
+    """Path to a valid COG fixture file."""
+    fixture_path = Path(__file__).parent.parent / "fixtures" / "raster" / "valid" / "singleband.tif"
+    if not fixture_path.exists():
+        pytest.skip(f"COG fixture not found: {fixture_path}")
+    return fixture_path
+
+
+class TestNoDuplicateNestingIntegration:
+    """Integration tests that add command does not create duplicate nested directories."""
+
+    @pytest.mark.integration
+    def test_add_cog_does_not_create_stem_subdirectory(
+        self, runner: CliRunner, cog_fixture: Path
+    ) -> None:
+        """Adding a COG file should not create a subdirectory named after the file stem.
+
+        Given: catalog/collection/item_dir/FILE.tif (real COG)
+        After add:
+          - STAC item metadata should be in item_dir, NOT in item_dir/FILE/
+          - NO new directory catalog/collection/item_dir/FILE/ should be created
+
+        This tests the bug where adding 26453E204934N.tif created a
+        26453E204934N/ subdirectory.
+        """
+        with runner.isolated_filesystem():
+            # Create catalog structure
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Create collection/item structure
+            # Simulating: 2025/26453e204934n/26453E204934N.tif
+            Path("imagery").mkdir()
+            Path("imagery/tile_001").mkdir()
+
+            # Copy real COG to test location with uppercase name (like the bug)
+            tif_file = Path("imagery/tile_001/TILE_001.tif")
+            shutil.copy(cog_fixture, tif_file)
+
+            # Get directory contents BEFORE add
+            dirs_before = {p.name for p in Path("imagery/tile_001").iterdir() if p.is_dir()}
+
+            # Run add command
+            result = runner.invoke(cli, ["add", str(tif_file), "-v"])
+
+            # Check command succeeded
+            assert result.exit_code == 0, f"Add failed: {result.output}"
+
+            # Get directory contents AFTER add
+            dirs_after = {p.name for p in Path("imagery/tile_001").iterdir() if p.is_dir()}
+            new_dirs = dirs_after - dirs_before
+
+            # CRITICAL: No new directory named after the file stem should exist
+            stem_dir = Path("imagery/tile_001/TILE_001")
+            assert not stem_dir.exists(), (
+                f"BUG: Duplicate nested directory '{stem_dir}' was created!\n"
+                f"New directories: {new_dirs}\n"
+                f"Full contents: {list(Path('imagery/tile_001').iterdir())}"
+            )
+
+    @pytest.mark.integration
+    def test_add_cog_item_json_not_in_nested_dir(
+        self, runner: CliRunner, cog_fixture: Path
+    ) -> None:
+        """STAC item JSON should NOT be in a nested subdirectory named after the file.
+
+        The item JSON should be at:
+          collection/item_dir/{item_id}.json or collection/item_dir/item.json
+        NOT at:
+          collection/item_dir/{file_stem}/{file_stem}.json
+        """
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            Path("data").mkdir()
+            Path("data/myitem").mkdir()
+
+            # Copy real COG with a distinctive name
+            tif_file = Path("data/myitem/RASTER_DATA.tif")
+            shutil.copy(cog_fixture, tif_file)
+
+            result = runner.invoke(cli, ["add", str(tif_file), "-v"])
+
+            assert result.exit_code == 0, f"Add failed: {result.output}"
+
+            # Check for incorrectly nested item JSON
+            wrong_location = Path("data/myitem/RASTER_DATA/RASTER_DATA.json")
+            wrong_dir = Path("data/myitem/RASTER_DATA")
+
+            assert not wrong_dir.is_dir(), (
+                f"BUG: Unexpected nested directory created: {wrong_dir}\n"
+                f"Contents: {list(Path('data/myitem').iterdir())}"
+            )
+
+            assert not wrong_location.exists(), (
+                f"BUG: Item JSON at wrong nested location: {wrong_location}"
+            )
+
+    @pytest.mark.integration
+    def test_add_preserves_flat_item_structure(self, runner: CliRunner, cog_fixture: Path) -> None:
+        """Adding a file should preserve the flat item directory structure.
+
+        The item directory (parent of the file) should contain:
+        - The original data file
+        - STAC item metadata JSON
+        - Possibly converted files
+
+        NOT a nested subdirectory named after the data file.
+        """
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Mimic real-world structure: collection/tile_id/TILE_ID.tif
+            Path("aerial").mkdir()
+            Path("aerial/26453e204934n").mkdir()  # lowercase dir name
+
+            # Uppercase filename (like the real bug scenario)
+            tif_file = Path("aerial/26453e204934n/26453E204934N.tif")
+            shutil.copy(cog_fixture, tif_file)
+
+            result = runner.invoke(cli, ["add", str(tif_file), "-v"])
+
+            assert result.exit_code == 0, f"Add failed: {result.output}"
+
+            item_dir = Path("aerial/26453e204934n")
+            contents = list(item_dir.iterdir())
+            content_names = [p.name for p in contents]
+            subdirs = [p.name for p in contents if p.is_dir()]
+
+            # The ONLY acceptable subdirectory would be something like .portolan
+            # NOT a directory named after the file stem
+            assert "26453E204934N" not in subdirs, (
+                f"BUG: Duplicate nested directory '26453E204934N/' found!\n"
+                f"Directory contents: {content_names}\n"
+                f"Subdirectories: {subdirs}"
+            )
+
+    @pytest.mark.integration
+    def test_find_shows_correct_structure_after_add(
+        self, runner: CliRunner, cog_fixture: Path
+    ) -> None:
+        """Verify the file structure after add matches expectations.
+
+        This is a diagnostic test that shows exactly what files/dirs are created.
+        """
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            Path("collection").mkdir()
+            Path("collection/item_dir").mkdir()
+
+            tif_file = Path("collection/item_dir/MYFILE.tif")
+            shutil.copy(cog_fixture, tif_file)
+
+            result = runner.invoke(cli, ["add", str(tif_file), "-v"])
+
+            assert result.exit_code == 0, f"Add failed: {result.output}"
+
+            # Collect all files and dirs under collection/
+            all_paths = []
+            for path in Path("collection").rglob("*"):
+                rel_path = path.relative_to(Path("collection"))
+                path_type = "dir" if path.is_dir() else "file"
+                all_paths.append(f"{path_type}: {rel_path}")
+
+            # Check no MYFILE directory was created
+            myfile_dir = Path("collection/item_dir/MYFILE")
+            assert not myfile_dir.exists(), (
+                "BUG: Duplicate nested directory created!\n"
+                "Structure after add:\n" + "\n".join(sorted(all_paths))
+            )

--- a/tests/integration/test_add_rm_integration.py
+++ b/tests/integration/test_add_rm_integration.py
@@ -293,21 +293,31 @@ class TestAddItemIdOverrideIntegration:
     """Integration tests for --item-id flag on 'portolan add' command.
 
     Issue #136: Users should be able to override automatic item ID derivation.
+
+    Per ADR-0031: --item-id only applies to raster data (item-level assets).
+    Vector data is collection-level and doesn't create items.
     """
 
     @pytest.mark.integration
     def test_add_with_item_id_creates_item_with_custom_id(
-        self, runner: CliRunner, initialized_catalog: Path, valid_points_geojson: Path
+        self, runner: CliRunner, initialized_catalog: Path, valid_singleband_cog: Path
     ) -> None:
-        """add --item-id creates STAC item with the custom ID."""
+        """add --item-id creates STAC item with the custom ID.
+
+        Per ADR-0031: Raster data = item-level asset (grandparent = collection).
+        Per ADR-0032: For rasters, collection is the grandparent, item is the parent.
+        The --item-id flag overrides the default item ID (parent directory name).
+        """
         import json
 
-        # Set up: create collection directory (leaf level per ADR-0032)
-        # Per ADR-0032: file's parent directory is the leaf collection
-        collection_dir = initialized_catalog / "demographics"
-        collection_dir.mkdir()
-        test_file = collection_dir / "census.geojson"
-        shutil.copy(valid_points_geojson, test_file)
+        # Set up: create structure for raster data
+        # Per ADR-0031: Raster structure is collection/item_dir/data.tif
+        # imagery = collection, scene-001 = item directory
+        collection_dir = initialized_catalog / "imagery"
+        item_dir = collection_dir / "scene-001"
+        item_dir.mkdir(parents=True)
+        test_file = item_dir / "data.tif"
+        shutil.copy(valid_singleband_cog, test_file)
 
         # Act: add with --item-id override
         result = runner.invoke(
@@ -317,7 +327,7 @@ class TestAddItemIdOverrideIntegration:
                 "--portolan-dir",
                 str(initialized_catalog),
                 "--item-id",
-                "custom-census-2024",
+                "custom-scene-2024",
                 str(test_file),
             ],
             catch_exceptions=False,
@@ -326,46 +336,40 @@ class TestAddItemIdOverrideIntegration:
         # Assert
         assert result.exit_code == 0, f"Add failed: {result.output}"
 
-        # Check versions.json exists and has a version entry
+        # Per ADR-0031: versions.json is at the collection level (imagery/)
         versions_path = collection_dir / "versions.json"
-        assert versions_path.exists(), "versions.json not created"
+        assert versions_path.exists(), "versions.json not created at collection level"
         with open(versions_path) as f:
             versions = json.load(f)
         assert len(versions["versions"]) > 0, "No version entries created"
 
-        # Verify the STAC item JSON uses the custom item ID.
-        # Asset keys in versions.json are "{item_id}/{filename}" so checking
-        # asset keys is indirect; reading the Item JSON is the correct contract.
-        # Pick the first asset href to locate the item directory.
-        latest_version = versions["versions"][-1]
-        asset_hrefs = [a["href"] for a in latest_version["assets"].values()]
-        assert len(asset_hrefs) > 0, "No assets in version entry"
-
-        # Item JSON lives at collection_dir/{item_id}/{item_id}.json
-        # Use the href (format: "collection_id/item_id/filename") to find item_id
-        item_id_from_href = asset_hrefs[0].split("/")[1]
-        item_json_path = collection_dir / item_id_from_href / f"{item_id_from_href}.json"
+        # Per ADR-0031: Raster item JSON is at item_dir/{item_id}.json
+        # The item_id is custom, but the item JSON stays alongside the data.
+        item_json_path = item_dir / "custom-scene-2024.json"
         assert item_json_path.exists(), f"Item JSON not found at {item_json_path}"
 
         with open(item_json_path) as f:
             item_json = json.load(f)
-        assert item_json["id"] == "custom-census-2024", (
-            f"STAC item ID should be 'custom-census-2024', got '{item_json['id']}'"
+        assert item_json["id"] == "custom-scene-2024", (
+            f"STAC item ID should be 'custom-scene-2024', got '{item_json['id']}'"
         )
 
     @pytest.mark.integration
     def test_add_with_item_id_stac_item_uses_custom_id(
-        self, runner: CliRunner, initialized_catalog: Path, valid_points_geojson: Path
+        self, runner: CliRunner, initialized_catalog: Path, valid_singleband_cog: Path
     ) -> None:
-        """add --item-id results in STAC item.json with custom ID field."""
+        """add --item-id results in STAC item.json with custom ID field.
+
+        Per ADR-0031: Raster data = item-level asset with item.json.
+        """
         import json
 
-        # Set up
+        # Set up: raster structure per ADR-0031
         collection_dir = initialized_catalog / "imagery"
         item_dir = collection_dir / "original-dir"
         item_dir.mkdir(parents=True)
-        test_file = item_dir / "satellite.geojson"
-        shutil.copy(valid_points_geojson, test_file)
+        test_file = item_dir / "satellite.tif"
+        shutil.copy(valid_singleband_cog, test_file)
 
         # Act
         result = runner.invoke(
@@ -383,21 +387,12 @@ class TestAddItemIdOverrideIntegration:
 
         assert result.exit_code == 0, f"Add failed: {result.output}"
 
-        # Find and read the item.json
-        # STAC item structure: collection_dir/item_id/item_id.json
-        # But since we override item_id, we still create in original dir
-        item_json_files = list(collection_dir.rglob("*.json"))
-        item_json = None
-        for f in item_json_files:
-            if f.name not in ("collection.json", "versions.json", "catalog.json"):
-                try:
-                    with open(f) as fh:
-                        data = json.load(fh)
-                        if data.get("type") == "Feature":
-                            item_json = data
-                            break
-                except (json.JSONDecodeError, KeyError):
-                    continue
+        # Per ADR-0031: Raster item JSON at item_dir/{item_id}.json (flat structure)
+        item_json_path = item_dir / "my-custom-item.json"
+        assert item_json_path.exists(), f"Item JSON not found at {item_json_path}"
+
+        with open(item_json_path) as fh:
+            item_json = json.load(fh)
 
         assert item_json is not None, "No STAC item found"
         assert item_json.get("id") == "my-custom-item", (

--- a/tests/unit/test_add_no_duplicate_nesting.py
+++ b/tests/unit/test_add_no_duplicate_nesting.py
@@ -1,0 +1,183 @@
+"""Unit tests for preventing duplicate directory nesting in add command.
+
+Tests that `portolan add collection/item_dir/FILE.tif` does NOT create
+an additional `collection/item_dir/FILE/` subdirectory for the STAC item.
+
+The item JSON should be stored without creating a duplicate nested directory
+based on the file stem.
+
+Related issue: portolan add creates duplicate nested subdirectories
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_cog_file(tmp_path: Path) -> Path:
+    """Create a minimal mock COG file for testing.
+
+    This creates a file that passes basic format detection but
+    doesn't require actual raster processing.
+    """
+    # For unit tests, we just need a file with .tif extension
+    # Integration tests will use real COG files
+    tif_file = tmp_path / "test.tif"
+    tif_file.write_bytes(b"x" * 1000)
+    return tif_file
+
+
+class TestNoDuplicateNesting:
+    """Tests that add command does not create duplicate nested directories."""
+
+    @pytest.mark.unit
+    def test_add_does_not_create_stem_subdirectory(self, runner: CliRunner) -> None:
+        """Adding a file should not create a subdirectory named after the file stem.
+
+        Given: catalog/collection/item_dir/FILE.tif
+        After add:
+          - STAC item metadata should be stored appropriately
+          - NO new directory catalog/collection/item_dir/FILE/ should be created
+
+        This tests the bug where adding 26453E204934N.tif created a
+        26453E204934N/ subdirectory.
+        """
+        with runner.isolated_filesystem():
+            # Create catalog structure
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Create collection/item structure with a TIF file
+            # Simulating: 2025/26453e204934n/26453E204934N.tif
+            Path("collection").mkdir()
+            Path("collection/item_dir").mkdir()
+            tif_file = Path("collection/item_dir/MYFILE.tif")
+            tif_file.write_bytes(b"x" * 1000)
+
+            # Get directory contents BEFORE add
+            dirs_before = {p for p in Path("collection/item_dir").iterdir() if p.is_dir()}
+
+            # Run add command
+            runner.invoke(cli, ["add", str(tif_file), "-v"])
+
+            # The command may fail due to format validation, but we can still
+            # check that no duplicate directory was created
+            dirs_after = {p for p in Path("collection/item_dir").iterdir() if p.is_dir()}
+            new_dirs = dirs_after - dirs_before
+
+            # CRITICAL: No new directory named after the file stem should exist
+            stem_dir = Path("collection/item_dir/MYFILE")
+            assert not stem_dir.exists(), (
+                f"Duplicate nested directory '{stem_dir}' was created. New directories: {new_dirs}"
+            )
+
+    @pytest.mark.unit
+    def test_add_preserves_flat_structure(self, runner: CliRunner) -> None:
+        """Adding a file should preserve the flat item directory structure.
+
+        The item directory (parent of the file) should contain:
+        - The original data file(s)
+        - STAC metadata (item.json or {item_id}.json)
+        - collection.json and versions.json at collection level
+
+        NOT a nested subdirectory named after the file.
+        """
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Create structure mimicking real data
+            Path("imagery").mkdir()
+            Path("imagery/tile_001").mkdir()
+            data_file = Path("imagery/tile_001/TILE_001.tif")
+            data_file.write_bytes(b"x" * 1000)
+
+            runner.invoke(cli, ["add", str(data_file), "-v"])
+
+            # Check the structure
+            item_dir = Path("imagery/tile_001")
+
+            # List all items in the directory
+            contents = list(item_dir.iterdir())
+            content_names = [p.name for p in contents]
+
+            # There should NOT be a TILE_001/ subdirectory
+            assert "TILE_001" not in content_names or not (item_dir / "TILE_001").is_dir(), (
+                f"Unexpected nested directory TILE_001/ found. Directory contents: {content_names}"
+            )
+
+    @pytest.mark.unit
+    def test_item_json_location(self, runner: CliRunner) -> None:
+        """STAC item JSON should be in the item directory, not a nested subdir.
+
+        If an item JSON is created, it should be at:
+          collection/item_dir/{item_id}.json
+        NOT at:
+          collection/item_dir/{file_stem}/{file_stem}.json
+        """
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            Path("data").mkdir()
+            Path("data/myitem").mkdir()
+            data_file = Path("data/myitem/DATAFILE.tif")
+            data_file.write_bytes(b"x" * 1000)
+
+            runner.invoke(cli, ["add", str(data_file), "-v"])
+
+            # Check for incorrectly nested item JSON
+            wrong_location = Path("data/myitem/DATAFILE/DATAFILE.json")
+            assert not wrong_location.exists(), (
+                f"Item JSON found at wrong nested location: {wrong_location}"
+            )
+
+            # Also check the parent directory doesn't exist
+            wrong_dir = Path("data/myitem/DATAFILE")
+            assert not wrong_dir.is_dir(), f"Unexpected nested directory created: {wrong_dir}"

--- a/tests/unit/test_collection_inference.py
+++ b/tests/unit/test_collection_inference.py
@@ -1,0 +1,177 @@
+"""Unit tests for collection ID inference based on format type.
+
+Per ADR-0031:
+- Vector data: parent directory = collection (collection-level asset)
+- Raster data: grandparent directory = collection, parent = item
+
+This ensures raster tiles like 2025/tile1/data.tif become:
+- Collection: 2025
+- Item: tile1
+
+Not (incorrectly):
+- Collection: 2025/tile1
+- Item: data (collection-level)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.dataset import infer_nested_collection_id
+
+
+class TestCollectionInferenceByFormat:
+    """Tests that collection inference respects ADR-0031 format distinctions."""
+
+    @pytest.mark.unit
+    def test_vector_file_uses_parent_as_collection(self, tmp_path: Path) -> None:
+        """Vector files should use parent directory as collection.
+
+        Structure: demographics/boundaries.parquet
+        Expected: collection = "demographics"
+        """
+        catalog_root = tmp_path
+        collection_dir = catalog_root / "demographics"
+        collection_dir.mkdir()
+        vector_file = collection_dir / "boundaries.parquet"
+        vector_file.write_bytes(b"PAR1" + b"\x00" * 100)  # Minimal parquet magic
+
+        result = infer_nested_collection_id(vector_file, catalog_root)
+
+        assert result == "demographics"
+
+    @pytest.mark.unit
+    def test_raster_file_uses_grandparent_as_collection(self, tmp_path: Path) -> None:
+        """Raster files should use grandparent directory as collection.
+
+        Structure: 2025/tile1/data.tif
+        Expected: collection = "2025", item = "tile1"
+        """
+        catalog_root = tmp_path
+        collection_dir = catalog_root / "2025"
+        collection_dir.mkdir()
+        item_dir = collection_dir / "tile1"
+        item_dir.mkdir()
+        raster_file = item_dir / "data.tif"
+        raster_file.write_bytes(b"II*\x00" + b"\x00" * 100)  # Minimal TIFF magic
+
+        result = infer_nested_collection_id(raster_file, catalog_root)
+
+        assert result == "2025"
+
+    @pytest.mark.unit
+    def test_nested_raster_uses_correct_depth(self, tmp_path: Path) -> None:
+        """Nested raster structure should still use grandparent as collection.
+
+        Structure: imagery/2025/tile1/scene.tif
+        Expected: collection = "imagery/2025", item = "tile1"
+        """
+        catalog_root = tmp_path
+        (catalog_root / "imagery" / "2025" / "tile1").mkdir(parents=True)
+        raster_file = catalog_root / "imagery" / "2025" / "tile1" / "scene.tif"
+        raster_file.write_bytes(b"II*\x00" + b"\x00" * 100)
+
+        result = infer_nested_collection_id(raster_file, catalog_root)
+
+        assert result == "imagery/2025"
+
+    @pytest.mark.unit
+    def test_nested_vector_uses_parent(self, tmp_path: Path) -> None:
+        """Nested vector structure should use parent as collection.
+
+        Structure: environment/air-quality/pm25.parquet
+        Expected: collection = "environment/air-quality"
+        """
+        catalog_root = tmp_path
+        (catalog_root / "environment" / "air-quality").mkdir(parents=True)
+        vector_file = catalog_root / "environment" / "air-quality" / "pm25.parquet"
+        vector_file.write_bytes(b"PAR1" + b"\x00" * 100)
+
+        result = infer_nested_collection_id(vector_file, catalog_root)
+
+        assert result == "environment/air-quality"
+
+    @pytest.mark.unit
+    def test_geojson_uses_parent_as_collection(self, tmp_path: Path) -> None:
+        """GeoJSON (vector) should use parent as collection.
+
+        Structure: boundaries/regions.geojson
+        Expected: collection = "boundaries"
+        """
+        catalog_root = tmp_path
+        collection_dir = catalog_root / "boundaries"
+        collection_dir.mkdir()
+        geojson_file = collection_dir / "regions.geojson"
+        geojson_file.write_text('{"type": "FeatureCollection", "features": []}')
+
+        result = infer_nested_collection_id(geojson_file, catalog_root)
+
+        assert result == "boundaries"
+
+    @pytest.mark.unit
+    def test_cog_uses_grandparent_as_collection(self, tmp_path: Path) -> None:
+        """COG (raster) should use grandparent as collection.
+
+        Structure: satellite/scene-001/B04.tif
+        Expected: collection = "satellite", item = "scene-001"
+        """
+        catalog_root = tmp_path
+        (catalog_root / "satellite" / "scene-001").mkdir(parents=True)
+        cog_file = catalog_root / "satellite" / "scene-001" / "B04.tif"
+        cog_file.write_bytes(b"II*\x00" + b"\x00" * 100)
+
+        result = infer_nested_collection_id(cog_file, catalog_root)
+
+        assert result == "satellite"
+
+    @pytest.mark.unit
+    def test_raster_at_shallow_depth_raises_error(self, tmp_path: Path) -> None:
+        """Raster file directly in collection (no item subdir) should raise.
+
+        Structure: imagery/data.tif (no item subdirectory)
+        Expected: ValueError (rasters need item subdirectory)
+        """
+        catalog_root = tmp_path
+        collection_dir = catalog_root / "imagery"
+        collection_dir.mkdir()
+        raster_file = collection_dir / "data.tif"
+        raster_file.write_bytes(b"II*\x00" + b"\x00" * 100)
+
+        with pytest.raises(ValueError, match="must be in a subdirectory"):
+            infer_nested_collection_id(raster_file, catalog_root)
+
+    @pytest.mark.unit
+    def test_shapefile_uses_parent_as_collection(self, tmp_path: Path) -> None:
+        """Shapefile (vector) should use parent as collection.
+
+        Structure: parcels/boundaries.shp
+        Expected: collection = "parcels"
+        """
+        catalog_root = tmp_path
+        collection_dir = catalog_root / "parcels"
+        collection_dir.mkdir()
+        shp_file = collection_dir / "boundaries.shp"
+        shp_file.write_bytes(b"\x00" * 100)  # Minimal content
+
+        result = infer_nested_collection_id(shp_file, catalog_root)
+
+        assert result == "parcels"
+
+    @pytest.mark.unit
+    def test_geopackage_uses_parent_as_collection(self, tmp_path: Path) -> None:
+        """GeoPackage (vector) should use parent as collection.
+
+        Structure: transportation/roads.gpkg
+        Expected: collection = "transportation"
+        """
+        catalog_root = tmp_path
+        collection_dir = catalog_root / "transportation"
+        collection_dir.mkdir()
+        gpkg_file = collection_dir / "roads.gpkg"
+        gpkg_file.write_bytes(b"SQLite format 3\x00" + b"\x00" * 100)
+
+        result = infer_nested_collection_id(gpkg_file, catalog_root)
+
+        assert result == "transportation"

--- a/tests/unit/test_list_metadata_exclusion.py
+++ b/tests/unit/test_list_metadata_exclusion.py
@@ -1,0 +1,264 @@
+"""Unit tests for metadata file exclusion in catalog list.
+
+Tests that internal metadata files (versions.json, collection.json, etc.)
+are excluded from the list output, and that .json files use content
+inspection to distinguish GeoJSON from plain JSON.
+
+Related issues:
+- versions.json incorrectly shown as "GeoJSON" in list output
+- PR #261: GeoJSON content detection in .json files
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.catalog_list import (
+    _STAC_METADATA_FILES,
+    _get_format_display_name,
+    _is_ignored,
+)
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+class TestMetadataFileExclusion:
+    """Tests that internal metadata files are excluded from list output."""
+
+    @pytest.mark.unit
+    def test_versions_json_in_stac_metadata_files(self) -> None:
+        """versions.json should be in _STAC_METADATA_FILES constant.
+
+        versions.json is internal Portolan metadata and should not appear
+        in the list output alongside user data files.
+        """
+        assert "versions.json" in _STAC_METADATA_FILES
+
+    @pytest.mark.unit
+    def test_is_ignored_excludes_versions_json(self) -> None:
+        """_is_ignored should return True for versions.json."""
+        # versions.json at collection level should be ignored
+        assert _is_ignored("versions.json", "any-item-id", []) is True
+
+    @pytest.mark.unit
+    def test_is_ignored_excludes_item_id_json(self) -> None:
+        """_is_ignored should return True for {item_id}.json files.
+
+        STAC item JSON files are often named after the item ID (e.g., regions.json
+        for item "regions"). These are STAC metadata, not user data files.
+        """
+        # Item JSON named after the item should be ignored
+        assert _is_ignored("regions.json", "regions", []) is True
+        assert _is_ignored("scene-001.json", "scene-001", []) is True
+
+        # But other JSON files should NOT be ignored
+        assert _is_ignored("config.json", "regions", []) is False
+        assert _is_ignored("data.json", "scene-001", []) is False
+
+    @pytest.mark.unit
+    def test_stac_item_json_not_detected_as_geojson(self, tmp_path: Path) -> None:
+        """STAC item JSON should NOT be detected as GeoJSON.
+
+        STAC items have "type": "Feature" like GeoJSON, but they also have
+        "stac_version" which distinguishes them. They are JSON, not GeoJSON.
+        """
+        from portolan_cli.formats import FormatType, _detect_json_type
+
+        # Create a STAC item JSON file
+        stac_item = tmp_path / "item.json"
+        stac_item.write_text(
+            json.dumps(
+                {
+                    "type": "Feature",
+                    "stac_version": "1.0.0",
+                    "id": "test-item",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "bbox": [0, 0, 0, 0],
+                    "properties": {"datetime": "2024-01-01T00:00:00Z"},
+                    "links": [],
+                    "assets": {},
+                }
+            )
+        )
+
+        # Should NOT be detected as GeoJSON (VECTOR)
+        assert _detect_json_type(stac_item) == FormatType.UNKNOWN
+
+        # But actual GeoJSON should still be detected
+        geojson = tmp_path / "points.json"
+        geojson.write_text(
+            json.dumps(
+                {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "geometry": {"type": "Point", "coordinates": [0, 0]},
+                            "properties": {},
+                        }
+                    ],
+                }
+            )
+        )
+        assert _detect_json_type(geojson) == FormatType.VECTOR
+
+    @pytest.mark.unit
+    def test_list_excludes_versions_json(self, runner: CliRunner) -> None:
+        """portolan list should not show versions.json in output.
+
+        versions.json is internal metadata for tracking file versions.
+        It should never appear in the list output.
+        """
+        with runner.isolated_filesystem():
+            # Create catalog structure
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Create collection with versions.json and a data file
+            Path("collection").mkdir()
+            Path("collection/item").mkdir()
+            Path("collection/item/data.parquet").write_bytes(b"x" * 1000)
+            Path("collection/versions.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": "1.0.0",
+                        "versions": [],
+                    }
+                )
+            )
+
+            result = runner.invoke(cli, ["list"])
+
+            assert result.exit_code == 0
+            # data.parquet should appear
+            assert "data.parquet" in result.output
+            # versions.json should NOT appear
+            assert "versions.json" not in result.output
+
+
+class TestJsonFormatDetection:
+    """Tests that .json files use content inspection for format display."""
+
+    @pytest.mark.unit
+    def test_plain_json_not_labeled_geojson(self) -> None:
+        """Plain .json files should be labeled 'JSON', not 'GeoJSON'.
+
+        Only files with actual GeoJSON content should be labeled 'GeoJSON'.
+        """
+        # A plain config.json should NOT be labeled GeoJSON
+        display_name = _get_format_display_name("config.json")
+        # Currently this fails because .json maps to "GeoJSON"
+        assert display_name == "JSON", f"Expected 'JSON' but got '{display_name}'"
+
+    @pytest.mark.unit
+    def test_geojson_extension_labeled_geojson(self) -> None:
+        """Files with .geojson extension should be labeled 'GeoJSON'."""
+        display_name = _get_format_display_name("data.geojson")
+        assert display_name == "GeoJSON"
+
+    @pytest.mark.unit
+    def test_list_shows_plain_json_as_json(self, runner: CliRunner) -> None:
+        """portolan list should show plain .json files as 'JSON', not 'GeoJSON'.
+
+        Content inspection should be used to determine if a .json file
+        is actually GeoJSON or just plain JSON.
+        """
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Create collection with a plain JSON config file
+            Path("collection").mkdir()
+            Path("collection/item").mkdir()
+            Path("collection/item/data.parquet").write_bytes(b"x" * 1000)
+            # This is plain JSON, NOT GeoJSON
+            Path("collection/item/config.json").write_text(
+                json.dumps({"setting": "value", "enabled": True})
+            )
+
+            result = runner.invoke(cli, ["list"])
+
+            assert result.exit_code == 0
+            # If config.json appears, it should be labeled JSON, not GeoJSON
+            if "config.json" in result.output:
+                # The format should be JSON, not GeoJSON
+                assert "(JSON," in result.output or "JSON)" in result.output
+                assert (
+                    "(GeoJSON," not in result.output
+                    or "config.json" not in result.output.split("GeoJSON")[0]
+                )
+
+    @pytest.mark.unit
+    def test_list_shows_geojson_content_as_geojson(self, runner: CliRunner) -> None:
+        """portolan list should show .json files with GeoJSON content as 'GeoJSON'."""
+        with runner.isolated_filesystem():
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "stac_version": "1.0.0",
+                        "id": "test",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+
+            # Create collection with a GeoJSON file saved as .json
+            Path("collection").mkdir()
+            Path("collection/item").mkdir()
+            # This IS GeoJSON content
+            Path("collection/item/points.json").write_text(
+                json.dumps(
+                    {
+                        "type": "FeatureCollection",
+                        "features": [
+                            {
+                                "type": "Feature",
+                                "geometry": {"type": "Point", "coordinates": [0, 0]},
+                                "properties": {},
+                            }
+                        ],
+                    }
+                )
+            )
+
+            result = runner.invoke(cli, ["list"])
+
+            assert result.exit_code == 0
+            # points.json should be labeled as GeoJSON because it has GeoJSON content
+            if "points.json" in result.output:
+                assert "GeoJSON" in result.output


### PR DESCRIPTION
## Summary
- Raster files now correctly use grandparent as collection (`collection/item/data.tif` → collection = `collection`)
- Vector files use parent as collection (`collection/data.parquet` → collection = `collection`)
- `.json` files now display as "JSON" by default; content inspection detects actual GeoJSON
- STAC items (with `stac_version`) excluded from GeoJSON detection — they're metadata, not data
- Excludes `{item_id}.json` from list output (STAC metadata, not user data)

## Test plan
- [x] Unit tests for format-aware collection inference (9 tests in `test_collection_inference.py`)
- [x] Unit tests for JSON/GeoJSON content detection (`test_list_metadata_exclusion.py`)
- [x] Unit + integration tests for no-duplicate-nesting (`test_add_no_duplicate_nesting.py`)
- [x] All 2687 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)