### PR TITLE
feat(progress): Unified progress output model (ADR-0040)

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -1292,9 +1292,9 @@ def _run_fix_workflow(
 
     # Fix geo-assets if in scope
     if run_geo_assets:
-        # Progress callback for conversion (skip for JSON mode)
+        # Progress callback for conversion (skip for JSON mode, per ADR-0040: per-file only in verbose)
         def show_conversion_progress(result: ConversionResult) -> None:
-            if not use_json and result.source:
+            if not use_json and verbose and result.source:
                 info_output(f"Converting: {result.source.name}")
 
         format_fix_report = check_directory(

--- a/portolan_cli/download.py
+++ b/portolan_cli/download.py
@@ -210,14 +210,20 @@ def _download_one_file(
     remote_key: str,
     local_path: Path,
     file_size: int,
+    *,
+    verbose: bool = False,
 ) -> tuple[Path, Exception | None, int]:
     """Download a single file and return result tuple for parallel processing.
+
+    Per ADR-0040: Per-file output only shown in verbose mode when used in
+    batch operations. Errors are always shown.
 
     Args:
         store: Object store instance
         remote_key: Remote object key to download
         local_path: Local path to save the file
         file_size: Expected file size in bytes
+        verbose: If True, show per-file download/success messages.
 
     Returns:
         Tuple of (local_path, error_or_none, bytes_downloaded)
@@ -228,7 +234,9 @@ def _download_one_file(
         start_time = time.time()
 
         filename = local_path.name
-        info(f"Downloading {filename} ({size_mb:.2f} MB) <- {remote_key}")
+        # Per ADR-0040: per-file output only in verbose mode
+        if verbose:
+            info(f"Downloading {filename} ({size_mb:.2f} MB) <- {remote_key}")
 
         # Ensure parent directory exists
         local_path.parent.mkdir(parents=True, exist_ok=True)
@@ -257,12 +265,15 @@ def _download_one_file(
         elapsed = time.time() - start_time
         speed_mbps = size_mb / elapsed if elapsed > 0 else 0
 
-        success(f"{filename} ({speed_mbps:.2f} MB/s)")
+        # Per ADR-0040: per-file output only in verbose mode
+        if verbose:
+            success(f"{filename} ({speed_mbps:.2f} MB/s)")
         return local_path, None, actual_size
     except Exception as e:
         # Clean up partial file if it exists (for any uncaught exceptions)
         if local_path.exists():
             local_path.unlink()
+        # Errors are always shown per ADR-0040
         error(f"{local_path.name}: {e}")
         return local_path, e, 0
 
@@ -453,8 +464,12 @@ def _execute_parallel_downloads(
     max_files: int,
     fail_fast: bool,
     overwrite: bool = True,
+    *,
+    verbose: bool = False,
 ) -> list[tuple[Path, Exception | None, int]]:
     """Execute parallel downloads using ThreadPoolExecutor.
+
+    Per ADR-0040: Per-file output controlled by verbose parameter.
 
     Args:
         store: Object store instance
@@ -464,6 +479,7 @@ def _execute_parallel_downloads(
         max_files: Max concurrent file downloads
         fail_fast: Stop on first error if True
         overwrite: If False, skip existing files
+        verbose: If True, show per-file download messages.
 
     Returns:
         List of (local_path, error_or_none, bytes_downloaded) tuples
@@ -508,7 +524,7 @@ def _execute_parallel_downloads(
             # Submit initial batch up to max_files
             for remote_key, file_size, local_path in files_iter:
                 future: DownloadResultFuture = executor.submit(
-                    _download_one_file, store, remote_key, local_path, file_size
+                    _download_one_file, store, remote_key, local_path, file_size, verbose=verbose
                 )
                 pending[future] = remote_key
                 if len(pending) >= max_files:
@@ -531,7 +547,12 @@ def _execute_parallel_downloads(
                 try:
                     remote_key, file_size, local_path = next(files_iter)
                     new_future: DownloadResultFuture = executor.submit(
-                        _download_one_file, store, remote_key, local_path, file_size
+                        _download_one_file,
+                        store,
+                        remote_key,
+                        local_path,
+                        file_size,
+                        verbose=verbose,
                     )
                     pending[new_future] = remote_key
                 except StopIteration:
@@ -541,7 +562,7 @@ def _execute_parallel_downloads(
         with ThreadPoolExecutor(max_workers=max_files) as executor:
             future_to_file = {
                 executor.submit(
-                    _download_one_file, store, remote_key, local_path, file_size
+                    _download_one_file, store, remote_key, local_path, file_size, verbose=verbose
                 ): remote_key
                 for remote_key, file_size, local_path in files_to_download
             }
@@ -567,8 +588,12 @@ def download_directory(
     s3_endpoint: str | None = None,
     s3_region: str | None = None,
     s3_use_ssl: bool = True,
+    verbose: bool = False,
 ) -> DownloadResult:
     """Download a directory from S3/GCS/Azure with parallel downloads.
+
+    Per ADR-0040: Per-file output controlled by verbose parameter.
+    Progress is shown via summary messages at start/end.
 
     Args:
         source: Object store URL (e.g., s3://bucket/prefix/)
@@ -583,6 +608,7 @@ def download_directory(
         s3_endpoint: Custom S3-compatible endpoint (e.g., "minio.example.com:9000")
         s3_region: S3 region (default: auto-detected)
         s3_use_ssl: Whether to use HTTPS for S3 endpoint (default: True)
+        verbose: If True, show per-file download messages (ADR-0040).
 
     Returns:
         DownloadResult with download statistics
@@ -641,7 +667,7 @@ def download_directory(
     max_files = max(1, max_files)
 
     results = _execute_parallel_downloads(
-        store, files, prefix, destination, max_files, fail_fast, overwrite
+        store, files, prefix, destination, max_files, fail_fast, overwrite, verbose=verbose
     )
 
     # Calculate results

--- a/portolan_cli/pull.py
+++ b/portolan_cli/pull.py
@@ -662,8 +662,14 @@ async def _download_assets_async(
     files_to_download: list[str],
     remote_assets: dict[str, dict[str, str | int]],
     concurrency: int = DEFAULT_CONCURRENCY,
+    *,
+    verbose: bool = False,
+    json_mode: bool = False,
 ) -> tuple[int, int]:
     """Download assets concurrently using asyncio.
+
+    Per ADR-0040: Uses progress bar for batch downloads. Per-file output
+    only shown in verbose mode.
 
     Args:
         store: Object store instance (pre-configured connection).
@@ -672,12 +678,19 @@ async def _download_assets_async(
         files_to_download: List of filenames to download.
         remote_assets: Dict mapping filename to asset metadata.
         concurrency: Maximum concurrent downloads.
+        verbose: If True, show per-file download messages.
+        json_mode: If True, suppress progress output (for agent/batch usage).
 
     Returns:
         Tuple of (files_downloaded, files_failed).
     """
+    from portolan_cli.async_utils import AsyncProgressReporter
+
     if not files_to_download:
         return 0, 0
+
+    # Calculate total bytes for progress bar
+    total_bytes = sum(int(remote_assets.get(f, {}).get("size_bytes", 0)) for f in files_to_download)
 
     # Semaphore for concurrency control
     semaphore = asyncio.Semaphore(concurrency)
@@ -686,79 +699,88 @@ async def _download_assets_async(
     downloaded = 0
     failed = 0
     total = len(files_to_download)
-    completed = 0
 
-    async def download_one(filename: str) -> tuple[str, bool, str | None]:
-        """Download a single file with semaphore control."""
-        nonlocal completed
+    async with AsyncProgressReporter(
+        total_files=total,
+        total_bytes=total_bytes,
+        json_mode=json_mode,
+        description="Downloading",
+    ) as progress:
 
-        asset = remote_assets.get(filename)
-        if not asset:
-            return filename, False, "Asset metadata not found"
+        async def download_one(filename: str) -> tuple[str, bool, str | None, int]:
+            """Download a single file with semaphore control."""
+            asset = remote_assets.get(filename)
+            if not asset:
+                return filename, False, "Asset metadata not found", 0
 
-        href = str(asset["href"])
+            href = str(asset["href"])
+            file_size = int(asset.get("size_bytes", 0))
 
-        # Security: Validate path before any filesystem operations
-        try:
-            local_path = _validate_safe_path(local_root, href)
-        except ValueError as e:
-            return filename, False, str(e)
-
-        # Construct remote_key by joining prefix and href
-        # Strip leading/trailing slashes for proper normalization
-        if prefix:
-            remote_key = f"{prefix.strip('/')}/{href.lstrip('/')}"
-        else:
-            remote_key = href.lstrip("/")
-
-        async with semaphore:
-            # Check circuit breaker AFTER acquiring semaphore (execution time, not scheduling time)
+            # Security: Validate path before any filesystem operations
             try:
-                circuit_breaker.check()
-            except CircuitBreakerError:
-                return filename, False, "Circuit breaker open - too many failures"
+                local_path = _validate_safe_path(local_root, href)
+            except ValueError as e:
+                return filename, False, str(e), 0
 
-            # Retry logic for rate limits
-            max_retries = 3
-            retry_delay = 1.0
-
-            for attempt in range(max_retries):
-                try:
-                    await _download_file_async(store, remote_key, local_path)
-                    circuit_breaker.record_success()
-                    completed += 1
-                    info(f"Downloaded ({completed}/{total}): {filename}")
-                    return filename, True, None
-                except Exception as e:
-                    error_str = str(e)
-                    if "429" in error_str and attempt < max_retries - 1:
-                        # Rate limited - wait and retry
-                        await asyncio.sleep(retry_delay * (attempt + 1))
-                        continue
-                    circuit_breaker.record_failure()
-                    return filename, False, error_str
-
-            return filename, False, "Max retries exceeded"
-
-    # Create tasks for all downloads
-    tasks = [download_one(filename) for filename in files_to_download]
-
-    # Execute all tasks concurrently
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-
-    # Process results
-    for result in results:
-        if isinstance(result, BaseException):
-            failed += 1
-            error(f"Download error: {result}")
-        elif isinstance(result, tuple):
-            filename, success_flag, err_msg = result
-            if success_flag:
-                downloaded += 1
+            # Construct remote_key by joining prefix and href
+            # Strip leading/trailing slashes for proper normalization
+            if prefix:
+                remote_key = f"{prefix.strip('/')}/{href.lstrip('/')}"
             else:
+                remote_key = href.lstrip("/")
+
+            async with semaphore:
+                # Check circuit breaker AFTER acquiring semaphore (execution time, not scheduling time)
+                try:
+                    circuit_breaker.check()
+                except CircuitBreakerError:
+                    return filename, False, "Circuit breaker open - too many failures", 0
+
+                # Retry logic for rate limits
+                max_retries = 3
+                retry_delay = 1.0
+
+                for attempt in range(max_retries):
+                    try:
+                        await _download_file_async(store, remote_key, local_path)
+                        circuit_breaker.record_success()
+                        # Per ADR-0040: per-file output only in verbose mode
+                        if verbose:
+                            info(f"Downloaded: {filename}")
+                        return filename, True, None, file_size
+                    except Exception as e:
+                        error_str = str(e)
+                        if "429" in error_str and attempt < max_retries - 1:
+                            # Rate limited - wait and retry
+                            await asyncio.sleep(retry_delay * (attempt + 1))
+                            continue
+                        circuit_breaker.record_failure()
+                        return filename, False, error_str, 0
+
+                return filename, False, "Max retries exceeded", 0
+
+        # Create tasks for all downloads
+        tasks = [download_one(filename) for filename in files_to_download]
+
+        # Execute all tasks concurrently
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Process results
+        for result in results:
+            if isinstance(result, BaseException):
                 failed += 1
-                if err_msg:
-                    error(f"Failed {filename}: {err_msg}")
+                error(f"Download error: {result}")
+                progress.advance(0)
+            elif isinstance(result, tuple):
+                filename, success_flag, err_msg, bytes_downloaded = result
+                if success_flag:
+                    downloaded += 1
+                    progress.advance(bytes_downloaded)
+                else:
+                    failed += 1
+                    progress.advance(0)
+                    if err_msg:
+                        error(f"Failed {filename}: {err_msg}")
 
     return downloaded, failed
 
@@ -778,6 +800,8 @@ async def pull_async(
     profile: str | None = None,
     concurrency: int = DEFAULT_CONCURRENCY,
     store: ObjectStore | None = None,
+    verbose: bool = False,
+    json_mode: bool = False,
 ) -> PullResult:
     """Pull updates from a remote catalog asynchronously.
 
@@ -801,6 +825,8 @@ async def pull_async(
         concurrency: Maximum concurrent downloads (default: 50).
         store: Optional pre-configured object store. If provided, reuses
             this connection instead of creating a new one (for connection pooling).
+        verbose: If True, show per-file download messages (ADR-0040).
+        json_mode: If True, suppress progress output (for agent/batch usage).
 
     Returns:
         PullResult with operation results.
@@ -898,6 +924,8 @@ async def pull_async(
         files_to_download=diff.files_to_download,
         remote_assets=diff.remote_assets,
         concurrency=concurrency,
+        verbose=verbose,
+        json_mode=json_mode,
     )
 
     # Handle failures
@@ -939,6 +967,8 @@ def pull(
     dry_run: bool = False,
     profile: str | None = None,
     concurrency: int = DEFAULT_CONCURRENCY,
+    verbose: bool = False,
+    json_mode: bool = False,
 ) -> PullResult:
     """Pull updates from a remote catalog (sync wrapper).
 
@@ -960,6 +990,8 @@ def pull(
         dry_run: If True, show what would happen without downloading.
         profile: AWS profile name (for S3).
         concurrency: Maximum concurrent downloads (default: 50).
+        verbose: If True, show per-file download messages (ADR-0040).
+        json_mode: If True, suppress progress output (for agent/batch usage).
 
     Returns:
         PullResult with operation results.
@@ -976,6 +1008,8 @@ def pull(
             dry_run=dry_run,
             profile=profile,
             concurrency=concurrency,
+            verbose=verbose,
+            json_mode=json_mode,
         )
     )
 
@@ -993,6 +1027,8 @@ async def pull_all_collections_async(
     dry_run: bool = False,
     profile: str | None = None,
     concurrency: int | None = None,
+    verbose: bool = False,
+    json_mode: bool = False,
 ) -> PullAllResult:
     """Pull all collections in a catalog from cloud storage asynchronously.
 
@@ -1006,6 +1042,8 @@ async def pull_all_collections_async(
         dry_run: If True, show what would be downloaded without downloading.
         profile: AWS profile name (for S3 only).
         concurrency: Maximum concurrent collection pulls. None = auto-detect.
+        verbose: If True, show per-file download messages (ADR-0040).
+        json_mode: If True, suppress progress output (for agent/batch usage).
 
     Returns:
         PullAllResult with aggregate statistics and per-collection errors.
@@ -1068,6 +1106,8 @@ async def pull_all_collections_async(
                     dry_run=dry_run,
                     profile=profile,
                     store=shared_store,  # Reuse connection across collections
+                    verbose=verbose,
+                    json_mode=json_mode,
                 )
                 return (collection, result, None)
             except Exception as e:
@@ -1143,6 +1183,8 @@ def pull_all_collections(
     dry_run: bool = False,
     profile: str | None = None,
     workers: int | None = None,
+    verbose: bool = False,
+    json_mode: bool = False,
 ) -> PullAllResult:
     """Pull all collections in a catalog from cloud storage (sync wrapper).
 
@@ -1157,6 +1199,8 @@ def pull_all_collections(
         profile: AWS profile name (for S3 only).
         workers: Number of parallel workers. None = auto-detect, 1 = sequential.
             (Maps to 'concurrency' in async implementation.)
+        verbose: If True, show per-file download messages (ADR-0040).
+        json_mode: If True, suppress progress output (for agent/batch usage).
 
     Returns:
         PullAllResult with aggregate statistics and per-collection errors.
@@ -1172,5 +1216,7 @@ def pull_all_collections(
             dry_run=dry_run,
             profile=profile,
             concurrency=workers,
+            verbose=verbose,
+            json_mode=json_mode,
         )
     )

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -548,6 +548,29 @@ def _discover_stac_files(
     return stac_files
 
 
+def _stat_files_safely(files: list[Path], errors: list[str]) -> tuple[dict[Path, int], list[Path]]:
+    """Stat files safely, recording errors for files that can't be stat'd.
+
+    This handles the case where files are deleted between discovery and upload.
+    Returns both the file sizes dict and the list of successfully stat'd files.
+
+    Args:
+        files: List of file paths to stat.
+        errors: List to append error messages to.
+
+    Returns:
+        Tuple of (file_sizes dict, list of files that were successfully stat'd).
+    """
+    file_sizes: dict[Path, int] = {}
+    for f in files:
+        try:
+            file_sizes[f] = f.stat().st_size
+        except OSError as e:
+            errors.append(f"Failed to stat {f}: {e}")
+    uploadable = [f for f in files if f in file_sizes]
+    return file_sizes, uploadable
+
+
 def _upload_stac_files(
     store: ObjectStore,
     catalog_root: Path,
@@ -597,19 +620,16 @@ def _upload_stac_files(
     ordered_files.extend(stac_files.get("collection", []))
     ordered_files.extend(stac_files.get("catalog", []))
 
-    total = len(ordered_files)
-    if total == 0:
+    if not ordered_files:
         return 0, [], []
 
-    # Pre-cache file sizes to avoid double stat() calls (once for total, once per file)
-    # Handle stat errors gracefully - files may have been deleted between discovery and upload
-    file_sizes: dict[Path, int] = {}
-    for f in ordered_files:
-        try:
-            file_sizes[f] = f.stat().st_size
-        except OSError as e:
-            errors.append(f"Failed to stat {f}: {e}")
+    # Pre-cache file sizes, handling stat errors for files deleted between discovery and upload
+    file_sizes, uploadable_files = _stat_files_safely(ordered_files, errors)
+    total = len(uploadable_files)
     total_bytes = sum(file_sizes.values())
+
+    if total == 0:
+        return 0, errors, []
 
     # Use progress bar for STAC uploads (ADR-0040: unified progress output)
     # Suppress in json_mode or when verbose (verbose shows per-file output)
@@ -620,7 +640,7 @@ def _upload_stac_files(
         total_bytes=total_bytes,
         json_mode=suppress_progress,
     ) as reporter:
-        for file_path in ordered_files:
+        for file_path in uploadable_files:
             try:
                 rel_path = file_path.relative_to(catalog_root)
                 target_key = f"{prefix}/{rel_path.as_posix()}".lstrip("/")
@@ -1058,9 +1078,17 @@ async def _upload_stac_files_async(
     if not all_files:
         return 0, [], []
 
-    # Pre-cache file sizes
-    file_sizes: dict[Path, int] = {f: f.stat().st_size for f in all_files}
+    # Pre-cache file sizes, handling stat errors for files deleted between discovery and upload
+    file_sizes, uploadable_files = _stat_files_safely(all_files, errors)
+    if not uploadable_files:
+        return 0, errors, []
+
     total_bytes = sum(file_sizes.values())
+
+    # Filter file lists to only include uploadable files
+    item_files = [f for f in item_files if f in file_sizes]
+    collection_files = [f for f in collection_files if f in file_sizes]
+    catalog_files = [f for f in catalog_files if f in file_sizes]
 
     # Semaphore for bounded concurrency
     semaphore = asyncio.Semaphore(concurrency)
@@ -1084,12 +1112,12 @@ async def _upload_stac_files_async(
 
     # Suppress progress bar when verbose (verbose replaces progress bar per ADR-0040)
     async with AsyncProgressReporter(
-        total_files=len(all_files),
+        total_files=len(uploadable_files),
         total_bytes=total_bytes,
         json_mode=json_mode or verbose,
     ) as reporter:
         completed = 0
-        total_count = len(all_files)
+        total_count = len(uploadable_files)
 
         def log_verbose(file_path: Path, size: int) -> None:
             """Log verbose output for a file upload."""

--- a/portolan_cli/upload.py
+++ b/portolan_cli/upload.py
@@ -601,15 +601,20 @@ def _upload_one_file(
     file_path: Path,
     source: Path,
     prefix: str,
+    verbose: bool = False,
     **kwargs: int,
 ) -> tuple[Path, Exception | None, int]:
     """Upload a single file and return result tuple for parallel processing.
+
+    Per ADR-0040: Per-file output only shown in verbose mode when used in
+    batch operations. Errors are always shown.
 
     Args:
         store: Object store instance
         file_path: Path to file to upload
         source: Source directory for relative path calculation
         prefix: Prefix for target key
+        verbose: If True, show per-file upload/success messages.
         **kwargs: Additional args passed to obs.put
 
     Returns:
@@ -621,16 +626,21 @@ def _upload_one_file(
         size_mb = file_size / (1024 * 1024)
         start_time = time.time()
 
-        info(f"Uploading {file_path.name} ({size_mb:.2f} MB) -> {target_key}")
+        # Per ADR-0040: per-file output only in verbose mode
+        if verbose:
+            info(f"Uploading {file_path.name} ({size_mb:.2f} MB) -> {target_key}")
 
         obs.put(store, target_key, file_path, max_concurrency=kwargs.get("max_concurrency", 12))
 
         elapsed = time.time() - start_time
         speed_mbps = size_mb / elapsed if elapsed > 0 else 0
 
-        success(f"{file_path.name} ({speed_mbps:.2f} MB/s)")
+        # Per ADR-0040: per-file output only in verbose mode
+        if verbose:
+            success(f"{file_path.name} ({speed_mbps:.2f} MB/s)")
         return file_path, None, file_size
     except Exception as e:
+        # Errors are always shown per ADR-0040
         error(f"{file_path.name}: {e}")
         return file_path, e, 0
 
@@ -760,8 +770,12 @@ def _execute_parallel_uploads(
     max_files: int,
     fail_fast: bool,
     kwargs: dict[str, int],
+    *,
+    verbose: bool = False,
 ) -> list[tuple[Path, Exception | None, int]]:
     """Execute parallel uploads using ThreadPoolExecutor.
+
+    Per ADR-0040: Per-file output controlled by verbose parameter.
 
     Args:
         store: Object store instance
@@ -771,6 +785,7 @@ def _execute_parallel_uploads(
         max_files: Max concurrent file uploads
         fail_fast: Stop on first error if True
         kwargs: Additional args for obs.put
+        verbose: If True, show per-file upload messages.
 
     Returns:
         List of (file_path, error_or_none, bytes_uploaded) tuples
@@ -790,7 +805,7 @@ def _execute_parallel_uploads(
             # Submit initial batch up to max_files
             for f in files_iter:
                 future: UploadResultFuture = executor.submit(
-                    _upload_one_file, store, f, source, prefix, **kwargs
+                    _upload_one_file, store, f, source, prefix, verbose, **kwargs
                 )
                 pending[future] = f
                 if len(pending) >= max_files:
@@ -813,7 +828,7 @@ def _execute_parallel_uploads(
                 try:
                     next_file = next(files_iter)
                     new_future: UploadResultFuture = executor.submit(
-                        _upload_one_file, store, next_file, source, prefix, **kwargs
+                        _upload_one_file, store, next_file, source, prefix, verbose, **kwargs
                     )
                     pending[new_future] = next_file
                 except StopIteration:
@@ -822,7 +837,7 @@ def _execute_parallel_uploads(
         # For non-fail_fast mode, submit all futures upfront for maximum parallelism
         with ThreadPoolExecutor(max_workers=max_files) as executor:
             future_to_file = {
-                executor.submit(_upload_one_file, store, f, source, prefix, **kwargs): f
+                executor.submit(_upload_one_file, store, f, source, prefix, verbose, **kwargs): f
                 for f in files
             }
 
@@ -846,8 +861,12 @@ def upload_directory(
     s3_endpoint: str | None = None,
     s3_region: str | None = None,
     s3_use_ssl: bool = True,
+    verbose: bool = False,
 ) -> UploadResult:
     """Upload a directory to S3/GCS/Azure with parallel uploads.
+
+    Per ADR-0040: Per-file output controlled by verbose parameter.
+    Progress is shown via summary messages at start/end.
 
     Args:
         source: Local directory path
@@ -861,6 +880,7 @@ def upload_directory(
         s3_endpoint: Custom S3-compatible endpoint (e.g., "minio.example.com:9000")
         s3_region: S3 region (default: auto-detected)
         s3_use_ssl: Whether to use HTTPS for S3 endpoint (default: True)
+        verbose: If True, show per-file upload messages (ADR-0040).
 
     Returns:
         UploadResult with upload statistics
@@ -907,7 +927,9 @@ def upload_directory(
     # Ensure max_files is at least 1 to avoid ThreadPoolExecutor ValueError
     max_files = max(1, max_files)
 
-    results = _execute_parallel_uploads(store, files, source, prefix, max_files, fail_fast, kwargs)
+    results = _execute_parallel_uploads(
+        store, files, source, prefix, max_files, fail_fast, kwargs, verbose=verbose
+    )
 
     # Calculate results
     errors = [(path, err) for path, err, _ in results if err is not None]


### PR DESCRIPTION
## Summary

Replace per-file output spam with Rich progress bars for `add` and `push` commands, implementing a "progress + summary" model per ADR-0040.

- **add command**: Rich progress bar with file pre-counting (replaces 27k "Adding: data.tif" lines)
- **push command**: STAC metadata uploads now use `UploadProgressReporter` (consistent with asset uploads)
- **Verbosity**: `--verbose` flag for per-file output (opt-in), progress bar by default
- **Agent-native**: Progress suppressed in JSON mode

### Before
```
portolan add eurosat-ms/
Adding: data.tif
Adding: data.tif
Adding: data.tif
... (27,000 lines)
```

### After
```
portolan add eurosat-ms/
Adding... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 27000/27000 files 0:00:45
✓ Added 27,000 files to 10 collections
```

## Test plan

- [x] Unit tests for `AddProgressReporter` and `count_files()`
- [x] All existing tests pass (359 tests)
- [x] Type checking passes (`mypy --strict`)
- [ ] Manual test with large catalog to verify progress bar behavior

Closes #315, Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Progress bars now suppress in verbose mode and only display when interactive, for cleaner terminal output.
  * Per-file upload, download, and pull messages are now shown only when verbose is enabled.
  * Download progress now accounts for byte counts for more accurate progress tracking.

* **Bug Fixes**
  * Uploads gracefully skip unreadable/missing files and continue processing.
  * Add command now prints the successful-add summary even when some failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->