### PR TITLE
feat(metadata): add --recursive flag to metadata init

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3927,7 +3927,8 @@ def metadata() -> None:
     "--recursive",
     is_flag=True,
     default=False,
-    help="Create templates at all STAC levels (catalogs, subcatalogs, collections).",
+    help="Create templates at all STAC levels (catalogs, subcatalogs, collections). "
+    "Skips items (item.json directories) and preserves existing files unless --force is used.",
 )
 @click.pass_context
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
@@ -3994,7 +3995,8 @@ def metadata_init(
 
     # Check for existing file
     metadata_file = portolan_dir / "metadata.yaml"
-    if metadata_file.exists() and not force:
+    file_existed = metadata_file.exists()
+    if file_existed and not force:
         if use_json:
             envelope = error_envelope(
                 "metadata init",
@@ -4019,7 +4021,7 @@ def metadata_init(
         relative_path = str(metadata_file.relative_to(catalog_path))
         envelope = success_envelope(
             "metadata init",
-            {"path": relative_path, "overwritten": force and metadata_file.exists()},
+            {"path": relative_path, "overwritten": force and file_existed},
         )
         output_json_envelope(envelope)
     else:
@@ -4179,6 +4181,52 @@ def _generate_readme_content(
     return generate_readme(stac=stac, metadata=metadata_dict), False
 
 
+def _recursive_init_error(use_json: bool, error_type: str, message: str) -> None:
+    """Output error for recursive init and exit."""
+    if use_json:
+        envelope = error_envelope(
+            "metadata init",
+            [ErrorDetail(type=error_type, message=message)],
+        )
+        output_json_envelope(envelope)
+    else:
+        error(message)
+    raise SystemExit(1)
+
+
+def _validate_recursive_start_path(
+    catalog_path: Path, start_path: str | None, use_json: bool
+) -> Path:
+    """Validate and return the starting directory for recursive init."""
+    if not start_path:
+        return catalog_path
+
+    base_dir = catalog_path / start_path
+    if not base_dir.exists():
+        _recursive_init_error(
+            use_json, "PathNotFoundError", f"Path '{start_path}' does not exist in catalog."
+        )
+    if not base_dir.is_dir():
+        _recursive_init_error(
+            use_json, "NotADirectoryError", f"Path '{start_path}' is not a directory."
+        )
+    return base_dir
+
+
+def _should_process_directory(dirpath: Path, catalog_path: Path) -> bool:
+    """Check if directory should be processed for metadata creation."""
+    if not dirpath.is_dir() or dirpath.is_symlink():
+        return False
+    # Skip hidden directories
+    if any(part.startswith(".") for part in dirpath.relative_to(catalog_path).parts):
+        return False
+    # Skip items (directories with item.json)
+    if (dirpath / "item.json").exists():
+        return False
+    # Only process STAC entities (catalogs/collections)
+    return (dirpath / "catalog.json").exists() or (dirpath / "collection.json").exists()
+
+
 def _metadata_init_recursive(
     catalog_path: Path,
     start_path: str | None,
@@ -4196,78 +4244,70 @@ def _metadata_init_recursive(
         start_path: Optional subdirectory to start from (relative to catalog root).
         use_json: Output JSON format.
         force: Overwrite existing metadata.yaml files.
+
+    Raises:
+        SystemExit: If start_path doesn't exist or permission errors occur.
     """
     from portolan_cli.metadata_yaml import generate_metadata_template
 
-    # Determine starting directory
-    if start_path:
-        base_dir = catalog_path / start_path
-    else:
-        base_dir = catalog_path
+    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json)
 
     created_paths: list[str] = []
     skipped_paths: list[str] = []
-
-    def _is_stac_entity(dirpath: Path) -> bool:
-        """Check if directory is a catalog or collection (not an item)."""
-        return (dirpath / "catalog.json").exists() or (dirpath / "collection.json").exists()
-
-    def _has_item_json(dirpath: Path) -> bool:
-        """Check if directory is an item (should be skipped)."""
-        return (dirpath / "item.json").exists()
+    permission_errors: list[str] = []
 
     def _create_metadata_at(dirpath: Path) -> bool:
         """Create metadata.yaml at directory. Returns True if created."""
         portolan_dir = dirpath / ".portolan"
         metadata_file = portolan_dir / "metadata.yaml"
-
-        # Skip if exists and not forcing
         if metadata_file.exists() and not force:
             return False
-
         portolan_dir.mkdir(parents=True, exist_ok=True)
-        template = generate_metadata_template()
-        metadata_file.write_text(template)
+        metadata_file.write_text(generate_metadata_template())
         return True
+
+    def _process_dir(dirpath: Path, rel_path: str) -> None:
+        """Process a directory: create metadata or record skip/error."""
+        try:
+            if _create_metadata_at(dirpath):
+                created_paths.append(rel_path)
+            else:
+                skipped_paths.append(rel_path)
+        except PermissionError:
+            permission_errors.append(rel_path)
 
     # Process base directory first (if it's a STAC entity or is catalog root)
     is_catalog_root = base_dir == catalog_path
-    if is_catalog_root or _is_stac_entity(base_dir):
-        rel_path = str(base_dir.relative_to(catalog_path) / ".portolan/metadata.yaml")
-        if is_catalog_root:
-            rel_path = ".portolan/metadata.yaml"
-        if _create_metadata_at(base_dir):
-            created_paths.append(rel_path)
-        else:
-            skipped_paths.append(rel_path)
+    is_stac = (base_dir / "catalog.json").exists() or (base_dir / "collection.json").exists()
+    if is_catalog_root or is_stac:
+        rel_path = (
+            ".portolan/metadata.yaml"
+            if is_catalog_root
+            else str(base_dir.relative_to(catalog_path) / ".portolan/metadata.yaml")
+        )
+        _process_dir(base_dir, rel_path)
 
-    # Walk tree for subdirectories
-    for dirpath in sorted(base_dir.rglob("*")):
-        if not dirpath.is_dir():
-            continue
-        # Skip hidden directories
-        if any(part.startswith(".") for part in dirpath.relative_to(catalog_path).parts):
-            continue
-        # Skip items
-        if _has_item_json(dirpath):
-            continue
-        # Only process STAC entities (catalogs/collections)
-        if not _is_stac_entity(dirpath):
-            continue
+    # Walk tree for subdirectories with permission error handling
+    try:
+        dir_iterator = sorted(base_dir.rglob("*"))
+    except PermissionError as e:
+        _recursive_init_error(use_json, "PermissionError", f"Permission denied during scan: {e}")
 
+    for dirpath in dir_iterator:
+        if not _should_process_directory(dirpath, catalog_path):
+            continue
         rel_path = str(dirpath.relative_to(catalog_path) / ".portolan/metadata.yaml")
-        if _create_metadata_at(dirpath):
-            created_paths.append(rel_path)
-        else:
-            skipped_paths.append(rel_path)
+        _process_dir(dirpath, rel_path)
 
     # Output results
     if use_json:
         envelope = success_envelope(
             "metadata init",
             {
+                "mode": "recursive",
                 "created": created_paths,
                 "skipped": skipped_paths,
+                "permission_errors": permission_errors,
                 "count": len(created_paths),
             },
         )
@@ -4279,7 +4319,11 @@ def _metadata_init_recursive(
                 detail(f"  {p}")
         if skipped_paths:
             info_output(f"Skipped {len(skipped_paths)} existing file(s)")
-        if not created_paths and not skipped_paths:
+        if permission_errors:
+            warn(f"Permission denied for {len(permission_errors)} location(s)")
+            for p in permission_errors:
+                detail(f"  {p}")
+        if not created_paths and not skipped_paths and not permission_errors:
             warn("No catalogs or collections found")
 
 

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -209,6 +209,106 @@ class TestMetadataInit:
             # demographics should NOT have metadata
             assert not Path("demographics/.portolan/metadata.yaml").exists()
 
+    @pytest.mark.unit
+    def test_recursive_nonexistent_path_fails(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata init --recursive with non-existent path should fail with clear error."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["metadata", "init", "nonexistent", "--recursive"])
+
+            assert result.exit_code != 0
+            assert "does not exist" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_recursive_nonexistent_path_json_output(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """metadata init --recursive with non-existent path should output JSON error."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(
+                cli, ["--format", "json", "metadata", "init", "nonexistent", "--recursive"]
+            )
+
+            assert result.exit_code != 0
+            output = json.loads(result.output)
+            assert output["success"] is False
+            assert any("PathNotFoundError" in e["type"] for e in output["errors"])
+
+    @pytest.mark.unit
+    def test_recursive_force_overwrites_content(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata init --recursive --force should actually overwrite existing content."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("demographics").mkdir()
+            Path("demographics/collection.json").write_text('{"type": "Collection"}')
+            Path("demographics/.portolan").mkdir()
+            original_content = "# Custom content\nlicense: CC-BY-4.0\n"
+            Path("demographics/.portolan/metadata.yaml").write_text(original_content)
+
+            result = runner.invoke(cli, ["metadata", "init", "--recursive", "--force"])
+
+            assert result.exit_code == 0
+            # Content should be overwritten with template
+            new_content = Path("demographics/.portolan/metadata.yaml").read_text()
+            assert new_content != original_content
+            assert "contact:" in new_content  # Template has contact field
+
+    @pytest.mark.unit
+    def test_recursive_json_output_complete_schema(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata init --recursive --json should have complete schema fields."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            # Create collection with existing metadata (to get skipped paths)
+            Path("demographics").mkdir()
+            Path("demographics/collection.json").write_text('{"type": "Collection"}')
+            Path("demographics/.portolan").mkdir()
+            Path("demographics/.portolan/metadata.yaml").write_text("license: MIT\n")
+            # Create another collection (to get created paths)
+            Path("climate").mkdir()
+            Path("climate/collection.json").write_text('{"type": "Collection"}')
+
+            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "--recursive"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["success"] is True
+            data = output["data"]
+            # Verify all schema fields exist
+            assert "mode" in data
+            assert data["mode"] == "recursive"
+            assert "created" in data
+            assert "skipped" in data
+            assert "permission_errors" in data
+            assert "count" in data
+            # Verify count matches created list length
+            assert data["count"] == len(data["created"])
+            # Verify types
+            assert isinstance(data["created"], list)
+            assert isinstance(data["skipped"], list)
+            assert isinstance(data["permission_errors"], list)
+
+    @pytest.mark.unit
+    def test_recursive_skips_symlinks(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata init --recursive should skip symlinks to prevent infinite loops."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("climate").mkdir()
+            Path("climate/catalog.json").write_text('{"type": "Catalog"}')
+            # Create a symlink that would cause infinite loop
+            try:
+                Path("climate/loop").symlink_to(Path.cwd() / "climate")
+            except OSError:
+                pytest.skip("Symlinks not supported on this platform")
+
+            result = runner.invoke(cli, ["metadata", "init", "--recursive"])
+
+            # Should complete without hanging/crashing
+            assert result.exit_code == 0
+            assert Path("climate/.portolan/metadata.yaml").exists()
+
 
 class TestMetadataValidate:
     """Tests for `portolan metadata validate` command."""


### PR DESCRIPTION
## Summary

- Add `-r/--recursive` flag to `portolan metadata init` that creates `metadata.yaml` templates at all STAC levels
- Walks catalog tree and creates templates at catalogs, subcatalogs, and collections
- Skips items (`item.json` directories) and preserves existing `metadata.yaml` files
- Supports explicit path: `portolan metadata init climate --recursive`

Closes #294

## Test plan

- [x] Unit tests for recursive creation at all levels
- [x] Unit test for skipping existing metadata files
- [x] Unit test for skipping items
- [x] Unit test for JSON output format
- [x] Unit test for explicit path with recursive
- [x] Manual integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--recursive/-r` flag to the `metadata init` command to create metadata templates across multiple STAC catalog directories.
  * Automatic skipping of non-applicable directories and existing files (overridable with `--force` flag).
  * JSON output format now supported for recursive initialization runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->