### PR TITLE
fix(push): upload root README.md and versions.json when pushing all collections (Issue #357)

### DIFF
--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -1764,7 +1764,7 @@ def _push_all_process_result(
             stats["errors"][coll] = ["Unknown error"]
 
 
-def _push_all_upload_catalog(
+def _push_all_upload_root_files(
     catalog_root: Path,
     destination: str,
     profile: str | None,
@@ -1772,32 +1772,52 @@ def _push_all_upload_catalog(
     dry_run: bool,
     stats: dict[str, Any],
 ) -> bool:
-    """Upload catalog.json after all collections (helper for push_all_collections).
+    """Upload root-level files after all collections (Issue #357).
 
-    Returns True if upload succeeded or was skipped, False if failed.
+    Uploads catalog.json and README.md from catalog root.
+    These are uploaded AFTER all collections succeed to maintain manifest-last atomicity.
+
+    Returns True if uploads succeeded or were skipped, False if any failed.
     """
     catalog_json = catalog_root / "catalog.json"
+    root_readme = catalog_root / "README.md"
 
-    if stats["successful"] > 0 and stats["failed"] == 0 and catalog_json.exists():
-        if dry_run:
-            info("[DRY RUN] Would upload catalog.json")
-            return True
-        try:
-            store, prefix = setup_store(destination, profile=profile, region=region)
-            target_key = f"{prefix}/catalog.json".lstrip("/")
-            obs.put(store, target_key, catalog_json.read_bytes())
-            success("Uploaded catalog.json")
-            stats["total_files"] += 1
-            return True
-        except Exception as e:
-            error(f"Failed to upload catalog.json: {e}")
-            stats["errors"]["catalog.json"] = [str(e)]
-            return False
-    elif stats["failed"] > 0:
-        warn("Skipping catalog.json upload because some collections failed")
-    elif not catalog_json.exists():
+    # Skip root file uploads if any collection failed
+    if stats["failed"] > 0:
+        warn("Skipping root file upload because some collections failed")
+        return True
+
+    if not catalog_json.exists():
         warn(f"catalog.json not found at {catalog_json} - remote catalog may be incomplete")
-    return True
+        return True
+
+    if dry_run:
+        info("[DRY RUN] Would upload catalog.json")
+        if root_readme.exists():
+            info("[DRY RUN] Would upload README.md")
+        return True
+
+    try:
+        store, prefix = setup_store(destination, profile=profile, region=region)
+
+        # Upload catalog.json
+        target_key = f"{prefix}/catalog.json".lstrip("/")
+        obs.put(store, target_key, catalog_json.read_bytes())
+        success("Uploaded catalog.json")
+        stats["total_files"] += 1
+
+        # Upload root README.md if it exists (Issue #357)
+        if root_readme.exists():
+            readme_key = f"{prefix}/README.md".lstrip("/")
+            obs.put(store, readme_key, root_readme.read_bytes())
+            success("Uploaded README.md")
+            stats["total_files"] += 1
+
+        return True
+    except Exception as e:
+        error(f"Failed to upload root files: {e}")
+        stats["errors"]["root_files"] = [str(e)]
+        return False
 
 
 async def push_all_collections_async(
@@ -1897,7 +1917,7 @@ async def push_all_collections_async(
                     json_mode=json_mode,
                     suppress_progress=True,
                     verbose=verbose,
-                    include_catalog=False,  # Uploaded once at end by _push_all_upload_catalog
+                    include_catalog=False,  # Uploaded once at end by _push_all_upload_root_files
                 )
                 return (collection, result, None)
             except Exception as e:
@@ -1918,7 +1938,7 @@ async def push_all_collections_async(
             coll, push_result, err_msg = result
             _push_all_process_result(coll, push_result, err_msg, i + 1, total, stats)
 
-    catalog_ok = _push_all_upload_catalog(
+    catalog_ok = _push_all_upload_root_files(
         catalog_root, destination, profile, region, dry_run, stats
     )
 

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -1774,43 +1774,62 @@ def _push_all_upload_root_files(
 ) -> bool:
     """Upload root-level files after all collections (Issue #357).
 
-    Uploads catalog.json and README.md from catalog root.
-    These are uploaded AFTER all collections succeed to maintain manifest-last atomicity.
+    Uploads from catalog root (in order):
+    1. README.md (documentation, optional)
+    2. catalog.json (STAC catalog metadata, required)
+    3. versions.json (manifest, required - uploaded LAST per manifest-last atomicity)
+
+    These are uploaded AFTER all collections succeed.
 
     Returns True if uploads succeeded or were skipped, False if any failed.
     """
     catalog_json = catalog_root / "catalog.json"
     root_readme = catalog_root / "README.md"
+    root_versions = catalog_root / "versions.json"
 
     # Skip root file uploads if any collection failed
     if stats["failed"] > 0:
         warn("Skipping root file upload because some collections failed")
         return True
 
+    # Also skip if no collections succeeded (nothing to manifest)
+    if stats["successful"] == 0:
+        warn("Skipping root file upload because no collections were pushed")
+        return True
+
     if not catalog_json.exists():
-        warn(f"catalog.json not found at {catalog_json} - remote catalog may be incomplete")
+        warn(f"catalog.json not found at {catalog_root} - remote catalog may be incomplete")
         return True
 
     if dry_run:
-        info("[DRY RUN] Would upload catalog.json")
         if root_readme.exists():
             info("[DRY RUN] Would upload README.md")
+        info("[DRY RUN] Would upload catalog.json")
+        if root_versions.exists():
+            info("[DRY RUN] Would upload versions.json")
         return True
 
     try:
         store, prefix = setup_store(destination, profile=profile, region=region)
 
-        # Upload catalog.json
-        target_key = f"{prefix}/catalog.json".lstrip("/")
-        obs.put(store, target_key, catalog_json.read_bytes())
-        success("Uploaded catalog.json")
-        stats["total_files"] += 1
-
-        # Upload root README.md if it exists (Issue #357)
+        # Upload README.md first (documentation, not critical)
         if root_readme.exists():
             readme_key = f"{prefix}/README.md".lstrip("/")
             obs.put(store, readme_key, root_readme.read_bytes())
             success("Uploaded README.md")
+            stats["total_files"] += 1
+
+        # Upload catalog.json (STAC metadata)
+        catalog_key = f"{prefix}/catalog.json".lstrip("/")
+        obs.put(store, catalog_key, catalog_json.read_bytes())
+        success("Uploaded catalog.json")
+        stats["total_files"] += 1
+
+        # Upload versions.json LAST (manifest-last atomicity per ADR-0005)
+        if root_versions.exists():
+            versions_key = f"{prefix}/versions.json".lstrip("/")
+            obs.put(store, versions_key, root_versions.read_bytes())
+            success("Uploaded versions.json")
             stats["total_files"] += 1
 
         return True

--- a/tests/unit/test_push_root_files.py
+++ b/tests/unit/test_push_root_files.py
@@ -1,0 +1,261 @@
+"""Tests for root-level file upload in push operations (Issue #357).
+
+This module verifies that root README.md is uploaded when pushing all collections.
+Root catalog.json was already being uploaded; root README.md was being skipped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from portolan_cli.push import (
+    PushResult,
+    push_all_collections,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _setup_valid_catalog(catalog_root: Path) -> None:
+    """Helper to create a valid catalog with .portolan/config.yaml."""
+    portolan_dir = catalog_root / ".portolan"
+    portolan_dir.mkdir(parents=True, exist_ok=True)
+    (portolan_dir / "config.yaml").write_text("version: '1.0'\n")
+
+
+def _create_catalog_json(catalog_root: Path) -> Path:
+    """Create a minimal catalog.json at root."""
+    catalog_json = catalog_root / "catalog.json"
+    catalog_json.write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "id": "test-catalog",
+                "description": "Test catalog",
+                "stac_version": "1.0.0",
+                "links": [],
+            }
+        )
+    )
+    return catalog_json
+
+
+def _create_root_readme(catalog_root: Path) -> Path:
+    """Create a README.md at catalog root."""
+    readme = catalog_root / "README.md"
+    readme.write_text("# Test Catalog\n\nThis is the root README.\n")
+    return readme
+
+
+def _create_collection(catalog_root: Path, name: str, with_readme: bool = False) -> None:
+    """Create a collection with required files."""
+    collection_dir = catalog_root / name
+    collection_dir.mkdir()
+    (collection_dir / "versions.json").write_text(
+        json.dumps({"versions": [{"version": "v1", "assets": {}}]})
+    )
+    (collection_dir / "collection.json").write_text(
+        json.dumps(
+            {
+                "type": "Collection",
+                "id": name,
+                "description": f"Test collection {name}",
+                "stac_version": "1.0.0",
+                "links": [],
+                "license": "proprietary",
+                "extent": {
+                    "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                    "temporal": {"interval": [[None, None]]},
+                },
+            }
+        )
+    )
+    if with_readme:
+        (collection_dir / "README.md").write_text(f"# {name}\n\nCollection README.\n")
+
+
+class TestPushAllCollectionsRootFiles:
+    """Tests for root-level file uploads in push_all_collections (Issue #357)."""
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_uploads_root_readme_after_collections(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections uploads root README.md after all collections succeed."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_readme(tmp_path)
+        _create_collection(tmp_path, "col1", with_readme=True)
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            conflicts=[],
+            errors=[],
+        )
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        assert result.success is True
+
+        # Verify obs.put was called for both catalog.json AND README.md
+        # Keys include prefix (e.g., "catalog/catalog.json")
+        put_calls = mock_obs_put.call_args_list
+        uploaded_keys = [c.args[1] for c in put_calls]
+
+        assert any(k.endswith("/catalog.json") or k == "catalog.json" for k in uploaded_keys), (
+            f"catalog.json should be uploaded, got: {uploaded_keys}"
+        )
+        assert any(k.endswith("/README.md") or k == "README.md" for k in uploaded_keys), (
+            f"Root README.md should be uploaded, got: {uploaded_keys}"
+        )
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_skips_root_readme_when_not_present(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections doesn't fail if root README.md doesn't exist."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        # No root README.md created
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            conflicts=[],
+            errors=[],
+        )
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        assert result.success is True
+
+        # Verify catalog.json was uploaded but README.md was not (doesn't exist)
+        # Keys include prefix (e.g., "catalog/catalog.json")
+        put_calls = mock_obs_put.call_args_list
+        uploaded_keys = [c.args[1] for c in put_calls]
+
+        assert any(k.endswith("/catalog.json") or k == "catalog.json" for k in uploaded_keys), (
+            f"catalog.json should be uploaded, got: {uploaded_keys}"
+        )
+        # Root README.md should NOT be uploaded (doesn't exist)
+        assert not any(k.endswith("/README.md") or k == "README.md" for k in uploaded_keys), (
+            f"Root README.md should NOT be uploaded when it doesn't exist, got: {uploaded_keys}"
+        )
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_skips_root_files_when_collection_fails(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections skips root files when any collection fails."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_readme(tmp_path)
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=False,
+            files_uploaded=0,
+            versions_pushed=0,
+            conflicts=[],
+            errors=["Upload failed"],
+        )
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        assert result.success is False
+
+        # Neither catalog.json nor README.md should be uploaded
+        mock_obs_put.assert_not_called()
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_dry_run_shows_root_readme_would_be_uploaded(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections in dry_run mode mentions root README.md."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_readme(tmp_path)
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=0,
+            versions_pushed=0,
+            conflicts=[],
+            errors=[],
+            dry_run=True,
+            would_push_versions=1,
+        )
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=True,
+            profile=None,
+        )
+
+        assert result.success is True
+        # In dry_run, obs.put should NOT be called
+        mock_obs_put.assert_not_called()
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_counts_root_files_in_total(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """Root files are counted in total_files_uploaded."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_readme(tmp_path)
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            conflicts=[],
+            errors=[],
+        )
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        assert result.success is True
+        # 5 from collection + 2 root files (catalog.json + README.md)
+        assert result.total_files_uploaded == 7

--- a/tests/unit/test_push_root_files.py
+++ b/tests/unit/test_push_root_files.py
@@ -1,7 +1,8 @@
 """Tests for root-level file upload in push operations (Issue #357).
 
-This module verifies that root README.md is uploaded when pushing all collections.
-Root catalog.json was already being uploaded; root README.md was being skipped.
+This module verifies that root README.md and versions.json are uploaded
+when pushing all collections. Root catalog.json was already being uploaded;
+root README.md and versions.json were being skipped.
 """
 
 from __future__ import annotations
@@ -51,6 +52,20 @@ def _create_root_readme(catalog_root: Path) -> Path:
     return readme
 
 
+def _create_root_versions(catalog_root: Path) -> Path:
+    """Create a versions.json at catalog root (Issue #357)."""
+    versions = catalog_root / "versions.json"
+    versions.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "collections": {},
+            }
+        )
+    )
+    return versions
+
+
 def _create_collection(catalog_root: Path, name: str, with_readme: bool = False) -> None:
     """Create a collection with required files."""
     collection_dir = catalog_root / name
@@ -83,13 +98,14 @@ class TestPushAllCollectionsRootFiles:
 
     @patch("portolan_cli.push.obs.put")
     @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
-    def test_uploads_root_readme_after_collections(
+    def test_uploads_all_root_files_after_collections(
         self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
     ) -> None:
-        """push_all_collections uploads root README.md after all collections succeed."""
+        """push_all_collections uploads README.md, catalog.json, and versions.json."""
         _setup_valid_catalog(tmp_path)
         _create_catalog_json(tmp_path)
         _create_root_readme(tmp_path)
+        _create_root_versions(tmp_path)
         _create_collection(tmp_path, "col1", with_readme=True)
 
         mock_push.return_value = PushResult(
@@ -110,27 +126,69 @@ class TestPushAllCollectionsRootFiles:
 
         assert result.success is True
 
-        # Verify obs.put was called for both catalog.json AND README.md
-        # Keys include prefix (e.g., "catalog/catalog.json")
+        # Verify obs.put was called for all three root files
         put_calls = mock_obs_put.call_args_list
         uploaded_keys = [c.args[1] for c in put_calls]
 
+        assert any(k.endswith("/README.md") or k == "README.md" for k in uploaded_keys), (
+            f"Root README.md should be uploaded, got: {uploaded_keys}"
+        )
         assert any(k.endswith("/catalog.json") or k == "catalog.json" for k in uploaded_keys), (
             f"catalog.json should be uploaded, got: {uploaded_keys}"
         )
-        assert any(k.endswith("/README.md") or k == "README.md" for k in uploaded_keys), (
-            f"Root README.md should be uploaded, got: {uploaded_keys}"
+        assert any(k.endswith("/versions.json") or k == "versions.json" for k in uploaded_keys), (
+            f"Root versions.json should be uploaded, got: {uploaded_keys}"
         )
 
     @patch("portolan_cli.push.obs.put")
     @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
-    def test_skips_root_readme_when_not_present(
+    def test_versions_json_uploaded_last(
         self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
     ) -> None:
-        """push_all_collections doesn't fail if root README.md doesn't exist."""
+        """versions.json is uploaded last (manifest-last atomicity per ADR-0005)."""
         _setup_valid_catalog(tmp_path)
         _create_catalog_json(tmp_path)
-        # No root README.md created
+        _create_root_readme(tmp_path)
+        _create_root_versions(tmp_path)
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            conflicts=[],
+            errors=[],
+        )
+
+        push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        # Check order: versions.json should be last
+        put_calls = mock_obs_put.call_args_list
+        uploaded_keys = [c.args[1] for c in put_calls]
+
+        # Find indices
+        versions_idx = next((i for i, k in enumerate(uploaded_keys) if "versions.json" in k), -1)
+        catalog_idx = next((i for i, k in enumerate(uploaded_keys) if "catalog.json" in k), -1)
+
+        assert versions_idx > catalog_idx, (
+            f"versions.json should be uploaded after catalog.json. Order: {uploaded_keys}"
+        )
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_skips_optional_files_when_not_present(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections doesn't fail if README.md or versions.json missing."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        # No root README.md or versions.json
         _create_collection(tmp_path, "col1")
 
         mock_push.return_value = PushResult(
@@ -151,18 +209,14 @@ class TestPushAllCollectionsRootFiles:
 
         assert result.success is True
 
-        # Verify catalog.json was uploaded but README.md was not (doesn't exist)
-        # Keys include prefix (e.g., "catalog/catalog.json")
         put_calls = mock_obs_put.call_args_list
         uploaded_keys = [c.args[1] for c in put_calls]
 
-        assert any(k.endswith("/catalog.json") or k == "catalog.json" for k in uploaded_keys), (
-            f"catalog.json should be uploaded, got: {uploaded_keys}"
-        )
-        # Root README.md should NOT be uploaded (doesn't exist)
-        assert not any(k.endswith("/README.md") or k == "README.md" for k in uploaded_keys), (
-            f"Root README.md should NOT be uploaded when it doesn't exist, got: {uploaded_keys}"
-        )
+        # catalog.json should be uploaded
+        assert any(k.endswith("/catalog.json") or k == "catalog.json" for k in uploaded_keys)
+        # Optional files should NOT be uploaded
+        assert not any(k.endswith("/README.md") or k == "README.md" for k in uploaded_keys)
+        assert not any(k.endswith("/versions.json") or k == "versions.json" for k in uploaded_keys)
 
     @patch("portolan_cli.push.obs.put")
     @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
@@ -173,6 +227,7 @@ class TestPushAllCollectionsRootFiles:
         _setup_valid_catalog(tmp_path)
         _create_catalog_json(tmp_path)
         _create_root_readme(tmp_path)
+        _create_root_versions(tmp_path)
         _create_collection(tmp_path, "col1")
 
         mock_push.return_value = PushResult(
@@ -193,18 +248,48 @@ class TestPushAllCollectionsRootFiles:
 
         assert result.success is False
 
-        # Neither catalog.json nor README.md should be uploaded
+        # No root files should be uploaded when collections fail
         mock_obs_put.assert_not_called()
 
     @patch("portolan_cli.push.obs.put")
     @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
-    def test_dry_run_shows_root_readme_would_be_uploaded(
+    def test_skips_root_files_when_zero_successful(
         self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
     ) -> None:
-        """push_all_collections in dry_run mode mentions root README.md."""
+        """push_all_collections skips root files when no collections succeeded.
+
+        This handles edge cases like empty catalogs or all collections skipped.
+        """
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_versions(tmp_path)
+        # No collections - push won't be called but stats["successful"] == 0
+
+        # Simulate scenario where discover_collections returns empty
+        # This is handled before _push_all_upload_root_files is called
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        # Should succeed but with 0 files uploaded
+        assert result.success is True
+        assert result.total_files_uploaded == 0
+        mock_obs_put.assert_not_called()
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_dry_run_shows_all_root_files(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections in dry_run mode mentions all root files."""
         _setup_valid_catalog(tmp_path)
         _create_catalog_json(tmp_path)
         _create_root_readme(tmp_path)
+        _create_root_versions(tmp_path)
         _create_collection(tmp_path, "col1")
 
         mock_push.return_value = PushResult(
@@ -231,13 +316,14 @@ class TestPushAllCollectionsRootFiles:
 
     @patch("portolan_cli.push.obs.put")
     @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
-    def test_counts_root_files_in_total(
+    def test_counts_all_root_files_in_total(
         self, mock_push: MagicMock, mock_obs_put: MagicMock, tmp_path: Path
     ) -> None:
-        """Root files are counted in total_files_uploaded."""
+        """All root files are counted in total_files_uploaded."""
         _setup_valid_catalog(tmp_path)
         _create_catalog_json(tmp_path)
         _create_root_readme(tmp_path)
+        _create_root_versions(tmp_path)
         _create_collection(tmp_path, "col1")
 
         mock_push.return_value = PushResult(
@@ -257,5 +343,81 @@ class TestPushAllCollectionsRootFiles:
         )
 
         assert result.success is True
-        # 5 from collection + 2 root files (catalog.json + README.md)
-        assert result.total_files_uploaded == 7
+        # 5 from collection + 3 root files (README.md + catalog.json + versions.json)
+        assert result.total_files_uploaded == 8
+
+    @patch("portolan_cli.push.setup_store")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_handles_upload_error(
+        self, mock_push: MagicMock, mock_setup_store: MagicMock, tmp_path: Path
+    ) -> None:
+        """push_all_collections handles errors during root file upload."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_readme(tmp_path)
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            conflicts=[],
+            errors=[],
+        )
+
+        # Make setup_store raise an error
+        mock_setup_store.side_effect = ConnectionError("Network unreachable")
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        # Should fail due to root file upload error
+        assert result.success is False
+        assert "root_files" in result.collection_errors
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.setup_store")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_handles_partial_upload_failure(
+        self,
+        mock_push: MagicMock,
+        mock_setup_store: MagicMock,
+        mock_obs_put: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """push_all_collections handles failure after partial upload."""
+        _setup_valid_catalog(tmp_path)
+        _create_catalog_json(tmp_path)
+        _create_root_readme(tmp_path)
+        _create_root_versions(tmp_path)
+        _create_collection(tmp_path, "col1")
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            conflicts=[],
+            errors=[],
+        )
+
+        mock_setup_store.return_value = (MagicMock(), "catalog")
+
+        # First call (README) succeeds, second call (catalog.json) fails
+        mock_obs_put.side_effect = [None, OSError("Disk full")]
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        # Should fail due to partial upload error
+        assert result.success is False
+        assert "root_files" in result.collection_errors


### PR DESCRIPTION
## Summary

- Root README.md and versions.json were being skipped during `portolan push` without `--collection`
- The `_push_all_upload_catalog` function only uploaded `catalog.json`
- Renamed function to `_push_all_upload_root_files` and added:
  - Root README.md upload (if exists)
  - Root versions.json upload LAST (manifest-last atomicity per ADR-0005)
  - Skip root files when zero collections succeed (edge case)

## Test plan

- [x] 9 unit tests covering root file upload behavior
- [x] Test for upload order (versions.json last)
- [x] Tests for error paths (setup failure, partial upload failure)
- [x] All push-related tests pass (229 tests)
- [x] Lint + type check pass

Fixes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)