### PR TITLE
fix(stac): collection-level vector assets skip item.json

### DIFF
--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -62,6 +62,7 @@ from portolan_cli.metadata_yaml import (
 )
 from portolan_cli.scan_detect import is_filegdb
 from portolan_cli.stac import (
+    add_asset_to_collection,
     add_collection_extensions_from_summaries,
     add_item_to_collection,
     add_projection_extension,
@@ -358,14 +359,15 @@ class PreparedDataset:
     by batching all version writes at the end. See Issue #281.
 
     Attributes:
-        item_id: STAC item identifier.
+        item_id: STAC item identifier (for item-level) or asset key (for collection-level).
         collection_id: Collection identifier (may include '/' for nested).
         format_type: Vector or raster format.
         bbox: Bounding box [min_x, min_y, max_x, max_y] in WGS84.
         asset_files: Dict mapping filename to (path, checksum) tuples.
-        item_json_path: Path to the item.json file that was created.
+        item_json_path: Path to item.json (None for collection-level vector assets per ADR-0031).
         is_collection_level_asset: If True, asset is at collection level (ADR-0031).
-        stac_item: The PySTAC Item object (for collection link updates).
+        stac_item: The PySTAC Item object (None for collection-level vector assets).
+        stac_assets: Assets to add to collection.json (for collection-level assets).
         metadata: Extracted metadata (GeoParquet or COG) for table extension (Issue #304).
     """
 
@@ -374,9 +376,10 @@ class PreparedDataset:
     format_type: FormatType
     bbox: list[float]
     asset_files: dict[str, tuple[Path, str]]
-    item_json_path: Path
+    item_json_path: Path | None  # None for collection-level vector assets
     is_collection_level_asset: bool = False
     stac_item: pystac.Item | None = None
+    stac_assets: dict[str, pystac.Asset] | None = None  # For collection-level addition
     metadata: GeoParquetMetadata | COGMetadata | None = None
 
 
@@ -736,6 +739,84 @@ def _add_statistics_to_properties(
             stac_properties["table:column_statistics"] = col_stats
 
 
+def _fix_collection_level_asset_hrefs(
+    stac_assets: dict[str, pystac.Asset],
+) -> dict[str, pystac.Asset]:
+    """Fix asset hrefs for collection-level assets (ADR-0031).
+
+    _scan_item_assets() computes hrefs relative to item.json, but for
+    collection-level assets they should be relative to collection.json.
+    Since both collection.json and assets are in the same directory,
+    href should be ./filename (not ../filename).
+
+    Args:
+        stac_assets: Assets with hrefs relative to item.json location.
+
+    Returns:
+        Assets with hrefs relative to collection.json location.
+    """
+    fixed_assets: dict[str, pystac.Asset] = {}
+    for key, asset in stac_assets.items():
+        href = asset.href
+        if href.startswith("../"):
+            href = href[3:]  # Remove ../ prefix
+        fixed_href = f"./{href}"
+        fixed_assets[key] = pystac.Asset(
+            href=fixed_href,
+            media_type=asset.media_type,
+            roles=asset.roles,
+        )
+    return fixed_assets
+
+
+def _create_and_save_item(
+    *,
+    item_id: str,
+    bbox: list[float],
+    item_datetime: datetime | None,
+    stac_properties: dict[str, Any],
+    stac_assets: dict[str, pystac.Asset],
+    format_type: FormatType,
+    metadata: GeoParquetMetadata | COGMetadata,
+    item_dir: Path,
+) -> tuple[pystac.Item, Path]:
+    """Create a STAC item with extensions and save it to disk.
+
+    Helper to reduce complexity in prepare_dataset().
+
+    Args:
+        item_id: STAC item identifier.
+        bbox: Bounding box [min_x, min_y, max_x, max_y].
+        item_datetime: Acquisition/creation datetime.
+        stac_properties: Properties to include in the item.
+        stac_assets: Assets to attach to the item.
+        format_type: Vector or raster format.
+        metadata: Extracted metadata for extension fields.
+        item_dir: Directory where item.json will be saved.
+
+    Returns:
+        Tuple of (item, item_json_path).
+    """
+    item = create_item(
+        item_id=item_id,
+        bbox=bbox,
+        datetime=item_datetime,
+        properties=stac_properties,
+        assets=stac_assets,
+    )
+    add_projection_extension(item, metadata)
+    if format_type == FormatType.VECTOR:
+        add_vector_extension(item, metadata)
+    elif format_type == FormatType.RASTER:
+        add_raster_extension(item, metadata)
+
+    item_json_path = item_dir / f"{item_id}.json"
+    item.set_self_href(str(item_json_path))
+    item.save_object()
+
+    return item, item_json_path
+
+
 def _apply_nodata_defaults_to_bands(
     stac_properties: dict[str, Any],
     metadata: COGMetadata,
@@ -935,24 +1016,35 @@ def prepare_dataset(
     if format_type == FormatType.RASTER and defaults and isinstance(metadata, COGMetadata):
         _apply_nodata_defaults_to_bands(stac_properties, metadata, defaults, path)
 
-    # Step 7: Create STAC item and save item.json (per-item file, no conflict)
-    item = create_item(
+    # Step 7: Create STAC item or collection-level assets (per ADR-0031)
+    # Collection-level vector assets: no item.json, assets go directly in collection.json
+    # Item-level assets (rasters, partitioned vectors): create item.json as usual
+    if is_collection_level_asset and format_type == FormatType.VECTOR:
+        # Collection-level vector asset: no item.json per ADR-0031
+        return PreparedDataset(
+            item_id=item_id_resolved,
+            collection_id=collection_id,
+            format_type=format_type,
+            bbox=bbox,
+            asset_files=asset_files,
+            item_json_path=None,  # No item.json for collection-level vector
+            is_collection_level_asset=True,
+            stac_item=None,
+            stac_assets=_fix_collection_level_asset_hrefs(stac_assets),
+            metadata=metadata,
+        )
+
+    # Item-level: create STAC item and save item.json
+    item, item_json_path = _create_and_save_item(
         item_id=item_id_resolved,
         bbox=bbox,
-        datetime=effective_datetime,
-        properties=stac_properties,
-        assets=stac_assets,
+        item_datetime=effective_datetime,
+        stac_properties=stac_properties,
+        stac_assets=stac_assets,
+        format_type=format_type,
+        metadata=metadata,
+        item_dir=item_dir,
     )
-    add_projection_extension(item, metadata)
-    if format_type == FormatType.VECTOR:
-        add_vector_extension(item, metadata)
-    elif format_type == FormatType.RASTER:
-        add_raster_extension(item, metadata)
-
-    item_json_path = item_dir / f"{item_id_resolved}.json"
-    item.set_self_href(str(item_json_path))
-    # Save item.json now (each item writes to its own file, no conflict)
-    item.save_object()
 
     return PreparedDataset(
         item_id=item_id_resolved,
@@ -1006,9 +1098,17 @@ def finalize_datasets(
             initial_bbox=first_item.bbox,
         )
 
-        # Add all items to collection (in memory)
+        # Add items or collection-level assets to collection (in memory)
+        # Per ADR-0031: Collection-level vector assets go directly in collection.assets
         for p in items:
-            if p.stac_item is not None:
+            if p.is_collection_level_asset and p.stac_assets is not None:
+                # Collection-level asset: add directly to collection.assets
+                for asset_key, asset in p.stac_assets.items():
+                    add_asset_to_collection(
+                        collection, asset_key, asset, update_extent_from_bbox=p.bbox
+                    )
+            elif p.stac_item is not None:
+                # Item-level: add item link to collection
                 add_item_to_collection(collection, p.stac_item, update_extent=True)
                 # Note: item_datetime would need to be passed through PreparedDataset
                 # if we want to update temporal extent per-item
@@ -1148,18 +1248,20 @@ def _finalize_with_backend(
 
     remote = get_setting("remote", catalog_path=catalog_root, collection=collection_id)
     first = items[0]
+    # For collection-level assets, item_json_path is None; use collection_dir
+    first_item_dir = first.item_json_path.parent if first.item_json_path else collection_dir
     context = {
         "catalog_root": catalog_root,
         "collection_id": collection_id,
         "collection_dir": collection_dir,
         "collection": collection,
         "item_id": first.item_id,
-        "item_dir": first.item_json_path.parent,
+        "item_dir": first_item_dir,
         "asset_files": first.asset_files,
         "items": [
             {
                 "item_id": p.item_id,
-                "item_dir": p.item_json_path.parent,
+                "item_dir": (p.item_json_path.parent if p.item_json_path else collection_dir),
                 "asset_files": p.asset_files,
             }
             for p in items

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -742,26 +742,42 @@ def _add_statistics_to_properties(
 def _fix_collection_level_asset_hrefs(
     stac_assets: dict[str, pystac.Asset],
 ) -> dict[str, pystac.Asset]:
-    """Fix asset hrefs for collection-level assets (ADR-0031).
+    """Fix asset hrefs and keys for collection-level assets (ADR-0031).
 
     _scan_item_assets() computes hrefs relative to item.json, but for
     collection-level assets they should be relative to collection.json.
     Since both collection.json and assets are in the same directory,
     href should be ./filename (not ../filename).
 
+    Also fixes asset keys: _scan_item_assets assigns "data" to primary files,
+    but for collection-level assets we need unique keys to avoid collisions
+    when multiple vectors exist in the same collection. Use file stem instead.
+
     Args:
         stac_assets: Assets with hrefs relative to item.json location.
 
     Returns:
-        Assets with hrefs relative to collection.json location.
+        Assets with hrefs relative to collection.json location, with unique keys.
     """
     fixed_assets: dict[str, pystac.Asset] = {}
     for key, asset in stac_assets.items():
         href = asset.href
+
+        # Normalize href: strip any ../ or ./ prefix, then add ./
         if href.startswith("../"):
-            href = href[3:]  # Remove ../ prefix
+            href = href[3:]
+        elif href.startswith("./"):
+            href = href[2:]
         fixed_href = f"./{href}"
-        fixed_assets[key] = pystac.Asset(
+
+        # Fix asset key: "data" → file stem for uniqueness across collection
+        # e.g., "data" with href "./census.parquet" → key "census"
+        if key == "data":
+            fixed_key = Path(href).stem
+        else:
+            fixed_key = key
+
+        fixed_assets[fixed_key] = pystac.Asset(
             href=fixed_href,
             media_type=asset.media_type,
             roles=asset.roles,

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -234,6 +234,52 @@ def add_item_to_collection(
         _update_collection_extent(collection, item)
 
 
+def add_asset_to_collection(
+    collection: pystac.Collection,
+    asset_key: str,
+    asset: pystac.Asset,
+    *,
+    update_extent_from_bbox: list[float] | None = None,
+) -> None:
+    """Add an asset directly to a collection (collection-level asset).
+
+    Per ADR-0031: Single vector files (GeoParquet, Shapefile, GeoPackage) are
+    collection-level assets—no item.json, asset directly in collection.json.
+
+    Args:
+        collection: The collection to add the asset to.
+        asset_key: Key for the asset (e.g., "data", "boundaries").
+        asset: The pystac.Asset to add.
+        update_extent_from_bbox: If provided, update collection's spatial extent
+            to encompass this bbox [min_x, min_y, max_x, max_y].
+    """
+    collection.add_asset(asset_key, asset)
+
+    if update_extent_from_bbox:
+        _update_collection_extent_from_bbox(collection, update_extent_from_bbox)
+
+
+def _update_collection_extent_from_bbox(
+    collection: pystac.Collection,
+    bbox: list[float],
+) -> None:
+    """Update a collection's spatial extent to include a bounding box.
+
+    Args:
+        collection: The collection to update.
+        bbox: Bounding box [min_x, min_y, max_x, max_y] to include.
+    """
+    current_bbox = collection.extent.spatial.bboxes[0]
+    new_bbox = [
+        min(current_bbox[0], bbox[0]),  # min_x
+        min(current_bbox[1], bbox[1]),  # min_y
+        max(current_bbox[2], bbox[2]),  # max_x
+        max(current_bbox[3], bbox[3]),  # max_y
+    ]
+
+    collection.extent.spatial = pystac.SpatialExtent(bboxes=[new_bbox])
+
+
 def _update_collection_extent(
     collection: pystac.Collection,
     item: pystac.Item,

--- a/tests/integration/test_collection_level_asset_workflow.py
+++ b/tests/integration/test_collection_level_asset_workflow.py
@@ -10,10 +10,46 @@ Per ADR-0031:
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
 from portolan_cli.dataset import add_dataset
+
+
+def _assert_no_item_json(collection_dir: Path) -> None:
+    """Assert no item.json files exist in collection (Issue #364)."""
+    item_json_files = [
+        f
+        for f in collection_dir.rglob("*.json")
+        if f.name not in ("collection.json", "versions.json", "catalog.json")
+    ]
+    assert len(item_json_files) == 0, (
+        f"Should NOT create item.json for collection-level vector, found: {[f.name for f in item_json_files]}"
+    )
+
+
+def _assert_collection_assets(collection_dir: Path, expected_assets: dict[str, str]) -> None:
+    """Assert collection.json has expected assets with correct hrefs."""
+    collection_json = collection_dir / "collection.json"
+    with open(collection_json) as f:
+        collection_data = json.load(f)
+
+    assets = collection_data.get("assets", {})
+    assert len(assets) == len(expected_assets), (
+        f"Expected {len(expected_assets)} assets, got {len(assets)}: {list(assets.keys())}"
+    )
+
+    for key, expected_href in expected_assets.items():
+        assert key in assets, f"Missing '{key}' asset, got: {list(assets.keys())}"
+        assert assets[key]["href"] == expected_href, (
+            f"{key} href should be '{expected_href}', got: {assets[key]['href']}"
+        )
+
+    # Verify NO item links
+    links = collection_data.get("links", [])
+    item_links = [link for link in links if link.get("rel") == "item"]
+    assert len(item_links) == 0, f"Should NOT have item links, got: {item_links}"
 
 
 @pytest.mark.integration
@@ -61,20 +97,10 @@ class TestCollectionLevelAssetWorkflow:
         assert not (collection_dir / "demographics").exists(), (
             "Should NOT have nested demographics/demographics/ directory (Bug #250)"
         )
-
-        # Verify: Asset file exists at collection level
         assert target_file.exists(), "Asset file should exist at collection level"
 
         # Verify: NO item.json exists (Issue #364)
-        item_json_files = [
-            f
-            for f in collection_dir.rglob("*.json")
-            if f.name not in ("collection.json", "versions.json", "catalog.json")
-        ]
-        assert len(item_json_files) == 0, (
-            f"Should NOT create item.json for collection-level vector (Issue #364), "
-            f"found: {[f.name for f in item_json_files]}"
-        )
+        _assert_no_item_json(collection_dir)
 
         # Verify: versions.json has correct href
         versions_file = collection_dir / "versions.json"
@@ -86,40 +112,12 @@ class TestCollectionLevelAssetWorkflow:
         assert len(versions_data["versions"]) == 1, "Should have one version"
         version = versions_data["versions"][0]
 
-        # Check asset key and href (critical test for Bug #250, updated per Issue #354)
-        # Asset key is collection-relative (filename only for collection-level assets)
-        # href is catalog-relative (includes collection path)
-        expected_key = "census.parquet"
-        expected_href = "demographics/census.parquet"
-        assert expected_key in version["assets"], (
-            f"Asset key should be '{expected_key}' (collection-relative), got {list(version['assets'].keys())}"
-        )
-        assert version["assets"][expected_key]["href"] == expected_href, (
-            f"Asset href should be '{expected_href}' (catalog-relative, no double nesting)"
-        )
+        # Asset key is collection-relative, href is catalog-relative (Issue #354)
+        assert "census.parquet" in version["assets"]
+        assert version["assets"]["census.parquet"]["href"] == "demographics/census.parquet"
 
-        # Verify: collection.json has asset in "assets" field (Issue #364)
-        collection_json = collection_dir / "collection.json"
-        assert collection_json.exists(), "collection.json should be created"
-
-        with open(collection_json) as f:
-            collection_data = json.load(f)
-
-        # Asset should be in collection.assets with file stem as key
-        assets = collection_data.get("assets", {})
-        assert "census" in assets, (
-            f"collection.json should have 'census' asset (file stem), got: {list(assets.keys())}"
-        )
-        assert assets["census"]["href"] == "./census.parquet", (
-            f"Asset href should be './census.parquet', got: {assets['census']['href']}"
-        )
-
-        # Verify NO item links
-        links = collection_data.get("links", [])
-        item_links = [link for link in links if link.get("rel") == "item"]
-        assert len(item_links) == 0, (
-            f"Should NOT have item links for collection-level asset (Issue #364), got: {item_links}"
-        )
+        # Verify collection.json has asset (Issue #364)
+        _assert_collection_assets(collection_dir, {"census": "./census.parquet"})
 
         # Verify: Result contains correct info
         assert result.item_id == "census", (
@@ -166,76 +164,33 @@ class TestCollectionLevelAssetWorkflow:
             description="Land parcels",
         )
 
-        # Verify both assets are tracked correctly in versions.json
+        # Verify versions.json tracks both assets
         versions_file = collection_dir / "versions.json"
         with open(versions_file) as f:
             versions_data = json.load(f)
 
-        # Should have two versions (one per asset)
-        assert len(versions_data["versions"]) == 2, "Should have two versions for two assets"
+        assert len(versions_data["versions"]) == 2, "Should have two versions"
 
-        # Check both assets have correct keys and hrefs (per Issue #354)
-        # Keys are collection-relative (filename only), hrefs are catalog-relative
         all_assets = {}
         for version in versions_data["versions"]:
             all_assets.update(version["assets"])
 
-        assert "census.parquet" in all_assets, "Census asset should be tracked (key is filename)"
-        assert "parcels.parquet" in all_assets, "Parcels asset should be tracked (key is filename)"
+        assert "census.parquet" in all_assets
+        assert "parcels.parquet" in all_assets
         assert all_assets["census.parquet"]["href"] == "demographics/census.parquet"
         assert all_assets["parcels.parquet"]["href"] == "demographics/parcels.parquet"
 
-        # Verify no double nesting for either asset
-        assert not (collection_dir / "demographics").exists(), (
-            "Should NOT have nested demographics/demographics/ directory"
+        # Verify no double nesting
+        assert not (collection_dir / "demographics").exists()
+
+        # Verify NO item.json and correct collection.json assets
+        _assert_no_item_json(collection_dir)
+        _assert_collection_assets(
+            collection_dir, {"census": "./census.parquet", "parcels": "./parcels.parquet"}
         )
 
-        # Verify NO item.json files exist (Issue #364)
-        item_json_files = [
-            f
-            for f in collection_dir.rglob("*.json")
-            if f.name not in ("collection.json", "versions.json", "catalog.json")
-        ]
-        assert len(item_json_files) == 0, (
-            f"Should NOT create item.json for collection-level vectors, "
-            f"found: {[f.name for f in item_json_files]}"
-        )
-
-        # Verify collection.json has both assets (Issue #364)
-        collection_json = collection_dir / "collection.json"
-        with open(collection_json) as f:
-            collection_data = json.load(f)
-
-        # Both assets should be present with distinct keys (file stems)
-        assets = collection_data.get("assets", {})
-        assert len(assets) == 2, (
-            f"collection.json should have 2 assets (census + parcels), got: {list(assets.keys())}"
-        )
-
-        # Verify distinct keys derived from file stems
-        assert "census" in assets, f"Missing 'census' asset, got: {list(assets.keys())}"
-        assert "parcels" in assets, f"Missing 'parcels' asset, got: {list(assets.keys())}"
-
-        # Verify hrefs point to correct files
-        assert assets["census"]["href"] == "./census.parquet", (
-            f"census href should be './census.parquet', got: {assets['census']['href']}"
-        )
-        assert assets["parcels"]["href"] == "./parcels.parquet", (
-            f"parcels href should be './parcels.parquet', got: {assets['parcels']['href']}"
-        )
-
-        # Verify NO item links
-        links = collection_data.get("links", [])
-        item_links = [link for link in links if link.get("rel") == "item"]
-        assert len(item_links) == 0, (
-            f"Should NOT have item links for collection-level assets, got: {item_links}"
-        )
-
-        # Verify items.parquet does NOT exist (Issue #364)
-        items_parquet = collection_dir / "items.parquet"
-        assert not items_parquet.exists(), (
-            "items.parquet should NOT exist for collection with only collection-level assets"
-        )
+        # Verify items.parquet does NOT exist
+        assert not (collection_dir / "items.parquet").exists()
 
     def test_mixed_collection_and_item_level_assets(self, fresh_catalog_no_versions, fixtures_dir):
         """Test collection with both collection-level and item-level assets.

--- a/tests/integration/test_collection_level_asset_workflow.py
+++ b/tests/integration/test_collection_level_asset_workflow.py
@@ -105,13 +105,13 @@ class TestCollectionLevelAssetWorkflow:
         with open(collection_json) as f:
             collection_data = json.load(f)
 
-        # Asset should be in collection.assets, not as item link
+        # Asset should be in collection.assets with file stem as key
         assets = collection_data.get("assets", {})
-        assert "data" in assets, (
-            f"collection.json should have 'data' asset (Issue #364), got: {list(assets.keys())}"
+        assert "census" in assets, (
+            f"collection.json should have 'census' asset (file stem), got: {list(assets.keys())}"
         )
-        assert assets["data"]["href"] == "./census.parquet", (
-            f"Asset href should be './census.parquet', got: {assets['data']['href']}"
+        assert assets["census"]["href"] == "./census.parquet", (
+            f"Asset href should be './census.parquet', got: {assets['census']['href']}"
         )
 
         # Verify NO item links
@@ -206,13 +206,23 @@ class TestCollectionLevelAssetWorkflow:
         with open(collection_json) as f:
             collection_data = json.load(f)
 
-        # Both should be in assets (note: each may have same key "data" which
-        # means the second overwrites the first - this is expected behavior
-        # per the current asset key strategy)
+        # Both assets should be present with distinct keys (file stems)
         assets = collection_data.get("assets", {})
-        # The second asset overwrites the first because both get "data" key
-        # This may need a follow-up fix for distinct asset keys
-        assert len(assets) >= 1, "collection.json should have assets"
+        assert len(assets) == 2, (
+            f"collection.json should have 2 assets (census + parcels), got: {list(assets.keys())}"
+        )
+
+        # Verify distinct keys derived from file stems
+        assert "census" in assets, f"Missing 'census' asset, got: {list(assets.keys())}"
+        assert "parcels" in assets, f"Missing 'parcels' asset, got: {list(assets.keys())}"
+
+        # Verify hrefs point to correct files
+        assert assets["census"]["href"] == "./census.parquet", (
+            f"census href should be './census.parquet', got: {assets['census']['href']}"
+        )
+        assert assets["parcels"]["href"] == "./parcels.parquet", (
+            f"parcels href should be './parcels.parquet', got: {assets['parcels']['href']}"
+        )
 
         # Verify NO item links
         links = collection_data.get("links", [])

--- a/tests/integration/test_collection_level_asset_workflow.py
+++ b/tests/integration/test_collection_level_asset_workflow.py
@@ -1,7 +1,12 @@
-"""Integration tests for collection-level asset workflow (Issue #250, ADR-0031).
+"""Integration tests for collection-level asset workflow (Issue #250, ADR-0031, Issue #364).
 
 Tests the complete workflow of adding collection-level vector assets,
 verifying STAC metadata generation, and ensuring correct path structure.
+
+Per ADR-0031:
+- Single vector files (GeoParquet, Shapefile, GeoPackage) are collection-level assets
+- No item.json created - asset goes directly in collection.json
+- items.parquet is NOT generated (no items to index)
 """
 
 import json
@@ -24,12 +29,13 @@ class TestCollectionLevelAssetWorkflow:
         1. Adding a collection-level vector file (demographics/census.parquet)
         2. Verifying no double-nested directories (demographics/demographics/)
         3. Verifying versions.json has correct href (demographics/census.parquet)
-        4. Verifying collection.json is created
+        4. Verifying collection.json has asset in "assets" field (Issue #364)
+        5. Verifying NO item.json exists (Issue #364)
 
         Per ADR-0031, collection-level assets should be organized as:
             demographics/
                 census.parquet          # Asset at collection level
-                collection.json
+                collection.json         # Has assets.data pointing to census.parquet
                 versions.json
         """
         # Setup: Create collection directory
@@ -59,6 +65,17 @@ class TestCollectionLevelAssetWorkflow:
         # Verify: Asset file exists at collection level
         assert target_file.exists(), "Asset file should exist at collection level"
 
+        # Verify: NO item.json exists (Issue #364)
+        item_json_files = [
+            f
+            for f in collection_dir.rglob("*.json")
+            if f.name not in ("collection.json", "versions.json", "catalog.json")
+        ]
+        assert len(item_json_files) == 0, (
+            f"Should NOT create item.json for collection-level vector (Issue #364), "
+            f"found: {[f.name for f in item_json_files]}"
+        )
+
         # Verify: versions.json has correct href
         versions_file = collection_dir / "versions.json"
         assert versions_file.exists(), "versions.json should exist"
@@ -81,9 +98,28 @@ class TestCollectionLevelAssetWorkflow:
             f"Asset href should be '{expected_href}' (catalog-relative, no double nesting)"
         )
 
-        # Verify: collection.json exists
+        # Verify: collection.json has asset in "assets" field (Issue #364)
         collection_json = collection_dir / "collection.json"
         assert collection_json.exists(), "collection.json should be created"
+
+        with open(collection_json) as f:
+            collection_data = json.load(f)
+
+        # Asset should be in collection.assets, not as item link
+        assets = collection_data.get("assets", {})
+        assert "data" in assets, (
+            f"collection.json should have 'data' asset (Issue #364), got: {list(assets.keys())}"
+        )
+        assert assets["data"]["href"] == "./census.parquet", (
+            f"Asset href should be './census.parquet', got: {assets['data']['href']}"
+        )
+
+        # Verify NO item links
+        links = collection_data.get("links", [])
+        item_links = [link for link in links if link.get("rel") == "item"]
+        assert len(item_links) == 0, (
+            f"Should NOT have item links for collection-level asset (Issue #364), got: {item_links}"
+        )
 
         # Verify: Result contains correct info
         assert result.item_id == "census", (
@@ -97,7 +133,8 @@ class TestCollectionLevelAssetWorkflow:
         """Test adding multiple collection-level assets to same collection.
 
         Verifies that multiple vector files in the same collection directory
-        are each tracked correctly without interference.
+        are each tracked correctly without interference, and both appear
+        in collection.json assets (Issue #364).
         """
         collection_dir = fresh_catalog_no_versions / "demographics"
         collection_dir.mkdir()
@@ -151,6 +188,43 @@ class TestCollectionLevelAssetWorkflow:
         # Verify no double nesting for either asset
         assert not (collection_dir / "demographics").exists(), (
             "Should NOT have nested demographics/demographics/ directory"
+        )
+
+        # Verify NO item.json files exist (Issue #364)
+        item_json_files = [
+            f
+            for f in collection_dir.rglob("*.json")
+            if f.name not in ("collection.json", "versions.json", "catalog.json")
+        ]
+        assert len(item_json_files) == 0, (
+            f"Should NOT create item.json for collection-level vectors, "
+            f"found: {[f.name for f in item_json_files]}"
+        )
+
+        # Verify collection.json has both assets (Issue #364)
+        collection_json = collection_dir / "collection.json"
+        with open(collection_json) as f:
+            collection_data = json.load(f)
+
+        # Both should be in assets (note: each may have same key "data" which
+        # means the second overwrites the first - this is expected behavior
+        # per the current asset key strategy)
+        assets = collection_data.get("assets", {})
+        # The second asset overwrites the first because both get "data" key
+        # This may need a follow-up fix for distinct asset keys
+        assert len(assets) >= 1, "collection.json should have assets"
+
+        # Verify NO item links
+        links = collection_data.get("links", [])
+        item_links = [link for link in links if link.get("rel") == "item"]
+        assert len(item_links) == 0, (
+            f"Should NOT have item links for collection-level assets, got: {item_links}"
+        )
+
+        # Verify items.parquet does NOT exist (Issue #364)
+        items_parquet = collection_dir / "items.parquet"
+        assert not items_parquet.exists(), (
+            "items.parquet should NOT exist for collection with only collection-level assets"
         )
 
     def test_mixed_collection_and_item_level_assets(self, fresh_catalog_no_versions, fixtures_dir):

--- a/tests/unit/test_collection_level_assets.py
+++ b/tests/unit/test_collection_level_assets.py
@@ -134,11 +134,11 @@ class TestCollectionLevelAssets:
             "Should not have duplicate 'demographics' subdirectory"
         )
 
-    def test_collection_level_asset_item_json_location(self, initialized_catalog, fixtures_dir):
-        """Test that item.json is created in correct location for collection-level assets.
+    def test_collection_level_vector_no_item_json(self, initialized_catalog, fixtures_dir):
+        """Test that collection-level vector assets do NOT create item.json (ADR-0031).
 
-        For collection-level assets, if an item.json is created, it should use a synthetic
-        item ID (not the collection name) to avoid path conflicts.
+        Per ADR-0031: Single vector files (GeoParquet, Shapefile, GeoPackage) are
+        collection-level assets - no item.json, asset directly in collection.json.
         """
         # Arrange
         collection_dir = initialized_catalog / "demographics"
@@ -158,20 +158,107 @@ class TestCollectionLevelAssets:
             description=None,
         )
 
-        # Assert: If item.json exists, it should NOT be at collection/collection/item.json
-        # It should either:
-        # 1. Not exist (collection-level assets don't need items), OR
-        # 2. Be at collection/item-id/item.json where item-id != collection-name
+        # Assert: NO item.json should exist anywhere in collection
+        item_json_files = list(collection_dir.rglob("*.json"))
+        item_json_names = [f.name for f in item_json_files]
 
-        # Check for the buggy path
-        buggy_item_json = collection_dir / "demographics" / "demographics.json"
-        assert not buggy_item_json.exists(), (
-            f"Should not create item.json at buggy path {buggy_item_json}"
+        # Only collection.json and versions.json should exist
+        assert "census.json" not in item_json_names, (
+            "Should NOT create item.json for collection-level vector asset"
         )
 
-        # If there's an item directory, it should NOT be named same as collection
-        item_dirs = [d for d in collection_dir.iterdir() if d.is_dir()]
-        for item_dir in item_dirs:
-            assert item_dir.name != "demographics", (
-                f"Item directory should not have same name as collection: {item_dir}"
-            )
+        # Verify no item subdirectory was created
+        subdirs = [d for d in collection_dir.iterdir() if d.is_dir()]
+        assert len(subdirs) == 0 or all(d.name.startswith(".") for d in subdirs), (
+            f"Should NOT create item subdirectory, found: {[d.name for d in subdirs]}"
+        )
+
+    def test_collection_level_vector_asset_in_collection_json(
+        self, initialized_catalog, fixtures_dir
+    ):
+        """Test that collection-level vector assets appear in collection.json assets.
+
+        Per ADR-0031: The asset should be in collection.json's "assets" field,
+        NOT as an item link.
+        """
+        # Arrange
+        collection_dir = initialized_catalog / "demographics"
+        collection_dir.mkdir()
+
+        test_file = fixtures_dir / "simple.parquet"
+        target_file = collection_dir / "census.parquet"
+        target_file.write_bytes(test_file.read_bytes())
+
+        # Act
+        add_dataset(
+            catalog_root=initialized_catalog,
+            path=target_file,
+            collection_id="demographics",
+            item_id=None,
+            title=None,
+            description=None,
+        )
+
+        # Assert: collection.json should have asset in "assets" field
+        collection_json = collection_dir / "collection.json"
+        assert collection_json.exists(), "collection.json should be created"
+
+        with open(collection_json) as f:
+            collection_data = json.load(f)
+
+        # Check assets field has our data
+        assets = collection_data.get("assets", {})
+        assert "data" in assets, (
+            f"collection.json should have 'data' asset, got: {list(assets.keys())}"
+        )
+        assert assets["data"]["href"] == "./census.parquet", (
+            f"Asset href should be './census.parquet', got: {assets['data']['href']}"
+        )
+
+        # Verify NO item links exist for this asset
+        links = collection_data.get("links", [])
+        item_links = [link for link in links if link.get("rel") == "item"]
+        assert len(item_links) == 0, (
+            f"Should NOT have item links for collection-level asset, got: {item_links}"
+        )
+
+    def test_explicit_item_id_forces_item_level(self, initialized_catalog, fixtures_dir):
+        """Test that explicit --item-id forces item-level structure (traditional).
+
+        When user explicitly provides item_id, the asset should be item-level
+        (with item.json), not collection-level.
+        """
+        # Arrange
+        collection_dir = initialized_catalog / "demographics"
+        collection_dir.mkdir()
+
+        test_file = fixtures_dir / "simple.parquet"
+        target_file = collection_dir / "census.parquet"
+        target_file.write_bytes(test_file.read_bytes())
+
+        # Act: Explicitly provide item_id
+        add_dataset(
+            catalog_root=initialized_catalog,
+            path=target_file,
+            collection_id="demographics",
+            item_id="census-2020",  # Explicit item ID
+            title=None,
+            description=None,
+        )
+
+        # Assert: item.json SHOULD exist when item_id is explicit
+        # The item.json location depends on implementation - it may be in
+        # a subdirectory or at collection level. Key is that it exists.
+        item_json_files = list(collection_dir.rglob("census-2020.json"))
+        assert len(item_json_files) == 1, (
+            "Should create item.json when explicit item_id is provided"
+        )
+
+        # And collection.json should have item link, not direct asset
+        collection_json = collection_dir / "collection.json"
+        with open(collection_json) as f:
+            collection_data = json.load(f)
+
+        links = collection_data.get("links", [])
+        item_links = [link for link in links if link.get("rel") == "item"]
+        assert len(item_links) == 1, "Should have item link when explicit item_id is provided"

--- a/tests/unit/test_collection_level_assets.py
+++ b/tests/unit/test_collection_level_assets.py
@@ -206,13 +206,13 @@ class TestCollectionLevelAssets:
         with open(collection_json) as f:
             collection_data = json.load(f)
 
-        # Check assets field has our data
+        # Check assets field has our data (key is file stem, not "data")
         assets = collection_data.get("assets", {})
-        assert "data" in assets, (
-            f"collection.json should have 'data' asset, got: {list(assets.keys())}"
+        assert "census" in assets, (
+            f"collection.json should have 'census' asset (file stem), got: {list(assets.keys())}"
         )
-        assert assets["data"]["href"] == "./census.parquet", (
-            f"Asset href should be './census.parquet', got: {assets['data']['href']}"
+        assert assets["census"]["href"] == "./census.parquet", (
+            f"Asset href should be './census.parquet', got: {assets['census']['href']}"
         )
 
         # Verify NO item links exist for this asset


### PR DESCRIPTION
## Summary

Fixes #364: Collection-level vector assets now correctly skip item.json creation per ADR-0031.

- Single vector files (GeoParquet, Shapefile, GeoPackage) directly in collection directory are **collection-level assets**
- No `item.json` created - asset goes directly in `collection.json` `assets` field
- No `items.parquet` generated (no items to index)

### Before (wrong)
```
collection/
├── collection.json     # assets: { geoparquet-items: items.parquet }
├── data.json           # item.json
└── data.parquet
```

### After (correct per ADR-0031)
```
collection/
├── collection.json     # assets: { data: ./data.parquet }
└── data.parquet
```

## Changes

| File | Changes |
|------|---------|
| `stac.py` | Add `add_asset_to_collection()` + `_update_collection_extent_from_bbox()` |
| `dataset.py` | Add helpers, skip item.json for collection-level vectors, add assets to collection.json |
| Tests | Verify item.json absence and collection.json structure |

## Test plan

- [x] Unit tests: `test_collection_level_assets.py` (8 tests)
- [x] Integration tests: `test_collection_level_asset_workflow.py`
- [x] Lint (ruff), type check (mypy), complexity (xenon) all pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collection-level vector assets are stored directly in collection metadata and asset hrefs are rewritten to collection-relative paths.
  * Collection extents are updated to include asset bounding boxes when provided.

* **Bug Fixes**
  * Prevents asset key collisions by remapping duplicate keys for collection assets.

* **Tests**
  * Integration and unit tests updated to enforce no item files for collection-level assets and validate collection assets/links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->