### PR TITLE
fix(deps): resolve CVE-2026-4539 (pygments)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "pystac>=1.10.0",  # STAC catalog/collection/item creation
     "pyyaml>=6.0",  # YAML config file support
     "rasterio>=1.3.0",  # Raster I/O (transitive via rio-cogeo, but we import directly)
+    "pygments>=2.20.0",  # CVE-2026-4539 fix (transitive via rich, pinned for security)
     "requests>=2.33.0",  # CVE-2026-25645 fix (transitive, pinned for security)
     "rich>=13.0.0",  # Terminal progress bars (transitive via geoparquet-io, but we import directly)
     "rio-cogeo>=5.0.0",  # COG creation/validation (includes rasterio)
@@ -244,8 +245,10 @@ extend_exclude = [
 ]
 
 [tool.deptry.per_rule_ignores]
-# requests is pinned to constrain transitive dependency for CVE-2026-25645
-DEP002 = ["requests"]
+# Security constraints for transitive dependencies (not directly imported)
+# - requests: CVE-2026-25645
+# - pygments: CVE-2026-4539
+DEP002 = ["requests", "pygments"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -3133,6 +3133,7 @@ dependencies = [
     { name = "geoparquet-io" },
     { name = "obstore" },
     { name = "pyarrow" },
+    { name = "pygments" },
     { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pystac" },
@@ -3210,6 +3211,7 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
     { name = "pyarrow", specifier = ">=12.0.0,<22.0.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyproj", specifier = ">=3.0.0" },
     { name = "pystac", specifier = ">=1.10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
@@ -3675,11 +3677,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pin `pygments>=2.20.0` to fix CVE-2026-4539
- Update deptry config to allow security constraint (transitive dep, not directly imported)

`requests>=2.33.0` was already pinned for CVE-2026-25645.

## References

- Matches geoparquet-io PR #317 security fixes
- `pip-audit` now passes with no vulnerabilities

## Test plan

- [x] `uv run pip-audit` shows no vulnerabilities
- [x] Pre-commit hooks pass
- [x] `uv sync` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated syntax highlighting library dependency to version 2.20.0 or later, now explicitly declared to ensure a security enhancement is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->