### PR TITLE
fix(imageserver): improve UX for bbox, tile size, and error handling

### DIFF
--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -158,9 +158,15 @@ portolan extract arcgis URL --bbox "-75.17,39.95,-75.15,39.97"
 
 # Or explicit service CRS coordinates (Web Mercator in this example)
 portolan extract arcgis URL --bbox "-8367886,4858679,-8365659,4861583"
+
+# Override CRS auto-detection with --bbox-crs
+portolan extract arcgis URL --bbox "100,200,300,400" --bbox-crs "EPSG:2269"
 ```
 
 **Automatic CRS conversion**: Portolan detects if your bbox coordinates appear to be in WGS84 (values in -180/180, -90/90 range) and automatically reprojects them to the service's native CRS. This means you can use familiar lat/lon coordinates without manual conversion.
+
+!!! tip "Overriding CRS Detection"
+    If you're working with a local CRS (like State Plane) where coordinates happen to fall in the WGS84 range, use `--bbox-crs` to specify the exact CRS and skip auto-detection.
 
 ### ImageServer Options
 

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -153,7 +153,7 @@ This will:
 For large ImageServers, use `--bbox` to extract a subset:
 
 ```bash
-# WGS84 coordinates (latitude/longitude) - auto-converted to service CRS
+# WGS84 coordinates (minx,miny,maxx,maxy = lon,lat order) - auto-converted to service CRS
 portolan extract arcgis URL --bbox "-75.17,39.95,-75.15,39.97"
 
 # Or explicit service CRS coordinates (Web Mercator in this example)
@@ -163,7 +163,7 @@ portolan extract arcgis URL --bbox "-8367886,4858679,-8365659,4861583"
 portolan extract arcgis URL --bbox "100,200,300,400" --bbox-crs "EPSG:2269"
 ```
 
-**Automatic CRS conversion**: Portolan detects if your bbox coordinates appear to be in WGS84 (values in -180/180, -90/90 range) and automatically reprojects them to the service's native CRS. This means you can use familiar lat/lon coordinates without manual conversion.
+**Bbox format**: The `--bbox` flag expects coordinates as `minx,miny,maxx,maxy` (longitude,latitude order for WGS84). When values fall within the WGS84 range (-180/180, -90/90), Portolan automatically reprojects them to the service's native CRS. Use `--bbox-crs` to specify an explicit CRS and skip auto-detection.
 
 !!! tip "Overriding CRS Detection"
     If you're working with a local CRS (like State Plane) where coordinates happen to fall in the WGS84 range, use `--bbox-crs` to specify the exact CRS and skip auto-detection.

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -28,6 +28,13 @@ Portolan auto-detects the service type from the URL:
 | `.../MapServer` | Vector features | GeoParquet |
 | `.../ImageServer` | Raster imagery | COG tiles |
 
+!!! warning "MapServer Raster Limitation"
+    **MapServer endpoints only support vector extraction.** Even if a MapServer hosts imagery, Portolan extracts the vector tile indexes and boundaries—not the imagery itself.
+
+    This is a fundamental ArcGIS limitation: MapServer's `/export` endpoint returns **rendered 8-bit visualization**, not source raster data. For source imagery extraction, you need an **ImageServer** endpoint.
+
+    If you're working with a data provider that only offers MapServer (e.g., PASDA), contact them to request ImageServer access, or use their download links for the source data.
+
 ---
 
 ## FeatureServer / MapServer Extraction
@@ -146,16 +153,19 @@ This will:
 For large ImageServers, use `--bbox` to extract a subset:
 
 ```bash
-# Extract only tiles within bounding box (in service CRS coordinates)
-portolan extract arcgis URL --bbox "-8841000,5405000,-8840000,5406000"
+# WGS84 coordinates (latitude/longitude) - auto-converted to service CRS
+portolan extract arcgis URL --bbox "-75.17,39.95,-75.15,39.97"
+
+# Or explicit service CRS coordinates (Web Mercator in this example)
+portolan extract arcgis URL --bbox "-8367886,4858679,-8365659,4861583"
 ```
 
-**Important**: The bbox coordinates must be in the service's native CRS (check the service metadata for `spatialReference.wkid`).
+**Automatic CRS conversion**: Portolan detects if your bbox coordinates appear to be in WGS84 (values in -180/180, -90/90 range) and automatically reprojects them to the service's native CRS. This means you can use familiar lat/lon coordinates without manual conversion.
 
 ### ImageServer Options
 
 ```bash
-# Tile size in pixels (default: 4096)
+# Tile size in pixels (default: 4096, auto-adjusted if exceeds service limit)
 portolan extract arcgis URL --tile-size 2048
 
 # Maximum concurrent downloads (default: 4)
@@ -163,7 +173,13 @@ portolan extract arcgis URL --max-concurrent 8
 
 # COG compression (default: deflate)
 portolan extract arcgis URL --compression jpeg  # Good for RGB imagery
+
+# Custom collection name (default: 'tiles')
+portolan extract arcgis URL --collection-name "naip-philly-2024"
 ```
+
+!!! tip "Tile Size Validation"
+    Portolan automatically fetches the service's maximum allowed tile dimensions during discovery. If your `--tile-size` exceeds this limit, it's auto-adjusted down with a warning—no more cryptic "bad magic bytes" errors.
 
 ### Output Structure
 
@@ -177,7 +193,7 @@ output/
 │   ├── imageserver-resume.json     # For resuming interrupted extractions
 │   └── metadata.yaml               # Seeded from service metadata
 ├── catalog.json
-└── tiles/                          # Collection (one per ImageServer)
+└── tiles/                          # Collection name (customizable via --collection-name)
     ├── collection.json
     ├── versions.json
     ├── tile_0_0/
@@ -188,6 +204,8 @@ output/
     │   └── tile_0_1.tif
     └── ...
 ```
+
+Use `--collection-name` to give the collection a meaningful name instead of the generic "tiles".
 
 ### Metadata After Extraction
 
@@ -209,6 +227,11 @@ Complete the `TODO` fields, then generate the README:
 # Generate README from STAC + metadata.yaml
 portolan readme tiles
 ```
+
+!!! info "metadata.yaml Supplements STAC"
+    The `metadata.yaml` file **supplements** STAC metadata—it doesn't replace or modify it. This separation keeps machine-extracted metadata (STAC) distinct from human-enriched metadata (metadata.yaml).
+
+    There is no `portolan metadata generate` command because `metadata.yaml` is for human enrichment only. The README command (`portolan readme`) reads from both STAC (machine-extracted) and metadata.yaml (human-enriched) to generate documentation.
 
 !!! tip "Overriding auto-seeded metadata"
     To replace auto-seeded values, edit the generated `metadata.yaml` directly. The file is never overwritten on subsequent extractions.

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -5011,6 +5011,7 @@ def _handle_imageserver_extraction(
     output_dir: Path,
     tile_size: int,
     bbox: str | None,
+    bbox_crs: str | None,
     compression: str | None,
     max_concurrent: int,
     timeout: float,
@@ -5080,6 +5081,7 @@ def _handle_imageserver_extraction(
         resume=resume,
         raw=False,  # ImageServer always creates STAC structure
         bbox=bbox_tuple,
+        bbox_crs=bbox_crs,
         timeout=timeout,
         compression=cog_settings.compression,
         use_json=json_output,
@@ -5325,6 +5327,12 @@ def extract() -> None:
     help="[ImageServer] Bounding box filter: minx,miny,maxx,maxy. WGS84 coords auto-converted to service CRS.",
 )
 @click.option(
+    "--bbox-crs",
+    type=str,
+    default=None,
+    help="[ImageServer] Explicit CRS of --bbox (e.g., EPSG:4326, EPSG:3857). Skips auto-detection.",
+)
+@click.option(
     "--compression",
     type=click.Choice(["DEFLATE", "JPEG", "LZW", "ZSTD"], case_sensitive=False),
     default=None,
@@ -5363,6 +5371,7 @@ def extract_arcgis_cmd(
     raw: bool,
     tile_size: int,
     bbox: str | None,
+    bbox_crs: str | None,
     compression: str | None,
     max_concurrent: int,
     collection_name: str | None,
@@ -5460,6 +5469,7 @@ def extract_arcgis_cmd(
             output_dir=output_dir,
             tile_size=tile_size,
             bbox=bbox,
+            bbox_crs=bbox_crs,
             compression=compression,
             max_concurrent=max_concurrent,
             timeout=timeout,

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -5019,6 +5019,7 @@ def _handle_imageserver_extraction(
     dry_run: bool,
     json_output: bool,
     auto: bool,
+    collection_name: str | None,
 ) -> None:
     """Handle ImageServer URL extraction (raster data)."""
     from portolan_cli.conversion_config import CogSettings, get_cog_settings
@@ -5082,6 +5083,7 @@ def _handle_imageserver_extraction(
         timeout=timeout,
         compression=cog_settings.compression,
         use_json=json_output,
+        collection_name=collection_name,
     )
 
     # Run extraction
@@ -5320,7 +5322,7 @@ def extract() -> None:
     "--bbox",
     type=str,
     default=None,
-    help="[ImageServer] Bounding box filter: minx,miny,maxx,maxy (in service CRS).",
+    help="[ImageServer] Bounding box filter: minx,miny,maxx,maxy. WGS84 coords auto-converted to service CRS.",
 )
 @click.option(
     "--compression",
@@ -5333,6 +5335,12 @@ def extract() -> None:
     type=click.IntRange(min=1, max=16),
     default=4,
     help="[ImageServer] Maximum concurrent tile downloads (default: 4).",
+)
+@click.option(
+    "--collection-name",
+    type=str,
+    default=None,
+    help="[ImageServer] Name for the collection (default: 'tiles').",
 )
 @click.pass_context
 def extract_arcgis_cmd(
@@ -5357,6 +5365,7 @@ def extract_arcgis_cmd(
     bbox: str | None,
     compression: str | None,
     max_concurrent: int,
+    collection_name: str | None,
 ) -> None:
     """Extract data from ArcGIS FeatureServer/MapServer/ImageServer.
 
@@ -5459,6 +5468,7 @@ def extract_arcgis_cmd(
             dry_run=dry_run,
             json_output=use_json,
             auto=auto,
+            collection_name=collection_name,
         )
         return
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -5005,6 +5005,44 @@ def _handle_list_services_mode(
             click.echo(f"Folders: {', '.join(result.folders)}")
 
 
+def _validate_collection_name_cli(
+    collection_name: str | None,
+    json_output: bool,
+    url: str,
+) -> None:
+    """Validate collection_name at CLI layer (fail fast, per ADR-0023).
+
+    Args:
+        collection_name: User-provided collection name (may be None).
+        json_output: If True, output errors as JSON.
+        url: Source URL for error context.
+
+    Raises:
+        SystemExit: If collection_name is invalid.
+    """
+    if collection_name is None:
+        return
+    # Reject path separators and parent references
+    if "/" in collection_name or "\\" in collection_name or ".." in collection_name:
+        _output_extract_error(
+            json_output,
+            "InvalidCollectionNameError",
+            f"Invalid collection name: '{collection_name}'. "
+            "Collection name must be a single directory name without path separators or '..'.",
+            url,
+        )
+        raise SystemExit(1)
+    # Reject empty or dot-only names
+    if not collection_name or collection_name in (".", ".."):
+        _output_extract_error(
+            json_output,
+            "InvalidCollectionNameError",
+            f"Invalid collection name: '{collection_name}'. Collection name cannot be empty.",
+            url,
+        )
+        raise SystemExit(1)
+
+
 def _handle_imageserver_extraction(
     ctx: click.Context,
     url: str,
@@ -5061,6 +5099,9 @@ def _handle_imageserver_extraction(
             predictor=cog_settings.predictor,
             resampling=cog_settings.resampling,
         )
+
+    # Validate collection_name at CLI layer (fail fast, per ADR-0023 flat catalog rule)
+    _validate_collection_name_cli(collection_name, json_output, url)
 
     # Confirmation prompt
     if not auto and not dry_run and not json_output:

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -327,6 +327,19 @@ async def download_tile(
         return len(content)
 
     except httpx.HTTPStatusError as e:
+        # Try to extract ArcGIS JSON error details from 4xx/5xx responses
+        content = e.response.content
+        if content.startswith(b"{"):
+            try:
+                error_data = json.loads(content.decode("utf-8"))
+                if "error" in error_data:
+                    arcgis_error = error_data["error"]
+                    code = arcgis_error.get("code", e.response.status_code)
+                    message = arcgis_error.get("message", "Unknown error")
+                    msg = f"ArcGIS error for tile {tile.get_id()}: [{code}] {message}"
+                    raise ImageServerExtractionError(msg) from e
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                pass  # Fall through to generic error
         msg = f"Tile download failed ({tile.get_id()}): HTTP {e.response.status_code}"
         raise ImageServerExtractionError(msg) from e
     except httpx.TimeoutException as e:

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -302,6 +302,19 @@ async def download_tile(
             # Check if it's an HTML error page
             if content.startswith(b"<!") or content.startswith(b"<html"):
                 msg = f"Server returned HTML instead of TIFF for tile {tile.get_id()}"
+            # Check if it's a JSON error response from ArcGIS
+            elif content.startswith(b"{"):
+                try:
+                    error_data = json.loads(content.decode("utf-8"))
+                    if "error" in error_data:
+                        arcgis_error = error_data["error"]
+                        code = arcgis_error.get("code", "unknown")
+                        message = arcgis_error.get("message", "Unknown error")
+                        msg = f"ArcGIS error for tile {tile.get_id()}: [{code}] {message}"
+                    else:
+                        msg = f"Unexpected JSON response for tile {tile.get_id()}: {content[:200].decode('utf-8', errors='replace')}"
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    msg = f"Invalid TIFF data for tile {tile.get_id()} (bad magic bytes)"
             else:
                 msg = f"Invalid TIFF data for tile {tile.get_id()} (bad magic bytes)"
             raise ImageServerExtractionError(msg)
@@ -373,6 +386,96 @@ async def _convert_to_cog(
         )
 
     await loop.run_in_executor(None, _do_convert)
+
+
+def _is_likely_wgs84(bbox: tuple[float, float, float, float]) -> bool:
+    """Detect if bbox coordinates appear to be in WGS84 (EPSG:4326).
+
+    WGS84 coordinates have characteristic ranges:
+    - Longitude: -180 to 180
+    - Latitude: -90 to 90
+
+    This heuristic checks if all values fall within these ranges.
+    False positives are possible for small-extent projected coordinates,
+    but unlikely for typical imagery bboxes.
+
+    Args:
+        bbox: Bounding box (minx, miny, maxx, maxy).
+
+    Returns:
+        True if bbox appears to be in WGS84, False otherwise.
+    """
+    minx, miny, maxx, maxy = bbox
+    return -180 <= minx <= 180 and -180 <= maxx <= 180 and -90 <= miny <= 90 and -90 <= maxy <= 90
+
+
+def _reproject_bbox(
+    bbox: tuple[float, float, float, float],
+    from_crs: str,
+    to_crs: str,
+) -> tuple[float, float, float, float]:
+    """Reproject a bounding box between coordinate reference systems.
+
+    Args:
+        bbox: Bounding box (minx, miny, maxx, maxy) in source CRS.
+        from_crs: Source CRS (e.g., "EPSG:4326").
+        to_crs: Target CRS (e.g., "EPSG:3857").
+
+    Returns:
+        Reprojected bounding box (minx, miny, maxx, maxy).
+
+    Raises:
+        ValueError: If CRS transformation fails.
+    """
+    from pyproj import CRS, Transformer
+
+    try:
+        transformer = Transformer.from_crs(
+            CRS.from_string(from_crs),
+            CRS.from_string(to_crs),
+            always_xy=True,  # Ensure x=lon, y=lat order
+        )
+        minx, miny, maxx, maxy = bbox
+        # Transform corners
+        new_minx, new_miny = transformer.transform(minx, miny)
+        new_maxx, new_maxy = transformer.transform(maxx, maxy)
+        return (new_minx, new_miny, new_maxx, new_maxy)
+    except Exception as e:
+        raise ValueError(f"Failed to reproject bbox from {from_crs} to {to_crs}: {e}") from e
+
+
+def reproject_bbox_if_needed(
+    bbox: tuple[float, float, float, float],
+    service_crs: str,
+) -> tuple[float, float, float, float]:
+    """Auto-detect WGS84 bbox and reproject to service CRS if needed.
+
+    If the bbox appears to be in WGS84 (based on coordinate ranges) and the
+    service uses a different CRS, the bbox is automatically reprojected.
+
+    Args:
+        bbox: User-provided bounding box (minx, miny, maxx, maxy).
+        service_crs: Service CRS string (e.g., "EPSG:3857").
+
+    Returns:
+        Bbox in service CRS (reprojected if needed, original otherwise).
+    """
+    # If service is already WGS84, no reprojection needed
+    service_crs_upper = service_crs.upper()
+    if service_crs_upper in ("EPSG:4326", "CRS:84"):
+        return bbox
+
+    # Check if bbox appears to be WGS84
+    if _is_likely_wgs84(bbox):
+        logger.info(
+            "Bbox appears to be WGS84 (coordinates in -180/180, -90/90 range). "
+            "Reprojecting to service CRS %s.",
+            service_crs,
+        )
+        return _reproject_bbox(bbox, "EPSG:4326", service_crs)
+
+    # Bbox doesn't look like WGS84, assume it's already in service CRS
+    return bbox
 
 
 def _intersect_bbox(
@@ -499,6 +602,7 @@ async def _process_tile(
     semaphore: asyncio.Semaphore,
     rate_limit_lock: asyncio.Lock,
     last_request_time: dict[str, float],
+    collection_name: str = "tiles",
 ) -> _TileProcessResult:
     """Process a single tile: download and convert to COG.
 
@@ -515,6 +619,7 @@ async def _process_tile(
         semaphore: Concurrency limiter.
         rate_limit_lock: Lock for rate limiting coordination.
         last_request_time: Shared dict tracking last request time per slot.
+        collection_name: Name for the collection directory (default: 'tiles').
 
     Returns:
         _TileProcessResult with tile, success status, bytes, duration, error, attempts.
@@ -526,10 +631,10 @@ async def _process_tile(
     async with semaphore:
         slot_id = str(id(asyncio.current_task()))
         # Create proper STAC structure: collection/item/asset.tif
-        # The collection is named after the service (sanitized), items are tile IDs
+        # The collection is named per --collection-name flag (default: 'tiles')
         # tile.get_id() already returns "tile_X_Y" format
         tile_id = tile.get_id()
-        item_dir = output_dir / "tiles" / tile_id
+        item_dir = output_dir / collection_name / tile_id
         item_dir.mkdir(parents=True, exist_ok=True)
         raw_path = item_dir / f"{tile_id}_raw.tif"
         cog_path = item_dir / f"{tile_id}.tif"
@@ -647,21 +752,22 @@ async def _process_tile(
                     pass  # Best effort cleanup
 
 
-def _setup_extraction_dirs(output_dir: Path) -> tuple[Path, Path]:
+def _setup_extraction_dirs(output_dir: Path, collection_name: str = "tiles") -> tuple[Path, Path]:
     """Create extraction output directories.
 
     Args:
         output_dir: Base output directory.
+        collection_name: Name for the collection directory (default: 'tiles').
 
     Returns:
-        Tuple of (tiles_dir, portolan_dir).
+        Tuple of (collection_dir, portolan_dir).
     """
     output_dir.mkdir(parents=True, exist_ok=True)
-    tiles_dir = output_dir / "tiles"
-    tiles_dir.mkdir(exist_ok=True)
+    collection_dir = output_dir / collection_name
+    collection_dir.mkdir(exist_ok=True)
     portolan_dir = output_dir / ".portolan"
     portolan_dir.mkdir(exist_ok=True)
-    return tiles_dir, portolan_dir
+    return collection_dir, portolan_dir
 
 
 def _load_effective_config(config: ExtractionConfig, output_dir: Path) -> ExtractionConfig:
@@ -719,6 +825,7 @@ def _seed_metadata_from_report(
 def _auto_init_catalog(
     output_dir: Path,
     service_name: str | None = None,
+    collection_name: str = "tiles",
 ) -> bool:
     """Initialize a Portolan catalog and add extracted COG files.
 
@@ -729,6 +836,7 @@ def _auto_init_catalog(
     Args:
         output_dir: Directory containing extracted COG files.
         service_name: Optional name for the catalog.
+        collection_name: Name for the collection directory (default: 'tiles').
 
     Returns:
         True if catalog was initialized, False if no files to add.
@@ -737,8 +845,8 @@ def _auto_init_catalog(
     from portolan_cli.dataset import add_files
 
     # Get list of extracted COG files (nested in item directories)
-    tiles_dir = output_dir / "tiles"
-    cog_files = list(tiles_dir.glob("*/*.tif"))
+    collection_dir = output_dir / collection_name
+    cog_files = list(collection_dir.glob("*/*.tif"))
 
     if not cog_files:
         return False  # Nothing to add
@@ -764,6 +872,7 @@ async def _extract_all_tiles(
     resume_state: ImageServerResumeState,
     resume_path: Path,
     on_progress: Callable[[TileProgress], None] | None = None,
+    collection_name: str = "tiles",
 ) -> _ProcessingStats:
     """Extract all tiles with concurrency control.
 
@@ -776,6 +885,7 @@ async def _extract_all_tiles(
         resume_state: Resume state to update.
         resume_path: Path to save resume state.
         on_progress: Optional progress callback (matches FeatureServer pattern).
+        collection_name: Name for the collection directory (default: 'tiles').
 
     Returns:
         Processing statistics with tile results.
@@ -797,6 +907,7 @@ async def _extract_all_tiles(
                 semaphore=semaphore,
                 rate_limit_lock=rate_limit_lock,
                 last_request_time=last_request_time,
+                collection_name=collection_name,
             )
             for tile in tiles
         ]
@@ -816,6 +927,7 @@ async def _extract_all_tiles(
                 error_msg=result.error_msg,
                 attempts=result.attempts,
                 on_progress=on_progress,
+                collection_name=collection_name,
             )
 
             # Batch resume state saves
@@ -840,6 +952,7 @@ def _update_stats_and_state(
     error_msg: str | None,
     attempts: int,
     on_progress: Callable[[TileProgress], None] | None = None,
+    collection_name: str = "tiles",
 ) -> None:
     """Update statistics, resume state, and tile results after processing a tile.
 
@@ -855,6 +968,7 @@ def _update_stats_and_state(
         duration: Processing duration in seconds.
         error_msg: Error message if failed.
         attempts: Number of attempts.
+        collection_name: Name for the collection directory (default: 'tiles').
         on_progress: Optional progress callback.
     """
     tile_id = tile.get_id()
@@ -865,7 +979,7 @@ def _update_stats_and_state(
         resume_state.succeeded_tiles.add((tile.x, tile.y))
 
         # Compute relative output path (tile_id already includes "tile_" prefix)
-        output_path = f"tiles/{tile_id}/{tile_id}.tif"
+        output_path = f"{collection_name}/{tile_id}/{tile_id}.tif"
 
         stats.tile_results.append(
             TileResult(
@@ -926,6 +1040,7 @@ async def extract_imageserver(
     resume: bool = False,
     bbox: tuple[float, float, float, float] | None = None,
     on_progress: Callable[[TileProgress], None] | None = None,
+    collection_name: str | None = None,
 ) -> ExtractionResult:
     """Extract raster tiles from ImageServer to COG files.
 
@@ -939,6 +1054,7 @@ async def extract_imageserver(
         resume: If True, resume from previous extraction.
         bbox: Optional bbox to subset extraction (minx, miny, maxx, maxy).
         on_progress: Optional callback for progress updates (matches FeatureServer pattern).
+        collection_name: Name for the collection directory (default: 'tiles').
 
     Returns:
         ExtractionResult with extraction statistics and full report.
@@ -949,10 +1065,14 @@ async def extract_imageserver(
     if config is None:
         config = ExtractionConfig()
 
+    # Default collection name to 'tiles' if not provided
+    if collection_name is None:
+        collection_name = "tiles"
+
     start_time = time.monotonic()
 
     # Setup
-    _, portolan_dir = _setup_extraction_dirs(output_dir)
+    _, portolan_dir = _setup_extraction_dirs(output_dir, collection_name)
     config = _load_effective_config(config, output_dir)
 
     # Discover service
@@ -960,9 +1080,32 @@ async def extract_imageserver(
     metadata = await discover_imageserver(url, timeout=config.timeout)
     info(f"Service: {metadata.name} ({metadata.pixel_type}, {metadata.band_count} bands)")
 
+    # Validate tile size against service limits (proactive check per issue #335)
+    max_tile_size = min(metadata.max_image_width, metadata.max_image_height)
+    if config.tile_size > max_tile_size:
+        warn(
+            f"Requested tile size ({config.tile_size}px) exceeds service limit "
+            f"({max_tile_size}px). Auto-adjusting to {max_tile_size}px."
+        )
+        config = ExtractionConfig(
+            tile_size=max_tile_size,
+            cog_settings=config.cog_settings,
+            max_retries=config.max_retries,
+            dry_run=config.dry_run,
+            raw=config.raw,
+            timeout=config.timeout,
+            max_concurrent=config.max_concurrent,
+            rate_limit_delay=config.rate_limit_delay,
+        )
+
+    # Get service CRS for bbox reprojection
+    service_crs = metadata.get_crs_string()
+
     # Compute tiles
     extent = metadata.full_extent
     if bbox:
+        # Auto-reproject bbox from WGS84 to service CRS if needed (per issue #335)
+        bbox = reproject_bbox_if_needed(bbox, service_crs)
         intersected = _intersect_bbox(bbox, extent)
         if intersected is None:
             info("User bbox does not intersect service extent - no tiles to extract")
@@ -1008,6 +1151,7 @@ async def extract_imageserver(
         resume_state,
         resume_path,
         on_progress=on_progress,
+        collection_name=collection_name,
     )
     _save_resume_state_locked(resume_state, resume_path)
 
@@ -1020,7 +1164,7 @@ async def extract_imageserver(
                 status="skipped",
                 size_bytes=None,
                 duration_seconds=None,
-                output_path=f"tiles/{tile_id}/{tile_id}.tif",
+                output_path=f"{collection_name}/{tile_id}/{tile_id}.tif",
                 error=None,
                 attempts=0,
             )
@@ -1050,7 +1194,7 @@ async def extract_imageserver(
     catalog_initialized = False
     if not config.raw:
         info("Initializing Portolan catalog...")
-        catalog_initialized = _auto_init_catalog(output_dir, metadata.name)
+        catalog_initialized = _auto_init_catalog(output_dir, metadata.name, collection_name)
         if catalog_initialized:
             success("Catalog initialized with STAC metadata")
         else:

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -33,7 +33,7 @@ import json
 import logging
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -447,29 +447,51 @@ def _reproject_bbox(
 def reproject_bbox_if_needed(
     bbox: tuple[float, float, float, float],
     service_crs: str,
+    bbox_crs: str | None = None,
 ) -> tuple[float, float, float, float]:
     """Auto-detect WGS84 bbox and reproject to service CRS if needed.
 
-    If the bbox appears to be in WGS84 (based on coordinate ranges) and the
+    If bbox_crs is explicitly provided, it is used directly. Otherwise,
+    if the bbox appears to be in WGS84 (based on coordinate ranges) and the
     service uses a different CRS, the bbox is automatically reprojected.
 
     Args:
         bbox: User-provided bounding box (minx, miny, maxx, maxy).
         service_crs: Service CRS string (e.g., "EPSG:3857").
+        bbox_crs: Optional explicit CRS of the bbox (e.g., "EPSG:4326").
+            If provided, auto-detection is skipped and this CRS is used.
 
     Returns:
         Bbox in service CRS (reprojected if needed, original otherwise).
     """
+    # If explicit bbox_crs provided, use it directly (no heuristics)
+    if bbox_crs is not None:
+        bbox_crs_upper = bbox_crs.upper()
+        service_crs_upper = service_crs.upper()
+        # Normalize CRS:84 to EPSG:4326 for comparison
+        if bbox_crs_upper == "CRS:84":
+            bbox_crs_upper = "EPSG:4326"
+        if service_crs_upper == "CRS:84":
+            service_crs_upper = "EPSG:4326"
+        if bbox_crs_upper == service_crs_upper:
+            return bbox
+        logger.info(
+            "Reprojecting bbox from %s to service CRS %s.",
+            bbox_crs,
+            service_crs,
+        )
+        return _reproject_bbox(bbox, bbox_crs, service_crs)
+
     # If service is already WGS84, no reprojection needed
     service_crs_upper = service_crs.upper()
     if service_crs_upper in ("EPSG:4326", "CRS:84"):
         return bbox
 
-    # Check if bbox appears to be WGS84
+    # Check if bbox appears to be WGS84 (heuristic auto-detection)
     if _is_likely_wgs84(bbox):
         logger.info(
             "Bbox appears to be WGS84 (coordinates in -180/180, -90/90 range). "
-            "Reprojecting to service CRS %s.",
+            "Reprojecting to service CRS %s. Use --bbox-crs to override.",
             service_crs,
         )
         return _reproject_bbox(bbox, "EPSG:4326", service_crs)
@@ -1033,6 +1055,40 @@ def _update_stats_and_state(
             )
 
 
+def _validate_collection_name(name: str) -> str:
+    """Validate and sanitize collection name to prevent path traversal.
+
+    Args:
+        name: User-provided collection name.
+
+    Returns:
+        Sanitized collection name (base name only, no path components).
+
+    Raises:
+        ValueError: If the sanitized name is empty or invalid.
+    """
+    # Extract just the base name (strips any path separators or .. components)
+    sanitized = Path(name).name
+
+    # Reject empty names or names that are just dots
+    if not sanitized or sanitized in (".", ".."):
+        raise ValueError(
+            f"Invalid collection name: '{name}'. "
+            "Collection name cannot be empty or contain path traversal sequences."
+        )
+
+    # Reject names with problematic characters for cross-platform compatibility
+    invalid_chars = '<>:"|?*'
+    for char in invalid_chars:
+        if char in sanitized:
+            raise ValueError(
+                f"Invalid collection name: '{name}'. "
+                f"Collection name cannot contain: {invalid_chars}"
+            )
+
+    return sanitized
+
+
 async def extract_imageserver(
     url: str,
     output_dir: Path,
@@ -1041,6 +1097,7 @@ async def extract_imageserver(
     bbox: tuple[float, float, float, float] | None = None,
     on_progress: Callable[[TileProgress], None] | None = None,
     collection_name: str | None = None,
+    bbox_crs: str | None = None,
 ) -> ExtractionResult:
     """Extract raster tiles from ImageServer to COG files.
 
@@ -1055,19 +1112,24 @@ async def extract_imageserver(
         bbox: Optional bbox to subset extraction (minx, miny, maxx, maxy).
         on_progress: Optional callback for progress updates (matches FeatureServer pattern).
         collection_name: Name for the collection directory (default: 'tiles').
+        bbox_crs: Optional explicit CRS of the bbox (e.g., "EPSG:4326", "EPSG:3857").
+            If provided, skips auto-detection and uses this CRS for reprojection.
 
     Returns:
         ExtractionResult with extraction statistics and full report.
 
     Raises:
         ImageServerDiscoveryError: If service discovery fails.
+        ValueError: If collection_name contains path traversal sequences.
     """
     if config is None:
         config = ExtractionConfig()
 
-    # Default collection name to 'tiles' if not provided
+    # Default collection name to 'tiles' if not provided, then validate
     if collection_name is None:
         collection_name = "tiles"
+    else:
+        collection_name = _validate_collection_name(collection_name)
 
     start_time = time.monotonic()
 
@@ -1087,16 +1149,8 @@ async def extract_imageserver(
             f"Requested tile size ({config.tile_size}px) exceeds service limit "
             f"({max_tile_size}px). Auto-adjusting to {max_tile_size}px."
         )
-        config = ExtractionConfig(
-            tile_size=max_tile_size,
-            cog_settings=config.cog_settings,
-            max_retries=config.max_retries,
-            dry_run=config.dry_run,
-            raw=config.raw,
-            timeout=config.timeout,
-            max_concurrent=config.max_concurrent,
-            rate_limit_delay=config.rate_limit_delay,
-        )
+        # Use dataclasses.replace to preserve all fields (including compression)
+        config = replace(config, tile_size=max_tile_size)
 
     # Get service CRS for bbox reprojection
     service_crs = metadata.get_crs_string()
@@ -1104,8 +1158,8 @@ async def extract_imageserver(
     # Compute tiles
     extent = metadata.full_extent
     if bbox:
-        # Auto-reproject bbox from WGS84 to service CRS if needed (per issue #335)
-        bbox = reproject_bbox_if_needed(bbox, service_crs)
+        # Reproject bbox to service CRS if needed (auto-detect or explicit via bbox_crs)
+        bbox = reproject_bbox_if_needed(bbox, service_crs, bbox_crs=bbox_crs)
         intersected = _intersect_bbox(bbox, extent)
         if intersected is None:
             info("User bbox does not intersect service extent - no tiles to extract")

--- a/portolan_cli/extract/arcgis/imageserver/orchestrator.py
+++ b/portolan_cli/extract/arcgis/imageserver/orchestrator.py
@@ -53,6 +53,7 @@ class ImageServerCLIOptions:
         resume: If True, resume from previous extraction.
         raw: If True, skip auto-init (only create COGs + report, no STAC catalog).
         bbox: Optional bounding box to subset extraction (minx, miny, maxx, maxy).
+        bbox_crs: Optional explicit CRS of bbox (e.g., "EPSG:4326"). Skips auto-detection.
         timeout: HTTP request timeout in seconds (default 120).
         compression: COG compression method ("DEFLATE" or "JPEG").
         use_json: If True, suppress progress output (for JSON mode).
@@ -65,6 +66,7 @@ class ImageServerCLIOptions:
     resume: bool = False
     raw: bool = False
     bbox: tuple[float, float, float, float] | None = None
+    bbox_crs: str | None = None
     timeout: float = 120.0
     compression: str = "DEFLATE"
     use_json: bool = False
@@ -157,6 +159,7 @@ async def run_imageserver_extraction(
             bbox=options.bbox,
             on_progress=on_progress,
             collection_name=options.collection_name,
+            bbox_crs=options.bbox_crs,
         )
 
         # Determine exit code based on results

--- a/portolan_cli/extract/arcgis/imageserver/orchestrator.py
+++ b/portolan_cli/extract/arcgis/imageserver/orchestrator.py
@@ -56,6 +56,7 @@ class ImageServerCLIOptions:
         timeout: HTTP request timeout in seconds (default 120).
         compression: COG compression method ("DEFLATE" or "JPEG").
         use_json: If True, suppress progress output (for JSON mode).
+        collection_name: Optional name for the collection (default: 'tiles').
     """
 
     tile_size: int = 4096
@@ -67,6 +68,7 @@ class ImageServerCLIOptions:
     timeout: float = 120.0
     compression: str = "DEFLATE"
     use_json: bool = False
+    collection_name: str | None = None
 
 
 def _create_progress_callback(
@@ -154,6 +156,7 @@ async def run_imageserver_extraction(
             resume=options.resume,
             bbox=options.bbox,
             on_progress=on_progress,
+            collection_name=options.collection_name,
         )
 
         # Determine exit code based on results

--- a/tests/integration/extract/test_imageserver_metadata_seeding.py
+++ b/tests/integration/extract/test_imageserver_metadata_seeding.py
@@ -332,6 +332,9 @@ class TestImageServerExtractionSeeding:
         mock_metadata.pixel_size_x = 0.5
         mock_metadata.pixel_size_y = 0.5
         mock_metadata.full_extent = {"xmin": -122.5, "ymin": 37.5, "xmax": -122.0, "ymax": 38.0}
+        mock_metadata.max_image_width = 4096
+        mock_metadata.max_image_height = 4096
+        mock_metadata.get_crs_string.return_value = "EPSG:4326"
         mock_metadata.description = "Test imagery"
         mock_metadata.copyright_text = "City of Test"
         mock_metadata.service_description = "Municipal aerial imagery"
@@ -402,6 +405,9 @@ class TestImageServerExtractionSeeding:
         mock_metadata.pixel_size_x = 0.5
         mock_metadata.pixel_size_y = 0.5
         mock_metadata.full_extent = {"xmin": -122.5, "ymin": 37.5, "xmax": -122.0, "ymax": 38.0}
+        mock_metadata.max_image_width = 4096
+        mock_metadata.max_image_height = 4096
+        mock_metadata.get_crs_string.return_value = "EPSG:4326"
         mock_metadata.description = "New imagery"
         mock_metadata.copyright_text = "New Copyright"
         mock_metadata.service_description = None
@@ -457,6 +463,9 @@ class TestImageServerExtractionSeeding:
         mock_metadata.pixel_size_x = 1.0
         mock_metadata.pixel_size_y = 1.0
         mock_metadata.full_extent = {"xmin": 0, "ymin": 0, "xmax": 100, "ymax": 100}
+        mock_metadata.max_image_width = 4096
+        mock_metadata.max_image_height = 4096
+        mock_metadata.get_crs_string.return_value = "EPSG:4326"
         mock_metadata.description = "Elevation"
         mock_metadata.copyright_text = None
         mock_metadata.service_description = "DEM data"

--- a/tests/unit/extract/arcgis/imageserver/test_extractor.py
+++ b/tests/unit/extract/arcgis/imageserver/test_extractor.py
@@ -399,18 +399,18 @@ class TestBboxCrsDetection:
         """Bbox is correctly reprojected from WGS84 to Web Mercator."""
         from portolan_cli.extract.arcgis.imageserver.extractor import _reproject_bbox
 
-        # Simple point near origin
-        bbox = (0.0, 0.0, 1.0, 1.0)
+        # Philadelphia area: known coordinates for verification
+        # WGS84: (-75.17, 39.95, -75.15, 39.97)
+        # Expected Web Mercator (approximately):
+        # minx: -8367886, miny: 4858679, maxx: -8365659, maxy: 4861583
+        bbox = (-75.17, 39.95, -75.15, 39.97)
         result = _reproject_bbox(bbox, "EPSG:4326", "EPSG:3857")
 
-        # Web Mercator coords should be much larger than WGS84
-        assert abs(result[0]) < 200000  # minx
-        assert abs(result[1]) < 200000  # miny
-        assert abs(result[2]) < 200000  # maxx
-        assert abs(result[3]) < 200000  # maxy
-        # But non-zero
-        assert result[2] > result[0]  # maxx > minx
-        assert result[3] > result[1]  # maxy > miny
+        # Verify against known correct values (within 100m tolerance)
+        assert -8368000 < result[0] < -8367000  # minx ~ -8367886
+        assert 4858000 < result[1] < 4859000  # miny ~ 4858679
+        assert -8366000 < result[2] < -8365000  # maxx ~ -8365659
+        assert 4861000 < result[3] < 4862000  # maxy ~ 4861583
 
     def test_reproject_bbox_if_needed_passthrough_for_wgs84_service(self) -> None:
         """Bbox is not reprojected if service is already WGS84."""
@@ -426,13 +426,88 @@ class TestBboxCrsDetection:
         """WGS84 bbox is auto-reprojected to service CRS."""
         from portolan_cli.extract.arcgis.imageserver.extractor import reproject_bbox_if_needed
 
-        # WGS84 coords
+        # WGS84 coords (Philadelphia)
         bbox = (-75.17, 39.95, -75.15, 39.97)
         result = reproject_bbox_if_needed(bbox, "EPSG:3857")
 
-        # Should be reprojected to Web Mercator (much larger numbers)
-        assert abs(result[0]) > 1000  # Web Mercator x values are large
-        assert abs(result[2]) > 1000
+        # Verify against known correct Web Mercator values
+        assert -8368000 < result[0] < -8367000  # minx ~ -8367886
+        assert 4858000 < result[1] < 4859000  # miny ~ 4858679
+        assert -8366000 < result[2] < -8365000  # maxx ~ -8365659
+        assert 4861000 < result[3] < 4862000  # maxy ~ 4861583
+
+    def test_reproject_bbox_if_needed_explicit_bbox_crs(self) -> None:
+        """Explicit bbox_crs parameter overrides auto-detection."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import reproject_bbox_if_needed
+
+        # State Plane coords that happen to be in WGS84 range (would trigger false positive)
+        bbox = (100.0, 50.0, 150.0, 80.0)
+
+        # Without explicit bbox_crs, this would be detected as WGS84 and reprojected
+        # With explicit bbox_crs matching service CRS, no reprojection happens
+        result = reproject_bbox_if_needed(bbox, "EPSG:3857", bbox_crs="EPSG:3857")
+
+        # Should be unchanged (same CRS)
+        assert result == bbox
+
+    def test_reproject_bbox_if_needed_explicit_bbox_crs_different(self) -> None:
+        """Explicit bbox_crs triggers reprojection when different from service CRS."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import reproject_bbox_if_needed
+
+        # Explicit WGS84 bbox
+        bbox = (-75.17, 39.95, -75.15, 39.97)
+        result = reproject_bbox_if_needed(bbox, "EPSG:3857", bbox_crs="EPSG:4326")
+
+        # Should be reprojected to Web Mercator
+        assert -8368000 < result[0] < -8367000
+
+
+@pytest.mark.unit
+class TestCollectionNameValidation:
+    """Tests for collection name validation (path traversal prevention)."""
+
+    def test_validate_collection_name_simple(self) -> None:
+        """Simple collection names pass validation."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _validate_collection_name
+
+        assert _validate_collection_name("tiles") == "tiles"
+        assert _validate_collection_name("naip-2024") == "naip-2024"
+        assert _validate_collection_name("my_collection") == "my_collection"
+
+    def test_validate_collection_name_strips_path_components(self) -> None:
+        """Path traversal attempts are sanitized."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _validate_collection_name
+
+        # Path traversal attempts get stripped to just the base name
+        assert _validate_collection_name("../../../etc") == "etc"
+        assert _validate_collection_name("/etc/passwd") == "passwd"
+        assert _validate_collection_name("foo/bar/baz") == "baz"
+
+    def test_validate_collection_name_rejects_empty(self) -> None:
+        """Empty names are rejected."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _validate_collection_name
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            _validate_collection_name("")
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            _validate_collection_name(".")
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            _validate_collection_name("..")
+
+    def test_validate_collection_name_rejects_invalid_chars(self) -> None:
+        """Names with invalid characters are rejected."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _validate_collection_name
+
+        with pytest.raises(ValueError, match="cannot contain"):
+            _validate_collection_name("foo<bar")
+
+        with pytest.raises(ValueError, match="cannot contain"):
+            _validate_collection_name("foo|bar")
+
+        with pytest.raises(ValueError, match="cannot contain"):
+            _validate_collection_name("foo?bar")
 
 
 @pytest.mark.unit

--- a/tests/unit/extract/arcgis/imageserver/test_extractor.py
+++ b/tests/unit/extract/arcgis/imageserver/test_extractor.py
@@ -360,3 +360,115 @@ class TestModuleImports:
         from dataclasses import is_dataclass
 
         assert is_dataclass(ExtractionResult)
+
+
+# =============================================================================
+# Tests for Issue #335 Fixes
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestBboxCrsDetection:
+    """Tests for WGS84 bbox detection and reprojection (issue #335 fix)."""
+
+    def test_is_likely_wgs84_with_lat_lon_coords(self) -> None:
+        """Bbox with WGS84-range coordinates is detected."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _is_likely_wgs84
+
+        # Philadelphia area in WGS84
+        bbox = (-75.17, 39.95, -75.15, 39.97)
+        assert _is_likely_wgs84(bbox) is True
+
+    def test_is_likely_wgs84_with_web_mercator_coords(self) -> None:
+        """Bbox with Web Mercator coordinates is NOT detected as WGS84."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _is_likely_wgs84
+
+        # Philadelphia area in Web Mercator (large numbers)
+        bbox = (-8367886, 4858679, -8365659, 4861583)
+        assert _is_likely_wgs84(bbox) is False
+
+    def test_is_likely_wgs84_edge_case_poles(self) -> None:
+        """Bbox at edge of WGS84 range is detected."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _is_likely_wgs84
+
+        # Global extent
+        bbox = (-180, -90, 180, 90)
+        assert _is_likely_wgs84(bbox) is True
+
+    def test_reproject_bbox_wgs84_to_web_mercator(self) -> None:
+        """Bbox is correctly reprojected from WGS84 to Web Mercator."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _reproject_bbox
+
+        # Simple point near origin
+        bbox = (0.0, 0.0, 1.0, 1.0)
+        result = _reproject_bbox(bbox, "EPSG:4326", "EPSG:3857")
+
+        # Web Mercator coords should be much larger than WGS84
+        assert abs(result[0]) < 200000  # minx
+        assert abs(result[1]) < 200000  # miny
+        assert abs(result[2]) < 200000  # maxx
+        assert abs(result[3]) < 200000  # maxy
+        # But non-zero
+        assert result[2] > result[0]  # maxx > minx
+        assert result[3] > result[1]  # maxy > miny
+
+    def test_reproject_bbox_if_needed_passthrough_for_wgs84_service(self) -> None:
+        """Bbox is not reprojected if service is already WGS84."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import reproject_bbox_if_needed
+
+        bbox = (-75.17, 39.95, -75.15, 39.97)
+        result = reproject_bbox_if_needed(bbox, "EPSG:4326")
+
+        # Should be unchanged
+        assert result == bbox
+
+    def test_reproject_bbox_if_needed_converts_wgs84_to_service_crs(self) -> None:
+        """WGS84 bbox is auto-reprojected to service CRS."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import reproject_bbox_if_needed
+
+        # WGS84 coords
+        bbox = (-75.17, 39.95, -75.15, 39.97)
+        result = reproject_bbox_if_needed(bbox, "EPSG:3857")
+
+        # Should be reprojected to Web Mercator (much larger numbers)
+        assert abs(result[0]) > 1000  # Web Mercator x values are large
+        assert abs(result[2]) > 1000
+
+
+@pytest.mark.unit
+class TestJsonErrorParsing:
+    """Tests for JSON error response parsing (issue #335 fix)."""
+
+    @pytest.mark.asyncio
+    async def test_download_tile_parses_arcgis_json_error(
+        self, sample_tile: TileSpec, tmp_path: Path
+    ) -> None:
+        """JSON error responses from ArcGIS are parsed correctly."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import (
+            ImageServerExtractionError,
+            download_tile,
+        )
+
+        mock_client = AsyncMock()
+        mock_response = AsyncMock()
+        # Simulate ArcGIS JSON error response (not a TIFF)
+        error_json = (
+            b'{"error":{"code":400,"message":"The requested image exceeds the size limit."}}'
+        )
+        mock_response.content = error_json
+        mock_response.status_code = 200  # ArcGIS returns 200 with error in body
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get.return_value = mock_response
+
+        output_path = tmp_path / "out.tif"
+        with pytest.raises(ImageServerExtractionError) as exc_info:
+            await download_tile(
+                "https://example.com/ImageServer",
+                sample_tile,
+                output_path,
+                mock_client,
+            )
+
+        # Error message should contain the ArcGIS error details
+        assert "400" in str(exc_info.value)
+        assert "exceeds the size limit" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Addresses all 5 issues from #335 (ImageServer extraction end-to-end test findings):

- **Issue 1** (MapServer raster): Documented the limitation—MapServer's `/export` returns rendered 8-bit visualization, not source data
- **Issue 2** (tile size error): Proactive validation against service `maxImageWidth`/`maxImageHeight` with auto-adjust + JSON error parsing fallback
- **Issue 3** (bbox CRS): Auto-detect WGS84 coordinates (values in -180/180, -90/90 range) and reproject to service CRS
- **Issue 4** (collection naming): Added `--collection-name` flag to customize the collection directory name
- **Issue 5** (metadata generate): Clarified docs—`metadata.yaml` supplements STAC, `portolan readme` reads from both

## Test plan

- [x] All existing ImageServer tests pass (142 tests)
- [x] Added 8 new unit tests for bbox CRS detection/reprojection and JSON error parsing
- [x] Pre-commit hooks pass (mypy, ruff, architecture rules)

## Changes

| File | Change |
|------|--------|
| `extractor.py` | Added `_is_likely_wgs84()`, `_reproject_bbox()`, `reproject_bbox_if_needed()`, JSON error parsing, tile size validation |
| `orchestrator.py` | Added `collection_name` to options |
| `cli.py` | Added `--collection-name` flag, updated `--bbox` help text |
| `docs/guides/extract-arcgis.md` | Added MapServer limitation warning, bbox auto-conversion docs, tile size validation tip, metadata workflow clarification |
| `test_extractor.py` | Added 8 tests for new functionality |

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --collection-name (defaults to "tiles") to customize extraction output layout
  * Added --bbox-crs to explicitly set bbox CRS; bbox auto-detection/reprojection supports WGS84 ranges

* **Bug Fixes**
  * Improved error reporting for invalid/non-TIFF tile responses (HTML/JSON/ArcGIS errors detected)
  * Tile-size auto-adjustment/clamping when service limits are exceeded, with warnings

* **Documentation**
  * Updated ImageServer bbox examples, MapServer vector-only warning, and note that metadata.yaml supplements STAC

* **Tests**
  * Added unit and integration tests for CRS handling and tile error detection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->