### PR TITLE
feat(extract): add CSW/ISO 19139 metadata seeding for WFS

### DIFF
--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -132,7 +132,7 @@ The extraction process automatically seeds metadata at two levels:
 | `accessInformation` | `known_issues` |
 | Service URL | `source_url` |
 
-**Collection-level** (`<collection>/.portolan/metadata.yaml`): Each extracted layer gets its own metadata file with layer-specific description from the ArcGIS layer details API.
+**Collection-level** (`<collection>/.portolan/metadata.yaml`): Each extracted layer gets its own metadata file with layer-specific description from the ArcGIS layer details API. For nested extractions (services-root mode), metadata is written to the correct collection directory regardless of nesting depth.
 
 Fields that require human input (like `contact.email` and `license`) are marked with `TODO` placeholders:
 

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -119,7 +119,9 @@ The `via` link uses the layer-specific URL (service URL + layer index), not just
 
 ### Auto-Seeded Metadata
 
-The extraction process automatically seeds `.portolan/metadata.yaml` with values from the ArcGIS service metadata:
+The extraction process automatically seeds metadata at two levels:
+
+**Catalog-level** (`.portolan/metadata.yaml`): Seeded from ArcGIS service metadata:
 
 | ArcGIS Field | metadata.yaml Field |
 |-------------|---------------------|
@@ -129,6 +131,8 @@ The extraction process automatically seeds `.portolan/metadata.yaml` with values
 | `serviceDescription` | `processing_notes` |
 | `accessInformation` | `known_issues` |
 | Service URL | `source_url` |
+
+**Collection-level** (`<collection>/.portolan/metadata.yaml`): Each extracted layer gets its own metadata file with layer-specific description from the ArcGIS layer details API.
 
 Fields that require human input (like `contact.email` and `license`) are marked with `TODO` placeholders:
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -674,14 +674,9 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
         if layer.status != "success" or not layer.output_path:
             continue
 
-        # Derive collection directory from output_path
-        # output_path is like "layer_name/layer_name.parquet"
-        # Collection dir is first component
-        output_parts = Path(layer.output_path).parts
-        if not output_parts:
-            continue
-
-        collection_dir = output_dir / output_parts[0]
+        # Derive collection directory from output_path's parent
+        # Handles nested paths like "service/layer/layer.parquet"
+        collection_dir = output_dir / Path(layer.output_path).parent
         collection_path = collection_dir / "collection.json"
 
         if not collection_path.exists():
@@ -722,11 +717,9 @@ def _seed_collection_metadata_arcgis(
         if layer_result.status != "success" or not layer_result.output_path:
             continue
 
-        output_parts = Path(layer_result.output_path).parts
-        if not output_parts:
-            continue
-
-        collection_dir = output_dir / output_parts[0]
+        # Derive collection directory from output_path's parent
+        # Handles nested paths like "service/layer/layer.parquet"
+        collection_dir = output_dir / Path(layer_result.output_path).parent
 
         # Fetch layer details to get description
         layer_description = None
@@ -735,8 +728,14 @@ def _seed_collection_metadata_arcgis(
             layer_details = fetch_layer_details(source_url, layer_result.id, timeout=timeout)
             layer_description = layer_details.get("description")
             layer_name = layer_details.get("name", layer_result.name)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(
+                "Failed to fetch layer details for %s (id=%s) from %s: %s",
+                layer_result.name,
+                layer_result.id,
+                source_url,
+                e,
+            )
 
         layer_url = f"{source_url.rstrip('/')}/{layer_result.id}"
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -596,6 +596,9 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
     # Add via links for provenance tracking (Issue #353)
     _add_via_links_to_collections(output_dir, report)
 
+    # Seed collection-level metadata.yaml with layer details
+    _seed_collection_metadata_arcgis(output_dir, report)
+
 
 def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
     """Seed metadata.yaml from extracted service metadata.
@@ -692,6 +695,58 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
             collection_path,
             layer_url,
             title=f"Source ArcGIS layer: {layer.name}",
+        )
+
+
+def _seed_collection_metadata_arcgis(
+    output_dir: Path,
+    report: ExtractionReport,
+    timeout: float = 60.0,
+) -> None:
+    """Seed metadata.yaml for each collection with ArcGIS layer-specific info.
+
+    Fetches layer details from ArcGIS API to get description for each layer.
+    Falls back gracefully if layer details fetch fails.
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report with layer results.
+        timeout: Request timeout for layer detail fetches.
+    """
+    from portolan_cli.extract.arcgis.discovery import fetch_layer_details
+    from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+    source_url = report.source_url
+
+    for layer_result in report.layers:
+        if layer_result.status != "success" or not layer_result.output_path:
+            continue
+
+        output_parts = Path(layer_result.output_path).parts
+        if not output_parts:
+            continue
+
+        collection_dir = output_dir / output_parts[0]
+
+        # Fetch layer details to get description
+        layer_description = None
+        layer_name = layer_result.name
+        try:
+            layer_details = fetch_layer_details(source_url, layer_result.id, timeout=timeout)
+            layer_description = layer_details.get("description")
+            layer_name = layer_details.get("name", layer_result.name)
+        except Exception:
+            pass
+
+        layer_url = f"{source_url.rstrip('/')}/{layer_result.id}"
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="arcgis_featureserver",
+            source_url=layer_url,
+            layer_name=layer_name,
+            title=layer_name,
+            description=layer_description,
         )
 
 

--- a/portolan_cli/extract/common/__init__.py
+++ b/portolan_cli/extract/common/__init__.py
@@ -4,6 +4,7 @@ This module provides shared functionality used across all extraction
 backends (ArcGIS, WFS, etc.):
 
 - filters: Glob-based filtering for services/layers
+- metadata_seeding: Collection-level metadata seeding
 - report: Extraction report models (LayerResult, ExtractionReport)
 - retry: Retry logic with exponential backoff
 - resume: Resume state for interrupted extractions
@@ -13,6 +14,9 @@ from portolan_cli.extract.common.filters import (
     apply_unified_filter,
     filter_layers,
     filter_services,
+)
+from portolan_cli.extract.common.metadata_seeding import (
+    seed_collection_metadata,
 )
 from portolan_cli.extract.common.report import (
     ExtractionReport,
@@ -39,6 +43,8 @@ __all__ = [
     "apply_unified_filter",
     "filter_layers",
     "filter_services",
+    # metadata_seeding
+    "seed_collection_metadata",
     # report
     "ExtractionReport",
     "ExtractionSummary",

--- a/portolan_cli/extract/common/metadata_seeding.py
+++ b/portolan_cli/extract/common/metadata_seeding.py
@@ -1,0 +1,136 @@
+"""Common metadata seeding utilities for extraction backends.
+
+This module provides shared functionality for seeding metadata.yaml files
+at the collection level from extracted layer metadata.
+
+Used by both WFS and ArcGIS extraction backends to populate collection-level
+.portolan/metadata.yaml with layer-specific info (title, description).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _is_technical_name(text: str | None) -> bool:
+    """Check if text looks like a technical/internal name rather than description.
+
+    Technical names are typically short identifiers that aren't useful as descriptions:
+    - Single words with underscores/dashes (e.g., "bu_building_emprise")
+    - Very short (under 20 chars) without spaces
+    - Prefixed with common tech patterns (e.g., "ns:LayerName")
+
+    Args:
+        text: Text to check.
+
+    Returns:
+        True if text looks like a technical name.
+    """
+    if not text:
+        return True
+
+    text = text.strip()
+
+    # Very short without spaces = likely technical
+    if len(text) < 20 and " " not in text:
+        return True
+
+    # Contains namespace prefix (ns:name pattern)
+    if re.match(r"^[a-z_]+:[A-Za-z]", text):
+        return True
+
+    # All lowercase with underscores, no spaces
+    if re.match(r"^[a-z0-9_]+$", text):
+        return True
+
+    return False
+
+
+def _select_best_description(
+    abstract: str | None,
+    title: str | None,
+    layer_name: str,
+) -> str | None:
+    """Select the best description from available metadata fields.
+
+    Prefers abstract if it's a real description, otherwise falls back to title.
+    Returns None if no good description is available.
+
+    Args:
+        abstract: Layer abstract/description.
+        title: Layer title.
+        layer_name: Layer name (used to detect if title/abstract just echoes it).
+
+    Returns:
+        Best available description, or None.
+    """
+    # If abstract looks like a real description, use it
+    if abstract and not _is_technical_name(abstract):
+        return abstract
+
+    # If title looks like a real description (not just the layer name), use it
+    if title and not _is_technical_name(title) and title.lower() != layer_name.lower():
+        return title
+
+    # If title is better than abstract (even if both are technical), prefer title
+    if title and (not abstract or _is_technical_name(abstract)):
+        # Title with spaces/dashes is better than underscore-only abstract
+        if " " in title or "-" in title:
+            return title
+
+    return abstract
+
+
+def seed_collection_metadata(
+    collection_dir: Path,
+    *,
+    source_type: str,
+    source_url: str,
+    layer_name: str,
+    title: str | None = None,
+    description: str | None = None,
+    keywords: list[str] | None = None,
+) -> bool:
+    """Seed metadata.yaml for a collection with layer-specific info.
+
+    Creates .portolan/metadata.yaml within the collection directory with
+    layer-specific metadata (title, description) plus inherited source info.
+
+    Automatically selects the best description from available fields:
+    - Prefers abstract if it's a real description (not just a technical name)
+    - Falls back to title if abstract looks like an identifier
+    - Uses title in processing_notes if different from layer name
+
+    Args:
+        collection_dir: Path to the collection directory.
+        source_type: Source type identifier (e.g., "wfs", "arcgis_featureserver").
+        source_url: URL of the layer/feature source.
+        layer_name: Layer name for processing_notes.
+        title: Layer title.
+        description: Layer description/abstract (will be intelligently selected).
+        keywords: Layer-specific keywords.
+
+    Returns:
+        True if metadata.yaml was created, False if skipped (already exists).
+    """
+    from portolan_cli.metadata_extraction import ExtractedMetadata
+    from portolan_cli.metadata_seeding import seed_metadata_yaml
+
+    # Select best description from available fields
+    best_description = _select_best_description(description, title, layer_name)
+
+    processing_notes = f"Extracted from {source_type} layer: {layer_name}"
+    if title and title != layer_name:
+        processing_notes = f"{processing_notes} ({title})"
+
+    extracted = ExtractedMetadata(
+        source_type=source_type,
+        source_url=source_url,
+        description=best_description,
+        keywords=keywords,
+        processing_notes=processing_notes,
+    )
+
+    metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+    return seed_metadata_yaml(extracted, metadata_path)

--- a/portolan_cli/extract/csw/__init__.py
+++ b/portolan_cli/extract/csw/__init__.py
@@ -1,0 +1,27 @@
+"""CSW (Catalog Service for Web) metadata extraction.
+
+This module provides functionality for fetching and parsing ISO 19139
+metadata from CSW services and static XML files.
+
+Primary entry point:
+    fetch_metadata_for_layer: Fetch metadata from a layer's metadataUrls
+"""
+
+from portolan_cli.extract.csw.client import (
+    detect_metadata_url_type,
+    fetch_metadata_for_layer,
+    fetch_metadata_record,
+    is_metadata_url_supported,
+)
+from portolan_cli.extract.csw.iso_parser import ISOParseError, parse_iso19139
+from portolan_cli.extract.csw.models import ISOMetadata
+
+__all__ = [
+    "ISOMetadata",
+    "ISOParseError",
+    "detect_metadata_url_type",
+    "fetch_metadata_for_layer",
+    "fetch_metadata_record",
+    "is_metadata_url_supported",
+    "parse_iso19139",
+]

--- a/portolan_cli/extract/csw/client.py
+++ b/portolan_cli/extract/csw/client.py
@@ -1,0 +1,128 @@
+"""CSW metadata client.
+
+This module provides functions for fetching ISO 19139 metadata from
+various sources (CSW GetRecordById, static XML files, etc.) and
+parsing them into ISOMetadata objects.
+
+The main entry point is fetch_metadata_for_layer() which handles
+the metadataUrls list from OWSLib layer objects.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import requests  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from portolan_cli.extract.csw.models import ISOMetadata
+
+# Default timeout for metadata fetches (seconds)
+DEFAULT_TIMEOUT = 30.0
+
+
+def fetch_metadata_record(
+    url: str,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> ISOMetadata | None:
+    """Fetch and parse ISO 19139 metadata from a URL.
+
+    Args:
+        url: URL to fetch (CSW GetRecordById or static XML).
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed ISOMetadata, or None if fetch/parse fails.
+    """
+    from portolan_cli.extract.csw.iso_parser import ISOParseError, parse_iso19139
+
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+        xml_content = response.text
+
+        return parse_iso19139(xml_content)
+
+    except requests.exceptions.RequestException:
+        return None
+    except ISOParseError:
+        return None
+    except Exception:
+        return None
+
+
+def detect_metadata_url_type(url: str) -> str:
+    """Detect the type of metadata URL.
+
+    Args:
+        url: Metadata URL to analyze.
+
+    Returns:
+        One of: "csw", "xml", "html", "geonetwork_api", "unknown"
+    """
+    url_lower = url.lower()
+
+    # CSW GetRecordById
+    if "getrecordbyid" in url_lower and "csw" in url_lower:
+        return "csw"
+
+    # Static XML file
+    if url_lower.endswith(".xml"):
+        return "xml"
+
+    # HTML page
+    if url_lower.endswith(".html") or url_lower.endswith(".htm"):
+        return "html"
+
+    # GeoNetwork REST API
+    if "/geonetwork/srv/api/records/" in url_lower:
+        return "geonetwork_api"
+
+    return "unknown"
+
+
+def is_metadata_url_supported(url: str) -> bool:
+    """Check if a metadata URL type is supported for fetching.
+
+    Args:
+        url: Metadata URL to check.
+
+    Returns:
+        True if we can fetch and parse this URL type.
+    """
+    url_type = detect_metadata_url_type(url)
+    return url_type in ("csw", "xml")
+
+
+def fetch_metadata_for_layer(
+    metadata_urls: list[dict[str, Any]] | None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> ISOMetadata | None:
+    """Fetch metadata from a layer's metadataUrls list.
+
+    Tries each supported URL in order until one succeeds.
+
+    Args:
+        metadata_urls: List of metadata URL dicts from OWSLib layer.
+            Each dict should have a "url" key.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Parsed ISOMetadata from first successful fetch, or None.
+    """
+    if not metadata_urls:
+        return None
+
+    for url_info in metadata_urls:
+        url = url_info.get("url")
+        if not url:
+            continue
+
+        if not is_metadata_url_supported(url):
+            continue
+
+        metadata = fetch_metadata_record(url, timeout=timeout)
+        if metadata is not None:
+            return metadata
+
+    return None

--- a/portolan_cli/extract/csw/client.py
+++ b/portolan_cli/extract/csw/client.py
@@ -10,12 +10,15 @@ the metadataUrls list from OWSLib layer objects.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import requests  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from portolan_cli.extract.csw.models import ISOMetadata
+
+logger = logging.getLogger(__name__)
 
 # Default timeout for metadata fetches (seconds)
 DEFAULT_TIMEOUT = 30.0
@@ -43,11 +46,11 @@ def fetch_metadata_record(
 
         return parse_iso19139(xml_content)
 
-    except requests.exceptions.RequestException:
+    except requests.exceptions.RequestException as e:
+        logger.debug("CSW fetch failed for %s: %s", url, e)
         return None
-    except ISOParseError:
-        return None
-    except Exception:
+    except ISOParseError as e:
+        logger.debug("ISO 19139 parse failed for %s: %s", url, e)
         return None
 
 

--- a/portolan_cli/extract/csw/iso_parser.py
+++ b/portolan_cli/extract/csw/iso_parser.py
@@ -1,0 +1,328 @@
+"""ISO 19139 XML parser.
+
+This module parses ISO 19139 metadata XML (typically from CSW GetRecordById)
+and extracts key fields into an ISOMetadata dataclass.
+
+Handles both CSW-wrapped responses (GetRecordByIdResponse) and direct
+MD_Metadata root elements.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+from portolan_cli.extract.csw.models import ISOMetadata
+
+# ISO 19139 XML namespaces
+NAMESPACES = {
+    "csw": "http://www.opengis.net/cat/csw/2.0.2",
+    "gmd": "http://www.isotc211.org/2005/gmd",
+    "gco": "http://www.isotc211.org/2005/gco",
+    "gmx": "http://www.isotc211.org/2005/gmx",
+    "srv": "http://www.isotc211.org/2005/srv",
+    "gml": "http://www.opengis.net/gml/3.2",
+    "xlink": "http://www.w3.org/1999/xlink",
+}
+
+
+class ISOParseError(Exception):
+    """Raised when ISO 19139 XML parsing fails."""
+
+    pass
+
+
+def parse_iso19139(xml_content: str) -> ISOMetadata:
+    """Parse ISO 19139 XML and extract metadata fields.
+
+    Args:
+        xml_content: ISO 19139 XML string (CSW response or direct MD_Metadata).
+
+    Returns:
+        ISOMetadata with extracted fields.
+
+    Raises:
+        ISOParseError: If XML parsing fails or required fields are missing.
+    """
+    try:
+        root = ET.fromstring(xml_content)  # noqa: S314
+    except ET.ParseError as e:
+        raise ISOParseError(f"Failed to parse XML: {e}") from e
+
+    # Find MD_Metadata element (may be wrapped in CSW response)
+    md_metadata = _find_md_metadata(root)
+    if md_metadata is None:
+        raise ISOParseError("No MD_Metadata element found in XML")
+
+    # Extract required fields
+    file_identifier = _get_text(md_metadata, ".//gmd:fileIdentifier/gco:CharacterString")
+    if not file_identifier:
+        raise ISOParseError("Missing required field: file_identifier")
+
+    title = _get_title(md_metadata)
+    if not title:
+        raise ISOParseError("Missing required field: title")
+
+    # Extract optional fields
+    return ISOMetadata(
+        file_identifier=file_identifier,
+        title=title,
+        abstract=_get_abstract(md_metadata),
+        keywords=_get_keywords(md_metadata),
+        contact_organization=_get_contact_organization(md_metadata),
+        contact_email=_get_contact_email(md_metadata),
+        license_url=_get_license_url(md_metadata),
+        license_text=_get_license_text(md_metadata),
+        access_constraints=_get_access_constraints(md_metadata),
+        lineage=_get_lineage(md_metadata),
+        thumbnail_url=_get_thumbnail_url(md_metadata),
+        scale_denominator=_get_scale_denominator(md_metadata),
+        topic_category=_get_topic_category(md_metadata),
+        maintenance_frequency=_get_maintenance_frequency(md_metadata),
+        date_created=_get_date_by_type(md_metadata, "creation"),
+        date_revised=_get_date_by_type(md_metadata, "revision"),
+        date_published=_get_date_by_type(md_metadata, "publication"),
+    )
+
+
+def _find_md_metadata(root: ET.Element) -> ET.Element | None:
+    """Find MD_Metadata element in XML tree.
+
+    Handles both CSW-wrapped responses and direct MD_Metadata roots.
+    """
+    # Check if root is MD_Metadata
+    if root.tag.endswith("MD_Metadata"):
+        return root
+
+    # Look for MD_Metadata in CSW response
+    md = root.find(".//gmd:MD_Metadata", NAMESPACES)
+    if md is not None:
+        return md
+
+    # Try without namespace (some servers don't use prefixes)
+    for elem in root.iter():
+        if elem.tag.endswith("MD_Metadata"):
+            return elem
+
+    return None
+
+
+def _get_text(element: ET.Element, xpath: str) -> str | None:
+    """Get text content from XPath, or None if not found."""
+    found = element.find(xpath, NAMESPACES)
+    if found is not None and found.text:
+        return found.text.strip()
+    return None
+
+
+def _get_title(md: ET.Element) -> str | None:
+    """Extract dataset title."""
+    return _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation"
+        "/gmd:CI_Citation/gmd:title/gco:CharacterString",
+    )
+
+
+def _get_abstract(md: ET.Element) -> str | None:
+    """Extract dataset abstract."""
+    return _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString",
+    )
+
+
+def _get_keywords(md: ET.Element) -> list[str] | None:
+    """Extract keywords from all thesauri, deduplicated."""
+    keywords: set[str] = set()
+
+    # Find all MD_Keywords blocks
+    for md_keywords in md.findall(
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification"
+        "/gmd:descriptiveKeywords/gmd:MD_Keywords",
+        NAMESPACES,
+    ):
+        # Extract from gco:CharacterString
+        for kw_elem in md_keywords.findall(".//gmd:keyword/gco:CharacterString", NAMESPACES):
+            if kw_elem.text and kw_elem.text.strip():
+                keywords.add(kw_elem.text.strip())
+
+        # Extract from gmx:Anchor
+        for kw_elem in md_keywords.findall(".//gmd:keyword/gmx:Anchor", NAMESPACES):
+            if kw_elem.text and kw_elem.text.strip():
+                keywords.add(kw_elem.text.strip())
+
+    return sorted(keywords) if keywords else None
+
+
+def _get_contact_organization(md: ET.Element) -> str | None:
+    """Extract primary contact organization."""
+    # Try pointOfContact first
+    org = _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact"
+        "/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString",
+    )
+    if org:
+        return org
+
+    # Fall back to metadata contact
+    return _get_text(
+        md, ".//gmd:contact/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString"
+    )
+
+
+def _get_contact_email(md: ET.Element) -> str | None:
+    """Extract primary contact email."""
+    # Try pointOfContact first
+    email = _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact"
+        "/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address"
+        "/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString",
+    )
+    if email:
+        return email
+
+    # Fall back to metadata contact
+    return _get_text(
+        md,
+        ".//gmd:contact/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact"
+        "/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString",
+    )
+
+
+def _get_license_url(md: ET.Element) -> str | None:
+    """Extract license URL from use constraints."""
+    # Look for Anchor elements with license URLs
+    for constraint in md.findall(
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints"
+        "/gmd:MD_LegalConstraints",
+        NAMESPACES,
+    ):
+        # Check useConstraints
+        for other in constraint.findall(".//gmd:otherConstraints/gmx:Anchor", NAMESPACES):
+            href = other.get(f"{{{NAMESPACES['xlink']}}}href", "")
+            if "creativecommons.org" in href or "opensource.org" in href:
+                return href
+
+    return None
+
+
+def _get_license_text(md: ET.Element) -> str | None:
+    """Extract license text description."""
+    # Look for Anchor elements with license text
+    for constraint in md.findall(
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints"
+        "/gmd:MD_LegalConstraints",
+        NAMESPACES,
+    ):
+        for other in constraint.findall(".//gmd:otherConstraints/gmx:Anchor", NAMESPACES):
+            href = other.get(f"{{{NAMESPACES['xlink']}}}href", "")
+            if "creativecommons.org" in href or "opensource.org" in href:
+                if other.text and other.text.strip():
+                    return other.text.strip()
+
+    return None
+
+
+def _get_access_constraints(md: ET.Element) -> str | None:
+    """Extract access constraints text."""
+    # Look for accessConstraints other constraints
+    for constraint in md.findall(
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints"
+        "/gmd:MD_LegalConstraints",
+        NAMESPACES,
+    ):
+        # Check if this is an access constraint block
+        access_code = constraint.find(".//gmd:accessConstraints", NAMESPACES)
+        if access_code is not None:
+            # Get the text from otherConstraints
+            other = constraint.find(".//gmd:otherConstraints/gmx:Anchor", NAMESPACES)
+            if other is not None and other.text:
+                return other.text.strip()
+            other_cs = constraint.find(".//gmd:otherConstraints/gco:CharacterString", NAMESPACES)
+            if other_cs is not None and other_cs.text:
+                return other_cs.text.strip()
+
+    return None
+
+
+def _get_lineage(md: ET.Element) -> str | None:
+    """Extract data lineage statement."""
+    return _get_text(
+        md,
+        ".//gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage"
+        "/gmd:LI_Lineage/gmd:statement/gco:CharacterString",
+    )
+
+
+def _get_thumbnail_url(md: ET.Element) -> str | None:
+    """Extract thumbnail/graphic overview URL."""
+    return _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:graphicOverview"
+        "/gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString",
+    )
+
+
+def _get_scale_denominator(md: ET.Element) -> int | None:
+    """Extract representative scale denominator."""
+    text = _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:spatialResolution"
+        "/gmd:MD_Resolution/gmd:equivalentScale/gmd:MD_RepresentativeFraction"
+        "/gmd:denominator/gco:Integer",
+    )
+    if text:
+        try:
+            return int(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _get_topic_category(md: ET.Element) -> str | None:
+    """Extract topic category code."""
+    return _get_text(
+        md,
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:topicCategory"
+        "/gmd:MD_TopicCategoryCode",
+    )
+
+
+def _get_maintenance_frequency(md: ET.Element) -> str | None:
+    """Extract maintenance frequency code."""
+    freq_elem = md.find(
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceMaintenance"
+        "/gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency"
+        "/gmd:MD_MaintenanceFrequencyCode",
+        NAMESPACES,
+    )
+    if freq_elem is not None:
+        return freq_elem.get("codeListValue")
+    return None
+
+
+def _get_date_by_type(md: ET.Element, date_type: str) -> str | None:
+    """Extract date by type (creation, revision, publication)."""
+    for ci_date in md.findall(
+        ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation"
+        "/gmd:CI_Citation/gmd:date/gmd:CI_Date",
+        NAMESPACES,
+    ):
+        type_code = ci_date.find(".//gmd:dateType/gmd:CI_DateTypeCode", NAMESPACES)
+        if type_code is not None and type_code.get("codeListValue") == date_type:
+            date_text = _get_text(ci_date, ".//gmd:date/gco:Date")
+            if date_text:
+                return date_text
+            # Try DateTime format
+            date_text = _get_text(ci_date, ".//gmd:date/gco:DateTime")
+            if date_text:
+                # Extract date portion from datetime
+                return date_text.split("T")[0]
+
+    return None

--- a/portolan_cli/extract/csw/iso_parser.py
+++ b/portolan_cli/extract/csw/iso_parser.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import defusedxml.ElementTree as ET
 
 if TYPE_CHECKING:
-    from xml.etree.ElementTree import Element
+    from xml.etree.ElementTree import Element  # nosec B405 - type hints only
 
 from portolan_cli.extract.csw.models import ISOMetadata
 

--- a/portolan_cli/extract/csw/iso_parser.py
+++ b/portolan_cli/extract/csw/iso_parser.py
@@ -9,9 +9,12 @@ MD_Metadata root elements.
 
 from __future__ import annotations
 
-from xml.etree.ElementTree import Element
+from typing import TYPE_CHECKING
 
 import defusedxml.ElementTree as ET
+
+if TYPE_CHECKING:
+    from xml.etree.ElementTree import Element
 
 from portolan_cli.extract.csw.models import ISOMetadata
 

--- a/portolan_cli/extract/csw/iso_parser.py
+++ b/portolan_cli/extract/csw/iso_parser.py
@@ -9,11 +9,9 @@ MD_Metadata root elements.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
-from typing import TYPE_CHECKING
+from xml.etree.ElementTree import Element
 
-if TYPE_CHECKING:
-    pass
+import defusedxml.ElementTree as ET
 
 from portolan_cli.extract.csw.models import ISOMetadata
 
@@ -48,7 +46,7 @@ def parse_iso19139(xml_content: str) -> ISOMetadata:
         ISOParseError: If XML parsing fails or required fields are missing.
     """
     try:
-        root = ET.fromstring(xml_content)  # noqa: S314
+        root = ET.fromstring(xml_content)
     except ET.ParseError as e:
         raise ISOParseError(f"Failed to parse XML: {e}") from e
 
@@ -88,7 +86,7 @@ def parse_iso19139(xml_content: str) -> ISOMetadata:
     )
 
 
-def _find_md_metadata(root: ET.Element) -> ET.Element | None:
+def _find_md_metadata(root: Element) -> Element | None:
     """Find MD_Metadata element in XML tree.
 
     Handles both CSW-wrapped responses and direct MD_Metadata roots.
@@ -110,7 +108,7 @@ def _find_md_metadata(root: ET.Element) -> ET.Element | None:
     return None
 
 
-def _get_text(element: ET.Element, xpath: str) -> str | None:
+def _get_text(element: Element, xpath: str) -> str | None:
     """Get text content from XPath, or None if not found."""
     found = element.find(xpath, NAMESPACES)
     if found is not None and found.text:
@@ -118,7 +116,7 @@ def _get_text(element: ET.Element, xpath: str) -> str | None:
     return None
 
 
-def _get_title(md: ET.Element) -> str | None:
+def _get_title(md: Element) -> str | None:
     """Extract dataset title."""
     return _get_text(
         md,
@@ -127,7 +125,7 @@ def _get_title(md: ET.Element) -> str | None:
     )
 
 
-def _get_abstract(md: ET.Element) -> str | None:
+def _get_abstract(md: Element) -> str | None:
     """Extract dataset abstract."""
     return _get_text(
         md,
@@ -135,7 +133,7 @@ def _get_abstract(md: ET.Element) -> str | None:
     )
 
 
-def _get_keywords(md: ET.Element) -> list[str] | None:
+def _get_keywords(md: Element) -> list[str] | None:
     """Extract keywords from all thesauri, deduplicated."""
     keywords: set[str] = set()
 
@@ -158,7 +156,7 @@ def _get_keywords(md: ET.Element) -> list[str] | None:
     return sorted(keywords) if keywords else None
 
 
-def _get_contact_organization(md: ET.Element) -> str | None:
+def _get_contact_organization(md: Element) -> str | None:
     """Extract primary contact organization."""
     # Try pointOfContact first
     org = _get_text(
@@ -175,7 +173,7 @@ def _get_contact_organization(md: ET.Element) -> str | None:
     )
 
 
-def _get_contact_email(md: ET.Element) -> str | None:
+def _get_contact_email(md: Element) -> str | None:
     """Extract primary contact email."""
     # Try pointOfContact first
     email = _get_text(
@@ -195,7 +193,7 @@ def _get_contact_email(md: ET.Element) -> str | None:
     )
 
 
-def _get_license_url(md: ET.Element) -> str | None:
+def _get_license_url(md: Element) -> str | None:
     """Extract license URL from use constraints."""
     # Look for Anchor elements with license URLs
     for constraint in md.findall(
@@ -212,7 +210,7 @@ def _get_license_url(md: ET.Element) -> str | None:
     return None
 
 
-def _get_license_text(md: ET.Element) -> str | None:
+def _get_license_text(md: Element) -> str | None:
     """Extract license text description."""
     # Look for Anchor elements with license text
     for constraint in md.findall(
@@ -229,7 +227,7 @@ def _get_license_text(md: ET.Element) -> str | None:
     return None
 
 
-def _get_access_constraints(md: ET.Element) -> str | None:
+def _get_access_constraints(md: Element) -> str | None:
     """Extract access constraints text."""
     # Look for accessConstraints other constraints
     for constraint in md.findall(
@@ -251,7 +249,7 @@ def _get_access_constraints(md: ET.Element) -> str | None:
     return None
 
 
-def _get_lineage(md: ET.Element) -> str | None:
+def _get_lineage(md: Element) -> str | None:
     """Extract data lineage statement."""
     return _get_text(
         md,
@@ -260,7 +258,7 @@ def _get_lineage(md: ET.Element) -> str | None:
     )
 
 
-def _get_thumbnail_url(md: ET.Element) -> str | None:
+def _get_thumbnail_url(md: Element) -> str | None:
     """Extract thumbnail/graphic overview URL."""
     return _get_text(
         md,
@@ -269,7 +267,7 @@ def _get_thumbnail_url(md: ET.Element) -> str | None:
     )
 
 
-def _get_scale_denominator(md: ET.Element) -> int | None:
+def _get_scale_denominator(md: Element) -> int | None:
     """Extract representative scale denominator."""
     text = _get_text(
         md,
@@ -285,7 +283,7 @@ def _get_scale_denominator(md: ET.Element) -> int | None:
     return None
 
 
-def _get_topic_category(md: ET.Element) -> str | None:
+def _get_topic_category(md: Element) -> str | None:
     """Extract topic category code."""
     return _get_text(
         md,
@@ -294,7 +292,7 @@ def _get_topic_category(md: ET.Element) -> str | None:
     )
 
 
-def _get_maintenance_frequency(md: ET.Element) -> str | None:
+def _get_maintenance_frequency(md: Element) -> str | None:
     """Extract maintenance frequency code."""
     freq_elem = md.find(
         ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceMaintenance"
@@ -307,7 +305,7 @@ def _get_maintenance_frequency(md: ET.Element) -> str | None:
     return None
 
 
-def _get_date_by_type(md: ET.Element, date_type: str) -> str | None:
+def _get_date_by_type(md: Element, date_type: str) -> str | None:
     """Extract date by type (creation, revision, publication)."""
     for ci_date in md.findall(
         ".//gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation"

--- a/portolan_cli/extract/csw/models.py
+++ b/portolan_cli/extract/csw/models.py
@@ -6,6 +6,7 @@ ISO 19139 XML records, typically fetched via CSW (Catalog Service for Web).
 
 from __future__ import annotations
 
+import textwrap
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from portolan_cli.metadata_extraction import ExtractedMetadata
 
 
-# Known license URL patterns mapped to SPDX identifiers
+# Known license URL patterns mapped to SPDX identifiers (all lowercase for matching)
 LICENSE_URL_TO_SPDX: dict[str, str] = {
     "creativecommons.org/licenses/by/4.0": "CC-BY-4.0",
     "creativecommons.org/licenses/by/3.0": "CC-BY-3.0",
@@ -27,8 +28,8 @@ LICENSE_URL_TO_SPDX: dict[str, str] = {
     "creativecommons.org/licenses/by-nc-nd/4.0": "CC-BY-NC-ND-4.0",
     "creativecommons.org/publicdomain/zero/1.0": "CC0-1.0",
     "creativecommons.org/publicdomain/mark/1.0": "CC-PDDC",
-    "opensource.org/licenses/MIT": "MIT",
-    "opensource.org/licenses/Apache-2.0": "Apache-2.0",
+    "opensource.org/licenses/mit": "MIT",
+    "opensource.org/licenses/apache-2.0": "Apache-2.0",
     "opendatacommons.org/licenses/odbl": "ODbL-1.0",
     "opendatacommons.org/licenses/by": "ODC-By-1.0",
     "opendatacommons.org/licenses/pddl": "PDDL-1.0",
@@ -99,21 +100,26 @@ class ISOMetadata:
         return None
 
     def has_useful_metadata(self) -> bool:
-        """Check if this metadata has more than just identifier/title.
+        """Check if this metadata has substantial content beyond identifier/title.
+
+        Requires at least one "strong" field (abstract, license, contact, lineage)
+        OR sufficient keywords (3+) to be considered useful.
 
         Returns:
             True if metadata contains useful fields beyond the basics.
         """
-        return any(
-            [
-                self.abstract,
-                self.keywords,
-                self.license_url,
-                self.contact_organization,
-                self.contact_email,
-                self.lineage,
-            ]
-        )
+        strong_fields = [
+            self.abstract,
+            self.license_url,
+            self.contact_organization,
+            self.contact_email,
+            self.lineage,
+        ]
+
+        has_strong = any(strong_fields)
+        has_sufficient_keywords = bool(self.keywords and len(self.keywords) >= 3)
+
+        return has_strong or has_sufficient_keywords
 
     def to_extracted_metadata(self, source_url: str) -> ExtractedMetadata:
         """Convert to ExtractedMetadata for use with metadata seeding.
@@ -140,14 +146,10 @@ class ISOMetadata:
 
         license_raw = "; ".join(license_parts) if license_parts else None
 
-        # Build processing notes from lineage
+        # Build processing notes from lineage (truncate on word boundary)
         processing_notes = None
         if self.lineage:
-            # Truncate very long lineage statements
-            if len(self.lineage) > 500:
-                processing_notes = self.lineage[:497] + "..."
-            else:
-                processing_notes = self.lineage
+            processing_notes = textwrap.shorten(self.lineage, width=500, placeholder="...")
 
         return ExtractedMetadata(
             source_type="csw_iso19139",
@@ -155,7 +157,8 @@ class ISOMetadata:
             description=self.abstract or self.title,
             attribution=self.contact_organization,
             keywords=self.keywords,
-            contact_name=self.contact_email,
+            contact_name=self.contact_organization,
+            contact_email=self.contact_email,
             processing_notes=processing_notes,
             known_issues=None,
             license_raw=license_raw,

--- a/portolan_cli/extract/csw/models.py
+++ b/portolan_cli/extract/csw/models.py
@@ -1,0 +1,162 @@
+"""Models for CSW/ISO 19139 metadata.
+
+This module defines dataclasses for representing metadata extracted from
+ISO 19139 XML records, typically fetched via CSW (Catalog Service for Web).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from portolan_cli.metadata_extraction import ExtractedMetadata
+
+
+# Known license URL patterns mapped to SPDX identifiers
+LICENSE_URL_TO_SPDX: dict[str, str] = {
+    "creativecommons.org/licenses/by/4.0": "CC-BY-4.0",
+    "creativecommons.org/licenses/by/3.0": "CC-BY-3.0",
+    "creativecommons.org/licenses/by/2.0": "CC-BY-2.0",
+    "creativecommons.org/licenses/by-sa/4.0": "CC-BY-SA-4.0",
+    "creativecommons.org/licenses/by-sa/3.0": "CC-BY-SA-3.0",
+    "creativecommons.org/licenses/by-nc/4.0": "CC-BY-NC-4.0",
+    "creativecommons.org/licenses/by-nc/3.0": "CC-BY-NC-3.0",
+    "creativecommons.org/licenses/by-nd/4.0": "CC-BY-ND-4.0",
+    "creativecommons.org/licenses/by-nc-sa/4.0": "CC-BY-NC-SA-4.0",
+    "creativecommons.org/licenses/by-nc-nd/4.0": "CC-BY-NC-ND-4.0",
+    "creativecommons.org/publicdomain/zero/1.0": "CC0-1.0",
+    "creativecommons.org/publicdomain/mark/1.0": "CC-PDDC",
+    "opensource.org/licenses/MIT": "MIT",
+    "opensource.org/licenses/Apache-2.0": "Apache-2.0",
+    "opendatacommons.org/licenses/odbl": "ODbL-1.0",
+    "opendatacommons.org/licenses/by": "ODC-By-1.0",
+    "opendatacommons.org/licenses/pddl": "PDDL-1.0",
+}
+
+
+@dataclass
+class ISOMetadata:
+    """Metadata extracted from an ISO 19139 record.
+
+    Represents the key fields from ISO 19115/19139 metadata that are useful
+    for seeding Portolan metadata.yaml files.
+
+    Attributes:
+        file_identifier: Unique identifier for the metadata record.
+        title: Dataset title.
+        abstract: Dataset description/abstract.
+        keywords: List of keywords from all thesauri.
+        contact_organization: Primary contact organization name.
+        contact_email: Primary contact email address.
+        license_url: URL to license (e.g., Creative Commons).
+        license_text: Human-readable license text.
+        access_constraints: Access constraint description.
+        lineage: Data lineage/provenance statement.
+        thumbnail_url: URL to preview image.
+        scale_denominator: Representative scale (e.g., 10000 for 1:10000).
+        topic_category: ISO topic category code.
+        maintenance_frequency: Update frequency code.
+        date_created: Creation date (YYYY-MM-DD).
+        date_revised: Last revision date.
+        date_published: Publication date.
+    """
+
+    file_identifier: str
+    title: str
+    abstract: str | None = None
+    keywords: list[str] | None = None
+    contact_organization: str | None = None
+    contact_email: str | None = None
+    license_url: str | None = None
+    license_text: str | None = None
+    access_constraints: str | None = None
+    lineage: str | None = None
+    thumbnail_url: str | None = None
+    scale_denominator: int | None = None
+    topic_category: str | None = None
+    maintenance_frequency: str | None = None
+    date_created: str | None = None
+    date_revised: str | None = None
+    date_published: str | None = None
+
+    def get_license_spdx(self) -> str | None:
+        """Extract SPDX license identifier from license URL.
+
+        Returns:
+            SPDX identifier (e.g., "CC-BY-4.0") or None if unrecognized.
+        """
+        if not self.license_url:
+            return None
+
+        # Normalize URL for matching
+        url_lower = self.license_url.lower()
+
+        for pattern, spdx in LICENSE_URL_TO_SPDX.items():
+            if pattern in url_lower:
+                return spdx
+
+        return None
+
+    def has_useful_metadata(self) -> bool:
+        """Check if this metadata has more than just identifier/title.
+
+        Returns:
+            True if metadata contains useful fields beyond the basics.
+        """
+        return any(
+            [
+                self.abstract,
+                self.keywords,
+                self.license_url,
+                self.contact_organization,
+                self.contact_email,
+                self.lineage,
+            ]
+        )
+
+    def to_extracted_metadata(self, source_url: str) -> ExtractedMetadata:
+        """Convert to ExtractedMetadata for use with metadata seeding.
+
+        Args:
+            source_url: The original source URL (WFS, etc.) for provenance.
+
+        Returns:
+            ExtractedMetadata compatible with seed_metadata_yaml.
+        """
+        from portolan_cli.metadata_extraction import ExtractedMetadata
+
+        # Build license info string
+        license_parts = []
+        if self.license_text:
+            license_parts.append(self.license_text)
+        if self.license_url:
+            spdx = self.get_license_spdx()
+            if spdx:
+                license_parts.append(f"SPDX: {spdx}")
+            license_parts.append(self.license_url)
+        if self.access_constraints:
+            license_parts.append(f"Access: {self.access_constraints}")
+
+        license_raw = "; ".join(license_parts) if license_parts else None
+
+        # Build processing notes from lineage
+        processing_notes = None
+        if self.lineage:
+            # Truncate very long lineage statements
+            if len(self.lineage) > 500:
+                processing_notes = self.lineage[:497] + "..."
+            else:
+                processing_notes = self.lineage
+
+        return ExtractedMetadata(
+            source_type="csw_iso19139",
+            source_url=source_url,
+            description=self.abstract or self.title,
+            attribution=self.contact_organization,
+            keywords=self.keywords,
+            contact_name=self.contact_email,
+            processing_notes=processing_notes,
+            known_issues=None,
+            license_raw=license_raw,
+        )

--- a/portolan_cli/extract/wfs/discovery.py
+++ b/portolan_cli/extract/wfs/discovery.py
@@ -36,6 +36,8 @@ class LayerInfo:
         typename: Original WFS typename (may include namespace prefix).
         title: Human-readable title from GetCapabilities.
         abstract: Layer description from GetCapabilities.
+        keywords: Layer-specific keywords from GetCapabilities.
+        metadata_urls: List of metadata URL dicts (e.g., CSW GetRecordById).
         bbox: Bounding box in WGS84 (xmin, ymin, xmax, ymax).
         id: Numeric ID for filtering compatibility (auto-assigned).
     """
@@ -44,6 +46,8 @@ class LayerInfo:
     typename: str
     title: str | None = None
     abstract: str | None = None
+    keywords: list[str] | None = None
+    metadata_urls: list[dict[str, Any]] | None = None
     bbox: tuple[float, float, float, float] | None = None
     id: int = 0
 
@@ -152,6 +156,69 @@ def list_layers(
     return layers
 
 
+def _extract_service_metadata(wfs: Any) -> dict[str, Any]:
+    """Extract service-level metadata from WFS capabilities object."""
+    result: dict[str, Any] = {
+        "service_title": None,
+        "service_abstract": None,
+        "provider": None,
+        "keywords": None,
+        "contact_name": None,
+        "access_constraints": None,
+        "fees": None,
+    }
+
+    if hasattr(wfs, "identification") and wfs.identification:
+        ident = wfs.identification
+        result["service_title"] = getattr(ident, "title", None)
+        result["service_abstract"] = getattr(ident, "abstract", None)
+        if hasattr(ident, "keywords") and ident.keywords:
+            result["keywords"] = [str(kw) for kw in ident.keywords]
+        result["access_constraints"] = getattr(ident, "accessconstraints", None)
+        result["fees"] = getattr(ident, "fees", None)
+
+    if hasattr(wfs, "provider") and wfs.provider:
+        prov = wfs.provider
+        result["provider"] = getattr(prov, "name", None)
+        if hasattr(prov, "contact") and prov.contact:
+            contact = prov.contact
+            parts = []
+            if hasattr(contact, "name") and contact.name:
+                parts.append(contact.name)
+            if hasattr(contact, "organization") and contact.organization:
+                parts.append(contact.organization)
+            if parts:
+                result["contact_name"] = ", ".join(parts)
+
+    return result
+
+
+def _build_layer_info(typename: str, layer: Any, layer_id: int) -> LayerInfo:
+    """Build LayerInfo from OWSLib layer object."""
+    keywords: list[str] | None = None
+    if hasattr(layer, "keywords") and layer.keywords:
+        keywords = [str(kw) for kw in layer.keywords]
+
+    metadata_urls: list[dict[str, Any]] | None = None
+    if hasattr(layer, "metadataUrls") and layer.metadataUrls:
+        metadata_urls = list(layer.metadataUrls)
+
+    bbox = None
+    if hasattr(layer, "boundingBoxWGS84") and layer.boundingBoxWGS84:
+        bbox = tuple(layer.boundingBoxWGS84)
+
+    return LayerInfo(
+        name=typename,
+        typename=typename,
+        title=getattr(layer, "title", None),
+        abstract=getattr(layer, "abstract", None),
+        keywords=keywords,
+        metadata_urls=metadata_urls,
+        bbox=bbox,
+        id=layer_id,
+    )
+
+
 def discover_layers(
     service_url: str,
     version: str = "1.1.0",
@@ -175,69 +242,24 @@ def discover_layers(
     try:
         from geoparquet_io.core.wfs import get_wfs_capabilities
 
-        # Get capabilities object from OWSLib
         wfs = get_wfs_capabilities(service_url, version)
+        svc = _extract_service_metadata(wfs)
 
-        # Extract service-level metadata
-        service_title = None
-        service_abstract = None
-        provider = None
-        keywords: list[str] | None = None
-        contact_name = None
-        access_constraints = None
-        fees = None
-
-        # Service identification
-        if hasattr(wfs, "identification") and wfs.identification:
-            ident = wfs.identification
-            service_title = getattr(ident, "title", None)
-            service_abstract = getattr(ident, "abstract", None)
-            if hasattr(ident, "keywords") and ident.keywords:
-                keywords = [str(kw) for kw in ident.keywords]
-            access_constraints = getattr(ident, "accessconstraints", None)
-            fees = getattr(ident, "fees", None)
-
-        # Provider information
-        if hasattr(wfs, "provider") and wfs.provider:
-            prov = wfs.provider
-            provider = getattr(prov, "name", None)
-            # Try to get contact info
-            if hasattr(prov, "contact") and prov.contact:
-                contact = prov.contact
-                contact_parts = []
-                if hasattr(contact, "name") and contact.name:
-                    contact_parts.append(contact.name)
-                if hasattr(contact, "organization") and contact.organization:
-                    contact_parts.append(contact.organization)
-                if contact_parts:
-                    contact_name = ", ".join(contact_parts)
-
-        # Build layer list
-        layers = []
-        for i, (typename, layer) in enumerate(wfs.contents.items()):
-            layers.append(
-                LayerInfo(
-                    name=typename,
-                    typename=typename,
-                    title=getattr(layer, "title", None),
-                    abstract=getattr(layer, "abstract", None),
-                    bbox=tuple(layer.boundingBoxWGS84)
-                    if hasattr(layer, "boundingBoxWGS84") and layer.boundingBoxWGS84
-                    else None,
-                    id=i,
-                )
-            )
+        layers = [
+            _build_layer_info(typename, layer, i)
+            for i, (typename, layer) in enumerate(wfs.contents.items())
+        ]
 
         return WFSDiscoveryResult(
             service_url=service_url,
             layers=layers,
-            service_title=service_title,
-            service_abstract=service_abstract,
-            provider=provider,
-            keywords=keywords,
-            contact_name=contact_name,
-            access_constraints=access_constraints,
-            fees=fees,
+            service_title=svc["service_title"],
+            service_abstract=svc["service_abstract"],
+            provider=svc["provider"],
+            keywords=svc["keywords"],
+            contact_name=svc["contact_name"],
+            access_constraints=svc["access_constraints"],
+            fees=svc["fees"],
         )
 
     except ImportError as e:

--- a/portolan_cli/extract/wfs/metadata.py
+++ b/portolan_cli/extract/wfs/metadata.py
@@ -14,6 +14,35 @@ if TYPE_CHECKING:
     from portolan_cli.metadata_extraction import ExtractedMetadata
 
 
+# Patterns that indicate software-generated boilerplate, not real descriptions
+_BOILERPLATE_PATTERNS = [
+    "reference implementation",
+    "supports all wfs operations",
+    "geoserver",  # Any mention of GeoServer is boilerplate
+    "mapserver",  # Any mention of MapServer is boilerplate
+    "deegree",
+    "qgis server",
+    "arcgis server",
+    "web feature service",  # Generic "Web Feature Service" title
+]
+
+
+def is_boilerplate_description(text: str | None) -> bool:
+    """Check if description is software boilerplate rather than real content.
+
+    Args:
+        text: Description text to check.
+
+    Returns:
+        True if text matches known boilerplate patterns.
+    """
+    if not text:
+        return False
+
+    lower = text.lower()
+    return any(pattern in lower for pattern in _BOILERPLATE_PATTERNS)
+
+
 @dataclass
 class WFSMetadata:
     """Metadata extracted from a WFS service.
@@ -59,15 +88,28 @@ class WFSMetadata:
     def to_extracted(self) -> ExtractedMetadata:
         """Convert to common ExtractedMetadata format.
 
+        Uses service_title as fallback when service_abstract is
+        boilerplate (e.g., GeoServer default text) or missing.
+        If both are boilerplate, description is None.
+
         Returns:
             ExtractedMetadata for use with metadata seeding.
         """
         from portolan_cli.metadata_extraction import ExtractedMetadata
 
+        # Use abstract unless it's boilerplate, then fall back to title
+        description = self.service_abstract
+        if is_boilerplate_description(description) or not description:
+            # Only use title if it's not also boilerplate
+            if self.service_title and not is_boilerplate_description(self.service_title):
+                description = self.service_title
+            else:
+                description = None
+
         return ExtractedMetadata(
             source_type="wfs",
             source_url=self.source_url,
-            description=self.service_abstract,
+            description=description,
             attribution=self.provider_name,
             keywords=self.keywords,
             contact_name=None,  # WFS doesn't typically expose contact

--- a/portolan_cli/extract/wfs/metadata.py
+++ b/portolan_cli/extract/wfs/metadata.py
@@ -14,21 +14,35 @@ if TYPE_CHECKING:
     from portolan_cli.metadata_extraction import ExtractedMetadata
 
 
-# Patterns that indicate software-generated boilerplate, not real descriptions
-_BOILERPLATE_PATTERNS = [
-    "reference implementation",
-    "supports all wfs operations",
-    "geoserver",  # Any mention of GeoServer is boilerplate
-    "mapserver",  # Any mention of MapServer is boilerplate
-    "deegree",
-    "qgis server",
-    "arcgis server",
-    "web feature service",  # Generic "Web Feature Service" title
+# Phrases that indicate software-generated boilerplate, not real descriptions.
+# These are specific default phrases, not just software names.
+_BOILERPLATE_PHRASES = [
+    "this is the reference implementation of wfs",
+    "this is the default geoserver",
+    "this is a geoserver instance",
+    "geoserver web feature service",
+    "mapserver web feature service",
+    "supports all wfs operations including",
+    "reference implementation of wfs",
+    "deegree web feature service",
+    "qgis server wfs",
+    "a compliant implementation of ogc",
+]
+
+# Short generic titles that are boilerplate
+_BOILERPLATE_TITLES = [
+    "geoserver",
+    "mapserver",
+    "web feature service",
+    "wfs",
 ]
 
 
 def is_boilerplate_description(text: str | None) -> bool:
     """Check if description is software boilerplate rather than real content.
+
+    Matches known default phrases from common WFS servers. Does NOT match
+    legitimate descriptions that merely mention the software name.
 
     Args:
         text: Description text to check.
@@ -39,8 +53,14 @@ def is_boilerplate_description(text: str | None) -> bool:
     if not text:
         return False
 
-    lower = text.lower()
-    return any(pattern in lower for pattern in _BOILERPLATE_PATTERNS)
+    lower = text.lower().strip()
+
+    # Check for exact match to short boilerplate titles
+    if lower in _BOILERPLATE_TITLES:
+        return True
+
+    # Check for boilerplate phrases anywhere in text
+    return any(phrase in lower for phrase in _BOILERPLATE_PHRASES)
 
 
 @dataclass

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -26,7 +26,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from portolan_cli.extract.common.filters import filter_layers
@@ -43,6 +43,9 @@ from portolan_cli.extract.wfs.discovery import LayerInfo, WFSDiscoveryResult, di
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from portolan_cli.extract.csw.models import ISOMetadata
+    from portolan_cli.extract.wfs.metadata import WFSMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -596,17 +599,22 @@ def extract_wfs_catalog(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, discovery_result)
 
     return report
 
 
-def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
+def _auto_init_catalog(
+    output_dir: Path,
+    report: ExtractionReport,
+    discovery_result: WFSDiscoveryResult | None = None,
+) -> None:
     """Initialize a Portolan catalog and add extracted files.
 
     Called automatically after extraction unless raw=True.
     Creates catalog.json, config.yaml, and collection.json for each layer.
-    Also adds provenance via links (GetFeature-style URLs).
+    Also adds provenance via links, seeds metadata.yaml from service metadata,
+    and seeds collection-level metadata.yaml with layer info.
     """
     from portolan_cli.catalog import add_files, init_catalog
 
@@ -628,6 +636,13 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
 
     # Add via links for provenance tracking
     _add_via_links_to_collections(output_dir, report)
+
+    # Seed catalog-level metadata.yaml from extracted service metadata
+    _seed_metadata_from_extraction(output_dir, report)
+
+    # Seed collection-level metadata.yaml with layer-specific info
+    if discovery_result:
+        _seed_collection_metadata_wfs(output_dir, report, discovery_result)
 
 
 def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) -> None:
@@ -665,3 +680,172 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
             layer_url,
             title=f"Source WFS layer: {layer.name}",
         )
+
+
+def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
+    """Seed catalog-level metadata.yaml from extracted WFS service metadata.
+
+    Called after catalog initialization to pre-populate metadata.yaml with
+    values extracted from the WFS service. Fields that couldn't be
+    extracted are marked with TODO placeholders.
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report containing metadata.
+    """
+    from portolan_cli.metadata_seeding import seed_metadata_yaml
+    from portolan_cli.output import info
+
+    if not report.metadata_extracted:
+        return
+
+    wfs_metadata = _report_metadata_to_wfs_metadata(report.metadata_extracted)
+    extracted = wfs_metadata.to_extracted()
+
+    metadata_path = output_dir / ".portolan" / "metadata.yaml"
+    if seed_metadata_yaml(extracted, metadata_path):
+        info(f"Seeded metadata.yaml from {extracted.source_type}")
+
+
+def _report_metadata_to_wfs_metadata(
+    report_metadata: MetadataExtracted,
+) -> WFSMetadata:
+    """Convert report MetadataExtracted back to WFSMetadata.
+
+    The extraction report stores a flattened version of the metadata.
+    This function reconstructs the WFSMetadata object for conversion
+    to ExtractedMetadata.
+
+    Args:
+        report_metadata: MetadataExtracted from the extraction report.
+
+    Returns:
+        WFSMetadata instance with the same data.
+    """
+    from portolan_cli.extract.wfs.metadata import WFSMetadata
+
+    return WFSMetadata(
+        source_url=report_metadata.source_url,
+        service_abstract=report_metadata.description,
+        provider_name=report_metadata.attribution,
+        keywords=report_metadata.keywords,
+        access_constraints=report_metadata.license_info_raw,
+    )
+
+
+def _seed_collection_metadata_wfs(
+    output_dir: Path,
+    report: ExtractionReport,
+    discovery_result: WFSDiscoveryResult,
+) -> None:
+    """Seed metadata.yaml for each collection with WFS layer-specific info.
+
+    For layers with MetadataURL (e.g., INSPIRE services), fetches rich ISO 19139
+    metadata from CSW. Falls back to GetCapabilities metadata if CSW fetch fails.
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report with layer results.
+        discovery_result: WFS discovery result with layer metadata.
+    """
+    from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+    from portolan_cli.output import detail
+
+    layer_info_by_name = {layer.name: layer for layer in discovery_result.layers}
+
+    for layer_result in report.layers:
+        if layer_result.status != "success" or not layer_result.output_path:
+            continue
+
+        layer_info = layer_info_by_name.get(layer_result.name)
+        if not layer_info:
+            continue
+
+        output_parts = Path(layer_result.output_path).parts
+        if not output_parts:
+            continue
+
+        collection_dir = output_dir / output_parts[0]
+
+        # Build layer-specific URL for provenance
+        layer_url = _build_wfs_url(
+            report.source_url,
+            {"service": "WFS", "request": "GetFeature", "typename": layer_info.name},
+        )
+
+        # Try to fetch rich ISO metadata from MetadataURL (e.g., INSPIRE CSW)
+        iso_metadata = _try_fetch_iso_metadata(layer_info.metadata_urls)
+
+        if iso_metadata and iso_metadata.has_useful_metadata():
+            # Use rich ISO metadata
+            detail(f"Using ISO metadata for {layer_info.name}")
+            _seed_collection_from_iso(
+                collection_dir,
+                iso_metadata,
+                layer_url,
+                layer_info.name,
+            )
+        else:
+            # Fall back to sparse WFS GetCapabilities metadata
+            seed_collection_metadata(
+                collection_dir,
+                source_type="wfs",
+                source_url=layer_url,
+                layer_name=layer_info.name,
+                title=layer_info.title,
+                description=layer_info.abstract,
+                keywords=layer_info.keywords,
+            )
+
+
+def _try_fetch_iso_metadata(
+    metadata_urls: list[dict[str, Any]] | None,
+) -> ISOMetadata | None:
+    """Try to fetch ISO 19139 metadata from MetadataURLs.
+
+    Args:
+        metadata_urls: List of metadata URL dicts from layer.
+
+    Returns:
+        Parsed ISOMetadata if successful, None otherwise.
+    """
+    if not metadata_urls:
+        return None
+
+    from portolan_cli.extract.csw import fetch_metadata_for_layer
+
+    return fetch_metadata_for_layer(metadata_urls, timeout=30.0)
+
+
+def _seed_collection_from_iso(
+    collection_dir: Path,
+    iso_metadata: ISOMetadata,
+    source_url: str,
+    layer_name: str,
+) -> bool:
+    """Seed collection metadata.yaml from ISO 19139 metadata.
+
+    Args:
+        collection_dir: Path to the collection directory.
+        iso_metadata: Parsed ISO metadata.
+        source_url: WFS layer URL for provenance.
+        layer_name: Layer name for processing notes.
+
+    Returns:
+        True if metadata.yaml was created, False if skipped.
+    """
+    from dataclasses import replace
+
+    from portolan_cli.metadata_seeding import seed_metadata_yaml
+
+    extracted = iso_metadata.to_extracted_metadata(source_url)
+
+    # Override processing notes with layer-specific info
+    extracted = replace(
+        extracted,
+        processing_notes=f"Extracted from WFS layer: {layer_name}. "
+        f"Metadata from ISO 19139 record: {iso_metadata.file_identifier}",
+    )
+
+    metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+    return seed_metadata_yaml(extracted, metadata_path)

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -784,8 +784,9 @@ def _seed_collection_metadata_wfs(
     # Seed metadata for each layer
     for layer_result, layer_info in layers_to_process:
         # Derive collection directory from output_path's parent
-        # output_path is guaranteed non-None by the filter above
-        assert layer_result.output_path is not None
+        # output_path is guaranteed non-None by the filter above, but check defensively
+        if not layer_result.output_path:
+            continue
         collection_dir = output_dir / Path(layer_result.output_path).parent
 
         # Build layer-specific URL for provenance

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -659,11 +659,9 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
         if layer.status != "success" or not layer.output_path:
             continue
 
-        output_parts = Path(layer.output_path).parts
-        if not output_parts:
-            continue
-
-        collection_dir = output_dir / output_parts[0]
+        # Derive collection directory from output_path's parent
+        # Handles nested paths like "service/layer/layer.parquet"
+        collection_dir = output_dir / Path(layer.output_path).parent
         collection_path = collection_dir / "collection.json"
 
         if not collection_path.exists():
@@ -737,35 +735,58 @@ def _seed_collection_metadata_wfs(
     output_dir: Path,
     report: ExtractionReport,
     discovery_result: WFSDiscoveryResult,
+    max_workers: int = 4,
 ) -> None:
     """Seed metadata.yaml for each collection with WFS layer-specific info.
 
     For layers with MetadataURL (e.g., INSPIRE services), fetches rich ISO 19139
-    metadata from CSW. Falls back to GetCapabilities metadata if CSW fetch fails.
+    metadata from CSW in parallel. Falls back to GetCapabilities metadata if CSW
+    fetch fails.
 
     Args:
         output_dir: The catalog output directory.
         report: The extraction report with layer results.
         discovery_result: WFS discovery result with layer metadata.
+        max_workers: Maximum parallel CSW fetches (default: 4).
     """
     from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
     from portolan_cli.output import detail
 
     layer_info_by_name = {layer.name: layer for layer in discovery_result.layers}
 
+    # Collect layers to process
+    layers_to_process: list[tuple[LayerResult, LayerInfo]] = []
     for layer_result in report.layers:
         if layer_result.status != "success" or not layer_result.output_path:
             continue
-
         layer_info = layer_info_by_name.get(layer_result.name)
-        if not layer_info:
-            continue
+        if layer_info:
+            layers_to_process.append((layer_result, layer_info))
 
-        output_parts = Path(layer_result.output_path).parts
-        if not output_parts:
-            continue
+    if not layers_to_process:
+        return
 
-        collection_dir = output_dir / output_parts[0]
+    # Fetch ISO metadata in parallel
+    iso_metadata_map: dict[str, ISOMetadata | None] = {}
+
+    def fetch_iso(layer_info: LayerInfo) -> tuple[str, ISOMetadata | None]:
+        return (layer_info.name, _try_fetch_iso_metadata(layer_info.metadata_urls))
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(fetch_iso, layer_info): layer_info.name
+            for _, layer_info in layers_to_process
+        }
+        for future in as_completed(futures):
+            layer_name, iso_metadata = future.result()
+            iso_metadata_map[layer_name] = iso_metadata
+
+    # Seed metadata for each layer
+    for layer_result, layer_info in layers_to_process:
+        # Derive collection directory from output_path's parent
+        # output_path is guaranteed non-None by the filter above
+        assert layer_result.output_path is not None
+        collection_dir = output_dir / Path(layer_result.output_path).parent
 
         # Build layer-specific URL for provenance
         layer_url = _build_wfs_url(
@@ -773,8 +794,7 @@ def _seed_collection_metadata_wfs(
             {"service": "WFS", "request": "GetFeature", "typename": layer_info.name},
         )
 
-        # Try to fetch rich ISO metadata from MetadataURL (e.g., INSPIRE CSW)
-        iso_metadata = _try_fetch_iso_metadata(layer_info.metadata_urls)
+        iso_metadata = iso_metadata_map.get(layer_info.name)
 
         if iso_metadata and iso_metadata.has_useful_metadata():
             # Use rich ISO metadata

--- a/portolan_cli/metadata_seeding.py
+++ b/portolan_cli/metadata_seeding.py
@@ -140,6 +140,9 @@ def _build_metadata_dict(extracted: ExtractedMetadata) -> dict[str, Any]:
     if extracted.source_url:
         metadata["source_url"] = extracted.source_url
 
+    if extracted.description:
+        metadata["description"] = extracted.description
+
     if extracted.attribution:
         metadata["attribution"] = extracted.attribution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,9 @@ skips = []  # Add specific checks to skip if needed, e.g., ["B101"]
 
 [tool.codespell]
 # "Nd" is a Unicode category code for "Number, decimal digit" used in Hypothesis tests
-ignore-words-list = "nd"
+# French words from Belgian ISO 19139 test fixture (tests/fixtures/csw/belgium_buildings_iso19139.xml)
+# "BU" is the INSPIRE theme code for Buildings (used in test fixtures)
+ignore-words-list = "nd,bu,ue,adresse,projet,environnement,copie,explicite,connexion,objets,visibles,issus,fonction,mesures,informations"
 
 # ---------- dead code ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
     "antimeridian>=0.3.11",  # RFC 7946 compliant antimeridian handling for STAC bbox
     "click>=8.3.1",
+    "defusedxml>=0.7.1",  # Safe XML parsing (XXE protection) for CSW/ISO 19139 metadata
     "geoparquet-io @ git+https://github.com/geoparquet/geoparquet-io.git@main",  # git: layer param support
     "httpx>=0.27.0",  # HTTP client for ArcGIS REST API discovery
     "obstore>=0.8.2",  # Cloud object storage (S3, GCS, Azure) via Rust bindings
@@ -77,6 +78,7 @@ dev = [
     "pytest-timeout>=2.3.1",
     "radon>=6.0.1",
     "ruff>=0.14.11",
+    "types-defusedxml>=0.7.0",  # Type stubs for defusedxml
     "types-PyYAML>=6.0",  # Type stubs for PyYAML
     "vulture>=2.14",
     "xenon>=0.9.3",

--- a/tests/fixtures/csw/README.md
+++ b/tests/fixtures/csw/README.md
@@ -1,0 +1,49 @@
+# CSW/ISO 19139 Test Fixtures
+
+Test fixtures for CSW (Catalog Service for Web) and ISO 19139 metadata parsing.
+
+## Fixtures
+
+### belgium_buildings_iso19139.xml
+- **Origin**: INSPIRE Wallonia geoportal (Belgium)
+- **Purpose**: Full ISO 19139 metadata record for comprehensive parser testing
+- **Size**: ~50KB (884 lines)
+- **Tests using it**: `test_iso_parser.py`, `test_client.py`
+- **Notes**: Contains all major ISO 19139 elements including contact info, keywords from multiple thesauri, CC-BY-4.0 license, lineage, and dates
+
+### minimal_iso19139.xml
+- **Origin**: Synthetic
+- **Purpose**: Minimal valid ISO 19139 with only required fields
+- **Size**: ~1KB
+- **Tests using it**: Parser edge case tests
+- **Notes**: Contains only file_identifier, title, and abstract
+
+### csw_wrapped_iso19139.xml
+- **Origin**: Synthetic
+- **Purpose**: ISO 19139 wrapped in CSW GetRecordByIdResponse envelope
+- **Size**: ~2KB
+- **Tests using it**: CSW response unwrapping tests
+- **Notes**: Tests that parser handles CSW wrapper correctly
+
+### title_only_iso19139.xml
+- **Origin**: Synthetic
+- **Purpose**: ISO 19139 with title but no abstract
+- **Size**: ~500B
+- **Tests using it**: `has_useful_metadata()` negative tests
+- **Notes**: Tests that sparse metadata is correctly identified
+
+### invalid_iso19139.xml
+- **Origin**: Synthetic
+- **Purpose**: Malformed XML for error handling tests
+- **Size**: ~200B
+- **Tests using it**: `test_iso_parser.py` error path tests
+- **Notes**: Valid XML but missing required ISO 19139 elements
+
+## Schema Notes
+
+ISO 19139 is the XML encoding of ISO 19115 (Geographic Metadata). Key namespaces:
+- `gmd`: Geographic Metadata Domain (main elements)
+- `gco`: Geographic Common (primitives like CharacterString)
+- `gmx`: Geographic Metadata Extension (Anchor elements for URLs)
+- `srv`: Service metadata
+- `csw`: Catalog Service for Web (wrapper namespace)

--- a/tests/fixtures/csw/belgium_buildings_iso19139.xml
+++ b/tests/fixtures/csw/belgium_buildings_iso19139.xml
@@ -1,0 +1,884 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csw:GetRecordByIdResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+  <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <gmd:fileIdentifier>
+      <gco:CharacterString>9a8322bd-f53a-4f99-ad9e-753b45bdee85</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:language>
+      <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+    </gmd:language>
+    <gmd:characterSet>
+      <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://www.isotc211.org/namespace/resources/codeList.xml#MD_CharacterSetCode" />
+    </gmd:characterSet>
+    <gmd:hierarchyLevel>
+      <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+    </gmd:hierarchyLevel>
+    <gmd:hierarchyLevelName>
+      <gco:CharacterString>Couche de données thématiques</gco:CharacterString>
+    </gmd:hierarchyLevelName>
+    <gmd:contact>
+      <gmd:CI_ResponsibleParty>
+        <gmd:organisationName>
+          <gco:CharacterString>Gestion et valorisation de la donnée (SPW - Secrétariat général - SPW Digital - Département Données transversales - Gestion et valorisation de la donnée)</gco:CharacterString>
+        </gmd:organisationName>
+        <gmd:contactInfo>
+          <gmd:CI_Contact>
+            <gmd:address>
+              <gmd:CI_Address>
+                <gmd:electronicMailAddress>
+                  <gco:CharacterString>helpdesk.carto@spw.wallonie.be</gco:CharacterString>
+                </gmd:electronicMailAddress>
+              </gmd:CI_Address>
+            </gmd:address>
+          </gmd:CI_Contact>
+        </gmd:contactInfo>
+        <gmd:role>
+          <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+        </gmd:role>
+      </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+      <gco:DateTime>2025-12-11T10:21:46.610618Z</gco:DateTime>
+    </gmd:dateStamp>
+    <gmd:metadataStandardName>
+      <gco:CharacterString>ISO 19115</gco:CharacterString>
+    </gmd:metadataStandardName>
+    <gmd:metadataStandardVersion>
+      <gco:CharacterString>2003/Cor 1:2006</gco:CharacterString>
+    </gmd:metadataStandardVersion>
+    <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem>
+        <gmd:referenceSystemIdentifier>
+          <gmd:RS_Identifier>
+            <gmd:code>
+              <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/3035">EPSG:3035</gmx:Anchor>
+            </gmd:code>
+          </gmd:RS_Identifier>
+        </gmd:referenceSystemIdentifier>
+      </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:identificationInfo>
+      <gmd:MD_DataIdentification>
+        <gmd:citation>
+          <gmd:CI_Citation>
+            <gmd:title>
+              <gco:CharacterString>INSPIRE - Bâtiments en Wallonie (BE)</gco:CharacterString>
+            </gmd:title>
+            <gmd:alternateTitle>
+              <gco:CharacterString>Building - Emprise</gco:CharacterString>
+            </gmd:alternateTitle>
+            <gmd:alternateTitle>
+              <gco:CharacterString>BuildingGeometry2D</gco:CharacterString>
+            </gmd:alternateTitle>
+            <gmd:alternateTitle>
+              <gco:CharacterString>INSPIRE_BU_EMPRISE</gco:CharacterString>
+            </gmd:alternateTitle>
+            <gmd:date>
+              <gmd:CI_Date>
+                <gmd:date>
+                  <gco:Date>2020-10-29</gco:Date>
+                </gmd:date>
+                <gmd:dateType>
+                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation">creation</gmd:CI_DateTypeCode>
+                </gmd:dateType>
+              </gmd:CI_Date>
+            </gmd:date>
+            <gmd:date>
+              <gmd:CI_Date>
+                <gmd:date>
+                  <gco:Date>2020-10-29</gco:Date>
+                </gmd:date>
+                <gmd:dateType>
+                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision">revision</gmd:CI_DateTypeCode>
+                </gmd:dateType>
+              </gmd:CI_Date>
+            </gmd:date>
+            <gmd:date>
+              <gmd:CI_Date>
+                <gmd:date>
+                  <gco:Date>2020-10-29</gco:Date>
+                </gmd:date>
+                <gmd:dateType>
+                  <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                </gmd:dateType>
+              </gmd:CI_Date>
+            </gmd:date>
+            <gmd:identifier>
+              <gmd:RS_Identifier>
+                <gmd:code>
+                  <gco:CharacterString>9a8322bd-f53a-4f99-ad9e-753b45bdee85</gco:CharacterString>
+                </gmd:code>
+                <gmd:codeSpace>
+                  <gco:CharacterString>https://geodata.wallonie.be/id/</gco:CharacterString>
+                </gmd:codeSpace>
+              </gmd:RS_Identifier>
+            </gmd:identifier>
+            <gmd:identifier>
+              <gmd:MD_Identifier>
+                <gmd:code>
+                  <gco:CharacterString>INSPIRE_BU_EMPRISE</gco:CharacterString>
+                </gmd:code>
+              </gmd:MD_Identifier>
+            </gmd:identifier>
+          </gmd:CI_Citation>
+        </gmd:citation>
+        <gmd:abstract>
+          <gco:CharacterString>Cette série de couches de données spatiales compile les informations du thème "Bâtiments".
+
+La Directive européenne 2007/2/CE - Directive INSPIRE - établit une infrastructure d'information géographique dans la Communauté européenne. INSPIRE s'applique à 34 domaines thématiques répartis en 3 Annexes. La présente série comprend les couches de données géographiques faisant référence aux Bâtiments.
+
+Au sens de la Directive, un bâtiment est "une installation couverte, utilisable pour la protection des êtres humains, des animaux, des choses ou pour la production de biens économiques. Un bâtiment désigne toute structure construite ou érigée de façon permanente sur son site. Les informations sur l'emplacement des bâtiments peuvent être fournies sous forme de points ou avec la forme de base réelle du bâtiment".
+
+La plupart des bâtiments peuvent être identifiés (géocodés) par adresse (thème distinct dans le cadre d'INSPIRE).
+
+Cette série de données propose une modélisation des bâtiments en Wallonie sur base du Projet Informatique de Cartographie Continue (PICC).
+
+Le PICC est la référence cartographique numérique en 3 dimensions de l'ensemble de la Wallonie. Il reprend selon leurs coordonnées x, y, z, avec une précision inférieure à 25 cm, tous les éléments identifiables du paysage wallon.</gco:CharacterString>
+        </gmd:abstract>
+        <gmd:status>
+          <gmd:MD_ProgressCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ProgressCode" codeListValue="completed">completed</gmd:MD_ProgressCode>
+        </gmd:status>
+        <gmd:pointOfContact>
+          <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+              <gco:CharacterString>Helpdesk carto du SPW (SPW - Secrétariat général - SPW Digital - Département Données transversales - Gestion et valorisation de la donnée)</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+              <gmd:CI_Contact>
+                <gmd:address>
+                  <gmd:CI_Address>
+                    <gmd:electronicMailAddress>
+                      <gco:CharacterString>helpdesk.carto@spw.wallonie.be</gco:CharacterString>
+                    </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+                </gmd:address>
+              </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+              <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</gmd:CI_RoleCode>
+            </gmd:role>
+          </gmd:CI_ResponsibleParty>
+        </gmd:pointOfContact>
+        <gmd:pointOfContact>
+          <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+              <gco:CharacterString>Production géomatique et traitement de données (SPW - Secrétariat général - SPW Digital - Département Données transversales - Production géomatique et traitement de données)</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+              <gmd:CI_Contact>
+                <gmd:address>
+                  <gmd:CI_Address>
+                    <gmd:electronicMailAddress>
+                      <gco:CharacterString>geometrologie@spw.wallonie.be</gco:CharacterString>
+                    </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+                </gmd:address>
+              </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+              <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="custodian">custodian</gmd:CI_RoleCode>
+            </gmd:role>
+          </gmd:CI_ResponsibleParty>
+        </gmd:pointOfContact>
+        <gmd:pointOfContact>
+          <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+              <gco:CharacterString>Service public de Wallonie (SPW)</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+              <gmd:CI_Contact>
+                <gmd:address>
+                  <gmd:CI_Address>
+                    <gmd:electronicMailAddress>
+                      <gco:CharacterString>helpdesk.carto@spw.wallonie.be</gco:CharacterString>
+                    </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+                </gmd:address>
+                <gmd:onlineResource>
+                  <gmd:CI_OnlineResource>
+                    <gmd:linkage>
+                      <gmd:URL>https://geoportail.wallonie.be</gmd:URL>
+                    </gmd:linkage>
+                    <gmd:protocol>
+                      <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                    </gmd:protocol>
+                    <gmd:name>
+                      <gco:CharacterString>Géoportail de la Wallonie</gco:CharacterString>
+                    </gmd:name>
+                    <gmd:description>
+                      <gco:CharacterString>Géoportail de la Wallonie</gco:CharacterString>
+                    </gmd:description>
+                    <gmd:function>
+                      <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+                    </gmd:function>
+                  </gmd:CI_OnlineResource>
+                </gmd:onlineResource>
+              </gmd:CI_Contact>
+            </gmd:contactInfo>
+            <gmd:role>
+              <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="owner">owner</gmd:CI_RoleCode>
+            </gmd:role>
+          </gmd:CI_ResponsibleParty>
+        </gmd:pointOfContact>
+        <gmd:resourceMaintenance>
+          <gmd:MD_MaintenanceInformation>
+            <gmd:maintenanceAndUpdateFrequency>
+              <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode" codeListValue="asNeeded" />
+            </gmd:maintenanceAndUpdateFrequency>
+          </gmd:MD_MaintenanceInformation>
+        </gmd:resourceMaintenance>
+        <gmd:graphicOverview>
+          <gmd:MD_BrowseGraphic>
+            <gmd:fileName>
+              <gco:CharacterString>https://metawal.wallonie.be/geonetwork/srv/api/records/9a8322bd-f53a-4f99-ad9e-753b45bdee85/attachments/picc_vdiff_2.png</gco:CharacterString>
+            </gmd:fileName>
+            <gmd:fileDescription>
+              <gco:CharacterString>picc_vdiff_2.png</gco:CharacterString>
+            </gmd:fileDescription>
+          </gmd:MD_BrowseGraphic>
+        </gmd:graphicOverview>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/theme-geoportail-wallon#SubThemesGeoportailWallon/1010">Faune et flore</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/theme-geoportail-wallon#ThemesGeoportailWallon/10">Nature et environnement</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/theme-geoportail-wallon">Thèmes du géoportail wallon</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2024-10-14</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.Themes_geoportail_wallon_hierarchy">geonetwork.thesaurus.external.theme.Themes_geoportail_wallon_hierarchy</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme/bu">Bâtiments</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme">GEMET - INSPIRE themes, version 1.0</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2008-06-01</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/theme/5">bâtiment</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://geonetwork-opensource.org/gemet-theme">GEMET themes</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2009-09-22</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.gemet-theme">geonetwork.thesaurus.external.theme.gemet-theme</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept/2387">habitation</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept/7144">bâtiment d'habitation</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept/13100">habitat urbain</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept/13104">habitat rural</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://www.eionet.europa.eu/gemet/concept/3808">habitat</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://geonetwork-opensource.org/gemet">GEMET</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2012-07-20</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/infrasig#WALONMAPNO">WalOnMapNO</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/infrasig/Opendata">Open Data</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/infrasig/ReportingINSPIRE">Reporting INSPIRE</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/infrasig#PanierTelechargementGeoportail">PanierTelechargementGeoportail</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="https://metawal.wallonie.be/thesaurus/infrasig">Mots-clés InfraSIG</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2024-10-10</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.infraSIG">geonetwork.thesaurus.external.theme.infraSIG</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gco:CharacterString>Bâtiments</gco:CharacterString>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gco:CharacterString>emprise</gco:CharacterString>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gco:CharacterString>Building</gco:CharacterString>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialScope/regional">Régional</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialScope">Champ géographique</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2019-05-22</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope">geonetwork.thesaurus.external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://data.europa.eu/bna/c_ac64a52d">Géospatiales</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://data.europa.eu/bna/c_60182062">Bâtiments</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://data.europa.eu/bna/asd487ae75">High-value dataset categories</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2024-12-11</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.high-value-dataset-category">geonetwork.thesaurus.external.theme.high-value-dataset-category</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg_impl/2023/138/oj">2023/138 - High Value Datasets Regulation</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://data.europa.eu/eli/dir/2007/2/oj">2007/2/EC - INSPIRE Directive</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://data.europa.eu/r5r/applicableLegislation">Applicable legislations</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2025-07-16</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.applicable-legislation">geonetwork.thesaurus.external.theme.applicable-legislation</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword>
+              <gmx:Anchor xlink:href="http://publications.europa.eu/resource/authority/data-theme/REGI">Régions et villes</gmx:Anchor>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title>
+                  <gmx:Anchor xlink:href="http://publications.europa.eu/resource/authority/data-theme">Themes de données européens DCAT-AP</gmx:Anchor>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2024-10-10</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:identifier>
+                  <gmd:MD_Identifier>
+                    <gmd:code>
+                      <gmx:Anchor xlink:href="https://metawal.wallonie.be/geonetwork/srv/api/registries/vocabularies/external.theme.data-theme-skos">geonetwork.thesaurus.external.theme.data-theme-skos</gmx:Anchor>
+                    </gmd:code>
+                  </gmd:MD_Identifier>
+                </gmd:identifier>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:resourceConstraints>
+          <gmd:MD_LegalConstraints>
+            <gmd:accessConstraints>
+              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions" />
+            </gmd:accessConstraints>
+            <gmd:otherConstraints>
+              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de limitation d'accès public à cette donnée.</gmx:Anchor>
+            </gmd:otherConstraints>
+          </gmd:MD_LegalConstraints>
+        </gmd:resourceConstraints>
+        <gmd:resourceConstraints>
+          <gmd:MD_LegalConstraints>
+            <gmd:useConstraints>
+              <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_RestrictionCode" codeListValue="otherRestrictions" />
+            </gmd:useConstraints>
+            <gmd:otherConstraints>
+              <gmx:Anchor xlink:href="https://creativecommons.org/licenses/by/4.0/">Licence CC-BY 4.0 : L’utilisateur peut utiliser et modifier les données pour en dériver une œuvre. Il peut publier les données et l’œuvre dérivée à condition de citer les sources.</gmx:Anchor>
+            </gmd:otherConstraints>
+            <gmd:otherConstraints>
+              <gco:CharacterString>Source : Service public de Wallonie (SPW) - INSPIRE - Bâtiments en Wallonie (BE) (2020-10-29) https://geodata.wallonie.be/id/9a8322bd-f53a-4f99-ad9e-753b45bdee85</gco:CharacterString>
+            </gmd:otherConstraints>
+          </gmd:MD_LegalConstraints>
+        </gmd:resourceConstraints>
+        <gmd:spatialRepresentationType>
+          <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector">vector</gmd:MD_SpatialRepresentationTypeCode>
+        </gmd:spatialRepresentationType>
+        <gmd:spatialResolution>
+          <gmd:MD_Resolution>
+            <gmd:equivalentScale>
+              <gmd:MD_RepresentativeFraction>
+                <gmd:denominator>
+                  <gco:Integer>10000</gco:Integer>
+                </gmd:denominator>
+              </gmd:MD_RepresentativeFraction>
+            </gmd:equivalentScale>
+          </gmd:MD_Resolution>
+        </gmd:spatialResolution>
+        <gmd:language>
+          <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+        </gmd:language>
+        <gmd:characterSet>
+          <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+        </gmd:characterSet>
+        <gmd:topicCategory>
+          <gmd:MD_TopicCategoryCode>imageryBaseMapsEarthCover</gmd:MD_TopicCategoryCode>
+        </gmd:topicCategory>
+        <gmd:extent>
+          <gmd:EX_Extent>
+            <gmd:description>
+              <gco:CharacterString>Région wallonne</gco:CharacterString>
+            </gmd:description>
+            <gmd:geographicElement>
+              <gmd:EX_GeographicBoundingBox>
+                <gmd:westBoundLongitude>
+                  <gco:Decimal>2.78</gco:Decimal>
+                </gmd:westBoundLongitude>
+                <gmd:eastBoundLongitude>
+                  <gco:Decimal>6.41</gco:Decimal>
+                </gmd:eastBoundLongitude>
+                <gmd:southBoundLatitude>
+                  <gco:Decimal>49.46</gco:Decimal>
+                </gmd:southBoundLatitude>
+                <gmd:northBoundLatitude>
+                  <gco:Decimal>50.85</gco:Decimal>
+                </gmd:northBoundLatitude>
+              </gmd:EX_GeographicBoundingBox>
+            </gmd:geographicElement>
+          </gmd:EX_Extent>
+        </gmd:extent>
+      </gmd:MD_DataIdentification>
+    </gmd:identificationInfo>
+    <gmd:distributionInfo>
+      <gmd:MD_Distribution>
+        <gmd:distributionFormat>
+          <gmd:MD_Format>
+            <gmd:name>
+              <gmx:Anchor xlink:href="https://www.iana.org/assignments/media-types/application/gml+xml">GML (.gml)</gmx:Anchor>
+            </gmd:name>
+            <gmd:version>
+              <gco:CharacterString>3.2.1</gco:CharacterString>
+            </gmd:version>
+          </gmd:MD_Format>
+        </gmd:distributionFormat>
+        <gmd:distributor>
+          <gmd:MD_Distributor>
+            <gmd:distributorContact>
+              <gmd:CI_ResponsibleParty>
+                <gmd:organisationName>
+                  <gco:CharacterString>Service public de Wallonie (SPW)</gco:CharacterString>
+                </gmd:organisationName>
+                <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                    <gmd:address>
+                      <gmd:CI_Address>
+                        <gmd:electronicMailAddress>
+                          <gco:CharacterString>helpdesk.carto@spw.wallonie.be</gco:CharacterString>
+                        </gmd:electronicMailAddress>
+                      </gmd:CI_Address>
+                    </gmd:address>
+                  </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor">distributor</gmd:CI_RoleCode>
+                </gmd:role>
+              </gmd:CI_ResponsibleParty>
+            </gmd:distributorContact>
+            <gmd:distributionOrderProcess>
+              <gmd:MD_StandardOrderProcess>
+                <gmd:orderingInstructions>
+                  <gco:CharacterString>Cette donnée est disponible en téléchargement direct ou via le panier du téléchargement du Géoportail.  Les instructions pour obtenir une copie physique d’une donnée sont détaillées sur https://geoportail.wallonie.be/telecharger
+L'utilisation des webservices est à privilégier pour disposer à tout moment de la version la plus à jour. Cette donnée est disponible sous les termes de la licence ouverte CC BY 4.0. Les réutilisations sont autorisées moyennant citation de la source et mention explicite des modifications apportées à la donnée.</gco:CharacterString>
+                </gmd:orderingInstructions>
+              </gmd:MD_StandardOrderProcess>
+            </gmd:distributionOrderProcess>
+          </gmd:MD_Distributor>
+        </gmd:distributor>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://geoservices.wallonie.be/geoserver/inspire_bu/ows?service=WMS&amp;version=1.3.0&amp;request=GetCapabilities</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>OGC:WMS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name>
+                  <gco:CharacterString>INSPIRE - Bâtiments en Wallonie (BE) - Service de visualisation WMS</gco:CharacterString>
+                </gmd:name>
+                <gmd:description>
+                  <gco:CharacterString>Ce service de visualisation WMS INSPIRE permet de consulter les couches de données du thème "Bâtiments" au sein du territoire wallon (Belgique).</gco:CharacterString>
+                </gmd:description>
+                <gmd:function>
+                  <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="browsing" />
+                </gmd:function>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://geoservices.wallonie.be/inspire/atom/BU_Service.xml</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>atom:feed</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name>
+                  <gco:CharacterString>INSPIRE - Bâtiments en Wallonie (BE) - Service de téléchargement</gco:CharacterString>
+                </gmd:name>
+                <gmd:description>
+                  <gco:CharacterString>Ce service de téléchargement ATOM Feed donne accès aux couches de données identifiée dans le thème INSPIRE "Bâtiments" au sein du territoire wallon (Belgique).</gco:CharacterString>
+                </gmd:description>
+                <gmd:function>
+                  <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="download" />
+                </gmd:function>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://geoservices.wallonie.be/geoserver/inspire_bu/ogc/features/v1/openapi</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>OGC API - Features</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name>
+                  <gco:CharacterString>Adresse de connexion au service OGC API Features permettant de télécharger la donnée "Bâtiments en Wallonie".</gco:CharacterString>
+                </gmd:name>
+                <gmd:description gco:nilReason="missing">
+                  <gco:CharacterString />
+                </gmd:description>
+                <gmd:function>
+                  <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="download" />
+                </gmd:function>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://geodata.wallonie.be/dataset/9a8322bd-f53a-4f99-ad9e-753b45bdee85</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name>
+                  <gco:CharacterString>Page de téléchargement des données</gco:CharacterString>
+                </gmd:name>
+                <gmd:description>
+                  <gco:CharacterString>Page à partir de laquelle vous avez accès au téléchargement direct de la donnée</gco:CharacterString>
+                </gmd:description>
+                <gmd:function>
+                  <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="download" />
+                </gmd:function>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+      </gmd:MD_Distribution>
+    </gmd:distributionInfo>
+    <gmd:dataQualityInfo>
+      <gmd:DQ_DataQuality>
+        <gmd:scope>
+          <gmd:DQ_Scope>
+            <gmd:level>
+              <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode" codeListValue="dataset" />
+            </gmd:level>
+            <gmd:levelDescription>
+              <gmd:MD_ScopeDescription>
+                <gmd:other>
+                  <gco:CharacterString>Couche de données thématiques</gco:CharacterString>
+                </gmd:other>
+              </gmd:MD_ScopeDescription>
+            </gmd:levelDescription>
+          </gmd:DQ_Scope>
+        </gmd:scope>
+        <gmd:report>
+          <gmd:DQ_DomainConsistency>
+            <gmd:result>
+              <gmd:DQ_ConformanceResult>
+                <gmd:specification xlink:href="http://inspire.ec.europa.eu/id/citation/ir/reg-1089-2010">
+                  <gmd:CI_Citation>
+                    <gmd:title>
+                      <gmx:Anchor xlink:href="http://data.europa.eu/eli/reg/2010/1089">RÈGLEMENT (UE) N o 1089/2010 DE LA COMMISSION du 23 novembre 2010 portant modalités d'application de la directive 2007/2/CE du Parlement européen et du Conseil en ce qui concerne l'interopérabilité des séries et des services de données géographiques</gmx:Anchor>
+                    </gmd:title>
+                    <gmd:date>
+                      <gmd:CI_Date>
+                        <gmd:date>
+                          <gco:Date>2010-12-08</gco:Date>
+                        </gmd:date>
+                        <gmd:dateType>
+                          <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                        </gmd:dateType>
+                      </gmd:CI_Date>
+                    </gmd:date>
+                  </gmd:CI_Citation>
+                </gmd:specification>
+                <gmd:explanation>
+                  <gco:CharacterString>Voir la spécification référencée</gco:CharacterString>
+                </gmd:explanation>
+                <gmd:pass>
+                  <gco:Boolean>true</gco:Boolean>
+                </gmd:pass>
+              </gmd:DQ_ConformanceResult>
+            </gmd:result>
+          </gmd:DQ_DomainConsistency>
+        </gmd:report>
+        <gmd:report>
+          <gmd:DQ_DomainConsistency>
+            <gmd:result>
+              <gmd:DQ_ConformanceResult>
+                <gmd:specification>
+                  <gmd:CI_Citation>
+                    <gmd:title>
+                      <gco:CharacterString>INSPIRE Data Specification on Buildings - Guidelines v 3.0.0</gco:CharacterString>
+                    </gmd:title>
+                    <gmd:date>
+                      <gmd:CI_Date>
+                        <gmd:date>
+                          <gco:Date>2013-12-10</gco:Date>
+                        </gmd:date>
+                        <gmd:dateType>
+                          <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
+                        </gmd:dateType>
+                      </gmd:CI_Date>
+                    </gmd:date>
+                  </gmd:CI_Citation>
+                </gmd:specification>
+                <gmd:explanation>
+                  <gco:CharacterString>Voir la spécification référencée</gco:CharacterString>
+                </gmd:explanation>
+                <gmd:pass>
+                  <gco:Boolean>true</gco:Boolean>
+                </gmd:pass>
+              </gmd:DQ_ConformanceResult>
+            </gmd:result>
+          </gmd:DQ_DomainConsistency>
+        </gmd:report>
+        <gmd:lineage>
+          <gmd:LI_Lineage>
+            <gmd:statement>
+              <gco:CharacterString>Le présent standard de données INSPIRE est le résultat d'une sélection réalisée sur la série de couche de données conformes au thème de l'Annexe III "Bâtiments" d'INSPIRE pour ne conserver que les Bâtiments ayant une représsentation en 2D.
+
+Cette série de données propose les bâtiments en Wallonie sur base d’informations provenant du PICC.
+
+Le PICC est élaboré à partir de différentes sources. 1) Source Photogrammétrique A partir d'un couple de photos numériques, des sociétés privées ont créé des vecteurs tridimensionnels. Ces vecteurs ont alors été contrôlés de différentes manières : - Le test de complétude a consisté à vérifier si l'ensemble des objets visibles sur les photographies aériennes ont bien été codifiés dans la base de données (PICC). - Le contrôle d'exactitude a consisté à vérifier que l'interprétation des objets issus des photographies aériennes était correcte. La complétude et l'exactitude ont été évaluées sur base d'un échantillonnage statistique. L'échantillonnage était d'environ 1 pavé sur 20. Tous les résultats ont ensuite été testés (test de Chi-Carré). 2) Levés issus de marchés publics. Des sociétés privées fournissent des levés. Ces levés sont alors évalués en fonction de trois tests : - Le test d'exactitude consiste à la vérification de la bonne utilisation de la légende. - Le test de complétude consiste quand à lui à vérifier que tous les vecteurs on bien été vectorisés et bien placés. - Le test de précision consiste à vérifier la concordance entre la localisation des objets sur le terrain et leur représentation vectorielle. Ces levés sont soit des levés topographiques, soit des mesures par « mobile mapping ». 3) Source interne La Direction de la géométrologie crée ses propres vecteurs tridimensionnels à partir de levés topographiques. La validation des levés internes s’effectuent lors de la phase d’intégration. 4) Source "Partenaire WALTOPO" Le SPW a signé une « convention partenariat – WALTOPO » avec plusieurs sociétés intervenant dans le domaine public. Ces « partenaires WALTOPO » transmettent leurs levés tridimensionnels à la Direction de la géométrologie. La validation des levés internes s’effectue selon les mêmes méthodes que pour les levés issus de marché public. II. CRITERES D’ACCEPTATION Tant pour la photogrammétrie que pour les levés, les critères d’acceptation sont les suivants : Complétude (points ou lignes) &lt; 5 % d'oublis. Exactitude (points ou lignes) &lt; 5 % d'erreurs. Le respect de ces critères se traduit par une intégration et une correction des erreurs résiduelles. III. ENRICHISSEMENT Une phase d’enrichissement a enfin été opérée. Elle consiste en l'individualisation des bâtiments, la création des surfaces sur ceux-ci, l'indication de leur fonction et l'annotation de tous les noms de rues et numéros de police.
+
+("Bâtiments du PICC - cf. https://geoportail.wallonie.be/catalogue/b795de68-726c-4bdf-a62a-a42686aa5b6f.html).</gco:CharacterString>
+            </gmd:statement>
+          </gmd:LI_Lineage>
+        </gmd:lineage>
+      </gmd:DQ_DataQuality>
+    </gmd:dataQualityInfo>
+  </gmd:MD_Metadata>
+</csw:GetRecordByIdResponse>

--- a/tests/fixtures/csw/csw_wrapped_iso19139.xml
+++ b/tests/fixtures/csw/csw_wrapped_iso19139.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csw:GetRecordByIdResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+  <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                   xmlns:gco="http://www.isotc211.org/2005/gco"
+                   xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                   xmlns:xlink="http://www.w3.org/1999/xlink">
+    <gmd:fileIdentifier>
+      <gco:CharacterString>csw-wrapped-test-id</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:identificationInfo>
+      <gmd:MD_DataIdentification>
+        <gmd:citation>
+          <gmd:CI_Citation>
+            <gmd:title>
+              <gco:CharacterString>CSW Wrapped Dataset</gco:CharacterString>
+            </gmd:title>
+          </gmd:CI_Citation>
+        </gmd:citation>
+        <gmd:abstract>
+          <gco:CharacterString>Dataset wrapped in CSW response.</gco:CharacterString>
+        </gmd:abstract>
+        <gmd:pointOfContact>
+          <gmd:CI_ResponsibleParty>
+            <gmd:organisationName>
+              <gco:CharacterString>Test Organization</gco:CharacterString>
+            </gmd:organisationName>
+            <gmd:contactInfo>
+              <gmd:CI_Contact>
+                <gmd:address>
+                  <gmd:CI_Address>
+                    <gmd:electronicMailAddress>
+                      <gco:CharacterString>test@example.com</gco:CharacterString>
+                    </gmd:electronicMailAddress>
+                  </gmd:CI_Address>
+                </gmd:address>
+              </gmd:CI_Contact>
+            </gmd:contactInfo>
+          </gmd:CI_ResponsibleParty>
+        </gmd:pointOfContact>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword><gco:CharacterString>test</gco:CharacterString></gmd:keyword>
+            <gmd:keyword><gco:CharacterString>sample</gco:CharacterString></gmd:keyword>
+            <gmd:keyword><gco:CharacterString>data</gco:CharacterString></gmd:keyword>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:resourceConstraints>
+          <gmd:MD_LegalConstraints>
+            <gmd:otherConstraints>
+              <gmx:Anchor xlink:href="https://creativecommons.org/licenses/by/4.0/">CC-BY 4.0</gmx:Anchor>
+            </gmd:otherConstraints>
+          </gmd:MD_LegalConstraints>
+        </gmd:resourceConstraints>
+      </gmd:MD_DataIdentification>
+    </gmd:identificationInfo>
+  </gmd:MD_Metadata>
+</csw:GetRecordByIdResponse>

--- a/tests/fixtures/csw/invalid_iso19139.xml
+++ b/tests/fixtures/csw/invalid_iso19139.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Invalid ISO 19139: missing required file_identifier and title -->
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gco="http://www.isotc211.org/2005/gco">
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:abstract>
+        <gco:CharacterString>An abstract without a title or identifier.</gco:CharacterString>
+      </gmd:abstract>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/fixtures/csw/minimal_iso19139.xml
+++ b/tests/fixtures/csw/minimal_iso19139.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                 xmlns:xlink="http://www.w3.org/1999/xlink">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>minimal-test-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Minimal Test Dataset</gco:CharacterString>
+          </gmd:title>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract>
+        <gco:CharacterString>A minimal test abstract for unit testing.</gco:CharacterString>
+      </gmd:abstract>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/fixtures/csw/title_only_iso19139.xml
+++ b/tests/fixtures/csw/title_only_iso19139.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                 xmlns:gco="http://www.isotc211.org/2005/gco">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>title-only-id</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title>
+            <gco:CharacterString>Title Only Dataset</gco:CharacterString>
+          </gmd:title>
+        </gmd:CI_Citation>
+      </gmd:citation>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+</gmd:MD_Metadata>

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -822,3 +822,197 @@ class TestServicesRootExtraction:
             multi_paths = [p for p in output_paths if "multilayer" in p]
             for path in multi_paths:
                 assert path.count("/") == 2, f"Multi-layer should be nested: {path}"
+
+
+class TestArcGISCollectionMetadataSeeding:
+    """Tests for ArcGIS collection-level metadata seeding."""
+
+    def test_seed_collection_metadata_creates_file(self, tmp_path: Path) -> None:
+        """Collection metadata seeding creates .portolan/metadata.yaml."""
+        from portolan_cli.extract.arcgis.orchestrator import _seed_collection_metadata_arcgis
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        # Create collection directory structure
+        collection_dir = tmp_path / "test_layer"
+        collection_dir.mkdir()
+        (collection_dir / ".portolan").mkdir()
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://services.arcgis.com/test/FeatureServer",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://services.arcgis.com/test/FeatureServer",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="Test Layer",
+                    status="success",
+                    features=100,
+                    size_bytes=2048,
+                    duration_seconds=1.0,
+                    output_path="test_layer/test_layer.parquet",
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=100,
+                total_size_bytes=2048,
+                total_duration_seconds=1.0,
+            ),
+        )
+
+        with patch("portolan_cli.extract.arcgis.discovery.fetch_layer_details") as mock_fetch:
+            mock_fetch.return_value = {
+                "name": "Test Layer",
+                "description": "A test layer with buildings",
+            }
+
+            _seed_collection_metadata_arcgis(tmp_path, report)
+
+        metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "A test layer with buildings" in content
+
+    def test_seed_collection_metadata_graceful_on_fetch_failure(self, tmp_path: Path) -> None:
+        """Collection seeding continues even if layer details fetch fails."""
+        from portolan_cli.extract.arcgis.orchestrator import _seed_collection_metadata_arcgis
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        # Create collection directory
+        collection_dir = tmp_path / "test_layer"
+        collection_dir.mkdir()
+        (collection_dir / ".portolan").mkdir()
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://services.arcgis.com/test/FeatureServer",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://services.arcgis.com/test/FeatureServer",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="Test Layer",
+                    status="success",
+                    features=100,
+                    size_bytes=2048,
+                    duration_seconds=1.0,
+                    output_path="test_layer/test_layer.parquet",
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=100,
+                total_size_bytes=2048,
+                total_duration_seconds=1.0,
+            ),
+        )
+
+        with patch("portolan_cli.extract.arcgis.discovery.fetch_layer_details") as mock_fetch:
+            mock_fetch.side_effect = Exception("Network error")
+
+            # Should not raise
+            _seed_collection_metadata_arcgis(tmp_path, report)
+
+        # Metadata file should still be created with basic info
+        metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "Test Layer" in content
+
+    def test_seed_collection_metadata_skips_failed_layers(self, tmp_path: Path) -> None:
+        """Collection seeding skips layers that failed extraction."""
+        from portolan_cli.extract.arcgis.orchestrator import _seed_collection_metadata_arcgis
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://services.arcgis.com/test/FeatureServer",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://services.arcgis.com/test/FeatureServer",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="Failed Layer",
+                    status="failed",
+                    features=0,
+                    size_bytes=0,
+                    duration_seconds=0.0,
+                    output_path="",
+                    warnings=[],
+                    error="Connection timeout",
+                    attempts=3,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=0,
+                failed=1,
+                skipped=0,
+                total_features=0,
+                total_size_bytes=0,
+                total_duration_seconds=0.0,
+            ),
+        )
+
+        with patch("portolan_cli.extract.arcgis.discovery.fetch_layer_details") as mock_fetch:
+            # Should not be called for failed layers
+            _seed_collection_metadata_arcgis(tmp_path, report)
+            mock_fetch.assert_not_called()

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -1016,3 +1016,72 @@ class TestArcGISCollectionMetadataSeeding:
             # Should not be called for failed layers
             _seed_collection_metadata_arcgis(tmp_path, report)
             mock_fetch.assert_not_called()
+
+    def test_seed_collection_metadata_arcgis_nested_output_path(self, tmp_path: Path) -> None:
+        """Collection seeding handles nested output paths correctly."""
+        from portolan_cli.extract.arcgis.orchestrator import _seed_collection_metadata_arcgis
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+
+        # Create nested collection directory structure (like services-root extract)
+        nested_dir = tmp_path / "MyService" / "layer_abc123"
+        nested_dir.mkdir(parents=True)
+        (nested_dir / ".portolan").mkdir()
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://example.com/arcgis/rest/services",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://example.com/arcgis/rest/services",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=5,
+                    name="Nested Layer",
+                    status="success",
+                    features=200,
+                    size_bytes=2000,
+                    duration_seconds=2.0,
+                    # Nested output path from services-root extract
+                    output_path="MyService/layer_abc123/layer_abc123.parquet",
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=200,
+                total_size_bytes=2000,
+                total_duration_seconds=2.0,
+            ),
+        )
+
+        with patch("portolan_cli.extract.arcgis.discovery.fetch_layer_details") as mock_fetch:
+            mock_fetch.return_value = {
+                "name": "Nested Layer",
+                "description": "Description from ArcGIS API",
+            }
+            _seed_collection_metadata_arcgis(tmp_path, report)
+
+        # Metadata should be in the nested collection directory (parent of parquet)
+        metadata_path = nested_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "Description from ArcGIS API" in content

--- a/tests/unit/extract/common/test_metadata_seeding.py
+++ b/tests/unit/extract/common/test_metadata_seeding.py
@@ -1,0 +1,393 @@
+"""Tests for common metadata seeding utilities.
+
+These tests verify the shared metadata seeding functionality used
+by both WFS and ArcGIS extraction backends.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestIsTechnicalName:
+    """Tests for _is_technical_name function."""
+
+    def test_underscore_only_identifier(self) -> None:
+        """Lowercase with underscores detected as technical."""
+        from portolan_cli.extract.common.metadata_seeding import _is_technical_name
+
+        assert _is_technical_name("bu_building_emprise") is True
+        assert _is_technical_name("road_centerlines") is True
+        assert _is_technical_name("census_2020") is True
+
+    def test_namespace_prefix(self) -> None:
+        """Namespace:name pattern detected as technical."""
+        from portolan_cli.extract.common.metadata_seeding import _is_technical_name
+
+        assert _is_technical_name("inspire_bu:BU.Building") is True
+        assert _is_technical_name("ns:LayerName") is True
+
+    def test_short_no_spaces(self) -> None:
+        """Short strings without spaces are technical."""
+        from portolan_cli.extract.common.metadata_seeding import _is_technical_name
+
+        assert _is_technical_name("buildings") is True
+        assert _is_technical_name("Layer-1") is True
+
+    def test_real_description(self) -> None:
+        """Real descriptions with spaces are not technical."""
+        from portolan_cli.extract.common.metadata_seeding import _is_technical_name
+
+        assert _is_technical_name("Building footprints for the region") is False
+        assert _is_technical_name("Road centerlines with classification") is False
+        assert _is_technical_name("Census blocks 2020") is False
+
+    def test_title_with_dashes(self) -> None:
+        """Titles with dashes and spaces are not technical."""
+        from portolan_cli.extract.common.metadata_seeding import _is_technical_name
+
+        assert _is_technical_name("Building - building_emprise") is False
+        assert _is_technical_name("Roads - main network") is False
+
+    def test_none_and_empty(self) -> None:
+        """None and empty are treated as technical (unusable)."""
+        from portolan_cli.extract.common.metadata_seeding import _is_technical_name
+
+        assert _is_technical_name(None) is True
+        assert _is_technical_name("") is True
+        assert _is_technical_name("   ") is True
+
+
+class TestSelectBestDescription:
+    """Tests for _select_best_description function."""
+
+    def test_prefers_real_abstract(self) -> None:
+        """Uses abstract when it's a real description."""
+        from portolan_cli.extract.common.metadata_seeding import _select_best_description
+
+        result = _select_best_description(
+            abstract="All building footprints in the study area",
+            title="Buildings Layer",
+            layer_name="buildings",
+        )
+        assert result == "All building footprints in the study area"
+
+    def test_falls_back_to_title(self) -> None:
+        """Falls back to title when abstract is technical."""
+        from portolan_cli.extract.common.metadata_seeding import _select_best_description
+
+        result = _select_best_description(
+            abstract="bu_building_emprise",
+            title="Building - building_emprise",
+            layer_name="inspire_bu:BU.Building_building_emprise",
+        )
+        assert result == "Building - building_emprise"
+
+    def test_prefers_title_with_spaces_over_underscore_abstract(self) -> None:
+        """Title with spaces beats abstract with underscores."""
+        from portolan_cli.extract.common.metadata_seeding import _select_best_description
+
+        result = _select_best_description(
+            abstract="road_network_2020",
+            title="Road Network 2020",
+            layer_name="roads",
+        )
+        # Title has spaces, abstract doesn't - prefer title
+        assert result == "Road Network 2020"
+
+    def test_none_abstract_uses_title(self) -> None:
+        """When abstract is None, use title."""
+        from portolan_cli.extract.common.metadata_seeding import _select_best_description
+
+        result = _select_best_description(
+            abstract=None,
+            title="Census Blocks",
+            layer_name="census",
+        )
+        assert result == "Census Blocks"
+
+    def test_both_technical_prefers_title_with_spaces(self) -> None:
+        """When both are short, prefer title if it has better format."""
+        from portolan_cli.extract.common.metadata_seeding import _select_best_description
+
+        result = _select_best_description(
+            abstract="buildings",
+            title="Buildings - Main",
+            layer_name="buildings",
+        )
+        assert result == "Buildings - Main"
+
+    def test_title_same_as_name_returns_abstract(self) -> None:
+        """When title equals layer name, prefer abstract even if short."""
+        from portolan_cli.extract.common.metadata_seeding import _select_best_description
+
+        result = _select_best_description(
+            abstract="building_footprints",
+            title="buildings",
+            layer_name="buildings",
+        )
+        # Title == layer_name, so we don't use it as description
+        assert result == "building_footprints"
+
+
+class TestSeedCollectionMetadata:
+    """Tests for seed_collection_metadata function."""
+
+    def test_creates_metadata_yaml_in_collection(self, tmp_path: Path) -> None:
+        """Creates .portolan/metadata.yaml in collection directory."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "my_collection"
+        collection_dir.mkdir()
+
+        result = seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs?service=WFS&request=GetFeature&typename=buildings",
+            layer_name="buildings",
+            title="Buildings Layer",
+            description="All buildings in the region",
+        )
+
+        assert result is True
+        metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+
+    def test_includes_layer_description(self, tmp_path: Path) -> None:
+        """Description from layer abstract is included in seeded file."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "roads"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="roads",
+            description="Road centerlines dataset with classification",
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        assert "Road centerlines dataset with classification" in content
+
+    def test_includes_layer_title_in_processing_notes(self, tmp_path: Path) -> None:
+        """Layer title appears in processing_notes when different from name."""
+        import yaml
+
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "census"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="arcgis_featureserver",
+            source_url="https://example.com/arcgis/rest/services/Census/FeatureServer/0",
+            layer_name="Census_Blocks",
+            title="Census Block Groups 2020",
+            description="Census block group boundaries",
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        metadata = yaml.safe_load(content)
+        assert "Census_Blocks" in metadata["processing_notes"]
+        assert "Census Block Groups 2020" in metadata["processing_notes"]
+
+    def test_skips_existing_metadata_yaml(self, tmp_path: Path) -> None:
+        """Does not overwrite existing metadata.yaml."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "existing"
+        collection_dir.mkdir()
+        portolan_dir = collection_dir / ".portolan"
+        portolan_dir.mkdir()
+        existing_content = "# User customized\nlicense: CC-BY-4.0\n"
+        (portolan_dir / "metadata.yaml").write_text(existing_content)
+
+        result = seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="test",
+            description="This should not appear",
+        )
+
+        assert result is False
+        content = (portolan_dir / "metadata.yaml").read_text()
+        assert "User customized" in content
+        assert "This should not appear" not in content
+
+    def test_handles_none_description(self, tmp_path: Path) -> None:
+        """Works when description is None."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "no_desc"
+        collection_dir.mkdir()
+
+        result = seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="unnamed_layer",
+            title=None,
+            description=None,
+        )
+
+        assert result is True
+        metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "source_url" in content
+        assert "processing_notes" in content
+
+    def test_handles_none_title(self, tmp_path: Path) -> None:
+        """Works when title is None - doesn't add title to processing_notes."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "no_title"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="my_layer",
+            title=None,
+            description="Has description but no title",
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        assert "my_layer" in content
+        assert "Has description but no title" in content
+
+    def test_title_same_as_name_not_duplicated(self, tmp_path: Path) -> None:
+        """When title equals layer_name, don't duplicate in processing_notes."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "same_name"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="buildings",
+            title="buildings",  # Same as layer_name
+            description="Some buildings",
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        # Should not have "(buildings)" appended since title == name
+        assert "Extracted from wfs layer: buildings" in content
+        assert "(buildings)" not in content
+
+    def test_includes_source_url(self, tmp_path: Path) -> None:
+        """Source URL is included in seeded metadata."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "with_url"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="arcgis_featureserver",
+            source_url="https://services.arcgis.com/abc/FeatureServer/0",
+            layer_name="test",
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        assert "https://services.arcgis.com/abc/FeatureServer/0" in content
+
+    def test_includes_keywords_when_provided(self, tmp_path: Path) -> None:
+        """Keywords are included when provided."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "with_keywords"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="parks",
+            keywords=["recreation", "green space", "urban"],
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        assert "recreation" in content
+        assert "green space" in content
+        assert "urban" in content
+
+    def test_creates_portolan_dir_if_missing(self, tmp_path: Path) -> None:
+        """Creates .portolan directory if it doesn't exist."""
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "new_collection"
+        collection_dir.mkdir()
+        # .portolan does not exist
+
+        result = seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="test",
+        )
+
+        assert result is True
+        assert (collection_dir / ".portolan").is_dir()
+        assert (collection_dir / ".portolan" / "metadata.yaml").exists()
+
+    def test_smart_description_selection_prefers_title_over_technical_abstract(
+        self, tmp_path: Path
+    ) -> None:
+        """Uses title when abstract is a technical name."""
+        import yaml
+
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "smart_select"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="inspire_bu:BU.Building_building_emprise",
+            title="Building - building_emprise",
+            description="bu_building_emprise",  # technical underscore name
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        metadata = yaml.safe_load(content)
+        # Should use title (with spaces/dashes) not abstract (underscores)
+        assert metadata["description"] == "Building - building_emprise"
+
+    def test_smart_description_selection_uses_good_abstract(self, tmp_path: Path) -> None:
+        """Uses abstract when it's a real description."""
+        import yaml
+
+        from portolan_cli.extract.common.metadata_seeding import seed_collection_metadata
+
+        collection_dir = tmp_path / "good_abstract"
+        collection_dir.mkdir()
+
+        seed_collection_metadata(
+            collection_dir,
+            source_type="wfs",
+            source_url="https://example.com/wfs",
+            layer_name="buildings",
+            title="Buildings Layer",
+            description="Footprints of all buildings in the region with roof types",
+        )
+
+        content = (collection_dir / ".portolan" / "metadata.yaml").read_text()
+        metadata = yaml.safe_load(content)
+        # Should use the good abstract, not fall back to title
+        assert (
+            metadata["description"] == "Footprints of all buildings in the region with roof types"
+        )

--- a/tests/unit/extract/csw/test_client.py
+++ b/tests/unit/extract/csw/test_client.py
@@ -40,10 +40,12 @@ class TestFetchMetadataRecord:
 
     def test_returns_none_on_http_error(self) -> None:
         """Returns None when HTTP request fails."""
+        import requests
+
         from portolan_cli.extract.csw.client import fetch_metadata_record
 
         mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = Exception("404 Not Found")
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
 
         with patch("requests.get", return_value=mock_response):
             metadata = fetch_metadata_record("https://example.com/csw?id=missing")
@@ -242,6 +244,8 @@ class TestFetchMetadataForLayer:
 
     def test_tries_next_url_on_failure(self, belgium_buildings_xml: str) -> None:
         """Tries next URL when first one fails."""
+        import requests
+
         from portolan_cli.extract.csw.client import fetch_metadata_for_layer
 
         call_count = 0
@@ -250,7 +254,7 @@ class TestFetchMetadataForLayer:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                raise Exception("First URL failed")
+                raise requests.exceptions.ConnectionError("First URL failed")
             mock_response = MagicMock()
             mock_response.text = belgium_buildings_xml
             mock_response.status_code = 200

--- a/tests/unit/extract/csw/test_client.py
+++ b/tests/unit/extract/csw/test_client.py
@@ -1,0 +1,269 @@
+"""Tests for CSW metadata client."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent.parent / "fixtures" / "csw"
+
+
+class TestFetchMetadataRecord:
+    """Tests for fetch_metadata_record function."""
+
+    @pytest.fixture
+    def belgium_buildings_xml(self) -> str:
+        """Load Belgium buildings ISO 19139 fixture."""
+        fixture_path = FIXTURES_DIR / "belgium_buildings_iso19139.xml"
+        return fixture_path.read_text(encoding="utf-8")
+
+    def test_fetches_and_parses_csw_url(self, belgium_buildings_xml: str) -> None:
+        """Fetches CSW URL and returns parsed ISOMetadata."""
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        mock_response = MagicMock()
+        mock_response.text = belgium_buildings_xml
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response) as mock_get:
+            metadata = fetch_metadata_record("https://example.com/csw?request=GetRecordById&id=abc")
+
+            mock_get.assert_called_once()
+            assert metadata is not None
+            assert metadata.file_identifier == "9a8322bd-f53a-4f99-ad9e-753b45bdee85"
+            assert metadata.title == "INSPIRE - Bâtiments en Wallonie (BE)"
+
+    def test_returns_none_on_http_error(self) -> None:
+        """Returns None when HTTP request fails."""
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("404 Not Found")
+
+        with patch("requests.get", return_value=mock_response):
+            metadata = fetch_metadata_record("https://example.com/csw?id=missing")
+
+            assert metadata is None
+
+    def test_returns_none_on_timeout(self) -> None:
+        """Returns None when request times out."""
+        import requests
+
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        with patch("requests.get", side_effect=requests.exceptions.Timeout):
+            metadata = fetch_metadata_record("https://example.com/csw?id=slow")
+
+            assert metadata is None
+
+    def test_returns_none_on_connection_error(self) -> None:
+        """Returns None when connection fails."""
+        import requests
+
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        with patch("requests.get", side_effect=requests.exceptions.ConnectionError):
+            metadata = fetch_metadata_record("https://example.com/csw?id=offline")
+
+            assert metadata is None
+
+    def test_returns_none_on_parse_error(self) -> None:
+        """Returns None when XML parsing fails."""
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        mock_response = MagicMock()
+        mock_response.text = "<html><body>Not XML metadata</body></html>"
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response):
+            metadata = fetch_metadata_record("https://example.com/not-csw")
+
+            assert metadata is None
+
+    def test_uses_custom_timeout(self, belgium_buildings_xml: str) -> None:
+        """Respects custom timeout parameter."""
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        mock_response = MagicMock()
+        mock_response.text = belgium_buildings_xml
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response) as mock_get:
+            fetch_metadata_record("https://example.com/csw", timeout=120.0)
+
+            mock_get.assert_called_once()
+            call_kwargs = mock_get.call_args.kwargs
+            assert call_kwargs.get("timeout") == 120.0
+
+    def test_default_timeout(self, belgium_buildings_xml: str) -> None:
+        """Uses default timeout of 30 seconds."""
+        from portolan_cli.extract.csw.client import fetch_metadata_record
+
+        mock_response = MagicMock()
+        mock_response.text = belgium_buildings_xml
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.get", return_value=mock_response) as mock_get:
+            fetch_metadata_record("https://example.com/csw")
+
+            call_kwargs = mock_get.call_args.kwargs
+            assert call_kwargs.get("timeout") == 30.0
+
+
+class TestDetectMetadataUrlType:
+    """Tests for detect_metadata_url_type function."""
+
+    def test_detects_csw_getrecordbyid(self) -> None:
+        """Detects CSW GetRecordById URLs."""
+        from portolan_cli.extract.csw.client import detect_metadata_url_type
+
+        url = "https://metawal.wallonie.be/geonetwork/inspire/fre/csw?REQUEST=GetRecordById&SERVICE=CSW&id=abc"
+        assert detect_metadata_url_type(url) == "csw"
+
+    def test_detects_csw_lowercase(self) -> None:
+        """Detects CSW URLs with lowercase parameters."""
+        from portolan_cli.extract.csw.client import detect_metadata_url_type
+
+        url = "https://example.com/csw?request=getrecordbyid&service=csw&id=abc"
+        assert detect_metadata_url_type(url) == "csw"
+
+    def test_detects_static_xml(self) -> None:
+        """Detects static XML file URLs."""
+        from portolan_cli.extract.csw.client import detect_metadata_url_type
+
+        assert detect_metadata_url_type("https://example.com/metadata.xml") == "xml"
+        assert detect_metadata_url_type("https://example.com/path/record.XML") == "xml"
+
+    def test_detects_html(self) -> None:
+        """Detects HTML page URLs."""
+        from portolan_cli.extract.csw.client import detect_metadata_url_type
+
+        assert detect_metadata_url_type("https://example.com/metadata.html") == "html"
+        assert detect_metadata_url_type("https://example.com/record.htm") == "html"
+
+    def test_detects_geonetwork_api(self) -> None:
+        """Detects GeoNetwork API URLs."""
+        from portolan_cli.extract.csw.client import detect_metadata_url_type
+
+        url = "https://example.com/geonetwork/srv/api/records/abc-123"
+        assert detect_metadata_url_type(url) == "geonetwork_api"
+
+    def test_returns_unknown_for_unrecognized(self) -> None:
+        """Returns 'unknown' for unrecognized URL patterns."""
+        from portolan_cli.extract.csw.client import detect_metadata_url_type
+
+        assert detect_metadata_url_type("https://example.com/some/path") == "unknown"
+        assert detect_metadata_url_type("https://example.com/data.json") == "unknown"
+
+
+class TestIsMetadataUrlSupported:
+    """Tests for is_metadata_url_supported function."""
+
+    def test_csw_is_supported(self) -> None:
+        """CSW URLs are supported."""
+        from portolan_cli.extract.csw.client import is_metadata_url_supported
+
+        url = "https://example.com/csw?request=GetRecordById&id=abc"
+        assert is_metadata_url_supported(url) is True
+
+    def test_static_xml_is_supported(self) -> None:
+        """Static XML URLs are supported."""
+        from portolan_cli.extract.csw.client import is_metadata_url_supported
+
+        assert is_metadata_url_supported("https://example.com/metadata.xml") is True
+
+    def test_html_is_not_supported(self) -> None:
+        """HTML URLs are not supported (can't parse)."""
+        from portolan_cli.extract.csw.client import is_metadata_url_supported
+
+        assert is_metadata_url_supported("https://example.com/metadata.html") is False
+
+    def test_unknown_is_not_supported(self) -> None:
+        """Unknown URL types are not supported."""
+        from portolan_cli.extract.csw.client import is_metadata_url_supported
+
+        assert is_metadata_url_supported("https://example.com/random") is False
+
+
+class TestFetchMetadataForLayer:
+    """Tests for fetch_metadata_for_layer convenience function."""
+
+    @pytest.fixture
+    def belgium_buildings_xml(self) -> str:
+        """Load Belgium buildings ISO 19139 fixture."""
+        fixture_path = FIXTURES_DIR / "belgium_buildings_iso19139.xml"
+        return fixture_path.read_text(encoding="utf-8")
+
+    def test_fetches_first_supported_url(self, belgium_buildings_xml: str) -> None:
+        """Fetches from first supported URL in list."""
+        from portolan_cli.extract.csw.client import fetch_metadata_for_layer
+
+        mock_response = MagicMock()
+        mock_response.text = belgium_buildings_xml
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        metadata_urls = [
+            {"url": "https://example.com/page.html"},  # Not supported
+            {"url": "https://example.com/csw?request=GetRecordById&id=abc"},  # Supported
+        ]
+
+        with patch("requests.get", return_value=mock_response):
+            metadata = fetch_metadata_for_layer(metadata_urls)
+
+            assert metadata is not None
+            assert metadata.file_identifier == "9a8322bd-f53a-4f99-ad9e-753b45bdee85"
+
+    def test_returns_none_for_empty_list(self) -> None:
+        """Returns None when no metadata URLs provided."""
+        from portolan_cli.extract.csw.client import fetch_metadata_for_layer
+
+        assert fetch_metadata_for_layer([]) is None
+        assert fetch_metadata_for_layer(None) is None
+
+    def test_returns_none_when_all_unsupported(self) -> None:
+        """Returns None when all URLs are unsupported types."""
+        from portolan_cli.extract.csw.client import fetch_metadata_for_layer
+
+        metadata_urls = [
+            {"url": "https://example.com/page.html"},
+            {"url": "https://example.com/other.htm"},
+        ]
+
+        assert fetch_metadata_for_layer(metadata_urls) is None
+
+    def test_tries_next_url_on_failure(self, belgium_buildings_xml: str) -> None:
+        """Tries next URL when first one fails."""
+        from portolan_cli.extract.csw.client import fetch_metadata_for_layer
+
+        call_count = 0
+
+        def mock_get(url: str, **kwargs: object) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise Exception("First URL failed")
+            mock_response = MagicMock()
+            mock_response.text = belgium_buildings_xml
+            mock_response.status_code = 200
+            mock_response.raise_for_status = MagicMock()
+            return mock_response
+
+        metadata_urls = [
+            {"url": "https://example.com/csw?request=GetRecordById&id=first"},
+            {"url": "https://example.com/csw?request=GetRecordById&id=second"},
+        ]
+
+        with patch("requests.get", side_effect=mock_get):
+            metadata = fetch_metadata_for_layer(metadata_urls)
+
+            assert metadata is not None
+            assert call_count == 2

--- a/tests/unit/extract/csw/test_iso_parser.py
+++ b/tests/unit/extract/csw/test_iso_parser.py
@@ -382,3 +382,43 @@ class TestExtractKeywordsFromThesauri:
         assert metadata.keywords is not None
         assert metadata.keywords.count("Buildings") == 1
         assert "Structures" in metadata.keywords
+
+    def test_invalid_fixture_raises_error(self) -> None:
+        """Invalid fixture file (missing required fields) raises ISOParseError."""
+        from portolan_cli.extract.csw.iso_parser import ISOParseError, parse_iso19139
+
+        fixture_path = FIXTURES_DIR / "invalid_iso19139.xml"
+        xml_content = fixture_path.read_text(encoding="utf-8")
+
+        with pytest.raises(ISOParseError, match="Missing required field"):
+            parse_iso19139(xml_content)
+
+    def test_minimal_fixture_parses(self) -> None:
+        """Minimal fixture parses successfully with only required fields."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        fixture_path = FIXTURES_DIR / "minimal_iso19139.xml"
+        xml_content = fixture_path.read_text(encoding="utf-8")
+
+        metadata = parse_iso19139(xml_content)
+
+        assert metadata.file_identifier == "minimal-test-id"
+        assert metadata.title == "Minimal Test Dataset"
+        assert metadata.abstract == "A minimal test abstract for unit testing."
+
+    def test_csw_wrapped_fixture_parses(self) -> None:
+        """CSW-wrapped fixture parses correctly, extracting MD_Metadata from wrapper."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        fixture_path = FIXTURES_DIR / "csw_wrapped_iso19139.xml"
+        xml_content = fixture_path.read_text(encoding="utf-8")
+
+        metadata = parse_iso19139(xml_content)
+
+        assert metadata.file_identifier == "csw-wrapped-test-id"
+        assert metadata.title == "CSW Wrapped Dataset"
+        assert metadata.contact_organization == "Test Organization"
+        assert metadata.contact_email == "test@example.com"
+        assert metadata.keywords is not None
+        assert "test" in metadata.keywords
+        assert metadata.license_url == "https://creativecommons.org/licenses/by/4.0/"

--- a/tests/unit/extract/csw/test_iso_parser.py
+++ b/tests/unit/extract/csw/test_iso_parser.py
@@ -1,0 +1,384 @@
+"""Tests for ISO 19139 XML parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent.parent / "fixtures" / "csw"
+
+
+class TestParseISO19139:
+    """Tests for parse_iso19139 function."""
+
+    @pytest.fixture
+    def belgium_buildings_xml(self) -> str:
+        """Load Belgium buildings ISO 19139 fixture."""
+        fixture_path = FIXTURES_DIR / "belgium_buildings_iso19139.xml"
+        return fixture_path.read_text(encoding="utf-8")
+
+    def test_parses_file_identifier(self, belgium_buildings_xml: str) -> None:
+        """Extracts file identifier from ISO metadata."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.file_identifier == "9a8322bd-f53a-4f99-ad9e-753b45bdee85"
+
+    def test_parses_title(self, belgium_buildings_xml: str) -> None:
+        """Extracts title from ISO metadata."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.title == "INSPIRE - Bâtiments en Wallonie (BE)"
+
+    def test_parses_abstract(self, belgium_buildings_xml: str) -> None:
+        """Extracts abstract from ISO metadata."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.abstract is not None
+        assert "Cette série de couches de données" in metadata.abstract
+        assert "Directive INSPIRE" in metadata.abstract
+        assert "PICC" in metadata.abstract
+
+    def test_parses_keywords(self, belgium_buildings_xml: str) -> None:
+        """Extracts keywords from multiple thesauri."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.keywords is not None
+        # From various thesauri in the document
+        assert "Bâtiments" in metadata.keywords
+        assert "Building" in metadata.keywords
+        assert "emprise" in metadata.keywords
+
+    def test_parses_contact_organization(self, belgium_buildings_xml: str) -> None:
+        """Extracts contact organization from first pointOfContact."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.contact_organization is not None
+        # First pointOfContact is Helpdesk carto du SPW
+        assert "Helpdesk carto du SPW" in metadata.contact_organization
+
+    def test_parses_contact_email(self, belgium_buildings_xml: str) -> None:
+        """Extracts contact email address."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.contact_email == "helpdesk.carto@spw.wallonie.be"
+
+    def test_parses_license_url(self, belgium_buildings_xml: str) -> None:
+        """Extracts license URL (CC-BY-4.0)."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.license_url == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_parses_license_text(self, belgium_buildings_xml: str) -> None:
+        """Extracts license text description."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.license_text is not None
+        assert "CC-BY 4.0" in metadata.license_text
+
+    def test_parses_access_constraints(self, belgium_buildings_xml: str) -> None:
+        """Extracts access constraints."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.access_constraints is not None
+        assert "limitation" in metadata.access_constraints.lower()
+
+    def test_parses_lineage(self, belgium_buildings_xml: str) -> None:
+        """Extracts lineage/provenance information."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.lineage is not None
+        assert "PICC" in metadata.lineage
+        assert "photogramm" in metadata.lineage.lower()
+
+    def test_parses_thumbnail_url(self, belgium_buildings_xml: str) -> None:
+        """Extracts thumbnail/graphic overview URL."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.thumbnail_url is not None
+        assert "picc_vdiff_2.png" in metadata.thumbnail_url
+
+    def test_parses_scale_denominator(self, belgium_buildings_xml: str) -> None:
+        """Extracts scale denominator."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.scale_denominator == 10000
+
+    def test_parses_topic_category(self, belgium_buildings_xml: str) -> None:
+        """Extracts topic category code."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.topic_category == "imageryBaseMapsEarthCover"
+
+    def test_parses_maintenance_frequency(self, belgium_buildings_xml: str) -> None:
+        """Extracts maintenance frequency code."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.maintenance_frequency == "asNeeded"
+
+    def test_parses_dates(self, belgium_buildings_xml: str) -> None:
+        """Extracts creation, revision, and publication dates."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        metadata = parse_iso19139(belgium_buildings_xml)
+
+        assert metadata.date_created == "2020-10-29"
+        assert metadata.date_revised == "2020-10-29"
+        assert metadata.date_published == "2020-10-29"
+
+    def test_handles_missing_optional_fields(self) -> None:
+        """Gracefully handles missing optional fields."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        minimal_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <csw:GetRecordByIdResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+          <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                           xmlns:gco="http://www.isotc211.org/2005/gco">
+            <gmd:fileIdentifier>
+              <gco:CharacterString>test-id</gco:CharacterString>
+            </gmd:fileIdentifier>
+            <gmd:identificationInfo>
+              <gmd:MD_DataIdentification>
+                <gmd:citation>
+                  <gmd:CI_Citation>
+                    <gmd:title>
+                      <gco:CharacterString>Test Title</gco:CharacterString>
+                    </gmd:title>
+                  </gmd:CI_Citation>
+                </gmd:citation>
+              </gmd:MD_DataIdentification>
+            </gmd:identificationInfo>
+          </gmd:MD_Metadata>
+        </csw:GetRecordByIdResponse>
+        """
+
+        metadata = parse_iso19139(minimal_xml)
+
+        assert metadata.file_identifier == "test-id"
+        assert metadata.title == "Test Title"
+        assert metadata.abstract is None
+        assert metadata.keywords is None
+        assert metadata.license_url is None
+
+    def test_handles_direct_md_metadata_root(self) -> None:
+        """Handles ISO XML with MD_Metadata as root (no CSW wrapper)."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        direct_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                         xmlns:gco="http://www.isotc211.org/2005/gco">
+          <gmd:fileIdentifier>
+            <gco:CharacterString>direct-id</gco:CharacterString>
+          </gmd:fileIdentifier>
+          <gmd:identificationInfo>
+            <gmd:MD_DataIdentification>
+              <gmd:citation>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Direct Title</gco:CharacterString>
+                  </gmd:title>
+                </gmd:CI_Citation>
+              </gmd:citation>
+              <gmd:abstract>
+                <gco:CharacterString>Direct abstract</gco:CharacterString>
+              </gmd:abstract>
+            </gmd:MD_DataIdentification>
+          </gmd:identificationInfo>
+        </gmd:MD_Metadata>
+        """
+
+        metadata = parse_iso19139(direct_xml)
+
+        assert metadata.file_identifier == "direct-id"
+        assert metadata.title == "Direct Title"
+        assert metadata.abstract == "Direct abstract"
+
+    def test_raises_on_invalid_xml(self) -> None:
+        """Raises ParseError on invalid XML."""
+        from portolan_cli.extract.csw.iso_parser import ISOParseError, parse_iso19139
+
+        with pytest.raises(ISOParseError, match="Failed to parse"):
+            parse_iso19139("not valid xml <<<<")
+
+    def test_raises_on_missing_required_fields(self) -> None:
+        """Raises ParseError when required fields are missing."""
+        from portolan_cli.extract.csw.iso_parser import ISOParseError, parse_iso19139
+
+        no_identifier_xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                         xmlns:gco="http://www.isotc211.org/2005/gco">
+          <gmd:identificationInfo>
+            <gmd:MD_DataIdentification>
+              <gmd:citation>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Title Only</gco:CharacterString>
+                  </gmd:title>
+                </gmd:CI_Citation>
+              </gmd:citation>
+            </gmd:MD_DataIdentification>
+          </gmd:identificationInfo>
+        </gmd:MD_Metadata>
+        """
+
+        with pytest.raises(ISOParseError, match="file_identifier"):
+            parse_iso19139(no_identifier_xml)
+
+
+class TestExtractKeywordsFromThesauri:
+    """Tests for keyword extraction from multiple thesauri."""
+
+    def test_extracts_from_character_string(self) -> None:
+        """Extracts keywords from gco:CharacterString elements."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                         xmlns:gco="http://www.isotc211.org/2005/gco">
+          <gmd:fileIdentifier>
+            <gco:CharacterString>test-id</gco:CharacterString>
+          </gmd:fileIdentifier>
+          <gmd:identificationInfo>
+            <gmd:MD_DataIdentification>
+              <gmd:citation>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Test</gco:CharacterString>
+                  </gmd:title>
+                </gmd:CI_Citation>
+              </gmd:citation>
+              <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                  <gmd:keyword>
+                    <gco:CharacterString>Keyword One</gco:CharacterString>
+                  </gmd:keyword>
+                  <gmd:keyword>
+                    <gco:CharacterString>Keyword Two</gco:CharacterString>
+                  </gmd:keyword>
+                </gmd:MD_Keywords>
+              </gmd:descriptiveKeywords>
+            </gmd:MD_DataIdentification>
+          </gmd:identificationInfo>
+        </gmd:MD_Metadata>
+        """
+
+        metadata = parse_iso19139(xml)
+
+        assert metadata.keywords is not None
+        assert "Keyword One" in metadata.keywords
+        assert "Keyword Two" in metadata.keywords
+
+    def test_extracts_from_anchor_elements(self) -> None:
+        """Extracts keywords from gmx:Anchor elements."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                         xmlns:gco="http://www.isotc211.org/2005/gco"
+                         xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                         xmlns:xlink="http://www.w3.org/1999/xlink">
+          <gmd:fileIdentifier>
+            <gco:CharacterString>test-id</gco:CharacterString>
+          </gmd:fileIdentifier>
+          <gmd:identificationInfo>
+            <gmd:MD_DataIdentification>
+              <gmd:citation>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Test</gco:CharacterString>
+                  </gmd:title>
+                </gmd:CI_Citation>
+              </gmd:citation>
+              <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                  <gmd:keyword>
+                    <gmx:Anchor xlink:href="http://example.com/keyword1">Anchor Keyword</gmx:Anchor>
+                  </gmd:keyword>
+                </gmd:MD_Keywords>
+              </gmd:descriptiveKeywords>
+            </gmd:MD_DataIdentification>
+          </gmd:identificationInfo>
+        </gmd:MD_Metadata>
+        """
+
+        metadata = parse_iso19139(xml)
+
+        assert metadata.keywords is not None
+        assert "Anchor Keyword" in metadata.keywords
+
+    def test_deduplicates_keywords(self) -> None:
+        """Removes duplicate keywords from different thesauri."""
+        from portolan_cli.extract.csw.iso_parser import parse_iso19139
+
+        xml = """<?xml version="1.0" encoding="UTF-8"?>
+        <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                         xmlns:gco="http://www.isotc211.org/2005/gco">
+          <gmd:fileIdentifier>
+            <gco:CharacterString>test-id</gco:CharacterString>
+          </gmd:fileIdentifier>
+          <gmd:identificationInfo>
+            <gmd:MD_DataIdentification>
+              <gmd:citation>
+                <gmd:CI_Citation>
+                  <gmd:title>
+                    <gco:CharacterString>Test</gco:CharacterString>
+                  </gmd:title>
+                </gmd:CI_Citation>
+              </gmd:citation>
+              <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                  <gmd:keyword>
+                    <gco:CharacterString>Buildings</gco:CharacterString>
+                  </gmd:keyword>
+                </gmd:MD_Keywords>
+              </gmd:descriptiveKeywords>
+              <gmd:descriptiveKeywords>
+                <gmd:MD_Keywords>
+                  <gmd:keyword>
+                    <gco:CharacterString>Buildings</gco:CharacterString>
+                  </gmd:keyword>
+                  <gmd:keyword>
+                    <gco:CharacterString>Structures</gco:CharacterString>
+                  </gmd:keyword>
+                </gmd:MD_Keywords>
+              </gmd:descriptiveKeywords>
+            </gmd:MD_DataIdentification>
+          </gmd:identificationInfo>
+        </gmd:MD_Metadata>
+        """
+
+        metadata = parse_iso19139(xml)
+
+        assert metadata.keywords is not None
+        assert metadata.keywords.count("Buildings") == 1
+        assert "Structures" in metadata.keywords

--- a/tests/unit/extract/csw/test_models.py
+++ b/tests/unit/extract/csw/test_models.py
@@ -137,11 +137,19 @@ class TestISOMetadata:
         )
         assert with_abstract.has_useful_metadata() is True
 
-        # Has keywords - useful
-        with_keywords = ISOMetadata(
+        # Sparse keywords (< 3) alone are NOT useful (too weak)
+        with_sparse_keywords = ISOMetadata(
             file_identifier="abc",
             title="Test",
             keywords=["buildings", "structures"],
+        )
+        assert with_sparse_keywords.has_useful_metadata() is False
+
+        # 3+ keywords are useful
+        with_keywords = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            keywords=["buildings", "structures", "urban"],
         )
         assert with_keywords.has_useful_metadata() is True
 

--- a/tests/unit/extract/csw/test_models.py
+++ b/tests/unit/extract/csw/test_models.py
@@ -1,0 +1,154 @@
+"""Tests for CSW/ISO metadata models."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestISOMetadata:
+    """Tests for ISOMetadata dataclass."""
+
+    def test_creates_with_all_fields(self) -> None:
+        """ISOMetadata stores all extracted fields."""
+        from portolan_cli.extract.csw.models import ISOMetadata
+
+        metadata = ISOMetadata(
+            file_identifier="9a8322bd-f53a-4f99-ad9e-753b45bdee85",
+            title="INSPIRE - Bâtiments en Wallonie (BE)",
+            abstract="Cette série de couches de données...",
+            keywords=["Bâtiments", "Building", "emprise"],
+            contact_organization="Service public de Wallonie (SPW)",
+            contact_email="helpdesk.carto@spw.wallonie.be",
+            license_url="https://creativecommons.org/licenses/by/4.0/",
+            license_text="CC-BY 4.0",
+            access_constraints="Pas de limitation d'accès public",
+            lineage="Le présent standard de données INSPIRE...",
+            thumbnail_url="https://example.com/thumbnail.png",
+            scale_denominator=10000,
+            topic_category="imageryBaseMapsEarthCover",
+            maintenance_frequency="asNeeded",
+            date_created="2020-10-29",
+            date_revised="2020-10-29",
+            date_published="2020-10-29",
+        )
+
+        assert metadata.file_identifier == "9a8322bd-f53a-4f99-ad9e-753b45bdee85"
+        assert metadata.title == "INSPIRE - Bâtiments en Wallonie (BE)"
+        assert "Bâtiments" in metadata.keywords
+        assert metadata.license_url == "https://creativecommons.org/licenses/by/4.0/"
+
+    def test_creates_with_minimal_fields(self) -> None:
+        """ISOMetadata works with only required fields."""
+        from portolan_cli.extract.csw.models import ISOMetadata
+
+        metadata = ISOMetadata(
+            file_identifier="abc-123",
+            title="Test Dataset",
+        )
+
+        assert metadata.file_identifier == "abc-123"
+        assert metadata.title == "Test Dataset"
+        assert metadata.abstract is None
+        assert metadata.keywords is None
+        assert metadata.license_url is None
+
+    def test_to_extracted_metadata(self) -> None:
+        """ISOMetadata converts to ExtractedMetadata for seeding."""
+        from portolan_cli.extract.csw.models import ISOMetadata
+
+        iso = ISOMetadata(
+            file_identifier="abc-123",
+            title="Buildings Dataset",
+            abstract="All buildings in the region",
+            keywords=["Buildings", "Structures"],
+            contact_organization="GIS Department",
+            contact_email="gis@example.com",
+            license_url="https://creativecommons.org/licenses/by/4.0/",
+            license_text="CC-BY 4.0",
+            lineage="Derived from aerial photography",
+        )
+
+        extracted = iso.to_extracted_metadata(source_url="https://example.com/wfs")
+
+        assert extracted.source_type == "csw_iso19139"
+        assert extracted.source_url == "https://example.com/wfs"
+        assert extracted.description == "All buildings in the region"
+        assert extracted.keywords == ["Buildings", "Structures"]
+        assert extracted.attribution == "GIS Department"
+        assert "CC-BY 4.0" in (extracted.license_raw or "")
+
+    def test_to_extracted_metadata_uses_title_if_no_abstract(self) -> None:
+        """Uses title as description when abstract is missing."""
+        from portolan_cli.extract.csw.models import ISOMetadata
+
+        iso = ISOMetadata(
+            file_identifier="abc-123",
+            title="Buildings Dataset",
+            abstract=None,
+        )
+
+        extracted = iso.to_extracted_metadata(source_url="https://example.com/wfs")
+
+        assert extracted.description == "Buildings Dataset"
+
+    def test_get_license_spdx_identifier(self) -> None:
+        """Extracts SPDX identifier from license URL."""
+        from portolan_cli.extract.csw.models import ISOMetadata
+
+        # CC-BY-4.0
+        iso = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            license_url="https://creativecommons.org/licenses/by/4.0/",
+        )
+        assert iso.get_license_spdx() == "CC-BY-4.0"
+
+        # CC0
+        iso2 = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            license_url="https://creativecommons.org/publicdomain/zero/1.0/",
+        )
+        assert iso2.get_license_spdx() == "CC0-1.0"
+
+        # Unknown
+        iso3 = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            license_url="https://example.com/custom-license",
+        )
+        assert iso3.get_license_spdx() is None
+
+    def test_has_useful_metadata(self) -> None:
+        """Checks if metadata has more than just identifier/title."""
+        from portolan_cli.extract.csw.models import ISOMetadata
+
+        # Minimal - not useful
+        minimal = ISOMetadata(file_identifier="abc", title="Test")
+        assert minimal.has_useful_metadata() is False
+
+        # Has abstract - useful
+        with_abstract = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            abstract="Real description here",
+        )
+        assert with_abstract.has_useful_metadata() is True
+
+        # Has keywords - useful
+        with_keywords = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            keywords=["buildings", "structures"],
+        )
+        assert with_keywords.has_useful_metadata() is True
+
+        # Has license - useful
+        with_license = ISOMetadata(
+            file_identifier="abc",
+            title="Test",
+            license_url="https://creativecommons.org/licenses/by/4.0/",
+        )
+        assert with_license.has_useful_metadata() is True

--- a/tests/unit/extract/wfs/test_discovery.py
+++ b/tests/unit/extract/wfs/test_discovery.py
@@ -99,6 +99,7 @@ class TestDiscoverLayers:
         mock_layer = MagicMock()
         mock_layer.title = "Buildings"
         mock_layer.abstract = "Building footprints"
+        mock_layer.keywords = ["Buildings", "Bâtiments"]
         mock_layer.boundingBoxWGS84 = (-122.5, 37.5, -122.0, 38.0)
 
         mock_wfs.contents = {"ns:buildings": mock_layer}
@@ -109,6 +110,7 @@ class TestDiscoverLayers:
 
         assert len(result.layers) == 1
         assert result.layers[0].name == "ns:buildings"
+        assert result.layers[0].keywords == ["Buildings", "Bâtiments"]
         assert result.service_url == "https://example.com/wfs"
         assert result.service_title == "Test WFS Service"
         assert result.service_abstract == "A test WFS service"
@@ -127,6 +129,7 @@ class TestDiscoverLayers:
         mock_layer = MagicMock()
         mock_layer.title = "Roads"
         mock_layer.abstract = None
+        mock_layer.keywords = None
         mock_layer.boundingBoxWGS84 = None
 
         mock_wfs.contents = {"roads": mock_layer}
@@ -136,8 +139,44 @@ class TestDiscoverLayers:
             result = discover_layers("https://example.com/wfs")
 
         assert len(result.layers) == 1
+        assert result.layers[0].keywords is None
         assert result.service_title is None
         assert result.provider is None
+
+    def test_discover_layers_extracts_layer_keywords(self) -> None:
+        """discover_layers extracts layer-specific keywords."""
+        from unittest.mock import MagicMock
+
+        mock_wfs = MagicMock()
+        mock_wfs.identification = None
+        mock_wfs.provider = None
+
+        # Layer with keywords
+        mock_layer1 = MagicMock()
+        mock_layer1.title = "Buildings"
+        mock_layer1.abstract = "Building footprints"
+        mock_layer1.keywords = ["Buildings", "Structures", "Bâtiments"]
+        mock_layer1.boundingBoxWGS84 = None
+
+        # Layer without keywords
+        mock_layer2 = MagicMock()
+        mock_layer2.title = "Roads"
+        mock_layer2.abstract = None
+        mock_layer2.keywords = []
+        mock_layer2.boundingBoxWGS84 = None
+
+        mock_wfs.contents = {"buildings": mock_layer1, "roads": mock_layer2}
+
+        with patch("geoparquet_io.core.wfs.get_wfs_capabilities") as mock_get:
+            mock_get.return_value = mock_wfs
+            result = discover_layers("https://example.com/wfs")
+
+        assert len(result.layers) == 2
+        buildings_layer = next(lyr for lyr in result.layers if lyr.name == "buildings")
+        roads_layer = next(lyr for lyr in result.layers if lyr.name == "roads")
+
+        assert buildings_layer.keywords == ["Buildings", "Structures", "Bâtiments"]
+        assert roads_layer.keywords is None  # Empty list -> None
 
 
 class TestLayerInfo:
@@ -171,6 +210,30 @@ class TestLayerInfo:
 
         d = layer.to_filter_dict()
         assert d["id"] == 5
+
+    def test_layer_info_with_keywords(self) -> None:
+        """LayerInfo stores layer-specific keywords."""
+        layer = LayerInfo(
+            name="buildings",
+            typename="inspire_bu:BU.Building",
+            title="Buildings",
+            abstract="Building footprints",
+            keywords=["Buildings", "Bâtiments"],
+            bbox=(-122.5, 37.5, -122.0, 38.0),
+            id=0,
+        )
+
+        assert layer.keywords == ["Buildings", "Bâtiments"]
+
+    def test_layer_info_keywords_default_none(self) -> None:
+        """LayerInfo keywords default to None."""
+        layer = LayerInfo(
+            name="roads",
+            typename="roads",
+            title="Roads",
+        )
+
+        assert layer.keywords is None
 
 
 class TestWFSDiscoveryError:

--- a/tests/unit/extract/wfs/test_metadata.py
+++ b/tests/unit/extract/wfs/test_metadata.py
@@ -95,3 +95,153 @@ class TestWFSMetadata:
         assert extracted.source_url == "https://example.com/wfs"
         assert extracted.description is None
         assert extracted.attribution is None
+
+    def test_to_extracted_detects_geoserver_boilerplate(self) -> None:
+        """GeoServer default description is detected as boilerplate."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title="INSPIRE Buildings Wallonia",
+            service_abstract="This is the reference implementation of WFS 1.0.0 and WFS 1.1.0, supports all WFS operations including Transaction.",
+            provider_name="SPW",
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        # Should use service_title as fallback, not boilerplate
+        assert extracted.description == "INSPIRE Buildings Wallonia"
+
+    def test_to_extracted_detects_mapserver_boilerplate(self) -> None:
+        """MapServer default description is detected as boilerplate."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title="City GIS Data",
+            service_abstract="WFS server maintained by MapServer",
+            provider_name="City GIS",
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        assert extracted.description == "City GIS Data"
+
+    def test_to_extracted_keeps_real_description(self) -> None:
+        """Real descriptions are kept, not replaced by title."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title="Buildings WFS",
+            service_abstract="INSPIRE buildings data for the Wallonia region of Belgium, including footprints and 3D models.",
+            provider_name="SPW",
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        assert (
+            extracted.description
+            == "INSPIRE buildings data for the Wallonia region of Belgium, including footprints and 3D models."
+        )
+
+    def test_to_extracted_title_fallback_when_abstract_none(self) -> None:
+        """When abstract is None, use service_title as description."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title="INSPIRE Buildings Wallonia",
+            service_abstract=None,
+            provider_name="SPW",
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        assert extracted.description == "INSPIRE Buildings Wallonia"
+
+    def test_to_extracted_none_when_both_missing(self) -> None:
+        """When both abstract and title are None, description is None."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title=None,
+            service_abstract=None,
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        assert extracted.description is None
+
+    def test_to_extracted_none_when_both_boilerplate(self) -> None:
+        """When both abstract and title are boilerplate, description is None."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title="GeoServer Web Feature Service",
+            service_abstract="This is the reference implementation of WFS 1.0.0",
+            provider_name="SPW",
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        # Both are boilerplate, so description should be None
+        assert extracted.description is None
+
+    def test_to_extracted_skips_boilerplate_title(self) -> None:
+        """Don't use boilerplate title as fallback."""
+        wfs_metadata = WFSMetadata(
+            source_url="https://example.com/wfs",
+            service_title="Web Feature Service",
+            service_abstract=None,
+            provider_name="SPW",
+        )
+
+        extracted = wfs_metadata.to_extracted()
+
+        # Title is generic boilerplate, don't use it
+        assert extracted.description is None
+
+
+class TestIsBoilerplateDescription:
+    """Tests for boilerplate detection."""
+
+    def test_geoserver_reference_implementation(self) -> None:
+        """Detect GeoServer default text."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        text = "This is the reference implementation of WFS 1.0.0 and WFS 1.1.0, supports all WFS operations including Transaction."
+        assert is_boilerplate_description(text) is True
+
+    def test_mapserver_mention(self) -> None:
+        """Detect MapServer boilerplate."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        assert is_boilerplate_description("WFS server maintained by MapServer") is True
+
+    def test_geoserver_mention(self) -> None:
+        """Detect GeoServer mention."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        assert is_boilerplate_description("Powered by GeoServer") is True
+
+    def test_real_description_not_boilerplate(self) -> None:
+        """Real descriptions are not flagged."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        text = "INSPIRE buildings data for the Wallonia region of Belgium"
+        assert is_boilerplate_description(text) is False
+
+    def test_none_not_boilerplate(self) -> None:
+        """None is not boilerplate (it's just missing)."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        assert is_boilerplate_description(None) is False
+
+    def test_empty_string_not_boilerplate(self) -> None:
+        """Empty string is not boilerplate."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        assert is_boilerplate_description("") is False
+
+    def test_geoserver_wfs_title_boilerplate(self) -> None:
+        """GeoServer default WFS title is boilerplate."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        assert is_boilerplate_description("GeoServer Web Feature Service") is True
+
+    def test_generic_wfs_title_boilerplate(self) -> None:
+        """Generic 'Web Feature Service' title is boilerplate."""
+        from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+
+        assert is_boilerplate_description("Web Feature Service") is True

--- a/tests/unit/extract/wfs/test_metadata.py
+++ b/tests/unit/extract/wfs/test_metadata.py
@@ -111,11 +111,11 @@ class TestWFSMetadata:
         assert extracted.description == "INSPIRE Buildings Wallonia"
 
     def test_to_extracted_detects_mapserver_boilerplate(self) -> None:
-        """MapServer default description is detected as boilerplate."""
+        """MapServer default WFS title is detected as boilerplate."""
         wfs_metadata = WFSMetadata(
             source_url="https://example.com/wfs",
             service_title="City GIS Data",
-            service_abstract="WFS server maintained by MapServer",
+            service_abstract="MapServer Web Feature Service",  # Actual boilerplate phrase
             provider_name="City GIS",
         )
 
@@ -203,17 +203,20 @@ class TestIsBoilerplateDescription:
         text = "This is the reference implementation of WFS 1.0.0 and WFS 1.1.0, supports all WFS operations including Transaction."
         assert is_boilerplate_description(text) is True
 
-    def test_mapserver_mention(self) -> None:
-        """Detect MapServer boilerplate."""
+    def test_mapserver_wfs_boilerplate(self) -> None:
+        """Detect MapServer WFS boilerplate phrase."""
         from portolan_cli.extract.wfs.metadata import is_boilerplate_description
 
-        assert is_boilerplate_description("WFS server maintained by MapServer") is True
+        assert is_boilerplate_description("MapServer Web Feature Service") is True
 
-    def test_geoserver_mention(self) -> None:
-        """Detect GeoServer mention."""
+    def test_geoserver_mention_not_boilerplate(self) -> None:
+        """Mere mention of GeoServer is NOT boilerplate (could be legitimate)."""
         from portolan_cli.extract.wfs.metadata import is_boilerplate_description
 
-        assert is_boilerplate_description("Powered by GeoServer") is True
+        # "Powered by GeoServer" is a legitimate description, not default text
+        assert is_boilerplate_description("Powered by GeoServer") is False
+        # But actual processing info is fine
+        assert is_boilerplate_description("Data processed using GeoServer tools") is False
 
     def test_real_description_not_boilerplate(self) -> None:
         """Real descriptions are not flagged."""

--- a/tests/unit/extract/wfs/test_orchestrator.py
+++ b/tests/unit/extract/wfs/test_orchestrator.py
@@ -434,3 +434,174 @@ class TestWFSMetadataSeeding:
 
         # No collection directory created since layer failed
         assert not (tmp_path / "failed_layer" / ".portolan" / "metadata.yaml").exists()
+
+    def test_seed_collection_metadata_wfs_uses_iso_metadata(self, tmp_path: Path) -> None:
+        """ISO metadata from CSW takes precedence over WFS GetCapabilities metadata."""
+
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+        from portolan_cli.extract.csw.models import ISOMetadata
+        from portolan_cli.extract.wfs.orchestrator import _seed_collection_metadata_wfs
+
+        # Create collection directory structure
+        collection_dir = tmp_path / "buildings_abc123"
+        collection_dir.mkdir()
+        (collection_dir / ".portolan").mkdir()
+
+        # Layer with metadata_urls (triggers CSW fetch)
+        discovery = make_discovery_result(
+            [
+                LayerInfo(
+                    name="ns:buildings",
+                    typename="ns:buildings",
+                    title="WFS Title",
+                    abstract="WFS Abstract (should be overridden)",
+                    bbox=None,
+                    id=0,
+                    metadata_urls=[{"url": "https://csw.example.com/record"}],
+                ),
+            ]
+        )
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://example.com/wfs",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://example.com/wfs",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="ns:buildings",
+                    status="success",
+                    features=100,
+                    size_bytes=1000,
+                    duration_seconds=1.0,
+                    output_path="buildings_abc123/buildings_abc123.parquet",
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=100,
+                total_size_bytes=1000,
+                total_duration_seconds=1.0,
+            ),
+        )
+
+        # Mock the CSW fetch to return rich ISO metadata
+        mock_iso = ISOMetadata(
+            file_identifier="test-iso-id",
+            title="ISO Title",
+            abstract="Rich ISO description from CSW",
+            contact_organization="ISO Contact Org",
+            contact_email="iso@example.com",
+        )
+
+        with patch(
+            "portolan_cli.extract.wfs.orchestrator._try_fetch_iso_metadata",
+            return_value=mock_iso,
+        ):
+            _seed_collection_metadata_wfs(tmp_path, report, discovery)
+
+        metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        # ISO metadata should be used, not WFS metadata
+        assert "Rich ISO description from CSW" in content
+        assert "WFS Abstract" not in content
+
+    def test_seed_collection_metadata_wfs_nested_output_path(self, tmp_path: Path) -> None:
+        """Collection seeding handles nested output paths correctly."""
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+        from portolan_cli.extract.wfs.orchestrator import _seed_collection_metadata_wfs
+
+        # Create nested collection directory structure (like multi-layer extract)
+        nested_dir = tmp_path / "service" / "layer_abc123"
+        nested_dir.mkdir(parents=True)
+        (nested_dir / ".portolan").mkdir()
+
+        discovery = make_discovery_result(
+            [
+                LayerInfo(
+                    name="ns:layer",
+                    typename="ns:layer",
+                    title="Nested Layer",
+                    abstract="Layer in nested structure",
+                    bbox=None,
+                    id=0,
+                ),
+            ]
+        )
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://example.com/wfs",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://example.com/wfs",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="ns:layer",
+                    status="success",
+                    features=50,
+                    size_bytes=500,
+                    duration_seconds=0.5,
+                    # Nested output path
+                    output_path="service/layer_abc123/layer_abc123.parquet",
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=50,
+                total_size_bytes=500,
+                total_duration_seconds=0.5,
+            ),
+        )
+
+        _seed_collection_metadata_wfs(tmp_path, report, discovery)
+
+        # Metadata should be in the nested collection directory
+        metadata_path = nested_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "Layer in nested structure" in content

--- a/tests/unit/extract/wfs/test_orchestrator.py
+++ b/tests/unit/extract/wfs/test_orchestrator.py
@@ -226,3 +226,211 @@ class TestExtractWfsCatalogListMode:
             )
 
         assert len(report.layers) == 1
+
+
+class TestWFSMetadataSeeding:
+    """Tests for WFS metadata seeding functions."""
+
+    def test_report_metadata_to_wfs_metadata_conversion(self) -> None:
+        """Converts MetadataExtracted to WFSMetadata correctly."""
+        from portolan_cli.extract.common.report import MetadataExtracted
+        from portolan_cli.extract.wfs.orchestrator import _report_metadata_to_wfs_metadata
+
+        report_metadata = MetadataExtracted(
+            source_url="https://example.com/wfs",
+            description="A test WFS service",
+            attribution="Test Provider",
+            keywords=["test", "wfs"],
+            contact_name="Test Contact",
+            processing_notes="WFS service: Test Service",
+            known_issues=None,
+            license_info_raw="CC-BY-4.0",
+        )
+
+        wfs_metadata = _report_metadata_to_wfs_metadata(report_metadata)
+
+        assert wfs_metadata.source_url == "https://example.com/wfs"
+        assert wfs_metadata.service_abstract == "A test WFS service"
+        assert wfs_metadata.provider_name == "Test Provider"
+        assert wfs_metadata.keywords == ["test", "wfs"]
+        assert wfs_metadata.access_constraints == "CC-BY-4.0"
+
+    def test_seed_metadata_from_extraction_creates_file(self, tmp_path: Path) -> None:
+        """Service-level metadata seeding creates catalog metadata.yaml."""
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            MetadataExtracted,
+        )
+        from portolan_cli.extract.wfs.orchestrator import _seed_metadata_from_extraction
+
+        # Create .portolan directory (normally created by extract_wfs_catalog)
+        (tmp_path / ".portolan").mkdir()
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://example.com/wfs",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://example.com/wfs",
+                description="Test WFS Service",
+                attribution="Test Provider",
+                keywords=["test"],
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[],
+            summary=ExtractionSummary(
+                total_layers=0,
+                succeeded=0,
+                failed=0,
+                skipped=0,
+                total_features=0,
+                total_size_bytes=0,
+                total_duration_seconds=0.0,
+            ),
+        )
+
+        _seed_metadata_from_extraction(tmp_path, report)
+
+        metadata_path = tmp_path / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "Test Provider" in content
+
+    def test_seed_collection_metadata_wfs_creates_files(self, tmp_path: Path) -> None:
+        """Collection-level metadata seeding creates per-collection metadata.yaml."""
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+        from portolan_cli.extract.wfs.orchestrator import _seed_collection_metadata_wfs
+
+        # Create collection directory structure
+        collection_dir = tmp_path / "buildings_abc123"
+        collection_dir.mkdir()
+        (collection_dir / ".portolan").mkdir()
+
+        discovery = make_discovery_result(
+            [
+                LayerInfo(
+                    name="ns:buildings",
+                    typename="ns:buildings",
+                    title="Buildings Layer",
+                    abstract="All buildings in the city",
+                    bbox=None,
+                    id=0,
+                ),
+            ]
+        )
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://example.com/wfs",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://example.com/wfs",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="ns:buildings",
+                    status="success",
+                    features=100,
+                    size_bytes=1000,
+                    duration_seconds=1.0,
+                    output_path="buildings_abc123/buildings_abc123.parquet",
+                    warnings=[],
+                    error=None,
+                    attempts=1,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=1,
+                failed=0,
+                skipped=0,
+                total_features=100,
+                total_size_bytes=1000,
+                total_duration_seconds=1.0,
+            ),
+        )
+
+        _seed_collection_metadata_wfs(tmp_path, report, discovery)
+
+        metadata_path = collection_dir / ".portolan" / "metadata.yaml"
+        assert metadata_path.exists()
+        content = metadata_path.read_text()
+        assert "All buildings in the city" in content
+        assert "Buildings Layer" in content
+
+    def test_seed_collection_metadata_wfs_skips_failed_layers(self, tmp_path: Path) -> None:
+        """Collection seeding skips failed layer results."""
+        from portolan_cli.extract.common.report import (
+            ExtractionReport,
+            ExtractionSummary,
+            LayerResult,
+            MetadataExtracted,
+        )
+        from portolan_cli.extract.wfs.orchestrator import _seed_collection_metadata_wfs
+
+        discovery = make_discovery_result([make_layer_info("failed_layer", 0)])
+
+        report = ExtractionReport(
+            extraction_date="2024-01-01T00:00:00Z",
+            source_url="https://example.com/wfs",
+            portolan_version="0.1.0",
+            gpio_version="1.0.0",
+            metadata_extracted=MetadataExtracted(
+                source_url="https://example.com/wfs",
+                description=None,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            ),
+            layers=[
+                LayerResult(
+                    id=0,
+                    name="failed_layer",
+                    status="failed",
+                    features=0,
+                    size_bytes=0,
+                    duration_seconds=0.0,
+                    output_path="",
+                    warnings=[],
+                    error="Connection timeout",
+                    attempts=3,
+                ),
+            ],
+            summary=ExtractionSummary(
+                total_layers=1,
+                succeeded=0,
+                failed=1,
+                skipped=0,
+                total_features=0,
+                total_size_bytes=0,
+                total_duration_seconds=0.0,
+            ),
+        )
+
+        # Should not raise, should just skip
+        _seed_collection_metadata_wfs(tmp_path, report, discovery)
+
+        # No collection directory created since layer failed
+        assert not (tmp_path / "failed_layer" / ".portolan" / "metadata.yaml").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -4041,6 +4041,7 @@ dependencies = [
     { name = "antimeridian" },
     { name = "click" },
     { name = "cryptography" },
+    { name = "defusedxml" },
     { name = "geoparquet-io" },
     { name = "httpx" },
     { name = "lxml" },
@@ -4083,6 +4084,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "radon" },
     { name = "ruff" },
+    { name = "types-defusedxml" },
     { name = "types-pyyaml" },
     { name = "vulture" },
     { name = "xenon" },
@@ -4118,6 +4120,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.4.1" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.13.4" },
     { name = "cryptography", specifier = ">=46.0.7" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.1" },
     { name = "geoparquet-io", git = "https://github.com/geoparquet/geoparquet-io.git?rev=main" },
     { name = "gitingest", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -4155,6 +4158,7 @@ requires-dist = [
     { name = "rio-cogeo", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.11" },
     { name = "stac-geoparquet", specifier = ">=0.6.0" },
+    { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
@@ -6176,6 +6180,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-defusedxml"
+version = "0.7.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/af/d324da5ffbf0af40477533a09ee6c902de335c445a8dcc88c58f62af6e5f/types_defusedxml-0.7.0.20260408.tar.gz", hash = "sha256:f35377d59344f98b57f9bf319cff2107aac35f9e4d42f9ed6cfeeafacffadb00", size = 10638, upload-time = "2026-04-08T04:26:12.239Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/68/7570cfb818d6a5b3ff964114527e28e360eccf18329b457f057a18596e64/types_defusedxml-0.7.0.20260408-py3-none-any.whl", hash = "sha256:2d68db82412170b91b3e490b7c118a4f4e5a27756a126e2453f629c8d514b106", size = 13435, upload-time = "2026-04-08T04:26:11.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- WFS extraction now fetches rich metadata from ISO 19139 records via MetadataURL links in GetCapabilities
- Collection-level `metadata.yaml` files are seeded with layer-specific descriptions, keywords, contact info, and license details
- Boilerplate detection filters out GeoServer/MapServer default text, falling back to service title when appropriate
- ArcGIS extractor also gains collection-level metadata seeding

## Changes

**New CSW module** (`portolan_cli/extract/csw/`):
- `iso_parser.py`: Parse ISO 19139 XML with XPath extractions for ~15 metadata fields
- `models.py`: `ISOMetadata` dataclass with SPDX license detection
- `client.py`: `fetch_metadata_for_layer()` to fetch and parse CSW/XML metadata URLs

**WFS extractor enhancements**:
- Extract `metadata_urls` from WFS layer discovery
- Seed collection-level `metadata.yaml` from ISO records when available
- Fall back to WFS layer abstract/title if no CSW metadata
- Boilerplate detection for GeoServer/MapServer default descriptions

**Common utilities**:
- `portolan_cli/extract/common/metadata_seeding.py`: Shared collection-level seeding helper

## Test plan

- [x] 514 extract unit tests pass
- [x] 3853 total unit tests pass
- [x] Live test with Belgium INSPIRE WFS shows rich ISO metadata in collection `metadata.yaml`
- [ ] CI passes

## Example output

**Collection metadata.yaml** (from ISO 19139):
```yaml
contact:
  name: helpdesk.carto@spw.wallonie.be
description: 'Cette série de couches de données spatiales compile les informations
  du thème "Bâtiments"...'
attribution: Helpdesk carto du SPW (SPW - Secrétariat général - SPW Digital...)
keywords:
- 2007/2/EC - INSPIRE Directive
- Building
- Bâtiments
- LIDAR
- ... (20+ keywords)
_license_info_from_source: 'Licence CC-BY 4.0...; SPDX: CC-BY-4.0'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collection-level metadata seeding with layer-specific details from ArcGIS, WFS, and CSW sources.
  * Introduced CSW/ISO 19139 metadata support for enhanced WFS layer discovery.
  * Added keywords extraction and improved description handling with boilerplate detection.

* **Documentation**
  * Updated guides to reflect two-scope metadata seeding: catalog-level and collection-level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->