### PR TITLE
feat(extract): flatten single-layer ArcGIS services (Issue #358)

### DIFF
--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -323,6 +323,55 @@ Example (FeatureServer):
 
 ---
 
+## Extracting from Services Root
+
+You can point Portolan at an entire ArcGIS services directory to extract all services at once:
+
+```bash
+portolan extract arcgis \
+  https://services.arcgis.com/{org_id}/ArcGIS/rest/services \
+  ./output --services "Census*,Demographics*"
+```
+
+### Filtering Services
+
+```bash
+# Include only services matching patterns
+portolan extract arcgis URL --services "Census*,Transport*"
+
+# Exclude services matching patterns
+portolan extract arcgis URL --exclude-services "*_Archive,*_Test"
+```
+
+### Output Structure
+
+Services root extraction creates a nested catalog structure. **Single-layer services are flattened** to avoid redundant nesting:
+
+**Single-layer service (flattened):**
+
+```
+bag_woonfunctie/              # Collection directly
+├── collection.json
+└── bag_woonfunctie.parquet
+```
+
+**Multi-layer service (nested):**
+
+```
+woontypering/                 # Subcatalog
+├── catalog.json
+├── woontypering_2020/
+│   ├── collection.json
+│   └── woontypering_2020.parquet
+└── woontypering_2021/
+    ├── collection.json
+    └── woontypering_2021.parquet
+```
+
+This keeps directory structures clean while preserving hierarchy where it matters.
+
+---
+
 ## Tips
 
 ### Finding ArcGIS Services

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -682,21 +682,27 @@ def _collect_layers_from_services(
     services: list[ServiceInfo],
     base_url: str,
     timeout: float,
-) -> tuple[list[LayerInfo], dict[int, ServiceInfo], list[tuple[str, str]]]:
+) -> tuple[list[LayerInfo], dict[int, ServiceInfo], dict[str, int], list[tuple[str, str]]]:
     """Collect all layers from multiple services.
 
     Returns:
-        Tuple of (all_layers, service_for_layer, discovery_errors).
-        discovery_errors is a list of (service_name, error_message) tuples.
+        Tuple of (all_layers, service_for_layer, layer_count_per_service, discovery_errors).
+        - all_layers: Flat list of all discovered layers
+        - service_for_layer: Maps layer index to its source service
+        - layer_count_per_service: Maps service name to total layer count (for flatten logic)
+        - discovery_errors: List of (service_name, error_message) tuples
     """
     all_layers: list[LayerInfo] = []
     service_for_layer: dict[int, ServiceInfo] = {}
+    layer_count_per_service: dict[str, int] = {}
     discovery_errors: list[tuple[str, str]] = []
 
     for service in services:
         service_url = service.get_url(base_url)
         try:
             service_discovery = discover_layers(service_url, timeout=timeout)
+            # Track layer count for this service (for flatten logic)
+            layer_count_per_service[service.name] = len(service_discovery.layers)
             for layer in service_discovery.layers:
                 layer_idx = len(all_layers)
                 all_layers.append(layer)
@@ -711,7 +717,7 @@ def _collect_layers_from_services(
             )
             continue  # Skip services that fail to discover
 
-    return all_layers, service_for_layer, discovery_errors
+    return all_layers, service_for_layer, layer_count_per_service, discovery_errors
 
 
 def _filter_layers_by_index(
@@ -788,8 +794,8 @@ def _extract_services_root(
     services = _discover_and_filter_services(url, service_filter, service_exclude, options.timeout)
 
     # Collect layers from all services
-    all_layers, service_for_layer, _discovery_errors = _collect_layers_from_services(
-        services, parsed.base_url, options.timeout
+    all_layers, service_for_layer, layer_count_per_service, _discovery_errors = (
+        _collect_layers_from_services(services, parsed.base_url, options.timeout)
     )
 
     # Apply layer filters
@@ -841,11 +847,20 @@ def _extract_services_root(
         service_slug = _slugify(service.name)
         layer_slug = _slugify(layer.name)
 
-        # Build output path: service_name/layer_name/layer_name.parquet
-        # Service as subcatalog, layer as collection
+        # Determine output path based on layer count:
+        # - Single-layer service: service_name/service_name.parquet (flattened - no subcatalog)
+        # - Multi-layer service: service_name/layer_name/layer_name.parquet (nested)
+        is_single_layer = layer_count_per_service.get(service.name, 0) == 1
         service_dir = output_dir / service_slug
-        collection_dir = service_dir / layer_slug
-        output_path = collection_dir / f"{layer_slug}.parquet"
+
+        if is_single_layer:
+            # Flatten: service becomes collection directly
+            output_path = service_dir / f"{service_slug}.parquet"
+        else:
+            # Nested: service is subcatalog, layer is collection
+            collection_dir = service_dir / layer_slug
+            output_path = collection_dir / f"{layer_slug}.parquet"
+
         relative_output_path = str(output_path.relative_to(output_dir))
 
         _emit_progress(on_progress, progress_idx, total, layer.name, "starting")

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -861,7 +861,7 @@ def _extract_services_root(
             collection_dir = service_dir / layer_slug
             output_path = collection_dir / f"{layer_slug}.parquet"
 
-        relative_output_path = str(output_path.relative_to(output_dir))
+        relative_output_path = output_path.relative_to(output_dir).as_posix()
 
         _emit_progress(on_progress, progress_idx, total, layer.name, "starting")
 

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -130,7 +130,7 @@ def check_pmtiles_available() -> None:
     """
     # Check for gpio-pmtiles
     try:
-        import gpio_pmtiles  # type: ignore[import-untyped]  # noqa: F401
+        import gpio_pmtiles  # type: ignore[import-not-found]  # noqa: F401
     except ImportError as e:
         raise PMTilesNotAvailableError() from e
 

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -130,7 +130,7 @@ def check_pmtiles_available() -> None:
     """
     # Check for gpio-pmtiles
     try:
-        import gpio_pmtiles  # type: ignore[import-not-found]  # noqa: F401
+        import gpio_pmtiles  # type: ignore[import-untyped]  # noqa: F401
     except ImportError as e:
         raise PMTilesNotAvailableError() from e
 

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -598,11 +598,12 @@ class TestServicesRootExtraction:
             assert (tmp_path / ".portolan" / "extraction-report.json").exists()
 
             # Verify _extract_single_layer was called with correct path structure
-            # (service as subcatalog: census_2020/block_groups/block_groups.parquet)
+            # Single-layer service is FLATTENED: census_2020/census_2020.parquet
+            # (not nested: census_2020/block_groups/block_groups.parquet)
             call_args = mock_extract.call_args
             output_path = call_args[0][2]  # Third positional arg is output_path
-            assert "census_2020" in str(output_path)
-            assert "block_groups" in str(output_path)
+            relative_path = output_path.relative_to(tmp_path)
+            assert str(relative_path) == "census_2020/census_2020.parquet"
 
     def test_services_root_applies_service_filter(self, tmp_path: Path) -> None:
         """Services root should apply service filter."""
@@ -643,3 +644,178 @@ class TestServicesRootExtraction:
 
             # Should only extract Census layers
             assert result.summary.total_layers == 1
+
+    def test_single_layer_service_flattened(self, tmp_path: Path) -> None:
+        """Single-layer service should create collection directly (no subcatalog).
+
+        Expected output structure:
+            bag_woonfunctie/
+            ├── collection.json  (created by auto-init)
+            └── bag_woonfunctie.parquet
+
+        NOT:
+            bag_woonfunctie/
+            ├── catalog.json  (subcatalog)
+            └── bag_woonfunctie/
+                └── bag_woonfunctie.parquet
+        """
+        mock_services = [
+            ServiceInfo(name="BAG_Woonfunctie", service_type="FeatureServer"),
+        ]
+        mock_single_layer = ServiceDiscoveryResult(
+            layers=[
+                LayerInfo(id=0, name="BAG_Woonfunctie", layer_type="Feature Layer"),
+            ],
+        )
+
+        with (
+            patch(
+                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+            ) as mock_discover_services,
+            patch(
+                "portolan_cli.extract.arcgis.orchestrator.discover_layers"
+            ) as mock_discover_layers,
+            patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
+        ):
+            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_layers.return_value = mock_single_layer
+            mock_extract.return_value = (100, 2048, 2.5)
+
+            options = ExtractionOptions(raw=True)
+            result = extract_arcgis_catalog(
+                url=TEST_SERVICES_ROOT_URL,
+                output_dir=tmp_path,
+                options=options,
+            )
+
+            # Should extract the layer
+            assert mock_extract.call_count == 1
+            assert result.summary.succeeded == 1
+
+            # Output path should be FLATTENED: service_name/service_name.parquet
+            # NOT nested: service_name/layer_name/layer_name.parquet
+            call_args = mock_extract.call_args
+            output_path = call_args[0][2]  # Third positional arg is output_path
+            relative_path = output_path.relative_to(tmp_path)
+
+            # Should be: bag_woonfunctie/bag_woonfunctie.parquet (flattened)
+            # NOT: bag_woonfunctie/bag_woonfunctie/bag_woonfunctie.parquet (nested)
+            assert str(relative_path) == "bag_woonfunctie/bag_woonfunctie.parquet"
+
+            # Verify the result output_path in report
+            layer_result = result.layers[0]
+            assert layer_result.output_path == "bag_woonfunctie/bag_woonfunctie.parquet"
+
+    def test_multi_layer_service_keeps_nesting(self, tmp_path: Path) -> None:
+        """Multi-layer service should keep subcatalog structure.
+
+        Expected output structure:
+            woontypering/
+            ├── catalog.json  (subcatalog)
+            ├── layer_a/
+            │   └── layer_a.parquet
+            └── layer_b/
+                └── layer_b.parquet
+        """
+        mock_services = [
+            ServiceInfo(name="Woontypering", service_type="FeatureServer"),
+        ]
+        mock_multi_layers = ServiceDiscoveryResult(
+            layers=[
+                LayerInfo(id=0, name="Woontypering_2020", layer_type="Feature Layer"),
+                LayerInfo(id=1, name="Woontypering_2021", layer_type="Feature Layer"),
+                LayerInfo(id=2, name="Woontypering_2022", layer_type="Feature Layer"),
+            ],
+        )
+
+        with (
+            patch(
+                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+            ) as mock_discover_services,
+            patch(
+                "portolan_cli.extract.arcgis.orchestrator.discover_layers"
+            ) as mock_discover_layers,
+            patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
+        ):
+            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_layers.return_value = mock_multi_layers
+            mock_extract.return_value = (100, 2048, 2.5)
+
+            options = ExtractionOptions(raw=True)
+            result = extract_arcgis_catalog(
+                url=TEST_SERVICES_ROOT_URL,
+                output_dir=tmp_path,
+                options=options,
+            )
+
+            # Should extract all 3 layers
+            assert mock_extract.call_count == 3
+            assert result.summary.succeeded == 3
+
+            # Output paths should be NESTED: service_name/layer_name/layer_name.parquet
+            # First layer: woontypering/woontypering_2020/woontypering_2020.parquet
+            first_call_output = mock_extract.call_args_list[0][0][2]
+            relative_first = first_call_output.relative_to(tmp_path)
+            assert str(relative_first) == "woontypering/woontypering_2020/woontypering_2020.parquet"
+
+            # Verify all layers have nested structure
+            for layer_result in result.layers:
+                parts = layer_result.output_path.split("/")
+                # Should have 3 parts: service/layer/file.parquet
+                assert len(parts) == 3, f"Expected nested path, got: {layer_result.output_path}"
+
+    def test_mixed_services_flatten_and_nest_appropriately(self, tmp_path: Path) -> None:
+        """Mix of single and multi-layer services should handle each correctly.
+
+        Single-layer service → flatten
+        Multi-layer service → keep nesting
+        """
+        mock_services = [
+            ServiceInfo(name="SingleLayer", service_type="FeatureServer"),
+            ServiceInfo(name="MultiLayer", service_type="FeatureServer"),
+        ]
+        mock_single = ServiceDiscoveryResult(
+            layers=[LayerInfo(id=0, name="OnlyLayer", layer_type="Feature Layer")],
+        )
+        mock_multi = ServiceDiscoveryResult(
+            layers=[
+                LayerInfo(id=0, name="LayerA", layer_type="Feature Layer"),
+                LayerInfo(id=1, name="LayerB", layer_type="Feature Layer"),
+            ],
+        )
+
+        with (
+            patch(
+                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+            ) as mock_discover_services,
+            patch(
+                "portolan_cli.extract.arcgis.orchestrator.discover_layers"
+            ) as mock_discover_layers,
+            patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
+        ):
+            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_layers.side_effect = [mock_single, mock_multi]
+            mock_extract.return_value = (100, 2048, 2.5)
+
+            options = ExtractionOptions(raw=True)
+            result = extract_arcgis_catalog(
+                url=TEST_SERVICES_ROOT_URL,
+                output_dir=tmp_path,
+                options=options,
+            )
+
+            assert result.summary.succeeded == 3
+
+            # Find results by output path
+            output_paths = [r.output_path for r in result.layers]
+
+            # Single-layer service should be flattened
+            # Expected: singlelayer/singlelayer.parquet (2 parts)
+            single_path = [p for p in output_paths if "singlelayer" in p][0]
+            assert single_path.count("/") == 1, f"Single-layer should be flat: {single_path}"
+
+            # Multi-layer service should keep nesting
+            # Expected: multilayer/layer_a/layer_a.parquet (3 parts)
+            multi_paths = [p for p in output_paths if "multilayer" in p]
+            for path in multi_paths:
+                assert path.count("/") == 2, f"Multi-layer should be nested: {path}"

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -603,7 +603,7 @@ class TestServicesRootExtraction:
             call_args = mock_extract.call_args
             output_path = call_args[0][2]  # Third positional arg is output_path
             relative_path = output_path.relative_to(tmp_path)
-            assert str(relative_path) == "census_2020/census_2020.parquet"
+            assert relative_path.as_posix() == "census_2020/census_2020.parquet"
 
     def test_services_root_applies_service_filter(self, tmp_path: Path) -> None:
         """Services root should apply service filter."""
@@ -700,7 +700,7 @@ class TestServicesRootExtraction:
 
             # Should be: bag_woonfunctie/bag_woonfunctie.parquet (flattened)
             # NOT: bag_woonfunctie/bag_woonfunctie/bag_woonfunctie.parquet (nested)
-            assert str(relative_path) == "bag_woonfunctie/bag_woonfunctie.parquet"
+            assert relative_path.as_posix() == "bag_woonfunctie/bag_woonfunctie.parquet"
 
             # Verify the result output_path in report
             layer_result = result.layers[0]
@@ -756,7 +756,10 @@ class TestServicesRootExtraction:
             # First layer: woontypering/woontypering_2020/woontypering_2020.parquet
             first_call_output = mock_extract.call_args_list[0][0][2]
             relative_first = first_call_output.relative_to(tmp_path)
-            assert str(relative_first) == "woontypering/woontypering_2020/woontypering_2020.parquet"
+            assert (
+                relative_first.as_posix()
+                == "woontypering/woontypering_2020/woontypering_2020.parquet"
+            )
 
             # Verify all layers have nested structure
             for layer_result in result.layers:


### PR DESCRIPTION
## Summary

- Single-layer ArcGIS services now create collections directly instead of unnecessary subcatalog nesting
- Multi-layer services retain the existing subcatalog structure

**Before (single-layer service):**
```
bag_woonfunctie/              # subcatalog
├── catalog.json
└── bag_woonfunctie/          # collection (redundant!)
    └── bag_woonfunctie.parquet
```

**After (single-layer service):**
```
bag_woonfunctie/              # collection directly
├── collection.json
└── bag_woonfunctie.parquet
```

## Test plan

- [x] `test_single_layer_service_flattened` - verifies flat output path
- [x] `test_multi_layer_service_keeps_nesting` - verifies nested structure preserved
- [x] `test_mixed_services_flatten_and_nest_appropriately` - mixed scenario
- [x] All 360 arcgis unit tests pass
- [x] All 3674 unit tests pass

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for ArcGIS "services root" extraction with CLI usage examples.

* **New Features**
  * Service filtering via include/exclude glob patterns (--services, --exclude-services flags).
  * Adaptive output layout: single-layer services flatten to service root, multi-layer services maintain per-layer directory nesting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->