### PR TITLE
fix(security): add SQL injection protection for layer names

### DIFF
--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -653,6 +653,52 @@ def convert_multilayer_file(
     return results
 
 
+def _validate_layer_name(layer: str) -> str:
+    """Validate and sanitize a layer name for use in SQL.
+
+    Layer names in GeoPackage/FileGDB can contain letters, numbers, underscores,
+    and spaces. We escape single quotes to prevent SQL injection.
+
+    Args:
+        layer: Layer name to validate.
+
+    Returns:
+        Sanitized layer name safe for SQL interpolation.
+
+    Raises:
+        ValueError: If layer name contains dangerous characters.
+    """
+    # Block obviously malicious patterns
+    dangerous_patterns = ["--", ";", "/*", "*/", "\\"]
+    for pattern in dangerous_patterns:
+        if pattern in layer:
+            raise ValueError(
+                f"Invalid layer name '{layer}': contains unsafe character sequence '{pattern}'"
+            )
+
+    # Escape single quotes (SQL standard: double them)
+    return layer.replace("'", "''")
+
+
+def _build_st_read_expr(input_path: str, layer: str | None = None) -> str:
+    """Build ST_Read expression with optional layer parameter.
+
+    Args:
+        input_path: Path or URL to the spatial file (already SQL-escaped).
+        layer: Optional layer name (will be validated and escaped).
+
+    Returns:
+        SQL expression for ST_Read.
+
+    Raises:
+        ValueError: If layer name contains invalid characters.
+    """
+    if layer:
+        safe_layer = _validate_layer_name(layer)
+        return f"ST_Read('{input_path}', layer := '{safe_layer}')"
+    return f"ST_Read('{input_path}')"
+
+
 def _convert_vector_layer(source: Path, layer: str, output: Path) -> None:
     """Convert a single layer from a multi-layer file to GeoParquet.
 
@@ -665,14 +711,17 @@ def _convert_vector_layer(source: Path, layer: str, output: Path) -> None:
         output: Path for the output GeoParquet file.
 
     Raises:
+        ValueError: If layer name contains SQL injection patterns.
         Exception: If conversion fails.
     """
     import duckdb
 
-    # Escape path for SQL
+    # Escape paths for SQL (single quotes)
     source_escaped = str(source).replace("'", "''")
     output_escaped = str(output).replace("'", "''")
-    layer_escaped = layer.replace("'", "''")
+
+    # Build ST_Read expression with validated layer name
+    st_read_expr = _build_st_read_expr(source_escaped, layer)
 
     con = duckdb.connect()
     try:
@@ -681,10 +730,10 @@ def _convert_vector_layer(source: Path, layer: str, output: Path) -> None:
         # Use COPY to write GeoParquet with spatial metadata
         query = f"""
             COPY (
-                SELECT * FROM ST_Read('{source_escaped}', layer='{layer_escaped}')
+                SELECT * FROM {st_read_expr}
             ) TO '{output_escaped}'
             WITH (FORMAT PARQUET)
-        """
+        """  # nosec B608 - layer name validated by _validate_layer_name()
         con.execute(query)
     finally:
         con.close()

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1343,3 +1343,111 @@ class TestConvertFileSourceMtime:
         # Source should still exist with same mtime
         assert source.exists()
         assert source.stat().st_mtime == source_mtime
+
+
+# =============================================================================
+# SQL Injection Prevention Tests (Security)
+# =============================================================================
+
+
+class TestValidateLayerName:
+    """Tests for _validate_layer_name SQL injection prevention."""
+
+    @pytest.mark.unit
+    def test_valid_simple_name(self) -> None:
+        """Simple alphanumeric layer names pass validation."""
+        from portolan_cli.convert import _validate_layer_name
+
+        assert _validate_layer_name("points") == "points"
+        assert _validate_layer_name("layer_1") == "layer_1"
+
+    @pytest.mark.unit
+    def test_valid_name_with_spaces(self) -> None:
+        """Layer names with spaces are valid (common in FileGDB)."""
+        from portolan_cli.convert import _validate_layer_name
+
+        assert _validate_layer_name("census tracts") == "census tracts"
+
+    @pytest.mark.unit
+    def test_escapes_single_quotes(self) -> None:
+        """Single quotes are escaped (doubled) for SQL safety."""
+        from portolan_cli.convert import _validate_layer_name
+
+        assert _validate_layer_name("layer'name") == "layer''name"
+        assert _validate_layer_name("O'Brien") == "O''Brien"
+
+    @pytest.mark.unit
+    def test_blocks_sql_comment_dash(self) -> None:
+        """SQL comment sequence (--) is blocked."""
+        from portolan_cli.convert import _validate_layer_name
+
+        with pytest.raises(ValueError, match="unsafe character sequence '--'"):
+            _validate_layer_name("layer--injection")
+
+    @pytest.mark.unit
+    def test_blocks_semicolon(self) -> None:
+        """Semicolon (statement terminator) is blocked."""
+        from portolan_cli.convert import _validate_layer_name
+
+        with pytest.raises(ValueError, match="unsafe character sequence ';'"):
+            _validate_layer_name("layer; DROP TABLE users;")
+
+    @pytest.mark.unit
+    def test_blocks_block_comment_start(self) -> None:
+        """Block comment start (/*) is blocked."""
+        from portolan_cli.convert import _validate_layer_name
+
+        with pytest.raises(ValueError, match=r"unsafe character sequence '/\*'"):
+            _validate_layer_name("layer/* comment */name")
+
+    @pytest.mark.unit
+    def test_blocks_block_comment_end(self) -> None:
+        """Block comment end (*/) is blocked."""
+        from portolan_cli.convert import _validate_layer_name
+
+        with pytest.raises(ValueError, match=r"unsafe character sequence '\*/'"):
+            _validate_layer_name("layer*/name")
+
+    @pytest.mark.unit
+    def test_blocks_backslash(self) -> None:
+        """Backslash (escape character) is blocked."""
+        from portolan_cli.convert import _validate_layer_name
+
+        with pytest.raises(ValueError, match=r"unsafe character sequence"):
+            _validate_layer_name("layer\\name")
+
+
+class TestBuildStReadExpr:
+    """Tests for _build_st_read_expr SQL expression builder."""
+
+    @pytest.mark.unit
+    def test_without_layer(self) -> None:
+        """Without layer parameter, returns simple ST_Read."""
+        from portolan_cli.convert import _build_st_read_expr
+
+        result = _build_st_read_expr("/path/to/file.gpkg")
+        assert result == "ST_Read('/path/to/file.gpkg')"
+
+    @pytest.mark.unit
+    def test_with_layer(self) -> None:
+        """With layer parameter, includes layer := syntax."""
+        from portolan_cli.convert import _build_st_read_expr
+
+        result = _build_st_read_expr("/path/to/file.gpkg", "buildings")
+        assert result == "ST_Read('/path/to/file.gpkg', layer := 'buildings')"
+
+    @pytest.mark.unit
+    def test_with_layer_containing_quote(self) -> None:
+        """Layer names with quotes are properly escaped."""
+        from portolan_cli.convert import _build_st_read_expr
+
+        result = _build_st_read_expr("/path/to/file.gpkg", "O'Brien's data")
+        assert result == "ST_Read('/path/to/file.gpkg', layer := 'O''Brien''s data')"
+
+    @pytest.mark.unit
+    def test_rejects_malicious_layer(self) -> None:
+        """Malicious layer names are rejected before SQL construction."""
+        from portolan_cli.convert import _build_st_read_expr
+
+        with pytest.raises(ValueError, match="unsafe character"):
+            _build_st_read_expr("/path/to/file.gpkg", "layer'; DROP TABLE x;--")


### PR DESCRIPTION
## Summary

- Add `_validate_layer_name()` to block SQL injection patterns (`--`, `;`, `/*`, `*/`, `\`)
- Add `_build_st_read_expr()` to safely construct `ST_Read` expressions
- Add `# nosec B608` to document intentionally validated SQL construction

Follows the same pattern as geoparquet-io PR #316.

## Test plan

- [x] 12 new unit tests for validation and expression building
- [x] All 70 convert tests pass
- [x] Bandit security scan passes (no Medium/High issues)

Fixes bandit B608 (CWE-89) SQL injection warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)