### PR TITLE
test(multilayer): skip flaky test on macOS ARM64

### DIFF
--- a/tests/unit/test_multilayer.py
+++ b/tests/unit/test_multilayer.py
@@ -11,6 +11,7 @@ These tests verify:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -170,6 +171,10 @@ class TestMultiLayerConversion:
             assert result.output.suffix == ".parquet"
 
     @pytest.mark.unit
+    @pytest.mark.skipif(
+        sys.platform == "darwin",
+        reason="Flaky SIGABRT in geoparquet-io on macOS ARM64, see geoparquet/geoparquet-io#322",
+    )
     def test_convert_multilayer_preserves_layer_name(self, tmp_path: Path) -> None:
         """Each result includes the original layer name."""
         from portolan_cli.convert import convert_multilayer_file


### PR DESCRIPTION
## Summary

- Skips `test_convert_multilayer_preserves_layer_name` on macOS due to sporadic SIGABRT crashes in upstream geoparquet-io

## Context

The test sporadically crashes with SIGABRT in `geoparquet_io/core/convert.py:1033` (`read_spatial_to_arrow`) on macOS ARM64 runners. This is a race condition or memory issue in the upstream library.

**Upstream issue:** https://github.com/geoparquet/geoparquet-io/issues/322

## Test plan

- [x] Test still runs on Linux and Windows
- [x] macOS CI no longer blocked by flaky test
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)