### PR TITLE
fix(extract): add via link provenance and fix asset path doubling

### DIFF
--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -55,8 +55,9 @@ This will:
 2. Extract each layer to GeoParquet format
 3. Apply Hilbert spatial sorting for efficient queries
 4. Initialize a Portolan catalog with STAC metadata
-5. Seed `.portolan/metadata.yaml` with values from the service
-6. Generate an extraction report in `.portolan/extraction-report.json`
+5. Add `via` provenance links to each collection (pointing to source layer URL)
+6. Seed `.portolan/metadata.yaml` with values from the service
+7. Generate an extraction report in `.portolan/extraction-report.json`
 
 ### Filtering Layers
 
@@ -96,6 +97,25 @@ output/
     ├── collection.json
     └── census_tracts.parquet
 ```
+
+### Provenance Tracking
+
+Each extracted collection includes a `via` link in its `collection.json` pointing to the original ArcGIS layer URL. This provides data lineage for auditing and reproducibility:
+
+```json
+{
+  "links": [
+    {
+      "rel": "via",
+      "href": "https://services.arcgis.com/.../FeatureServer/0",
+      "type": "text/html",
+      "title": "Source ArcGIS layer: Census Block Groups"
+    }
+  ]
+}
+```
+
+The `via` link uses the layer-specific URL (service URL + layer index), not just the service root.
 
 ### Auto-Seeded Metadata
 

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -1222,9 +1222,10 @@ def _batch_update_versions(
     for p in items:
         for filename, (file_path, file_checksum) in p.asset_files.items():
             # For collection-level assets (ADR-0031), omit item_id from path
+            # asset_key is collection-relative; href is catalog-relative
             if p.is_collection_level_asset:
                 href = f"{collection_id}/{filename}"
-                asset_key = f"{collection_id}/{filename}"
+                asset_key = filename  # Issue #354: collection-relative, not doubled
             else:
                 href = f"{collection_id}/{p.item_id}/{filename}"
                 asset_key = f"{p.item_id}/{filename}"

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -553,7 +553,8 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
 
     Called automatically after extraction unless raw=True.
     Creates catalog.json, config.yaml, and collection.json for each layer.
-    Also seeds metadata.yaml from extracted service metadata.
+    Also seeds metadata.yaml from extracted service metadata and adds
+    provenance links (Issue #353).
     """
     from portolan_cli.catalog import init_catalog
     from portolan_cli.dataset import add_files
@@ -591,6 +592,9 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
 
     # Seed metadata.yaml from extracted service metadata
     _seed_metadata_from_extraction(output_dir, report)
+
+    # Add via links for provenance tracking (Issue #353)
+    _add_via_links_to_collections(output_dir, report)
 
 
 def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
@@ -647,6 +651,48 @@ def _report_metadata_to_arcgis_metadata(
         known_issues=report_metadata.known_issues,
         license_info_raw=report_metadata.license_info_raw,
     )
+
+
+def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) -> None:
+    """Add via provenance links to each extracted collection.
+
+    Per Issue #353: Each collection should have a `via` link pointing to
+    the original data source (ArcGIS layer URL).
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report with layer info and source URL.
+    """
+    from portolan_cli.stac import add_via_link
+
+    source_url = report.source_url
+
+    for layer in report.layers:
+        if layer.status != "success" or not layer.output_path:
+            continue
+
+        # Derive collection directory from output_path
+        # output_path is like "layer_name/layer_name.parquet"
+        # Collection dir is first component
+        output_parts = Path(layer.output_path).parts
+        if not output_parts:
+            continue
+
+        collection_dir = output_dir / output_parts[0]
+        collection_path = collection_dir / "collection.json"
+
+        if not collection_path.exists():
+            continue
+
+        # Build layer-specific URL: service_url + "/" + layer_id
+        # This gives more specific provenance than just the service URL
+        layer_url = f"{source_url.rstrip('/')}/{layer.id}"
+
+        add_via_link(
+            collection_path,
+            layer_url,
+            title=f"Source ArcGIS layer: {layer.name}",
+        )
 
 
 def _discover_and_filter_services(

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -848,4 +848,4 @@ def add_via_link(
     }
     links.append(via_link)
 
-    collection_path.write_text(json.dumps(collection_data, indent=2))
+    collection_path.write_text(json.dumps(collection_data, indent=2) + "\n")

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -800,3 +800,52 @@ def update_collection_summaries(collection: pystac.Collection) -> None:
 
     summarizer = Summarizer(field_strategies)
     collection.summaries = summarizer.summarize(items)
+
+
+def add_via_link(
+    collection_path: Path,
+    source_url: str,
+    *,
+    title: str | None = None,
+) -> None:
+    """Add a `via` provenance link to a collection.json file.
+
+    The `via` link relation points to the original data source from which
+    the collection was extracted. This is useful for provenance tracking
+    and data lineage.
+
+    Per STAC spec, `via` links indicate "the source from which the data
+    was originally obtained."
+
+    Args:
+        collection_path: Path to the collection.json file.
+        source_url: URL of the original data source (e.g., ArcGIS FeatureServer).
+        title: Optional title for the link. Defaults to "Source data service".
+
+    Note:
+        This function is idempotent - adding the same URL twice will not
+        create duplicate links.
+    """
+    import json
+
+    if not collection_path.exists():
+        return
+
+    collection_data = json.loads(collection_path.read_text())
+    links = collection_data.setdefault("links", [])
+
+    # Check if via link already exists with same href
+    for link in links:
+        if link.get("rel") == "via" and link.get("href") == source_url:
+            return  # Already exists, idempotent
+
+    # Add via link
+    via_link = {
+        "rel": "via",
+        "href": source_url,
+        "type": "text/html",
+        "title": title or "Source data service",
+    }
+    links.append(via_link)
+
+    collection_path.write_text(json.dumps(collection_data, indent=2))

--- a/tests/integration/test_collection_level_asset_workflow.py
+++ b/tests/integration/test_collection_level_asset_workflow.py
@@ -69,13 +69,16 @@ class TestCollectionLevelAssetWorkflow:
         assert len(versions_data["versions"]) == 1, "Should have one version"
         version = versions_data["versions"][0]
 
-        # Check asset key and href (critical test for Bug #250)
+        # Check asset key and href (critical test for Bug #250, updated per Issue #354)
+        # Asset key is collection-relative (filename only for collection-level assets)
+        # href is catalog-relative (includes collection path)
+        expected_key = "census.parquet"
         expected_href = "demographics/census.parquet"
-        assert expected_href in version["assets"], (
-            f"Asset key should be '{expected_href}', got {list(version['assets'].keys())}"
+        assert expected_key in version["assets"], (
+            f"Asset key should be '{expected_key}' (collection-relative), got {list(version['assets'].keys())}"
         )
-        assert version["assets"][expected_href]["href"] == expected_href, (
-            f"Asset href should be '{expected_href}' (no double nesting)"
+        assert version["assets"][expected_key]["href"] == expected_href, (
+            f"Asset href should be '{expected_href}' (catalog-relative, no double nesting)"
         )
 
         # Verify: collection.json exists
@@ -134,13 +137,16 @@ class TestCollectionLevelAssetWorkflow:
         # Should have two versions (one per asset)
         assert len(versions_data["versions"]) == 2, "Should have two versions for two assets"
 
-        # Check both assets have correct hrefs
+        # Check both assets have correct keys and hrefs (per Issue #354)
+        # Keys are collection-relative (filename only), hrefs are catalog-relative
         all_assets = {}
         for version in versions_data["versions"]:
             all_assets.update(version["assets"])
 
-        assert "demographics/census.parquet" in all_assets, "Census asset should be tracked"
-        assert "demographics/parcels.parquet" in all_assets, "Parcels asset should be tracked"
+        assert "census.parquet" in all_assets, "Census asset should be tracked (key is filename)"
+        assert "parcels.parquet" in all_assets, "Parcels asset should be tracked (key is filename)"
+        assert all_assets["census.parquet"]["href"] == "demographics/census.parquet"
+        assert all_assets["parcels.parquet"]["href"] == "demographics/parcels.parquet"
 
         # Verify no double nesting for either asset
         assert not (collection_dir / "demographics").exists(), (
@@ -197,9 +203,12 @@ class TestCollectionLevelAssetWorkflow:
         for version in versions_data["versions"]:
             all_assets.update(version["assets"])
 
-        # Collection-level asset has full path from catalog root
-        assert "demographics/census.parquet" in all_assets, (
-            "Collection-level asset should be tracked with correct path"
+        # Collection-level asset key is filename only (per Issue #354)
+        assert "census.parquet" in all_assets, (
+            "Collection-level asset key should be filename (collection-relative)"
+        )
+        assert all_assets["census.parquet"]["href"] == "demographics/census.parquet", (
+            "Collection-level asset href should be catalog-relative"
         )
 
         # Item-level asset key is relative to item (not full path from catalog root)

--- a/tests/unit/test_collection_level_assets.py
+++ b/tests/unit/test_collection_level_assets.py
@@ -77,16 +77,17 @@ class TestCollectionLevelAssets:
         assert len(versions_data["versions"]) > 0, "Should have at least one version"
         version = versions_data["versions"][0]
 
-        # Check the asset href
-        assert "demographics/census.parquet" in version["assets"], (
-            f"Asset key should be 'demographics/census.parquet', got: {list(version['assets'].keys())}"
+        # Check the asset key - should be collection-relative (Issue #354)
+        # For collection-level assets, key is filename only; href includes collection path
+        assert "census.parquet" in version["assets"], (
+            f"Asset key should be 'census.parquet' (collection-relative), got: {list(version['assets'].keys())}"
         )
 
-        asset = version["assets"]["demographics/census.parquet"]
+        asset = version["assets"]["census.parquet"]
 
-        # The critical assertion - href should NOT have double nesting
+        # The critical assertion - href should include collection path (catalog-relative)
         assert asset["href"] == "demographics/census.parquet", (
-            f"Expected 'demographics/census.parquet', got '{asset['href']}' (double nesting bug)"
+            f"Expected href 'demographics/census.parquet', got '{asset['href']}'"
         )
 
     def test_collection_level_asset_no_duplicate_directory(self, initialized_catalog, fixtures_dir):

--- a/tests/unit/test_issue_353_via_link.py
+++ b/tests/unit/test_issue_353_via_link.py
@@ -1,0 +1,330 @@
+"""Unit tests for Issue #353: Extract should add rel:via provenance link.
+
+Tests that extraction commands add a `via` link to collection.json
+pointing to the original data source URL.
+
+STAC `via` link relation:
+- rel: "via"
+- href: The source URL (e.g., ArcGIS FeatureServer URL)
+- type: "text/html" (for web service URLs)
+- title: Describes the source (e.g., "Source ArcGIS Feature Service")
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+class TestViaLinkGeneration:
+    """Tests for adding `via` provenance link to collection.json."""
+
+    def test_auto_init_adds_via_link_to_collection(self, tmp_path: Path) -> None:
+        """_auto_init_catalog adds via link to each collection."""
+        from portolan_cli.extract.arcgis.orchestrator import _auto_init_catalog
+        from portolan_cli.extract.arcgis.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        # Copy a real fixture
+        layer_dir = output_dir / "test_layer"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        source_url = (
+            "https://services.arcgis.com/abc/arcgis/rest/services/TestService/FeatureServer"
+        )
+        report = ExtractionReport(
+            extraction_date="2026-04-23T12:00:00Z",
+            source_url=source_url,
+            portolan_version="0.1.0",
+            gpio_version="0.5.0",
+            metadata_extracted=MetadataExtracted(
+                source_url=source_url,
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="test_layer",
+                    status="success",
+                    output_path="test_layer/data.parquet",
+                    features=100,
+                    size_bytes=output_parquet.stat().st_size,
+                    duration_seconds=1.0,
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                )
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=100,
+                total_size_bytes=output_parquet.stat().st_size,
+                total_duration_seconds=1.0,
+            ),
+        )
+
+        _auto_init_catalog(output_dir, report)
+
+        # Verify collection.json has via link
+        collection_json_path = output_dir / "test_layer" / "collection.json"
+        assert collection_json_path.exists(), "collection.json should exist"
+
+        collection_data = json.loads(collection_json_path.read_text())
+        links = collection_data.get("links", [])
+
+        # Find via link
+        via_links = [link for link in links if link.get("rel") == "via"]
+        assert len(via_links) == 1, "Should have exactly one via link"
+
+        via_link = via_links[0]
+        # Via link uses layer-specific URL (service URL + layer ID)
+        expected_url = f"{source_url}/0"  # Layer ID 0
+        assert via_link["href"] == expected_url, (
+            f"via href should be layer URL, got {via_link['href']}"
+        )
+        assert via_link.get("type") == "text/html", "via type should be text/html"
+        assert "title" in via_link, "via link should have a title"
+
+    def test_via_link_uses_layer_specific_url_when_available(self, tmp_path: Path) -> None:
+        """When layer URL differs from service URL, use layer-specific URL."""
+        from portolan_cli.extract.arcgis.orchestrator import _auto_init_catalog
+        from portolan_cli.extract.arcgis.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "census_tracts"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        # Service URL is the FeatureServer, but layer is index 3
+        service_url = (
+            "https://services.arcgis.com/abc/arcgis/rest/services/Demographics/FeatureServer"
+        )
+        layer_url = f"{service_url}/3"
+
+        report = ExtractionReport(
+            extraction_date="2026-04-23T12:00:00Z",
+            source_url=service_url,
+            portolan_version="0.1.0",
+            gpio_version="0.5.0",
+            metadata_extracted=MetadataExtracted(
+                source_url=service_url,
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=3,  # Layer index 3
+                    name="Census Tracts",
+                    status="success",
+                    output_path="census_tracts/data.parquet",
+                    features=100,
+                    size_bytes=output_parquet.stat().st_size,
+                    duration_seconds=1.0,
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                )
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=100,
+                total_size_bytes=output_parquet.stat().st_size,
+                total_duration_seconds=1.0,
+            ),
+        )
+
+        _auto_init_catalog(output_dir, report)
+
+        # Verify via link points to layer-specific URL
+        collection_json_path = output_dir / "census_tracts" / "collection.json"
+        collection_data = json.loads(collection_json_path.read_text())
+        links = collection_data.get("links", [])
+
+        via_links = [link for link in links if link.get("rel") == "via"]
+        assert len(via_links) == 1
+
+        # Should use layer URL (service URL + layer index)
+        expected_url = layer_url
+        assert via_links[0]["href"] == expected_url
+
+    def test_no_via_link_for_failed_layers(self, tmp_path: Path) -> None:
+        """Failed layers don't get collections, so no via link needed."""
+        from portolan_cli.extract.arcgis.orchestrator import _auto_init_catalog
+        from portolan_cli.extract.arcgis.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+        (output_dir / ".portolan").mkdir()
+
+        source_url = "https://services.arcgis.com/abc/arcgis/rest/services/Test/FeatureServer"
+        report = ExtractionReport(
+            extraction_date="2026-04-23T12:00:00Z",
+            source_url=source_url,
+            portolan_version="0.1.0",
+            gpio_version="0.5.0",
+            metadata_extracted=MetadataExtracted(
+                source_url=source_url,
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="Failed Layer",
+                    status="failed",
+                    output_path=None,
+                    features=None,
+                    size_bytes=None,
+                    duration_seconds=None,
+                    warnings=[],
+                    error="Network error",
+                    attempts=3,
+                )
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=0,
+                failed=1,
+                skipped=0,
+                total_features=0,
+                total_size_bytes=0,
+                total_duration_seconds=0.0,
+            ),
+        )
+
+        # Should not create catalog (no successful extractions)
+        _auto_init_catalog(output_dir, report)
+
+        # No collection.json should exist
+        assert not (output_dir / "failed_layer" / "collection.json").exists()
+
+
+class TestViaLinkHelper:
+    """Tests for the via link helper function."""
+
+    def test_add_via_link_to_collection(self, tmp_path: Path) -> None:
+        """add_via_link modifies collection.json in place."""
+        from portolan_cli.stac import add_via_link
+
+        # Create a minimal collection.json
+        collection_path = tmp_path / "collection.json"
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "stac_version": "1.1.0",
+            "links": [
+                {"rel": "self", "href": "./collection.json"},
+                {"rel": "root", "href": "../catalog.json"},
+            ],
+        }
+        collection_path.write_text(json.dumps(collection_data))
+
+        source_url = "https://example.com/arcgis/rest/services/Test/FeatureServer/0"
+        add_via_link(collection_path, source_url)
+
+        # Read back and verify
+        updated = json.loads(collection_path.read_text())
+        via_links = [link for link in updated["links"] if link.get("rel") == "via"]
+
+        assert len(via_links) == 1
+        assert via_links[0]["href"] == source_url
+        assert via_links[0]["type"] == "text/html"
+        assert "title" in via_links[0]
+
+    def test_add_via_link_idempotent(self, tmp_path: Path) -> None:
+        """Adding same via link twice doesn't duplicate."""
+        from portolan_cli.stac import add_via_link
+
+        collection_path = tmp_path / "collection.json"
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "stac_version": "1.1.0",
+            "links": [],
+        }
+        collection_path.write_text(json.dumps(collection_data))
+
+        source_url = "https://example.com/service"
+
+        # Add twice
+        add_via_link(collection_path, source_url)
+        add_via_link(collection_path, source_url)
+
+        # Should still have only one via link
+        updated = json.loads(collection_path.read_text())
+        via_links = [link for link in updated["links"] if link.get("rel") == "via"]
+        assert len(via_links) == 1
+
+    def test_add_via_link_custom_title(self, tmp_path: Path) -> None:
+        """add_via_link accepts optional custom title."""
+        from portolan_cli.stac import add_via_link
+
+        collection_path = tmp_path / "collection.json"
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "stac_version": "1.1.0",
+            "links": [],
+        }
+        collection_path.write_text(json.dumps(collection_data))
+
+        source_url = "https://example.com/service"
+        add_via_link(collection_path, source_url, title="Custom Source Title")
+
+        updated = json.loads(collection_path.read_text())
+        via_links = [link for link in updated["links"] if link.get("rel") == "via"]
+        assert via_links[0]["title"] == "Custom Source Title"

--- a/tests/unit/test_issue_354_asset_paths.py
+++ b/tests/unit/test_issue_354_asset_paths.py
@@ -1,0 +1,341 @@
+"""Unit tests for Issue #354: Fix asset path resolution in versions.json.
+
+Tests that asset keys in versions.json are collection-relative (no path doubling).
+
+Bug: Asset keys were incorrectly including collection directory name as prefix:
+  WRONG:  "fme_disk_tunnels/fme_disk_tunnels.parquet"
+  RIGHT:  "fme_disk_tunnels.parquet"
+
+The asset key should be collection-relative, while href contains the full path.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+class TestAssetKeyGeneration:
+    """Tests for correct asset key generation in versions.json."""
+
+    def test_collection_level_asset_key_is_filename_only(self, tmp_path: Path) -> None:
+        """Collection-level assets have filename-only keys, not prefixed with collection_id."""
+        from portolan_cli.dataset import finalize_datasets, prepare_dataset
+
+        # Set up catalog
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        (catalog_root / ".portolan").mkdir()
+
+        # Create config.yaml sentinel
+        config_yaml = catalog_root / ".portolan" / "config.yaml"
+        config_yaml.write_text("title: Test Catalog\n")
+
+        # Create catalog.json
+        catalog_json = catalog_root / "catalog.json"
+        catalog_json.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test",
+                    "stac_version": "1.1.0",
+                    "description": "Test",
+                    "links": [],
+                }
+            )
+        )
+
+        # Copy fixture to collection directory (collection-level asset)
+        collection_id = "my_collection"
+        collection_dir = catalog_root / collection_id
+        collection_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        parquet_path = collection_dir / "my_collection.parquet"
+        shutil.copy(fixture_path, parquet_path)
+
+        # Prepare and finalize
+        prepared = prepare_dataset(
+            path=parquet_path,
+            catalog_root=catalog_root,
+            collection_id=collection_id,
+        )
+
+        finalize_datasets(catalog_root, [prepared])
+
+        # Check versions.json
+        versions_path = collection_dir / "versions.json"
+        assert versions_path.exists(), "versions.json should exist"
+
+        versions_data = json.loads(versions_path.read_text())
+        latest_version = versions_data["versions"][-1]
+        asset_keys = list(latest_version["assets"].keys())
+
+        # Asset key should NOT include collection_id prefix
+        # WRONG: "my_collection/my_collection.parquet"
+        # RIGHT: "my_collection.parquet"
+        assert "my_collection.parquet" in asset_keys, (
+            f"Asset key should be filename only, got: {asset_keys}"
+        )
+        assert "my_collection/my_collection.parquet" not in asset_keys, (
+            "Asset key should NOT include collection_id prefix"
+        )
+
+    def test_item_level_asset_key_includes_item_id(self, tmp_path: Path) -> None:
+        """Item-level assets have item_id/filename keys."""
+        from portolan_cli.dataset import finalize_datasets, prepare_dataset
+
+        # Set up catalog
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        (catalog_root / ".portolan").mkdir()
+
+        config_yaml = catalog_root / ".portolan" / "config.yaml"
+        config_yaml.write_text("title: Test Catalog\n")
+
+        catalog_json = catalog_root / "catalog.json"
+        catalog_json.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test",
+                    "stac_version": "1.1.0",
+                    "description": "Test",
+                    "links": [],
+                }
+            )
+        )
+
+        # Copy fixture to item directory (item-level asset)
+        collection_id = "my_collection"
+        item_id = "my_item"
+        collection_dir = catalog_root / collection_id
+        item_dir = collection_dir / item_id
+        item_dir.mkdir(parents=True)
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        parquet_path = item_dir / "data.parquet"
+        shutil.copy(fixture_path, parquet_path)
+
+        # Prepare and finalize
+        prepared = prepare_dataset(
+            path=parquet_path,
+            catalog_root=catalog_root,
+            collection_id=collection_id,
+            item_id=item_id,
+        )
+
+        finalize_datasets(catalog_root, [prepared])
+
+        # Check versions.json
+        versions_path = collection_dir / "versions.json"
+        versions_data = json.loads(versions_path.read_text())
+        latest_version = versions_data["versions"][-1]
+        asset_keys = list(latest_version["assets"].keys())
+
+        # Item-level asset key should be item_id/filename
+        expected_key = f"{item_id}/data.parquet"
+        assert expected_key in asset_keys, (
+            f"Asset key should be '{expected_key}', got: {asset_keys}"
+        )
+
+    def test_nested_catalog_asset_key_no_doubling(self, tmp_path: Path) -> None:
+        """Nested catalogs don't double the path in asset keys."""
+        from portolan_cli.dataset import finalize_datasets, prepare_dataset
+
+        # Set up catalog with nested structure
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        (catalog_root / ".portolan").mkdir()
+
+        config_yaml = catalog_root / ".portolan" / "config.yaml"
+        config_yaml.write_text("title: Test Catalog\n")
+
+        catalog_json = catalog_root / "catalog.json"
+        catalog_json.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "root",
+                    "stac_version": "1.1.0",
+                    "description": "Root",
+                    "links": [],
+                }
+            )
+        )
+
+        # Nested collection: subcatalog/collection
+        collection_id = "subcatalog/fme_disk_tunnels"
+        collection_dir = catalog_root / "subcatalog" / "fme_disk_tunnels"
+        collection_dir.mkdir(parents=True)
+
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        parquet_path = collection_dir / "fme_disk_tunnels.parquet"
+        shutil.copy(fixture_path, parquet_path)
+
+        # Prepare and finalize
+        prepared = prepare_dataset(
+            path=parquet_path,
+            catalog_root=catalog_root,
+            collection_id=collection_id,
+        )
+
+        finalize_datasets(catalog_root, [prepared])
+
+        # Check versions.json
+        versions_path = collection_dir / "versions.json"
+        versions_data = json.loads(versions_path.read_text())
+        latest_version = versions_data["versions"][-1]
+        asset_keys = list(latest_version["assets"].keys())
+
+        # Asset key should be collection-relative (filename only for collection-level)
+        # WRONG: "fme_disk_tunnels/fme_disk_tunnels.parquet" or
+        #        "subcatalog/fme_disk_tunnels/fme_disk_tunnels.parquet"
+        # RIGHT: "fme_disk_tunnels.parquet"
+        assert "fme_disk_tunnels.parquet" in asset_keys, (
+            f"Asset key should be filename only, got: {asset_keys}"
+        )
+
+        # Verify href is correct (full path from catalog root)
+        asset = latest_version["assets"]["fme_disk_tunnels.parquet"]
+        expected_href = "subcatalog/fme_disk_tunnels/fme_disk_tunnels.parquet"
+        assert asset["href"] == expected_href, (
+            f"href should be '{expected_href}', got: {asset['href']}"
+        )
+
+
+class TestBatchUpdateVersionsAssetKeys:
+    """Tests for _batch_update_versions asset key generation."""
+
+    def test_batch_update_collection_level_asset_keys(self, tmp_path: Path) -> None:
+        """_batch_update_versions generates correct keys for collection-level assets."""
+        from portolan_cli.dataset import PreparedDataset, _batch_update_versions
+        from portolan_cli.formats import FormatType
+
+        collection_dir = tmp_path / "my_collection"
+        collection_dir.mkdir()
+
+        # Create a dummy asset file
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        asset_path = collection_dir / "my_collection.parquet"
+        shutil.copy(fixture_path, asset_path)
+
+        # Create prepared dataset with correct fields
+        prepared = PreparedDataset(
+            item_id="my_collection",
+            collection_id="my_collection",
+            format_type=FormatType.VECTOR,
+            bbox=[0, 0, 1, 1],
+            asset_files={"my_collection.parquet": (asset_path, "abc123")},
+            item_json_path=collection_dir / "item.json",
+            is_collection_level_asset=True,
+        )
+
+        _batch_update_versions(
+            collection_dir=collection_dir,
+            collection_id="my_collection",
+            items=[prepared],
+        )
+
+        # Check versions.json
+        versions_path = collection_dir / "versions.json"
+        versions_data = json.loads(versions_path.read_text())
+        latest = versions_data["versions"][-1]
+
+        # Key should be filename only, NOT "my_collection/my_collection.parquet"
+        assert "my_collection.parquet" in latest["assets"]
+        assert "my_collection/my_collection.parquet" not in latest["assets"]
+
+    def test_batch_update_item_level_asset_keys(self, tmp_path: Path) -> None:
+        """_batch_update_versions generates correct keys for item-level assets."""
+        from portolan_cli.dataset import PreparedDataset, _batch_update_versions
+        from portolan_cli.formats import FormatType
+
+        collection_dir = tmp_path / "my_collection"
+        item_dir = collection_dir / "my_item"
+        item_dir.mkdir(parents=True)
+
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        asset_path = item_dir / "data.parquet"
+        shutil.copy(fixture_path, asset_path)
+
+        prepared = PreparedDataset(
+            item_id="my_item",
+            collection_id="my_collection",
+            format_type=FormatType.VECTOR,
+            bbox=[0, 0, 1, 1],
+            asset_files={"data.parquet": (asset_path, "abc123")},
+            item_json_path=item_dir / "item.json",
+            is_collection_level_asset=False,
+        )
+
+        _batch_update_versions(
+            collection_dir=collection_dir,
+            collection_id="my_collection",
+            items=[prepared],
+        )
+
+        versions_path = collection_dir / "versions.json"
+        versions_data = json.loads(versions_path.read_text())
+        latest = versions_data["versions"][-1]
+
+        # Key should be "my_item/data.parquet"
+        assert "my_item/data.parquet" in latest["assets"]
+
+
+class TestAssetPathsInExtraction:
+    """Tests for asset path handling in extraction workflow."""
+
+    def test_extracted_asset_keys_are_collection_relative(self, tmp_path: Path) -> None:
+        """Extraction workflow produces collection-relative asset keys."""
+        from unittest.mock import patch
+
+        from portolan_cli.extract.arcgis.discovery import LayerInfo, ServiceDiscoveryResult
+        from portolan_cli.extract.arcgis.orchestrator import (
+            ExtractionOptions,
+            extract_arcgis_catalog,
+        )
+
+        output_dir = tmp_path / "extraction_output"
+        fixture_src = FIXTURES_DIR / "simple.parquet"
+
+        def mock_extract_side_effect(
+            service_url: str, layer: object, output_path: Path, options: object
+        ) -> tuple[int, int, float]:
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(fixture_src, output_path)
+            return (100, output_path.stat().st_size, 1.0)
+
+        with patch(
+            "portolan_cli.extract.arcgis.orchestrator._extract_single_layer",
+            side_effect=mock_extract_side_effect,
+        ):
+            with patch("portolan_cli.extract.arcgis.orchestrator.discover_layers") as mock:
+                mock.return_value = ServiceDiscoveryResult(
+                    layers=[LayerInfo(id=0, name="TestLayer", layer_type="Feature Layer")],
+                )
+
+                extract_arcgis_catalog(
+                    url="https://example.com/arcgis/rest/services/Test/FeatureServer",
+                    output_dir=output_dir,
+                    options=ExtractionOptions(dry_run=False, raw=False),
+                )
+
+        # Check versions.json in extracted collection
+        versions_path = output_dir / "testlayer" / "versions.json"
+        if versions_path.exists():
+            versions_data = json.loads(versions_path.read_text())
+            latest = versions_data["versions"][-1]
+            asset_keys = list(latest["assets"].keys())
+
+            # No doubled paths
+            for key in asset_keys:
+                assert not key.startswith("testlayer/testlayer"), (
+                    f"Asset key should not double collection name: {key}"
+                )

--- a/tests/unit/test_issue_354_asset_paths.py
+++ b/tests/unit/test_issue_354_asset_paths.py
@@ -329,13 +329,14 @@ class TestAssetPathsInExtraction:
 
         # Check versions.json in extracted collection
         versions_path = output_dir / "testlayer" / "versions.json"
-        if versions_path.exists():
-            versions_data = json.loads(versions_path.read_text())
-            latest = versions_data["versions"][-1]
-            asset_keys = list(latest["assets"].keys())
+        assert versions_path.exists(), "versions.json should be created by extraction"
 
-            # No doubled paths
-            for key in asset_keys:
-                assert not key.startswith("testlayer/testlayer"), (
-                    f"Asset key should not double collection name: {key}"
-                )
+        versions_data = json.loads(versions_path.read_text())
+        latest = versions_data["versions"][-1]
+        asset_keys = list(latest["assets"].keys())
+
+        # No doubled paths
+        for key in asset_keys:
+            assert not key.startswith("testlayer/testlayer"), (
+                f"Asset key should not double collection name: {key}"
+            )


### PR DESCRIPTION
## Summary

- **Issue #353**: Extract commands now add `rel:via` links to collection.json pointing to the original data source URL
- **Issue #354**: Asset keys in versions.json are now collection-relative (fixes path doubling bug)

## Changes

### Via Link Provenance (#353)
- Added `add_via_link()` helper to `stac.py` for adding provenance links
- Extraction auto-init now calls `_add_via_links_to_collections()` to add via links to each collection
- Each collection gets a layer-specific URL (`service_url/layer_id`) for precise provenance

### Asset Path Fix (#354)
- Fixed `_batch_update_versions()` to use filename-only asset keys for collection-level assets
- Asset keys are now collection-relative (`data.parquet`) not doubled (`collection/data.parquet`)
- `href` still contains the full catalog-relative path

## Test plan

- [x] Unit tests for via link generation (6 tests)
- [x] Unit tests for asset key generation (6 tests)
- [x] Updated existing `test_collection_level_assets.py` for new key format
- [x] Full unit test suite passes (3685 tests)

## Documentation

- Updated `docs/guides/extract-arcgis.md` with provenance tracking section

🤖 Generated with [Claude Code](https://claude.com/claude-code)