### PR TITLE
feat(convert): make COG conversion settings configurable via config.yaml

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -137,11 +137,14 @@ Configure Cloud-Optimized GeoTIFF conversion parameters. By default, Portolan us
 conversion:
   cog:
     compression: JPEG      # DEFLATE (default), JPEG, LZW, ZSTD, WEBP
-    quality: 95            # JPEG quality 1-100 (only applies to JPEG)
+    quality: 95            # Quality 1-100 (applies to JPEG and WEBP)
     tile_size: 512         # Internal tile size in pixels
     predictor: 2           # 1=none, 2=horizontal (default), 3=floating point
     resampling: nearest    # Overview resampling: nearest, bilinear, cubic, etc.
 ```
+
+!!! note "Validation"
+    Invalid settings produce warnings but don't block conversion. Quality is clamped to 1-100, and unknown compression/resampling values are passed through to let rio-cogeo handle errors.
 
 #### Use Cases
 

--- a/portolan_cli/check.py
+++ b/portolan_cli/check.py
@@ -390,6 +390,7 @@ def check_directory(
             path,
             on_progress=on_progress,
             file_paths=convertible_files,
+            catalog_path=catalog_path,
         )
         report.conversion_report = conversion_report
 

--- a/portolan_cli/conversion_config.py
+++ b/portolan_cli/conversion_config.py
@@ -25,12 +25,15 @@ See:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
 from portolan_cli.config import load_config
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -161,6 +164,46 @@ def get_conversion_overrides(catalog_path: Path) -> ConversionOverrides:
 # COG Settings (Issue #279)
 # =============================================================================
 
+# Valid compression algorithms supported by rio-cogeo
+# See: rio_cogeo.profiles.cog_profiles
+VALID_COG_COMPRESSIONS: frozenset[str] = frozenset(
+    {
+        "DEFLATE",
+        "LZW",
+        "ZSTD",
+        "JPEG",
+        "WEBP",
+        "LERC",
+        "LERC_DEFLATE",
+        "LERC_ZSTD",
+        "PACKBITS",
+        "LZMA",
+        "RAW",  # No compression
+    }
+)
+
+# Lossy compression methods (predictor doesn't apply)
+LOSSY_COMPRESSIONS: frozenset[str] = frozenset({"JPEG", "WEBP"})
+
+# Compression methods that support quality setting
+QUALITY_COMPRESSIONS: frozenset[str] = frozenset({"JPEG", "WEBP"})
+
+# Valid resampling methods for overview generation
+# See: rio_cogeo.cogeo.cog_translate overview_resampling parameter
+VALID_RESAMPLING_METHODS: frozenset[str] = frozenset(
+    {
+        "nearest",
+        "bilinear",
+        "cubic",
+        "cubic_spline",
+        "lanczos",
+        "average",
+        "mode",
+        "gauss",
+        "rms",
+    }
+)
+
 
 @dataclass(frozen=True)
 class CogSettings:
@@ -170,7 +213,7 @@ class CogSettings:
 
     Attributes:
         compression: Compression algorithm (DEFLATE, JPEG, LZW, ZSTD, etc.).
-        quality: JPEG quality (1-100). Only applies when compression is JPEG.
+        quality: Quality setting (1-100). Applies to JPEG and WEBP compression.
         tile_size: Internal tile size in pixels (default 512).
         predictor: Compression predictor (1=none, 2=horizontal, 3=floating point).
         resampling: Overview resampling method (nearest, bilinear, cubic, etc.).
@@ -183,11 +226,97 @@ class CogSettings:
     resampling: str = "nearest"
 
 
+def validate_cog_settings(settings: CogSettings) -> list[str]:
+    """Validate COG settings and return warnings for any issues.
+
+    Does not raise exceptions — returns a list of warning messages. This allows
+    conversion to proceed with potentially suboptimal settings while informing
+    the user of issues.
+
+    Args:
+        settings: CogSettings instance to validate.
+
+    Returns:
+        List of warning messages. Empty list if all settings are valid.
+    """
+    warnings: list[str] = []
+
+    # Validate compression
+    if settings.compression not in VALID_COG_COMPRESSIONS:
+        warnings.append(
+            f"Unknown compression '{settings.compression}'. "
+            f"Valid values: {', '.join(sorted(VALID_COG_COMPRESSIONS))}. "
+            "Conversion may fail."
+        )
+
+    # Validate resampling
+    if settings.resampling not in VALID_RESAMPLING_METHODS:
+        warnings.append(
+            f"Unknown resampling method '{settings.resampling}'. "
+            f"Valid values: {', '.join(sorted(VALID_RESAMPLING_METHODS))}. "
+            "Conversion may fail."
+        )
+
+    # Validate quality bounds
+    if settings.quality is not None:
+        if not 1 <= settings.quality <= 100:
+            warnings.append(
+                f"Quality {settings.quality} is out of range. "
+                "Valid range: 1-100. Using clamped value."
+            )
+        # Warn if quality is set for non-lossy compression
+        if settings.compression not in QUALITY_COMPRESSIONS:
+            warnings.append(
+                f"Quality setting ({settings.quality}) is ignored for "
+                f"'{settings.compression}' compression. "
+                f"Quality only applies to: {', '.join(sorted(QUALITY_COMPRESSIONS))}."
+            )
+
+    # Validate tile_size
+    if settings.tile_size < 64:
+        warnings.append(
+            f"tile_size {settings.tile_size} is very small. "
+            "Minimum recommended: 64. This may cause performance issues."
+        )
+    elif settings.tile_size > 4096:
+        warnings.append(
+            f"tile_size {settings.tile_size} is very large. "
+            "Maximum recommended: 4096. This may cause memory issues."
+        )
+    # Warn if not a power of 2 (common convention, not strict requirement)
+    elif settings.tile_size & (settings.tile_size - 1) != 0:
+        warnings.append(
+            f"tile_size {settings.tile_size} is not a power of 2. "
+            "While valid, power-of-2 sizes (256, 512, 1024) are conventional."
+        )
+
+    # Validate predictor
+    if settings.predictor not in (1, 2, 3):
+        warnings.append(
+            f"Predictor {settings.predictor} is invalid. "
+            "Valid values: 1 (none), 2 (horizontal), 3 (floating point). "
+            "Using predictor=2."
+        )
+
+    # Warn about predictor with lossy compression
+    if settings.compression in LOSSY_COMPRESSIONS and settings.predictor != 1:
+        warnings.append(
+            f"Predictor={settings.predictor} is ignored for lossy compression "
+            f"'{settings.compression}'. Consider setting predictor=1 to avoid confusion."
+        )
+
+    return warnings
+
+
 def get_cog_settings(catalog_path: Path) -> CogSettings:
     """Load COG conversion settings from catalog config.
 
     Reads the 'conversion.cog' section from .portolan/config.yaml and returns
     a CogSettings instance with values from config merged with defaults.
+
+    Validates settings and logs warnings for any issues. Invalid values are
+    either corrected (e.g., quality clamped to 1-100) or passed through to
+    let rio-cogeo handle the error with its own message.
 
     Args:
         catalog_path: Root path of the catalog.
@@ -215,6 +344,9 @@ def get_cog_settings(catalog_path: Path) -> CogSettings:
     quality = cog.get("quality")
     if not isinstance(quality, int):
         quality = None
+    elif quality is not None:
+        # Clamp quality to valid range
+        quality = max(1, min(100, quality))
 
     tile_size = cog.get("tile_size")
     if not isinstance(tile_size, int):
@@ -227,11 +359,21 @@ def get_cog_settings(catalog_path: Path) -> CogSettings:
     resampling = cog.get("resampling")
     if not isinstance(resampling, str):
         resampling = "nearest"
+    else:
+        # Normalize resampling to lowercase
+        resampling = resampling.lower()
 
-    return CogSettings(
+    settings = CogSettings(
         compression=compression,
         quality=quality,
         tile_size=tile_size,
         predictor=predictor,
         resampling=resampling,
     )
+
+    # Validate and log warnings
+    warnings = validate_cog_settings(settings)
+    for warning in warnings:
+        logger.warning("COG config: %s", warning)
+
+    return settings

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -22,7 +22,12 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from portolan_cli.constants import GEOSPATIAL_EXTENSIONS
-from portolan_cli.conversion_config import CogSettings, get_cog_settings
+from portolan_cli.conversion_config import (
+    LOSSY_COMPRESSIONS,
+    QUALITY_COMPRESSIONS,
+    CogSettings,
+    get_cog_settings,
+)
 from portolan_cli.errors import (
     ConversionFailedError,
 )
@@ -379,13 +384,17 @@ def _convert_raster(source: Path, output_dir: Path, settings: CogSettings | None
         profile = cog_profiles.get("deflate")  # type: ignore[no-untyped-call]
         profile["compress"] = settings.compression
 
-    # Apply settings from config
-    profile["predictor"] = settings.predictor
+    # Apply tile size settings
     profile["blockxsize"] = settings.tile_size
     profile["blockysize"] = settings.tile_size
 
-    # Add quality for JPEG compression
-    if settings.quality is not None and compression_lower == "jpeg":
+    # Apply predictor only for non-lossy compression
+    # Predictor is meaningless for JPEG/WEBP and can cause issues
+    if settings.compression not in LOSSY_COMPRESSIONS:
+        profile["predictor"] = settings.predictor
+
+    # Apply quality for JPEG and WEBP compression
+    if settings.quality is not None and settings.compression in QUALITY_COMPRESSIONS:
         profile["quality"] = settings.quality
 
     # Write to temp file first to avoid corrupting source if output_path == source
@@ -472,6 +481,7 @@ def convert_directory(
     on_progress: Callable[[ConversionResult], None] | None = None,
     recursive: bool = True,
     file_paths: list[Path] | None = None,
+    catalog_path: Path | None = None,
 ) -> ConversionReport:
     """Convert all geospatial files in a directory to cloud-native formats.
 
@@ -488,6 +498,8 @@ def convert_directory(
         file_paths: Optional list of specific files to convert. If provided,
             skips directory scanning and converts only these files. Useful
             when the caller has already scanned and filtered the files.
+        catalog_path: Path to the catalog root for loading conversion config.
+            If None, uses ADR-0019 defaults for COG conversion.
 
     Returns:
         ConversionReport with results for all processed files.
@@ -523,7 +535,7 @@ def convert_directory(
         # Determine output directory for this file
         file_output_dir = output_dir if output_dir else file_path.parent
 
-        result = convert_file(file_path, output_dir=file_output_dir)
+        result = convert_file(file_path, output_dir=file_output_dir, catalog_path=catalog_path)
         results.append(result)
 
         # Invoke callback if provided

--- a/tests/integration/test_convert_workflow.py
+++ b/tests/integration/test_convert_workflow.py
@@ -380,3 +380,107 @@ conversion:
         # Verify default DEFLATE compression
         with rasterio.open(result.output) as src:
             assert src.compression.name.upper() == "DEFLATE"
+
+    def test_convert_directory_uses_catalog_path(
+        self,
+        non_cog_tif: Path,
+        tmp_path: Path,
+    ) -> None:
+        """convert_directory passes catalog_path to convert_file."""
+        import rasterio
+
+        from portolan_cli.convert import ConversionStatus, convert_directory
+
+        # Create catalog with LZW compression config
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        config_file = portolan_dir / "config.yaml"
+        config_file.write_text("""
+conversion:
+  cog:
+    compression: LZW
+""")
+
+        # Create a subdirectory with the source file
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        source = data_dir / "input.tif"
+        shutil.copy(non_cog_tif, source)
+
+        # Convert using convert_directory with catalog_path
+        report = convert_directory(data_dir, catalog_path=tmp_path)
+
+        assert report.succeeded == 1
+        assert report.failed == 0
+
+        # Verify the config was applied
+        result = report.results[0]
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+
+        with rasterio.open(result.output) as src:
+            assert src.compression.name.upper() == "LZW"
+
+    def test_convert_directory_without_catalog_uses_defaults(
+        self,
+        non_cog_tif: Path,
+        tmp_path: Path,
+    ) -> None:
+        """convert_directory without catalog_path uses defaults."""
+        import rasterio
+
+        from portolan_cli.convert import ConversionStatus, convert_directory
+
+        # Create a subdirectory with the source file (no .portolan config)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        source = data_dir / "input.tif"
+        shutil.copy(non_cog_tif, source)
+
+        # Convert without catalog_path
+        report = convert_directory(data_dir)
+
+        assert report.succeeded == 1
+
+        result = report.results[0]
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+
+        # Should use default DEFLATE
+        with rasterio.open(result.output) as src:
+            assert src.compression.name.upper() == "DEFLATE"
+
+    def test_webp_compression_with_quality(
+        self,
+        non_cog_tif: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Convert uses WEBP compression with quality from config."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        # Create catalog with WEBP compression config
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        config_file = portolan_dir / "config.yaml"
+        config_file.write_text("""
+conversion:
+  cog:
+    compression: WEBP
+    quality: 80
+""")
+
+        source = tmp_path / "input.tif"
+        shutil.copy(non_cog_tif, source)
+
+        result = convert_file(source, output_dir=tmp_path, catalog_path=tmp_path)
+
+        # WEBP may not be available in all GDAL builds, so check if it succeeded
+        if result.status == ConversionStatus.SUCCESS:
+            import rasterio
+
+            assert result.output is not None
+            with rasterio.open(result.output) as src:
+                assert src.compression.name.upper() == "WEBP"
+        else:
+            # WEBP not available - that's OK, just verify error is clear
+            assert result.error is not None

--- a/tests/unit/test_conversion_config.py
+++ b/tests/unit/test_conversion_config.py
@@ -641,3 +641,182 @@ conversion:
         settings = get_cog_settings(tmp_path)
 
         assert settings.compression == "JPEG"
+
+
+# =============================================================================
+# COG Settings Validation Tests
+# =============================================================================
+
+
+class TestValidateCogSettings:
+    """Tests for validate_cog_settings() function."""
+
+    @pytest.mark.unit
+    def test_valid_settings_returns_empty_list(self) -> None:
+        """validate_cog_settings() returns empty list for valid settings."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings()  # All defaults are valid
+        warnings = validate_cog_settings(settings)
+
+        assert warnings == []
+
+    @pytest.mark.unit
+    def test_invalid_compression_warns(self) -> None:
+        """validate_cog_settings() warns about invalid compression."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(compression="MAGIC")
+        warnings = validate_cog_settings(settings)
+
+        assert len(warnings) == 1
+        assert "Unknown compression 'MAGIC'" in warnings[0]
+
+    @pytest.mark.unit
+    def test_invalid_resampling_warns(self) -> None:
+        """validate_cog_settings() warns about invalid resampling."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(resampling="superfast")
+        warnings = validate_cog_settings(settings)
+
+        assert len(warnings) == 1
+        assert "Unknown resampling method 'superfast'" in warnings[0]
+
+    @pytest.mark.unit
+    def test_quality_out_of_range_warns(self) -> None:
+        """validate_cog_settings() warns about quality out of range."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(compression="JPEG", quality=150)
+        warnings = validate_cog_settings(settings)
+
+        assert any("out of range" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_quality_on_non_lossy_compression_warns(self) -> None:
+        """validate_cog_settings() warns when quality is set for non-lossy compression."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(compression="DEFLATE", quality=95)
+        warnings = validate_cog_settings(settings)
+
+        assert any("ignored for 'DEFLATE'" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_tile_size_too_small_warns(self) -> None:
+        """validate_cog_settings() warns about very small tile sizes."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(tile_size=32)
+        warnings = validate_cog_settings(settings)
+
+        assert any("very small" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_tile_size_too_large_warns(self) -> None:
+        """validate_cog_settings() warns about very large tile sizes."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(tile_size=8192)
+        warnings = validate_cog_settings(settings)
+
+        assert any("very large" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_non_power_of_2_tile_size_warns(self) -> None:
+        """validate_cog_settings() warns about non-power-of-2 tile sizes."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(tile_size=500)
+        warnings = validate_cog_settings(settings)
+
+        assert any("not a power of 2" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_invalid_predictor_warns(self) -> None:
+        """validate_cog_settings() warns about invalid predictor values."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(predictor=5)
+        warnings = validate_cog_settings(settings)
+
+        assert any("Predictor 5 is invalid" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_predictor_with_lossy_compression_warns(self) -> None:
+        """validate_cog_settings() warns about predictor with lossy compression."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(compression="JPEG", predictor=2)
+        warnings = validate_cog_settings(settings)
+
+        assert any("ignored for lossy compression" in w for w in warnings)
+
+    @pytest.mark.unit
+    def test_webp_quality_no_warning(self) -> None:
+        """validate_cog_settings() does not warn when WEBP has quality."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        settings = CogSettings(compression="WEBP", quality=90, predictor=1)
+        warnings = validate_cog_settings(settings)
+
+        # Should have no warnings (predictor=1 is OK for lossy, quality is valid for WEBP)
+        assert warnings == []
+
+
+class TestGetCogSettingsValidation:
+    """Tests that get_cog_settings() validates and logs warnings."""
+
+    @pytest.mark.unit
+    def test_quality_clamped_to_valid_range(self, tmp_path: Path) -> None:
+        """get_cog_settings() clamps quality to 1-100."""
+        from portolan_cli.conversion_config import get_cog_settings
+
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        config_file = portolan_dir / "config.yaml"
+        config_file.write_text("""
+conversion:
+  cog:
+    compression: JPEG
+    quality: 150
+""")
+        settings = get_cog_settings(tmp_path)
+
+        assert settings.quality == 100  # Clamped to max
+
+    @pytest.mark.unit
+    def test_quality_clamped_minimum(self, tmp_path: Path) -> None:
+        """get_cog_settings() clamps quality minimum to 1."""
+        from portolan_cli.conversion_config import get_cog_settings
+
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        config_file = portolan_dir / "config.yaml"
+        config_file.write_text("""
+conversion:
+  cog:
+    compression: JPEG
+    quality: -5
+""")
+        settings = get_cog_settings(tmp_path)
+
+        assert settings.quality == 1  # Clamped to min
+
+    @pytest.mark.unit
+    def test_resampling_normalized_to_lowercase(self, tmp_path: Path) -> None:
+        """get_cog_settings() normalizes resampling to lowercase."""
+        from portolan_cli.conversion_config import get_cog_settings
+
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        config_file = portolan_dir / "config.yaml"
+        config_file.write_text("""
+conversion:
+  cog:
+    resampling: BILINEAR
+""")
+        settings = get_cog_settings(tmp_path)
+
+        assert settings.resampling == "bilinear"


### PR DESCRIPTION
## Summary

- Add `CogSettings` dataclass and `get_cog_settings()` function to load COG conversion settings from `.portolan/config.yaml`
- Update `convert_file()` to accept optional `catalog_path` parameter for loading config
- Support configurable compression, quality, tile size, predictor, and resampling method
- Follow ADR-0024 hierarchical config precedence (CLI > env > collection > catalog > default)

## Config Example

```yaml
# .portolan/config.yaml
conversion:
  cog:
    compression: JPEG      # DEFLATE (default), JPEG, LZW, ZSTD, WEBP
    quality: 95            # JPEG quality 1-100
    tile_size: 512         # Internal tile size in pixels
    predictor: 2           # 1=none, 2=horizontal, 3=floating point
    resampling: nearest    # Overview resampling method
```

## Test plan

- [x] Unit tests for `CogSettings` dataclass (defaults, custom values, frozen)
- [x] Unit tests for `get_cog_settings()` (config parsing, edge cases)
- [x] Integration tests verifying settings are applied to actual COG conversion
- [x] All 2906 existing unit tests pass
- [x] mypy type checking passes
- [x] ruff linting passes

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure Cloud Optimized GeoTIFF (COG) conversion: compression, quality, tile size, predictor, and resampling via catalog config; conversions respect these settings.

* **Documentation**
  * Added a COG settings reference with examples, parameter guidance, supported compression list, and validation notes.

* **Bug Fixes**
  * Catalog-root conversion settings are now honored during fix/convert runs.

* **Tests**
  * Added unit and integration tests covering COG config parsing, validation, clamping, and end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->