### PR TITLE
feat(stac): implement STAC extension foundation (Wave 1)

### DIFF
--- a/portolan_cli/crs.py
+++ b/portolan_cli/crs.py
@@ -2,21 +2,45 @@
 
 Provides functions for transforming coordinates between coordinate reference systems,
 with a focus on STAC's requirement for WGS84 (EPSG:4326) bounding boxes.
+
+Handles antimeridian crossings per RFC 7946: when a bbox spans the antimeridian,
+the western bound (minx) will be greater than the eastern bound (maxx).
 """
 
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
+import antimeridian
 from pyproj import CRS, Transformer
+from pyproj.exceptions import CRSError
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# WGS84 CRS (cached for reuse)
+WGS84 = CRS.from_epsg(4326)
+
+# Number of points to sample along each edge for accurate transformation
+# Higher values = more accurate for curved projections, but slower
+EDGE_SAMPLE_POINTS = 10
 
 
 def transform_bbox_to_wgs84(
     bbox: tuple[float, float, float, float],
     source_crs: str | None,
 ) -> tuple[float, float, float, float]:
-    """Transform bbox from source CRS to WGS84.
+    """Transform bbox from source CRS to WGS84 with antimeridian handling.
 
     STAC requires Item bbox and geometry to be in WGS84 (EPSG:4326) per RFC 7946.
-    This function transforms a bbox from any source CRS to WGS84.
+    This function transforms a bbox from any source CRS to WGS84, properly handling
+    antimeridian crossings.
+
+    For antimeridian-crossing bboxes, returns (west, south, east, north) where
+    west > east per RFC 7946 Section 5.2.
 
     Args:
         bbox: Bounding box as (minx, miny, maxx, maxy) in source CRS.
@@ -24,37 +48,130 @@ def transform_bbox_to_wgs84(
                    If None, returns bbox unchanged (assumed WGS84).
 
     Returns:
-        Bounding box as (minx, miny, maxx, maxy) in WGS84.
+        Bounding box as (west, south, east, north) in WGS84.
+        For antimeridian-crossing bboxes, west > east.
+
+    Raises:
+        No exceptions raised - returns original bbox with warning on CRS errors.
     """
     if source_crs is None:
         return bbox
 
-    # Parse source CRS
+    # Parse source CRS with specific exception handling
     try:
         src_crs = CRS.from_user_input(source_crs)
-    except Exception:
-        # If we can't parse the CRS, return unchanged
+    except CRSError as e:
+        logger.warning("Could not parse CRS '%s': %s. Returning bbox unchanged.", source_crs, e)
+        return bbox
+    except TypeError as e:
+        # CRS.from_user_input can raise TypeError for invalid input types
+        logger.warning("Invalid CRS type '%s': %s. Returning bbox unchanged.", type(source_crs), e)
         return bbox
 
     # Check if already WGS84
-    epsg = src_crs.to_epsg()
+    if _is_wgs84(src_crs):
+        return bbox
+
+    # Transform bbox to WGS84 polygon and compute RFC 7946 compliant bbox
+    try:
+        return _transform_and_compute_bbox(bbox, src_crs)
+    except Exception as e:
+        # Catch transformation errors (e.g., coordinates outside projection bounds)
+        logger.warning(
+            "CRS transformation failed for bbox %s from %s: %s. Returning bbox unchanged.",
+            bbox,
+            source_crs,
+            e,
+        )
+        return bbox
+
+
+def _is_wgs84(crs: CRS) -> bool:
+    """Check if a CRS is WGS84 (EPSG:4326)."""
+    epsg = crs.to_epsg()
     if epsg == 4326:
-        return bbox
+        return True
+    # Also check by comparing CRS objects (handles WKT inputs)
+    return crs.equals(WGS84)
 
-    # Also check by comparing to WGS84 CRS object for WKT inputs
-    wgs84 = CRS.from_epsg(4326)
-    if src_crs.equals(wgs84):
-        return bbox
 
-    # Create transformer
-    transformer = Transformer.from_crs(src_crs, wgs84, always_xy=True)
+def _transform_and_compute_bbox(
+    bbox: tuple[float, float, float, float],
+    src_crs: CRS,
+) -> tuple[float, float, float, float]:
+    """Transform bbox and compute RFC 7946 compliant WGS84 bbox.
 
-    # Transform all four corners to handle projection distortion
+    Samples points along bbox edges for accuracy with curved projections,
+    then uses the antimeridian library to compute a proper bbox that handles
+    antimeridian crossings.
+    """
     minx, miny, maxx, maxy = bbox
-    corners_x = [minx, maxx, minx, maxx]
-    corners_y = [miny, miny, maxy, maxy]
 
-    xs, ys = transformer.transform(corners_x, corners_y)
+    # Create transformer (always_xy ensures lon/lat order)
+    transformer = Transformer.from_crs(src_crs, WGS84, always_xy=True)
 
-    # Compute new bbox from transformed corners
-    return (min(xs), min(ys), max(xs), max(ys))
+    # Sample points along all four edges for accuracy with curved projections
+    edge_points = _sample_bbox_edges(minx, miny, maxx, maxy, EDGE_SAMPLE_POINTS)
+
+    # Transform all points to WGS84
+    src_x = [p[0] for p in edge_points]
+    src_y = [p[1] for p in edge_points]
+    wgs84_x, wgs84_y = transformer.transform(src_x, src_y)
+
+    # Build a polygon from the transformed points (closed ring)
+    ring = list(zip(wgs84_x, wgs84_y, strict=True))
+    ring.append(ring[0])  # Close the ring
+
+    geojson_polygon: dict[str, object] = {
+        "type": "Polygon",
+        "coordinates": [ring],
+    }
+
+    # Fix antimeridian crossings if present
+    fixed_geojson = antimeridian.fix_geojson(geojson_polygon)
+
+    # Compute RFC 7946 compliant bbox (handles antimeridian crossing)
+    bbox_list = antimeridian.bbox(fixed_geojson)
+
+    return (bbox_list[0], bbox_list[1], bbox_list[2], bbox_list[3])
+
+
+def _sample_bbox_edges(
+    minx: float,
+    miny: float,
+    maxx: float,
+    maxy: float,
+    n_points: int,
+) -> list[tuple[float, float]]:
+    """Sample points along bbox edges for accurate transformation.
+
+    Returns points in order: bottom edge → right edge → top edge → left edge.
+    This forms a closed ring when the first point is appended at the end.
+    """
+    points: list[tuple[float, float]] = []
+
+    # Bottom edge (left to right)
+    for i in range(n_points):
+        t = i / n_points
+        x = minx + t * (maxx - minx)
+        points.append((x, miny))
+
+    # Right edge (bottom to top)
+    for i in range(n_points):
+        t = i / n_points
+        y = miny + t * (maxy - miny)
+        points.append((maxx, y))
+
+    # Top edge (right to left)
+    for i in range(n_points):
+        t = i / n_points
+        x = maxx - t * (maxx - minx)
+        points.append((x, maxy))
+
+    # Left edge (top to bottom)
+    for i in range(n_points):
+        t = i / n_points
+        y = maxy - t * (maxy - miny)
+        points.append((minx, y))
+
+    return points

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -36,6 +36,7 @@ from portolan_cli.constants import (
     SIDECAR_PATTERNS,
     TABULAR_EXTENSIONS,
 )
+from portolan_cli.crs import transform_bbox_to_wgs84
 from portolan_cli.errors import NoGeometryError
 from portolan_cli.formats import FormatType, detect_format, is_cloud_optimized_geotiff
 from portolan_cli.metadata import (
@@ -47,6 +48,8 @@ from portolan_cli.metadata.geoparquet import GeoParquetMetadata
 from portolan_cli.scan_detect import is_filegdb
 from portolan_cli.stac import (
     add_item_to_collection,
+    add_projection_extension,
+    add_table_extension,
     create_collection,
     create_item,
     load_catalog,
@@ -649,7 +652,7 @@ def add_dataset(
         output_path = convert_raster(path, item_dir)
         metadata = extract_cog_metadata(output_path)
 
-    # Step 4: Extract bbox (handle tuple -> list conversion)
+    # Step 4: Extract bbox and transform to WGS84 (STAC requirement per RFC 7946)
     if not metadata.bbox:
         # Clean up orphaned artifact before raising (Issue #190 review)
         _cleanup_orphaned_output(output_path, item_dir, path)
@@ -657,7 +660,10 @@ def add_dataset(
             path=metadata.id if hasattr(metadata, "id") else path.stem,
             reason="The source file may have no valid geometry.",
         )
-    bbox = list(metadata.bbox)
+    # Transform bbox from native CRS to WGS84 (handles antimeridian crossing)
+    crs_str = metadata.crs if isinstance(metadata.crs, str) else None
+    wgs84_bbox = transform_bbox_to_wgs84(metadata.bbox, crs_str)
+    bbox = list(wgs84_bbox)
 
     # Step 5: Scan ALL files in item_dir for assets (per issue #133)
     stac_assets, asset_files, asset_paths = _scan_item_assets(
@@ -681,6 +687,9 @@ def add_dataset(
         assets=stac_assets,
     )
 
+    # Add projection extension (native CRS info: proj:code, proj:bbox, proj:shape, proj:transform)
+    add_projection_extension(item, metadata)
+
     # Set item href explicitly to prevent PySTAC from creating a nested subdirectory.
     # By default, PySTAC's normalize_hrefs() + save() creates {item_id}/{item_id}.json
     # but we want the item JSON in the existing item_dir (same as data files).
@@ -695,6 +704,10 @@ def add_dataset(
 
     # Add item to collection (PySTAC may add duplicate links if called multiple times)
     add_item_to_collection(collection, item, update_extent=True)
+
+    # Add table extension for vector data (row count, columns, primary geometry)
+    if format_type == FormatType.VECTOR:
+        add_table_extension(collection, metadata)
 
     # Step 8: De-duplicate item links before saving
     _deduplicate_collection_item_links(collection)

--- a/portolan_cli/metadata/cog.py
+++ b/portolan_cli/metadata/cog.py
@@ -29,6 +29,8 @@ class COGMetadata:
         nodata: Legacy single nodata value (first band). Use nodatavals for per-band.
         resolution: Pixel resolution as (x_res, y_res).
         nodatavals: Per-band nodata values as tuple. If None, falls back to nodata.
+        transform: Affine transform as 6 coefficients (a, b, c, d, e, f).
+                  Maps pixel coordinates to CRS coordinates.
     """
 
     bbox: tuple[float, float, float, float]
@@ -40,6 +42,7 @@ class COGMetadata:
     nodata: float | None
     resolution: tuple[float, float]
     nodatavals: tuple[float | None, ...] | None = None
+    transform: tuple[float, float, float, float, float, float] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dict."""
@@ -57,6 +60,8 @@ class COGMetadata:
             # Convert tuple to list, preserving None values
             nodatavals_list: list[float | None] = list(self.nodatavals)
             result["nodatavals"] = nodatavals_list
+        if self.transform is not None:
+            result["transform"] = list(self.transform)
         return result
 
     def to_stac_properties(self) -> dict[str, Any]:
@@ -125,6 +130,18 @@ def extract_cog_metadata(path: Path) -> COGMetadata:
         # src.nodatavals returns a tuple with one value per band
         nodatavals = src.nodatavals if src.nodatavals else None
 
+        # Extract affine transform as GDAL GeoTransform format
+        # GDAL format: (origin_x, pixel_width, rotation_x, origin_y, rotation_y, pixel_height)
+        gdal_transform = src.transform.to_gdal()
+        transform = (
+            gdal_transform[0],
+            gdal_transform[1],
+            gdal_transform[2],
+            gdal_transform[3],
+            gdal_transform[4],
+            gdal_transform[5],
+        )
+
         return COGMetadata(
             bbox=bbox,
             crs=crs,
@@ -135,6 +152,7 @@ def extract_cog_metadata(path: Path) -> COGMetadata:
             nodata=src.nodata,  # Keep for backward compatibility
             resolution=resolution,
             nodatavals=nodatavals,
+            transform=transform,
         )
 
 
@@ -194,16 +212,25 @@ def extract_schema_from_cog(
         else:
             warnings.append("Raster has no CRS defined. Consider adding CRS metadata.")
 
+        # Get per-band nodata values (fallback to uniform nodata if not available)
+        nodatavals = src.nodatavals if src.nodatavals else None
+
         # Build BandSchema for each band
         bands: list[BandSchema] = []
         for i in range(1, src.count + 1):
             # Get band description if available
             description = src.descriptions[i - 1] if src.descriptions else None
 
+            # Use per-band nodata if available, otherwise fall back to uniform nodata
+            if nodatavals is not None and len(nodatavals) >= i:
+                band_nodata = nodatavals[i - 1]
+            else:
+                band_nodata = src.nodata
+
             band = BandSchema(
                 name=f"band_{i}",
                 data_type=str(src.dtypes[i - 1]),
-                nodata=src.nodata,
+                nodata=band_nodata,
                 description=description,
             )
             bands.append(band)

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -242,11 +242,13 @@ def _update_collection_extent(
 
 
 # STAC Extension schema URLs (v1.1.0 compatible)
+# Note: "file" extension is reserved for future use (checksums, sizes)
+# Currently only table, projection, and raster are actively used
 EXTENSION_URLS = {
     "table": "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "projection": "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
     "raster": "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "file": "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+    "file": "https://stac-extensions.github.io/file/v2.1.0/schema.json",  # Reserved for future
 }
 
 
@@ -324,12 +326,18 @@ def add_projection_extension(
 ) -> None:
     """Add Projection extension fields to an item from metadata.
 
-    Sets proj:code and proj:bbox based on the provided metadata object.
-    proj:bbox stores the native CRS bbox (before WGS84 transformation).
+    Always sets (when available):
+    - proj:code: CRS code (EPSG or WKT)
+    - proj:bbox: Bounding box in native CRS
+
+    For raster metadata (COGMetadata), also sets:
+    - proj:shape: [height, width] in pixels
+    - proj:transform: GDAL GeoTransform array
 
     Args:
         item: The item to add extension fields to.
         metadata: A metadata object with crs and bbox attributes.
+                 For rasters, should also have width, height, and transform.
     """
     if not hasattr(metadata, "crs") or metadata.crs is None:
         return
@@ -341,12 +349,35 @@ def add_projection_extension(
         if crs_str.upper().startswith("EPSG:"):
             item.properties["proj:code"] = crs_str.upper()
         else:
-            # WKT or other format - could extract EPSG if possible
+            # WKT or other format - store as-is
             item.properties["proj:code"] = crs_str
+    elif isinstance(crs_str, dict):
+        # PROJJSON format (used by some GeoParquet files)
+        # Try to extract EPSG code if available
+        if "id" in crs_str and "code" in crs_str["id"]:
+            authority = crs_str["id"].get("authority", "EPSG")
+            code = crs_str["id"]["code"]
+            item.properties["proj:code"] = f"{authority}:{code}"
+        else:
+            # Store as WKT2 if we can't extract EPSG
+            item.properties["proj:code"] = str(crs_str)
 
     # Set proj:bbox (native CRS bbox)
     if hasattr(metadata, "bbox") and metadata.bbox is not None:
         item.properties["proj:bbox"] = list(metadata.bbox)
+
+    # Set raster-specific fields if available (COGMetadata)
+    # proj:shape is [height, width] per the extension spec
+    # Check for actual int values, not just attribute existence (MagicMock creates attributes dynamically)
+    height = getattr(metadata, "height", None)
+    width = getattr(metadata, "width", None)
+    if isinstance(height, int) and isinstance(width, int):
+        item.properties["proj:shape"] = [height, width]
+
+    # proj:transform is GDAL GeoTransform array
+    transform = getattr(metadata, "transform", None)
+    if transform is not None and isinstance(transform, (list, tuple)):
+        item.properties["proj:transform"] = list(transform)
 
     # Update stac_extensions if not already present
     ext_url = EXTENSION_URLS["projection"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
+    "antimeridian>=0.3.11",  # RFC 7946 compliant antimeridian handling for STAC bbox
     "click>=8.3.1",
     "geoparquet-io>=0.3.0",
     "obstore>=0.8.2",  # Cloud object storage (S3, GCS, Azure) via Rust bindings

--- a/tests/integration/test_stac_extensions_integration.py
+++ b/tests/integration/test_stac_extensions_integration.py
@@ -1,0 +1,355 @@
+"""Integration tests for STAC extension support.
+
+Tests the full workflow integration of STAC extensions:
+- Table extension added to collections for vector data
+- Projection extension added to items (including proj:shape/transform for rasters)
+- Bbox transformation to WGS84 with antimeridian handling
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.crs import transform_bbox_to_wgs84
+from portolan_cli.metadata.cog import extract_cog_metadata
+from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
+from portolan_cli.stac import (
+    EXTENSION_URLS,
+    add_projection_extension,
+    add_table_extension,
+    create_collection,
+    create_item,
+)
+
+
+class TestGeoParquetTableExtension:
+    """Integration tests for Table extension with real GeoParquet files."""
+
+    @pytest.mark.integration
+    def test_table_extension_from_open_buildings(self, open_buildings_path: Path) -> None:
+        """Table extension extracts correct metadata from Open Buildings GeoParquet."""
+        metadata = extract_geoparquet_metadata(open_buildings_path)
+        collection = create_collection(
+            collection_id="open-buildings",
+            description="Open Buildings test",
+        )
+
+        add_table_extension(collection, metadata)
+
+        # Verify table extension fields
+        assert collection.extra_fields.get("table:row_count") == 1000
+        assert collection.extra_fields.get("table:primary_geometry") == metadata.geometry_column
+        assert "table:columns" in collection.extra_fields
+
+        # Verify extension URL is added
+        assert EXTENSION_URLS["table"] in (collection.stac_extensions or [])
+
+    @pytest.mark.integration
+    def test_table_extension_columns_match_schema(self, nwi_wetlands_path: Path) -> None:
+        """Table extension columns match GeoParquet schema."""
+        metadata = extract_geoparquet_metadata(nwi_wetlands_path)
+        collection = create_collection(
+            collection_id="nwi-wetlands",
+            description="NWI Wetlands test",
+        )
+
+        add_table_extension(collection, metadata)
+
+        columns = collection.extra_fields.get("table:columns", [])
+        column_names = {col["name"] for col in columns}
+
+        # Columns should match schema keys
+        assert column_names == set(metadata.schema.keys())
+
+
+class TestProjectionExtensionVector:
+    """Integration tests for Projection extension with vector data."""
+
+    @pytest.mark.integration
+    def test_projection_extension_skips_when_crs_none(self, open_buildings_path: Path) -> None:
+        """Projection extension does nothing when CRS is None."""
+        metadata = extract_geoparquet_metadata(open_buildings_path)
+
+        # Many GeoParquet files have CRS=None (implied WGS84)
+        assert metadata.crs is None
+
+        item = create_item(
+            item_id="open-buildings-item",
+            bbox=list(metadata.bbox),
+        )
+
+        add_projection_extension(item, metadata)
+
+        # No projection extension should be added
+        assert "proj:code" not in item.properties
+
+    @pytest.mark.integration
+    def test_projection_extension_with_utm_data(self, fixtures_dir: Path) -> None:
+        """Projection extension extracts CRS from UTM GeoParquet."""
+        utm_path = fixtures_dir / "vector" / "open-buildings-utm31n.parquet"
+        if not utm_path.exists():
+            pytest.skip("UTM fixture not available")
+
+        metadata = extract_geoparquet_metadata(utm_path)
+        item = create_item(item_id="utm-item", bbox=[0, 0, 1, 1])
+
+        add_projection_extension(item, metadata)
+
+        # Should have EPSG code for UTM Zone 31N
+        assert item.properties.get("proj:code") == "EPSG:32631"
+        assert "proj:bbox" in item.properties
+        assert item.properties["proj:bbox"] == list(metadata.bbox)
+
+        # Vector data should NOT have proj:shape (no width/height)
+        assert "proj:shape" not in item.properties
+
+
+class TestProjectionExtensionRaster:
+    """Integration tests for Projection extension with raster data."""
+
+    @pytest.mark.integration
+    def test_projection_extension_from_cog(self, fixtures_dir: Path) -> None:
+        """Projection extension extracts full metadata from COG."""
+        cog_path = fixtures_dir / "raster" / "valid" / "singleband.tif"
+        metadata = extract_cog_metadata(cog_path)
+
+        item = create_item(
+            item_id="singleband-item",
+            bbox=list(metadata.bbox),
+        )
+
+        add_projection_extension(item, metadata)
+
+        # Verify projection extension fields
+        assert "proj:code" in item.properties
+        assert "proj:bbox" in item.properties
+
+        # Raster-specific fields
+        assert "proj:shape" in item.properties
+        assert item.properties["proj:shape"] == [metadata.height, metadata.width]
+
+        assert "proj:transform" in item.properties
+        assert len(item.properties["proj:transform"]) == 6
+
+    @pytest.mark.integration
+    def test_projection_extension_transform_is_gdal_format(self, fixtures_dir: Path) -> None:
+        """proj:transform is in GDAL GeoTransform format."""
+        cog_path = fixtures_dir / "raster" / "valid" / "singleband.tif"
+        metadata = extract_cog_metadata(cog_path)
+
+        item = create_item(item_id="transform-test", bbox=list(metadata.bbox))
+        add_projection_extension(item, metadata)
+
+        transform = item.properties["proj:transform"]
+
+        # GDAL GeoTransform: [origin_x, pixel_width, rotation_x, origin_y, rotation_y, pixel_height]
+        # For north-up images: rotation_x and rotation_y should be 0
+        assert len(transform) == 6
+        # pixel_width (index 1) should be positive
+        assert transform[1] > 0
+        # pixel_height (index 5) should be negative for north-up
+        assert transform[5] < 0
+
+    @pytest.mark.integration
+    def test_cog_metadata_includes_transform(self, fixtures_dir: Path) -> None:
+        """COGMetadata extraction includes transform attribute."""
+        cog_path = fixtures_dir / "raster" / "valid" / "singleband.tif"
+        metadata = extract_cog_metadata(cog_path)
+
+        assert metadata.transform is not None
+        assert len(metadata.transform) == 6
+
+        # to_dict should include transform
+        d = metadata.to_dict()
+        assert "transform" in d
+        assert d["transform"] == list(metadata.transform)
+
+
+class TestBboxTransformation:
+    """Integration tests for bbox CRS transformation."""
+
+    @pytest.mark.integration
+    def test_utm_bbox_transforms_to_wgs84(self, fixtures_dir: Path) -> None:
+        """UTM bbox transforms correctly to WGS84."""
+        utm_path = fixtures_dir / "vector" / "open-buildings-utm31n.parquet"
+        if not utm_path.exists():
+            pytest.skip("UTM fixture not available")
+
+        metadata = extract_geoparquet_metadata(utm_path)
+
+        # UTM bbox should have coordinates in meters (large values)
+        native_bbox = metadata.bbox
+        assert native_bbox is not None
+
+        # Transform to WGS84
+        crs_str = metadata.crs if isinstance(metadata.crs, str) else None
+        wgs84_bbox = transform_bbox_to_wgs84(native_bbox, crs_str)
+
+        # WGS84 bbox should be in degrees
+        west, south, east, north = wgs84_bbox
+        assert -180 <= west <= 180
+        assert -90 <= south <= 90
+        assert -180 <= east <= 180
+        assert -90 <= north <= 90
+
+    @pytest.mark.integration
+    def test_wgs84_bbox_unchanged(self, open_buildings_path: Path) -> None:
+        """WGS84 bbox passes through unchanged."""
+        metadata = extract_geoparquet_metadata(open_buildings_path)
+
+        # This file should be in WGS84
+        crs_str = metadata.crs if isinstance(metadata.crs, str) else None
+        if crs_str and "4326" in crs_str:
+            wgs84_bbox = transform_bbox_to_wgs84(metadata.bbox, crs_str)
+            assert wgs84_bbox == metadata.bbox
+
+
+class TestAntimeridianHandling:
+    """Integration tests for antimeridian handling."""
+
+    @pytest.mark.integration
+    def test_antimeridian_bbox_valid(self, fieldmaps_boundaries_path: Path) -> None:
+        """Antimeridian-crossing bbox produces valid WGS84 coordinates."""
+        metadata = extract_geoparquet_metadata(fieldmaps_boundaries_path)
+
+        crs_str = metadata.crs if isinstance(metadata.crs, str) else None
+        wgs84_bbox = transform_bbox_to_wgs84(metadata.bbox, crs_str)
+
+        west, south, east, north = wgs84_bbox
+
+        # All coordinates should be valid numbers
+        assert all(isinstance(c, float) for c in wgs84_bbox)
+        assert all(c == c for c in wgs84_bbox)  # Not NaN
+
+        # Latitude should be valid and ordered
+        assert -90 <= south <= 90
+        assert -90 <= north <= 90
+        assert south <= north
+
+        # Longitude should be valid (may have west > east for antimeridian crossing)
+        assert -180 <= west <= 180
+        assert -180 <= east <= 180
+
+    @pytest.mark.integration
+    def test_antimeridian_geojson_fixture(self, fixtures_dir: Path) -> None:
+        """Test antimeridian handling with dedicated fixture."""
+        antimeridian_path = fixtures_dir / "edge" / "antimeridian.geojson"
+        if not antimeridian_path.exists():
+            pytest.skip("Antimeridian fixture not available")
+
+        # Read the GeoJSON to get the bbox
+        with open(antimeridian_path) as f:
+            geojson = json.load(f)
+
+        if "bbox" in geojson:
+            bbox = tuple(geojson["bbox"])
+            # Antimeridian-crossing bbox should be handled gracefully
+            result = transform_bbox_to_wgs84(bbox, "EPSG:4326")
+
+            # Result should be valid
+            assert len(result) == 4
+            assert all(isinstance(c, float) for c in result)
+
+
+class TestEndToEndWorkflow:
+    """End-to-end integration tests for the full STAC extension workflow."""
+
+    @pytest.mark.integration
+    def test_vector_workflow_adds_table_extension(self, open_buildings_path: Path) -> None:
+        """Vector workflow adds table extension (projection only if CRS present)."""
+        # Extract metadata (simulating dataset.py workflow)
+        metadata = extract_geoparquet_metadata(open_buildings_path)
+
+        # Transform bbox
+        crs_str = metadata.crs if isinstance(metadata.crs, str) else None
+        wgs84_bbox = transform_bbox_to_wgs84(metadata.bbox, crs_str)
+
+        # Create STAC structures
+        collection = create_collection(
+            collection_id="test-collection",
+            description="Test",
+        )
+        item = create_item(
+            item_id="test-item",
+            bbox=list(wgs84_bbox),
+            properties=metadata.to_stac_properties(),
+        )
+
+        # Add extensions
+        add_projection_extension(item, metadata)
+        add_table_extension(collection, metadata)
+
+        # Table extension should always be added for vector data
+        assert "table:row_count" in collection.extra_fields
+        assert "table:columns" in collection.extra_fields
+
+        # Projection extension only added if CRS is present
+        # (Open Buildings has CRS=None, so no projection extension)
+        if metadata.crs is None:
+            assert "proj:code" not in item.properties
+        else:
+            assert "proj:code" in item.properties
+
+    @pytest.mark.integration
+    def test_vector_workflow_with_crs_adds_all_extensions(self, fixtures_dir: Path) -> None:
+        """Vector workflow with CRS adds both table and projection extensions."""
+        utm_path = fixtures_dir / "vector" / "open-buildings-utm31n.parquet"
+        if not utm_path.exists():
+            pytest.skip("UTM fixture not available")
+
+        metadata = extract_geoparquet_metadata(utm_path)
+
+        # Transform bbox from UTM to WGS84
+        crs_str = metadata.crs if isinstance(metadata.crs, str) else None
+        wgs84_bbox = transform_bbox_to_wgs84(metadata.bbox, crs_str)
+
+        # Create STAC structures
+        collection = create_collection(
+            collection_id="utm-collection",
+            description="Test UTM",
+        )
+        item = create_item(
+            item_id="utm-item",
+            bbox=list(wgs84_bbox),
+            properties=metadata.to_stac_properties(),
+        )
+
+        # Add extensions
+        add_projection_extension(item, metadata)
+        add_table_extension(collection, metadata)
+
+        # Both extensions should be present
+        assert "proj:code" in item.properties
+        assert item.properties["proj:code"] == "EPSG:32631"
+        assert "table:row_count" in collection.extra_fields
+        assert "table:columns" in collection.extra_fields
+
+    @pytest.mark.integration
+    def test_raster_workflow_adds_projection_extension(self, fixtures_dir: Path) -> None:
+        """Full raster workflow adds projection extension with shape/transform."""
+        cog_path = fixtures_dir / "raster" / "valid" / "singleband.tif"
+        metadata = extract_cog_metadata(cog_path)
+
+        # Transform bbox
+        wgs84_bbox = transform_bbox_to_wgs84(metadata.bbox, metadata.crs)
+
+        # Create STAC item with raster properties
+        item = create_item(
+            item_id="raster-item",
+            bbox=list(wgs84_bbox),
+            properties=metadata.to_stac_properties(),
+        )
+
+        # Add projection extension
+        add_projection_extension(item, metadata)
+
+        # Verify raster-specific fields
+        assert "proj:shape" in item.properties
+        assert "proj:transform" in item.properties
+        assert "raster:bands" in item.properties
+
+        # Verify extension URLs
+        assert EXTENSION_URLS["projection"] in (item.stac_extensions or [])

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -126,6 +126,8 @@ class TestAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {"geoparquet:feature_count": 1},
             )
             mock_checksum.return_value = "abc123"
@@ -240,6 +242,8 @@ class TestAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "xyz789"
@@ -294,6 +298,8 @@ class TestAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "new123"
@@ -717,6 +723,8 @@ class TestAddDatasetMissingBbox:
                 crs="EPSG:4326",
                 feature_count=0,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "xyz789"
@@ -787,6 +795,8 @@ class TestAddDatasetItemIdDerivation:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {"geoparquet:feature_count": 1},
             )
             mock_checksum.return_value = "abc123"
@@ -849,6 +859,8 @@ class TestAddDatasetItemIdDerivation:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {"geoparquet:feature_count": 1},
             )
             mock_checksum.return_value = "abc123"
@@ -1286,6 +1298,8 @@ class TestMultiAssetAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {"geoparquet:feature_count": 1},
             )
             mock_checksum.return_value = "abc123"
@@ -1331,6 +1345,8 @@ class TestMultiAssetAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "xyz789"
@@ -1379,6 +1395,8 @@ class TestMultiAssetAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "xyz789"
@@ -1424,6 +1442,8 @@ class TestMultiAssetAddDataset:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "xyz789"

--- a/tests/unit/test_dataset_directory.py
+++ b/tests/unit/test_dataset_directory.py
@@ -167,6 +167,8 @@ class TestAddDirectory:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "abc"
@@ -237,6 +239,8 @@ class TestAddDirectory:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_meta_r.return_value = MagicMock(
@@ -313,6 +317,8 @@ class TestAddDirectory:
                 crs="EPSG:4326",
                 feature_count=1,
                 geometry_type="Point",
+                geometry_column="geometry",  # Required for table extension
+                schema={"id": "int64", "geometry": "binary"},  # Required for table extension
                 to_stac_properties=lambda: {},
             )
             mock_checksum.return_value = "abc"

--- a/tests/unit/test_stac_extensions.py
+++ b/tests/unit/test_stac_extensions.py
@@ -4,17 +4,19 @@ Tests the STAC extension support including:
 - STAC version 1.1.0
 - stac_extensions array population
 - Table extension for GeoParquet
-- Projection extension fields
-- Bbox WGS84 transformation
+- Projection extension fields (including raster-specific: proj:shape, proj:transform)
+- Bbox WGS84 transformation with antimeridian handling
 - Per-band nodata for COGs
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import pytest
+
+from portolan_cli.metadata.cog import COGMetadata
+from portolan_cli.metadata.geoparquet import GeoParquetMetadata
 
 
 class TestStacVersion:
@@ -107,11 +109,17 @@ class TestTableExtension:
             collection_id="test-table",
             description="Test table extension",
         )
-        metadata = _make_geoparquet_metadata(feature_count=1234)
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=1234,
+            schema={"id": "int64", "geometry": "binary"},
+        )
 
         add_table_extension(collection, metadata)
 
-        # Table extension fields are in extra_fields for collections
         assert collection.extra_fields.get("table:row_count") == 1234
 
     @pytest.mark.unit
@@ -123,7 +131,14 @@ class TestTableExtension:
             collection_id="test-geom",
             description="Test geometry column",
         )
-        metadata = _make_geoparquet_metadata(geometry_column="geom")
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Point",
+            geometry_column="geom",
+            feature_count=100,
+            schema={"id": "int64", "geom": "binary"},
+        )
 
         add_table_extension(collection, metadata)
 
@@ -138,8 +153,13 @@ class TestTableExtension:
             collection_id="test-columns",
             description="Test columns",
         )
-        metadata = _make_geoparquet_metadata(
-            schema={"id": "int64", "name": "string", "geom": "binary"}
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=100,
+            schema={"id": "int64", "name": "string", "geom": "binary"},
         )
 
         add_table_extension(collection, metadata)
@@ -148,6 +168,28 @@ class TestTableExtension:
         assert len(columns) == 3
         column_names = {col["name"] for col in columns}
         assert column_names == {"id", "name", "geom"}
+
+    @pytest.mark.unit
+    def test_add_table_extension_adds_stac_extensions_url(self) -> None:
+        """add_table_extension adds table extension URL to stac_extensions."""
+        from portolan_cli.stac import EXTENSION_URLS, add_table_extension, create_collection
+
+        collection = create_collection(
+            collection_id="test-ext-url",
+            description="Test extension URL",
+        )
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Point",
+            geometry_column="geometry",
+            feature_count=100,
+            schema={"id": "int64"},
+        )
+
+        add_table_extension(collection, metadata)
+
+        assert EXTENSION_URLS["table"] in (collection.stac_extensions or [])
 
 
 class TestProjectionExtension:
@@ -162,11 +204,37 @@ class TestProjectionExtension:
             item_id="test-proj",
             bbox=[-122.5, 37.5, -122.0, 38.0],
         )
-        metadata = _make_metadata_with_crs("EPSG:32610")
+        metadata = GeoParquetMetadata(
+            bbox=(-122.5, 37.5, -122.0, 38.0),
+            crs="EPSG:32610",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=100,
+            schema={"id": "int64"},
+        )
 
         add_projection_extension(item, metadata)
 
         assert item.properties.get("proj:code") == "EPSG:32610"
+
+    @pytest.mark.unit
+    def test_add_projection_extension_normalizes_epsg_case(self) -> None:
+        """add_projection_extension normalizes EPSG codes to uppercase."""
+        from portolan_cli.stac import add_projection_extension, create_item
+
+        item = create_item(item_id="test-case", bbox=[0, 0, 1, 1])
+        metadata = GeoParquetMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="epsg:4326",  # lowercase
+            geometry_type="Point",
+            geometry_column="geometry",
+            feature_count=1,
+            schema={},
+        )
+
+        add_projection_extension(item, metadata)
+
+        assert item.properties.get("proj:code") == "EPSG:4326"
 
     @pytest.mark.unit
     def test_add_projection_extension_sets_proj_bbox(self) -> None:
@@ -175,10 +243,17 @@ class TestProjectionExtension:
 
         item = create_item(
             item_id="test-proj-bbox",
-            bbox=[-122.5, 37.5, -122.0, 38.0],  # WGS84 bbox
+            bbox=[-122.5, 37.5, -122.0, 38.0],
         )
         native_bbox = (500000, 4150000, 510000, 4160000)  # UTM coords
-        metadata = _make_metadata_with_crs("EPSG:32610", bbox=native_bbox)
+        metadata = GeoParquetMetadata(
+            bbox=native_bbox,
+            crs="EPSG:32610",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=100,
+            schema={"id": "int64"},
+        )
 
         add_projection_extension(item, metadata)
 
@@ -193,15 +268,112 @@ class TestProjectionExtension:
             item_id="test-no-crs",
             bbox=[0, 0, 1, 1],
         )
-        metadata = _make_metadata_with_crs(None)
+        metadata = GeoParquetMetadata(
+            bbox=(0, 0, 1, 1),
+            crs=None,
+            geometry_type="Point",
+            geometry_column="geometry",
+            feature_count=1,
+            schema={},
+        )
 
         add_projection_extension(item, metadata)
 
         assert "proj:code" not in item.properties
 
+    @pytest.mark.unit
+    def test_add_projection_extension_handles_projjson(self) -> None:
+        """add_projection_extension handles PROJJSON CRS format."""
+        from portolan_cli.stac import add_projection_extension, create_item
+
+        item = create_item(item_id="test-projjson", bbox=[0, 0, 1, 1])
+        # PROJJSON format with id containing authority and code
+        projjson_crs: dict[str, Any] = {
+            "type": "GeographicCRS",
+            "name": "WGS 84",
+            "id": {"authority": "EPSG", "code": 4326},
+        }
+        metadata = GeoParquetMetadata(
+            bbox=(0, 0, 1, 1),
+            crs=projjson_crs,  # type: ignore[arg-type]
+            geometry_type="Point",
+            geometry_column="geometry",
+            feature_count=1,
+            schema={},
+        )
+
+        add_projection_extension(item, metadata)
+
+        assert item.properties.get("proj:code") == "EPSG:4326"
+
+    @pytest.mark.unit
+    def test_add_projection_extension_sets_proj_shape_for_raster(self) -> None:
+        """add_projection_extension sets proj:shape for COGMetadata."""
+        from portolan_cli.stac import add_projection_extension, create_item
+
+        item = create_item(item_id="test-shape", bbox=[0, 0, 1, 1])
+        metadata = COGMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="EPSG:4326",
+            width=256,
+            height=512,
+            band_count=3,
+            dtype="uint8",
+            nodata=None,
+            resolution=(0.01, 0.01),
+            transform=(0.0, 0.01, 0.0, 1.0, 0.0, -0.01),
+        )
+
+        add_projection_extension(item, metadata)
+
+        # proj:shape is [height, width] per STAC spec
+        assert item.properties.get("proj:shape") == [512, 256]
+
+    @pytest.mark.unit
+    def test_add_projection_extension_sets_proj_transform_for_raster(self) -> None:
+        """add_projection_extension sets proj:transform for COGMetadata."""
+        from portolan_cli.stac import add_projection_extension, create_item
+
+        item = create_item(item_id="test-transform", bbox=[0, 0, 1, 1])
+        transform = (0.0, 0.01, 0.0, 1.0, 0.0, -0.01)  # GDAL GeoTransform
+        metadata = COGMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="EPSG:4326",
+            width=100,
+            height=100,
+            band_count=1,
+            dtype="float32",
+            nodata=-9999.0,
+            resolution=(0.01, 0.01),
+            transform=transform,
+        )
+
+        add_projection_extension(item, metadata)
+
+        assert item.properties.get("proj:transform") == list(transform)
+
+    @pytest.mark.unit
+    def test_add_projection_extension_adds_stac_extensions_url(self) -> None:
+        """add_projection_extension adds projection extension URL to stac_extensions."""
+        from portolan_cli.stac import EXTENSION_URLS, add_projection_extension, create_item
+
+        item = create_item(item_id="test-ext-url", bbox=[0, 0, 1, 1])
+        metadata = GeoParquetMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="EPSG:4326",
+            geometry_type="Point",
+            geometry_column="geometry",
+            feature_count=1,
+            schema={},
+        )
+
+        add_projection_extension(item, metadata)
+
+        assert EXTENSION_URLS["projection"] in (item.stac_extensions or [])
+
 
 class TestBboxWgs84Transformation:
-    """Tests for bbox WGS84 transformation."""
+    """Tests for bbox WGS84 transformation with antimeridian handling."""
 
     @pytest.mark.unit
     def test_transform_bbox_to_wgs84_passes_through_4326(self) -> None:
@@ -256,16 +428,42 @@ class TestBboxWgs84Transformation:
         assert abs(result[0] - bbox[0]) < 0.001
         assert abs(result[1] - bbox[1]) < 0.001
 
+    @pytest.mark.unit
+    def test_transform_bbox_to_wgs84_handles_invalid_crs(self) -> None:
+        """transform_bbox_to_wgs84 logs warning and returns unchanged bbox for invalid CRS."""
+        from portolan_cli.crs import transform_bbox_to_wgs84
+
+        bbox = (100, 200, 300, 400)
+        result = transform_bbox_to_wgs84(bbox, "NOT_A_VALID_CRS")
+
+        # Should return unchanged bbox (with warning logged)
+        assert result == bbox
+
+    @pytest.mark.unit
+    def test_transform_bbox_to_wgs84_antimeridian_crossing(self) -> None:
+        """transform_bbox_to_wgs84 handles antimeridian crossing (west > east)."""
+        from portolan_cli.crs import transform_bbox_to_wgs84
+
+        # Bbox that crosses the antimeridian (Fiji area)
+        # In WGS84, this should result in west > east per RFC 7946
+        fiji_bbox = (177.0, -19.0, -179.0, -16.0)
+        result = transform_bbox_to_wgs84(fiji_bbox, "EPSG:4326")
+
+        # For antimeridian-crossing bbox, west (minx) > east (maxx)
+        west, south, east, north = result
+        # The antimeridian library should preserve or fix this
+        assert south < north  # Latitude should be normal
+        # Either west > east (crossing) or normal bbox
+        assert -180 <= west <= 180
+        assert -180 <= east <= 180
+
 
 class TestPerBandNodata:
     """Tests for per-band nodata in COG metadata."""
 
     @pytest.mark.unit
-    def test_cog_metadata_has_per_band_nodata(self, tmp_path: Path) -> None:
+    def test_cog_metadata_has_per_band_nodata(self) -> None:
         """COGMetadata.to_stac_properties returns per-band nodata values."""
-        from portolan_cli.metadata.cog import COGMetadata
-
-        # Create metadata with multi-band nodata
         metadata = COGMetadata(
             bbox=(0, 0, 1, 1),
             crs="EPSG:4326",
@@ -273,9 +471,9 @@ class TestPerBandNodata:
             height=100,
             band_count=3,
             dtype="uint8",
-            nodata=None,  # Will be replaced by nodatavals
+            nodata=None,
             resolution=(1.0, 1.0),
-            nodatavals=(0, 255, 128),  # Different nodata per band
+            nodatavals=(0, 255, 128),
         )
 
         props = metadata.to_stac_properties()
@@ -287,10 +485,8 @@ class TestPerBandNodata:
         assert bands[2]["nodata"] == 128
 
     @pytest.mark.unit
-    def test_cog_metadata_handles_uniform_nodata(self, tmp_path: Path) -> None:
+    def test_cog_metadata_handles_uniform_nodata(self) -> None:
         """COGMetadata handles uniform nodata across bands."""
-        from portolan_cli.metadata.cog import COGMetadata
-
         metadata = COGMetadata(
             bbox=(0, 0, 1, 1),
             crs="EPSG:4326",
@@ -308,50 +504,62 @@ class TestPerBandNodata:
 
         assert all(b["nodata"] == -9999.0 for b in bands)
 
+    @pytest.mark.unit
+    def test_cog_metadata_falls_back_to_uniform_nodata(self) -> None:
+        """COGMetadata falls back to uniform nodata when nodatavals is None."""
+        metadata = COGMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="EPSG:4326",
+            width=100,
+            height=100,
+            band_count=2,
+            dtype="int16",
+            nodata=-32768,
+            resolution=(1.0, 1.0),
+            nodatavals=None,  # Fall back to uniform nodata
+        )
 
-# Helper functions for creating test metadata objects
+        props = metadata.to_stac_properties()
+        bands = props["raster:bands"]
 
+        assert len(bands) == 2
+        assert all(b["nodata"] == -32768 for b in bands)
 
-def _make_geoparquet_metadata(
-    *,
-    feature_count: int = 100,
-    geometry_column: str = "geometry",
-    schema: dict[str, str] | None = None,
-    bbox: tuple[float, float, float, float] | None = None,
-    crs: str | None = "EPSG:4326",
-) -> Any:
-    """Create a mock GeoParquetMetadata-like object for testing."""
-    from dataclasses import dataclass
+    @pytest.mark.unit
+    def test_cog_metadata_to_dict_includes_transform(self) -> None:
+        """COGMetadata.to_dict includes transform when present."""
+        transform = (0.0, 0.01, 0.0, 1.0, 0.0, -0.01)
+        metadata = COGMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="EPSG:4326",
+            width=100,
+            height=100,
+            band_count=1,
+            dtype="float32",
+            nodata=None,
+            resolution=(0.01, 0.01),
+            transform=transform,
+        )
 
-    @dataclass
-    class MockGeoParquetMetadata:
-        bbox: tuple[float, float, float, float] | None
-        crs: str | None
-        geometry_type: str | None
-        geometry_column: str | None
-        feature_count: int
-        schema: dict[str, str]
+        d = metadata.to_dict()
 
-    return MockGeoParquetMetadata(
-        bbox=bbox or (-180, -90, 180, 90),
-        crs=crs,
-        geometry_type="Polygon",
-        geometry_column=geometry_column,
-        feature_count=feature_count,
-        schema=schema or {"id": "int64", "geometry": "binary"},
-    )
+        assert d["transform"] == list(transform)
 
+    @pytest.mark.unit
+    def test_cog_metadata_to_dict_omits_transform_when_none(self) -> None:
+        """COGMetadata.to_dict omits transform when None."""
+        metadata = COGMetadata(
+            bbox=(0, 0, 1, 1),
+            crs="EPSG:4326",
+            width=100,
+            height=100,
+            band_count=1,
+            dtype="float32",
+            nodata=None,
+            resolution=(0.01, 0.01),
+            transform=None,
+        )
 
-def _make_metadata_with_crs(
-    crs: str | None,
-    bbox: tuple[float, float, float, float] | None = None,
-) -> Any:
-    """Create a mock metadata object with CRS for testing."""
-    from dataclasses import dataclass
+        d = metadata.to_dict()
 
-    @dataclass
-    class MockMetadata:
-        crs: str | None
-        bbox: tuple[float, float, float, float] | None
-
-    return MockMetadata(crs=crs, bbox=bbox)
+        assert "transform" not in d

--- a/uv.lock
+++ b/uv.lock
@@ -215,6 +215,20 @@ wheels = [
 ]
 
 [[package]]
+name = "antimeridian"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "shapely" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/f6/9f78256aeaf4d22b562e198d655c40a532b9f146079a8b7ff980335f2a05/antimeridian-0.4.6.tar.gz", hash = "sha256:57b8f9013d15300324bb5bd94993d5077545b36a381e08c3462931f3cd278ef9", size = 12633112, upload-time = "2026-03-03T17:16:05.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/78/4c89075defd1761cf7aa64f8f572a4b75a8a0a63cd7f03ff4a13cd192b6a/antimeridian-0.4.6-py3-none-any.whl", hash = "sha256:76de915ebf1b8238de21858091d4f886729960a7bfd5bc88583944554f3d2fe9", size = 15501, upload-time = "2026-03-03T17:16:03.99Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3114,6 +3128,7 @@ name = "portolan-cli"
 version = "0.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "antimeridian" },
     { name = "click" },
     { name = "geoparquet-io" },
     { name = "obstore" },
@@ -3173,6 +3188,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "antimeridian", specifier = ">=0.3.11" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.3" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.4.1" },
@@ -4666,6 +4682,74 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/5b/5e1c117ac84e3cefcf8d7a7f6b2461795a87e20869da065a5c087149060b/setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1", size = 12587, upload-time = "2025-09-05T12:51:21.195Z" },
     { url = "https://files.pythonhosted.org/packages/73/02/b9eadc226195dcfa90eed37afe56b5dd6fa2f0e5220ab8b7867b8862b926/setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65", size = 14286, upload-time = "2025-09-05T12:51:22.61Z" },
     { url = "https://files.pythonhosted.org/packages/28/26/1be1d2a53c2a91ec48fa2ff4a409b395f836798adf194d99de9c059419ea/setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a", size = 13282, upload-time = "2025-09-05T12:51:24.094Z" },
+]
+
+[[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/89/c3548aa9b9812a5d143986764dededfa48d817714e947398bdda87c77a72/shapely-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7ae48c236c0324b4e139bea88a306a04ca630f49be66741b340729d380d8f52f", size = 1825959, upload-time = "2025-09-24T13:50:00.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/7ebc947080442edd614ceebe0ce2cdbd00c25e832c240e1d1de61d0e6b38/shapely-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eba6710407f1daa8e7602c347dfc94adc02205ec27ed956346190d66579eb9ea", size = 1629196, upload-time = "2025-09-24T13:50:03.447Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/c9c27881c20d00fc409e7e059de569d5ed0abfcec9c49548b124ebddea51/shapely-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef4a456cc8b7b3d50ccec29642aa4aeda959e9da2fe9540a92754770d5f0cf1f", size = 2951065, upload-time = "2025-09-24T13:50:05.266Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8a/0ab1f7433a2a85d9e9aea5b1fbb333f3b09b309e7817309250b4b7b2cc7a/shapely-2.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e38a190442aacc67ff9f75ce60aec04893041f16f97d242209106d502486a142", size = 3058666, upload-time = "2025-09-24T13:50:06.872Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c6/5a30ffac9c4f3ffd5b7113a7f5299ccec4713acd5ee44039778a7698224e/shapely-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:40d784101f5d06a1fd30b55fc11ea58a61be23f930d934d86f19a180909908a4", size = 3966905, upload-time = "2025-09-24T13:50:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/e92f3035ba43e53959007f928315a68fbcf2eeb4e5ededb6f0dc7ff1ecc3/shapely-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f6f6cd5819c50d9bcf921882784586aab34a4bd53e7553e175dece6db513a6f0", size = 4129260, upload-time = "2025-09-24T13:50:11.183Z" },
+    { url = "https://files.pythonhosted.org/packages/42/24/605901b73a3d9f65fa958e63c9211f4be23d584da8a1a7487382fac7fdc5/shapely-2.1.2-cp310-cp310-win32.whl", hash = "sha256:fe9627c39c59e553c90f5bc3128252cb85dc3b3be8189710666d2f8bc3a5503e", size = 1544301, upload-time = "2025-09-24T13:50:12.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/6db795b8dd3919851856bd2ddd13ce434a748072f6fdee42ff30cbd3afa3/shapely-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:1d0bfb4b8f661b3b4ec3565fa36c340bfb1cda82087199711f86a88647d26b2f", size = 1722074, upload-time = "2025-09-24T13:50:13.909Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/1ff672dea9ec6a7b5d422eb6d095ed886e2e523733329f75fdcb14ee1149/shapely-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:91121757b0a36c9aac3427a651a7e6567110a4a67c97edf04f8d55d4765f6618", size = 1820038, upload-time = "2025-09-24T13:50:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ce/28fab8c772ce5db23a0d86bf0adaee0c4c79d5ad1db766055fa3dab442e2/shapely-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:16a9c722ba774cf50b5d4541242b4cce05aafd44a015290c82ba8a16931ff63d", size = 1626039, upload-time = "2025-09-24T13:50:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8b/868b7e3f4982f5006e9395c1e12343c66a8155c0374fdc07c0e6a1ab547d/shapely-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cc4f7397459b12c0b196c9efe1f9d7e92463cbba142632b4cc6d8bbbbd3e2b09", size = 3001519, upload-time = "2025-09-24T13:50:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/13/02/58b0b8d9c17c93ab6340edd8b7308c0c5a5b81f94ce65705819b7416dba5/shapely-2.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136ab87b17e733e22f0961504d05e77e7be8c9b5a8184f685b4a91a84efe3c26", size = 3110842, upload-time = "2025-09-24T13:50:21.77Z" },
+    { url = "https://files.pythonhosted.org/packages/af/61/8e389c97994d5f331dcffb25e2fa761aeedfb52b3ad9bcdd7b8671f4810a/shapely-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:16c5d0fc45d3aa0a69074979f4f1928ca2734fb2e0dde8af9611e134e46774e7", size = 4021316, upload-time = "2025-09-24T13:50:23.626Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d4/9b2a9fe6039f9e42ccf2cb3e84f219fd8364b0c3b8e7bbc857b5fbe9c14c/shapely-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ddc759f72b5b2b0f54a7e7cde44acef680a55019eb52ac63a7af2cf17cb9cd2", size = 4178586, upload-time = "2025-09-24T13:50:25.443Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f6/9840f6963ed4decf76b08fd6d7fed14f8779fb7a62cb45c5617fa8ac6eab/shapely-2.1.2-cp311-cp311-win32.whl", hash = "sha256:2fa78b49485391224755a856ed3b3bd91c8455f6121fee0db0e71cefb07d0ef6", size = 1543961, upload-time = "2025-09-24T13:50:26.968Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1e/3f8ea46353c2a33c1669eb7327f9665103aa3a8dfe7f2e4ef714c210b2c2/shapely-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:c64d5c97b2f47e3cd9b712eaced3b061f2b71234b3fc263e0fcf7d889c6559dc", size = 1722856, upload-time = "2025-09-24T13:50:28.497Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c0/f3b6453cf2dfa99adc0ba6675f9aaff9e526d2224cbd7ff9c1a879238693/shapely-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe2533caae6a91a543dec62e8360fe86ffcdc42a7c55f9dfd0128a977a896b94", size = 1833550, upload-time = "2025-09-24T13:50:30.019Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/59dee0bc4b913b7ab59ab1086225baca5b8f19865e6101db9ebb7243e132/shapely-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba4d1333cc0bc94381d6d4308d2e4e008e0bd128bdcff5573199742ee3634359", size = 1643556, upload-time = "2025-09-24T13:50:32.291Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/a5397e75b435b9895cd53e165083faed5d12fd9626eadec15a83a2411f0f/shapely-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bd308103340030feef6c111d3eb98d50dc13feea33affc8a6f9fa549e9458a3", size = 2988308, upload-time = "2025-09-24T13:50:33.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b", size = 3099844, upload-time = "2025-09-24T13:50:35.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f3/9876b64d4a5a321b9dc482c92bb6f061f2fa42131cba643c699f39317cb9/shapely-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9eddfe513096a71896441a7c37db72da0687b34752c4e193577a145c71736fc", size = 3988842, upload-time = "2025-09-24T13:50:37.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/704c7292f7014c7e74ec84eddb7b109e1fbae74a16deae9c1504b1d15565/shapely-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:980c777c612514c0cf99bc8a9de6d286f5e186dcaf9091252fcd444e5638193d", size = 4152714, upload-time = "2025-09-24T13:50:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/319c9dc788884ad0785242543cdffac0e6530e4d0deb6c4862bc4143dcf3/shapely-2.1.2-cp312-cp312-win32.whl", hash = "sha256:9111274b88e4d7b54a95218e243282709b330ef52b7b86bc6aaf4f805306f454", size = 1542745, upload-time = "2025-09-24T13:50:41.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/cb6c1c505cb31e818e900b9312d514f381fbfa5c4363edfce0fcc4f8c1a4/shapely-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:743044b4cfb34f9a67205cee9279feaf60ba7d02e69febc2afc609047cb49179", size = 1722861, upload-time = "2025-09-24T13:50:43.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/90/98ef257c23c46425dc4d1d31005ad7c8d649fe423a38b917db02c30f1f5a/shapely-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b510dda1a3672d6879beb319bc7c5fd302c6c354584690973c838f46ec3e0fa8", size = 1832644, upload-time = "2025-09-24T13:50:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5e/7d7f54ba960c13302584c73704d8c4d15404a51024631adb60b126a4ae88/shapely-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe7b77dc63d707c09726b7908f575fc04ff1d1ad0f3fb92aec212396bc6cfe5e", size = 2970931, upload-time = "2025-09-24T13:50:48.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/578faf235a5b09f16b5f02833c53822294d7f21b242f8e2d0cf03fb64321/shapely-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a84e0582858d841d54355246ddfcbd1fce3179f185da7470f41ce39d001ee1af", size = 3979960, upload-time = "2025-09-24T13:50:51.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/48/74/fb402c5a6235d1c65a97348b48cdedb75fb19eca2b1d66d04969fc1c6091/shapely-2.1.2-cp313-cp313-win32.whl", hash = "sha256:9c3a3c648aedc9f99c09263b39f2d8252f199cb3ac154fadc173283d7d111350", size = 1541890, upload-time = "2025-09-24T13:50:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/3647fe7ad990af60ad98b889657a976042c9988c2807cf322a9d6685f462/shapely-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:ca2591bff6645c216695bdf1614fca9c82ea1144d4a7591a466fef64f28f0715", size = 1722151, upload-time = "2025-09-24T13:50:57.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/49/63953754faa51ffe7d8189bfbe9ca34def29f8c0e34c67cbe2a2795f269d/shapely-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2d93d23bdd2ed9dc157b46bc2f19b7da143ca8714464249bef6771c679d5ff40", size = 1834130, upload-time = "2025-09-24T13:50:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e7/fc4e9a19929522877fa602f705706b96e78376afb7fad09cad5b9af1553c/shapely-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d8382dd120d64b03698b7298b89611a6ea6f55ada9d39942838b79c9bc89801", size = 3018460, upload-time = "2025-09-24T13:51:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/48/de/b59a620b1f3a129c3fecc2737104a0a7e04e79335bd3b0a1f1609744cf17/shapely-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:346ec0c1a0fcd32f57f00e4134d1200e14bf3f5ae12af87ba83ca275c502498c", size = 4030760, upload-time = "2025-09-24T13:51:06.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements Wave 1 of the STAC Extension Foundation (#272), adding comprehensive STAC extension support:

- **STAC Version**: Updated from 1.0.0 to 1.1.0 (unified `bands` array per spec)
- **Extension Array**: Added `build_stac_extensions()` for dynamic population based on prefixed fields
- **Table Extension**: Added `add_table_extension()` for GeoParquet metadata (columns, row_count, primary_geometry)
- **Projection Extension**: Added `add_projection_extension()` for CRS info (proj:code, proj:bbox)
- **CRS Transformation**: Created `portolan_cli/crs.py` with `transform_bbox_to_wgs84()` for RFC 7946 compliance
- **Per-band Nodata**: Updated `COGMetadata` with `nodatavals` for multi-band raster support
- **Dependency**: Added pyproj as explicit dependency (was transitive via rasterio)

## Test plan

- [x] All 18 new unit tests pass (TDD approach)
- [x] All 2705 existing unit tests pass
- [x] mypy --strict passes
- [x] ruff check passes
- [x] All pre-commit hooks pass
- [ ] Manual verification with real GeoParquet/COG files (optional)

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CRS bbox transformation to WGS84 with antimeridian handling.
  * Enhanced COG metadata: per-band nodata and affine transform exported; STAC properties include per-band raster nodata.
  * Emit STAC Table and Projection extensions (STAC 1.1) on collection/item outputs.

* **Tests**
  * Added unit and integration tests covering STAC extensions, bbox transformation, COG metadata, and antimeridian cases.

* **Chores**
  * Bumped STAC version to 1.1.0 and added pyproj dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->