### PR TITLE
fix(extract): propagate rich metadata to STAC from WFS/ArcGIS

### DIFF
--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -591,10 +591,17 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
             except ValueError:
                 pass
 
-    init_catalog(output_dir, title=title, description=description)
+    # Filter technical names BEFORE init_catalog to avoid writing them
+    # (update_stac_metadata can't overwrite if init_catalog already wrote them)
+    from portolan_cli.stac import is_technical_name
+
+    filtered_title = None if is_technical_name(title) else title
+    filtered_description = None if is_technical_name(description) else description
+
+    init_catalog(output_dir, title=filtered_title, description=filtered_description)
 
     # Per Issue #369: Update catalog.json with rich metadata
-    # (in case init_catalog used defaults due to technical name filtering)
+    # This handles cases where init_catalog used defaults
     catalog_path = output_dir / "catalog.json"
     update_stac_metadata(catalog_path, title=title, description=description)
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -555,9 +555,13 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
     Creates catalog.json, config.yaml, and collection.json for each layer.
     Also seeds metadata.yaml from extracted service metadata and adds
     provenance links (Issue #353).
+
+    Per Issue #369: Propagates rich metadata from ArcGIS service to STAC files,
+    avoiding generic placeholders.
     """
     from portolan_cli.catalog import init_catalog
     from portolan_cli.dataset import add_files
+    from portolan_cli.stac import update_stac_metadata
 
     # Get list of successfully extracted parquet files
     parquet_files = [
@@ -570,19 +574,29 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
         return  # Nothing to add
 
     # Initialize the catalog
-    # Extract title from service metadata if available
+    # Extract title from service metadata if available (Issue #369)
     title = None
-    if report.metadata_extracted and report.metadata_extracted.source_url:
+    description = None
+    if report.metadata_extracted:
+        # Use description from service metadata
+        description = report.metadata_extracted.description
+
         # Use service name from URL as title
-        from portolan_cli.extract.arcgis.url_parser import parse_arcgis_url
+        if report.metadata_extracted.source_url:
+            from portolan_cli.extract.arcgis.url_parser import parse_arcgis_url
 
-        try:
-            parsed = parse_arcgis_url(report.metadata_extracted.source_url)
-            title = parsed.service_name
-        except ValueError:
-            pass
+            try:
+                parsed = parse_arcgis_url(report.metadata_extracted.source_url)
+                title = parsed.service_name
+            except ValueError:
+                pass
 
-    init_catalog(output_dir, title=title)
+    init_catalog(output_dir, title=title, description=description)
+
+    # Per Issue #369: Update catalog.json with rich metadata
+    # (in case init_catalog used defaults due to technical name filtering)
+    catalog_path = output_dir / "catalog.json"
+    update_stac_metadata(catalog_path, title=title, description=description)
 
     # Add all extracted parquet files
     add_files(
@@ -597,6 +611,7 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
     _add_via_links_to_collections(output_dir, report)
 
     # Seed collection-level metadata.yaml with layer details
+    # and update collection.json with rich metadata (Issue #369)
     _seed_collection_metadata_arcgis(output_dir, report)
 
 

--- a/portolan_cli/extract/common/metadata_seeding.py
+++ b/portolan_cli/extract/common/metadata_seeding.py
@@ -9,42 +9,9 @@ Used by both WFS and ArcGIS extraction backends to populate collection-level
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
-
-def _is_technical_name(text: str | None) -> bool:
-    """Check if text looks like a technical/internal name rather than description.
-
-    Technical names are typically short identifiers that aren't useful as descriptions:
-    - Single words with underscores/dashes (e.g., "bu_building_emprise")
-    - Very short (under 20 chars) without spaces
-    - Prefixed with common tech patterns (e.g., "ns:LayerName")
-
-    Args:
-        text: Text to check.
-
-    Returns:
-        True if text looks like a technical name.
-    """
-    if not text:
-        return True
-
-    text = text.strip()
-
-    # Very short without spaces = likely technical
-    if len(text) < 20 and " " not in text:
-        return True
-
-    # Contains namespace prefix (ns:name pattern)
-    if re.match(r"^[a-z_]+:[A-Za-z]", text):
-        return True
-
-    # All lowercase with underscores, no spaces
-    if re.match(r"^[a-z0-9_]+$", text):
-        return True
-
-    return False
+from portolan_cli.stac import is_technical_name as _is_technical_name
 
 
 def _select_best_description(

--- a/portolan_cli/extract/common/metadata_seeding.py
+++ b/portolan_cli/extract/common/metadata_seeding.py
@@ -97,6 +97,9 @@ def seed_collection_metadata(
     Creates .portolan/metadata.yaml within the collection directory with
     layer-specific metadata (title, description) plus inherited source info.
 
+    Also updates collection.json with title/description per Issue #369
+    (propagate rich metadata to STAC, not just metadata.yaml).
+
     Automatically selects the best description from available fields:
     - Prefers abstract if it's a real description (not just a technical name)
     - Falls back to title if abstract looks like an identifier
@@ -116,6 +119,7 @@ def seed_collection_metadata(
     """
     from portolan_cli.metadata_extraction import ExtractedMetadata
     from portolan_cli.metadata_seeding import seed_metadata_yaml
+    from portolan_cli.stac import update_stac_metadata
 
     # Select best description from available fields
     best_description = _select_best_description(description, title, layer_name)
@@ -133,4 +137,15 @@ def seed_collection_metadata(
     )
 
     metadata_path = collection_dir / ".portolan" / "metadata.yaml"
-    return seed_metadata_yaml(extracted, metadata_path)
+    seeded = seed_metadata_yaml(extracted, metadata_path)
+
+    # Per Issue #369: Also update collection.json with title/description
+    # This ensures STAC has meaningful metadata, not generic placeholders
+    collection_path = collection_dir / "collection.json"
+    update_stac_metadata(
+        collection_path,
+        title=title,
+        description=best_description,
+    )
+
+    return seeded

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -615,8 +615,12 @@ def _auto_init_catalog(
     Creates catalog.json, config.yaml, and collection.json for each layer.
     Also adds provenance via links, seeds metadata.yaml from service metadata,
     and seeds collection-level metadata.yaml with layer info.
+
+    Per Issue #369: Propagates rich metadata from WFS service to STAC files,
+    avoiding generic placeholders.
     """
     from portolan_cli.catalog import add_files, init_catalog
+    from portolan_cli.stac import update_stac_metadata
 
     parquet_files = [
         output_dir / result.output_path
@@ -627,7 +631,16 @@ def _auto_init_catalog(
     if not parquet_files:
         return
 
-    init_catalog(output_dir, title=None)
+    # Extract service title and description from discovery result (Issue #369)
+    service_title = discovery_result.service_title if discovery_result else None
+    service_description = discovery_result.service_abstract if discovery_result else None
+
+    init_catalog(output_dir, title=service_title, description=service_description)
+
+    # If init_catalog didn't use the metadata (e.g., technical names filtered),
+    # update catalog.json directly to ensure rich metadata is propagated
+    catalog_path = output_dir / "catalog.json"
+    update_stac_metadata(catalog_path, title=service_title, description=service_description)
 
     add_files(
         paths=parquet_files,
@@ -641,6 +654,7 @@ def _auto_init_catalog(
     _seed_metadata_from_extraction(output_dir, report)
 
     # Seed collection-level metadata.yaml with layer-specific info
+    # and update collection.json with rich metadata (Issue #369)
     if discovery_result:
         _seed_collection_metadata_wfs(output_dir, report, discovery_result)
 
@@ -846,6 +860,9 @@ def _seed_collection_from_iso(
 ) -> bool:
     """Seed collection metadata.yaml from ISO 19139 metadata.
 
+    Also updates collection.json with title/description from ISO metadata
+    per Issue #369 (propagate rich metadata to STAC, not just metadata.yaml).
+
     Args:
         collection_dir: Path to the collection directory.
         iso_metadata: Parsed ISO metadata.
@@ -858,6 +875,7 @@ def _seed_collection_from_iso(
     from dataclasses import replace
 
     from portolan_cli.metadata_seeding import seed_metadata_yaml
+    from portolan_cli.stac import update_stac_metadata
 
     extracted = iso_metadata.to_extracted_metadata(source_url)
 
@@ -869,4 +887,15 @@ def _seed_collection_from_iso(
     )
 
     metadata_path = collection_dir / ".portolan" / "metadata.yaml"
-    return seed_metadata_yaml(extracted, metadata_path)
+    seeded = seed_metadata_yaml(extracted, metadata_path)
+
+    # Per Issue #369: Also update collection.json with title/description
+    # ISO metadata has rich title and abstract that should appear in STAC
+    collection_path = collection_dir / "collection.json"
+    update_stac_metadata(
+        collection_path,
+        title=iso_metadata.title,
+        description=iso_metadata.abstract,
+    )
+
+    return seeded

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -635,10 +635,17 @@ def _auto_init_catalog(
     service_title = discovery_result.service_title if discovery_result else None
     service_description = discovery_result.service_abstract if discovery_result else None
 
-    init_catalog(output_dir, title=service_title, description=service_description)
+    # Filter technical names BEFORE init_catalog to avoid writing them
+    # (update_stac_metadata can't overwrite if init_catalog already wrote them)
+    from portolan_cli.stac import is_technical_name
 
-    # If init_catalog didn't use the metadata (e.g., technical names filtered),
-    # update catalog.json directly to ensure rich metadata is propagated
+    filtered_title = None if is_technical_name(service_title) else service_title
+    filtered_description = None if is_technical_name(service_description) else service_description
+
+    init_catalog(output_dir, title=filtered_title, description=filtered_description)
+
+    # Per Issue #369: Update catalog.json with rich metadata
+    # This handles cases where init_catalog used defaults
     catalog_path = output_dir / "catalog.json"
     update_stac_metadata(catalog_path, title=service_title, description=service_description)
 

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -935,13 +935,17 @@ def add_via_link(
     collection_path.write_text(json.dumps(collection_data, indent=2) + "\n")
 
 
-def _is_technical_name(text: str | None) -> bool:
+def is_technical_name(text: str | None) -> bool:
     """Check if text looks like a technical/internal name rather than description.
 
-    Technical names are typically short identifiers that aren't useful as metadata:
-    - Single words with underscores/dashes (e.g., "bu_building_emprise")
-    - Very short (under 20 chars) without spaces
-    - Prefixed with common tech patterns (e.g., "ns:LayerName")
+    Technical names are typically identifiers that aren't useful as metadata:
+    - Pure snake_case names without spaces (e.g., "bu_building_emprise_v2")
+    - Namespace-prefixed (e.g., "ns:LayerName")
+    - Short all-lowercase without spaces (e.g., "layer1")
+
+    Valid titles include:
+    - CamelCase names (e.g., "DenHaagHousing")
+    - Titles with spaces, even if they contain underscores (e.g., "Building - building_emprise")
 
     Args:
         text: Text to check.
@@ -956,19 +960,28 @@ def _is_technical_name(text: str | None) -> bool:
 
     text = text.strip()
 
-    # Very short without spaces = likely technical
-    if len(text) < 20 and " " not in text:
-        return True
+    # Has spaces → probably human-readable, even if it contains underscores
+    if " " in text:
+        return False
 
-    # Contains namespace prefix (ns:name pattern)
+    # Contains namespace prefix (ns:name pattern) → technical
     if re.match(r"^[a-z_]+:[A-Za-z]", text):
         return True
 
-    # All lowercase with underscores, no spaces
-    if re.match(r"^[a-z0-9_]+$", text):
+    # No spaces + underscores → snake_case identifier
+    if "_" in text:
+        return True
+
+    # Short all-lowercase without CamelCase → technical (e.g., "layer1", "parcels2024")
+    # CamelCase (has uppercase after first char) is allowed
+    if not re.search(r"[A-Z]", text[1:]) and len(text) < 20:
         return True
 
     return False
+
+
+# Alias for internal use (maintains backward compatibility)
+_is_technical_name = is_technical_name
 
 
 def update_stac_metadata(
@@ -1015,7 +1028,15 @@ def update_stac_metadata(
     if effective_title is None and effective_description is None:
         return False
 
-    stac_data = json.loads(path.read_text())
+    try:
+        stac_data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Failed to parse %s: %s — skipping metadata update", path, e
+        )
+        return False
 
     updated = False
 

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -933,3 +933,101 @@ def add_via_link(
     links.append(via_link)
 
     collection_path.write_text(json.dumps(collection_data, indent=2) + "\n")
+
+
+def _is_technical_name(text: str | None) -> bool:
+    """Check if text looks like a technical/internal name rather than description.
+
+    Technical names are typically short identifiers that aren't useful as metadata:
+    - Single words with underscores/dashes (e.g., "bu_building_emprise")
+    - Very short (under 20 chars) without spaces
+    - Prefixed with common tech patterns (e.g., "ns:LayerName")
+
+    Args:
+        text: Text to check.
+
+    Returns:
+        True if text looks like a technical name.
+    """
+    import re
+
+    if not text:
+        return True
+
+    text = text.strip()
+
+    # Very short without spaces = likely technical
+    if len(text) < 20 and " " not in text:
+        return True
+
+    # Contains namespace prefix (ns:name pattern)
+    if re.match(r"^[a-z_]+:[A-Za-z]", text):
+        return True
+
+    # All lowercase with underscores, no spaces
+    if re.match(r"^[a-z0-9_]+$", text):
+        return True
+
+    return False
+
+
+def update_stac_metadata(
+    path: Path,
+    title: str | None = None,
+    description: str | None = None,
+) -> bool:
+    """Update title and/or description in a STAC catalog.json or collection.json.
+
+    This function patches existing STAC files with metadata extracted from
+    external sources (WFS GetCapabilities, ArcGIS REST API, ISO 19139).
+    Used by extraction --auto mode to propagate rich metadata to STAC.
+
+    Per Issue #369: Extraction should populate STAC with meaningful metadata,
+    not leave generic placeholders like "Collection: layer_name_abc123".
+
+    Skips technical-looking names (underscore identifiers, namespace prefixes)
+    to avoid replacing human-readable content with machine identifiers.
+
+    Args:
+        path: Path to catalog.json or collection.json file.
+        title: New title (None to skip updating title).
+        description: New description (None to skip updating description).
+
+    Returns:
+        True if file was updated, False if no changes made or file missing.
+
+    Note:
+        This function is idempotent. Calling multiple times with the same
+        values produces the same result.
+    """
+    import json
+
+    if not path.exists():
+        return False
+
+    # Filter out technical names
+    effective_title = title if title and not _is_technical_name(title) else None
+    effective_description = (
+        description if description and not _is_technical_name(description) else None
+    )
+
+    # Nothing to update
+    if effective_title is None and effective_description is None:
+        return False
+
+    stac_data = json.loads(path.read_text())
+
+    updated = False
+
+    if effective_title is not None:
+        stac_data["title"] = effective_title
+        updated = True
+
+    if effective_description is not None:
+        stac_data["description"] = effective_description
+        updated = True
+
+    if updated:
+        path.write_text(json.dumps(stac_data, indent=2, ensure_ascii=False) + "\n")
+
+    return updated

--- a/tests/integration/extract/test_extract_auto_init.py
+++ b/tests/integration/extract/test_extract_auto_init.py
@@ -325,3 +325,169 @@ class TestExtractWithRawFlag:
         # Should have catalog.json (default behavior)
         assert (output_dir / "catalog.json").exists(), "default extraction should create catalog"
         assert (output_dir / ".portolan" / "config.yaml").exists()
+
+
+class TestMetadataPropagation:
+    """Tests for Issue #369: Propagate rich metadata to STAC files.
+
+    Verifies that extraction --auto mode populates catalog.json and
+    collection.json with meaningful metadata from services, not generic
+    placeholders like 'Collection: layer_name_abc123'.
+    """
+
+    def test_arcgis_service_description_propagates_to_catalog(self, tmp_path: Path) -> None:
+        """ArcGIS service description populates catalog.json description field."""
+        import json
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        # Copy a real fixture
+        layer_dir = output_dir / "test_layer"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        # Create report with rich service description
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    output_path="test_layer/data.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+            source_url="https://services.arcgis.com/abc/arcgis/rest/services/Housing/FeatureServer",
+        )
+        # Add description to metadata
+        report.metadata_extracted = MetadataExtracted(
+            source_url=report.source_url,
+            description="This dataset contains housing information for the municipality including parcels, buildings, and addresses.",
+            attribution="Municipal GIS Department",
+            keywords=["housing", "parcels", "buildings"],
+            contact_name="John Doe",
+            processing_notes=None,
+            known_issues=None,
+            license_info_raw=None,
+        )
+
+        _auto_init_catalog(output_dir, report)
+
+        # Check catalog.json has the description
+        catalog_json = json.loads((output_dir / "catalog.json").read_text())
+        assert "housing information" in catalog_json.get("description", "").lower(), (
+            "Catalog description should contain service description"
+        )
+
+    def test_arcgis_layer_description_propagates_to_collection(self, tmp_path: Path) -> None:
+        """ArcGIS layer description populates collection.json description field."""
+        import json
+        from unittest.mock import patch
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        # Copy a real fixture
+        layer_dir = output_dir / "buildings"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    layer_id=0,
+                    name="Buildings",
+                    output_path="buildings/data.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        # Mock fetch_layer_details to return rich description
+        # Note: imported inside _seed_collection_metadata_arcgis, so patch at source
+        with patch("portolan_cli.extract.arcgis.discovery.fetch_layer_details") as mock_fetch:
+            mock_fetch.return_value = {
+                "name": "Buildings",
+                "description": "Building footprints with construction year and height attributes",
+            }
+            _auto_init_catalog(output_dir, report)
+
+        # Check collection.json has the layer description
+        collection_json = json.loads((layer_dir / "collection.json").read_text())
+        assert "building footprints" in collection_json.get("description", "").lower(), (
+            "Collection description should contain layer description"
+        )
+
+    def test_technical_names_not_used_as_catalog_title(self, tmp_path: Path) -> None:
+        """Technical names like 'bu_building_v2' should not become catalog title."""
+        import json
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "test_layer"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        # URL with technical service name
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    output_path="test_layer/data.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+            source_url="https://example.com/arcgis/rest/services/bu_building_emprise_v2/FeatureServer",
+        )
+
+        _auto_init_catalog(output_dir, report)
+
+        # Title might be set to technical name by URL parsing, but description
+        # should use default, not the technical name
+        catalog_json = json.loads((output_dir / "catalog.json").read_text())
+        # The key thing is we don't error out and catalog is created
+        assert catalog_json.get("id") is not None
+
+    def test_collection_gets_title_from_layer_metadata(self, tmp_path: Path) -> None:
+        """Collection.json title populated from layer metadata."""
+        import json
+        from unittest.mock import patch
+
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "parcels"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    layer_id=0,
+                    name="Parcels",
+                    output_path="parcels/data.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        # Mock fetch_layer_details to return title
+        # Note: imported inside _seed_collection_metadata_arcgis, so patch at source
+        with patch("portolan_cli.extract.arcgis.discovery.fetch_layer_details") as mock_fetch:
+            mock_fetch.return_value = {
+                "name": "Land Parcels",
+                "description": "Municipal land parcel boundaries",
+            }
+            _auto_init_catalog(output_dir, report)
+
+        collection_json = json.loads((layer_dir / "collection.json").read_text())
+        # Title should be present (either from layer name or as set)
+        assert collection_json.get("title") == "Land Parcels", (
+            "Collection title should be set from layer metadata"
+        )

--- a/tests/integration/extract/test_extract_auto_init.py
+++ b/tests/integration/extract/test_extract_auto_init.py
@@ -446,11 +446,19 @@ class TestMetadataPropagation:
 
         _auto_init_catalog(output_dir, report)
 
-        # Title might be set to technical name by URL parsing, but description
-        # should use default, not the technical name
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
-        # The key thing is we don't error out and catalog is created
+        # Catalog should be created
         assert catalog_json.get("id") is not None
+        # Technical name should NOT appear in title (Issue #369)
+        title = catalog_json.get("title")
+        assert title is None or "bu_building_emprise_v2" not in title, (
+            f"Technical name leaked into catalog title: {title}"
+        )
+        # Description should use default, not the technical name
+        description = catalog_json.get("description", "")
+        assert "bu_building_emprise_v2" not in description, (
+            f"Technical name leaked into description: {description}"
+        )
 
     def test_collection_gets_title_from_layer_metadata(self, tmp_path: Path) -> None:
         """Collection.json title populated from layer metadata."""

--- a/tests/integration/extract/wfs/test_wfs_extract.py
+++ b/tests/integration/extract/wfs/test_wfs_extract.py
@@ -765,5 +765,10 @@ class TestWFSMetadataPropagation:
         _auto_init_catalog(output_dir, report, discovery)
 
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
-        # Technical title should be filtered, but description should be set
+        # Technical title should be filtered (Issue #369)
+        title = catalog_json.get("title")
+        assert title is None or "wfs_service_internal_v2" not in title, (
+            f"Technical service title leaked into catalog: {title}"
+        )
+        # Description should be set from the meaningful abstract
         assert "meaningful service description" in catalog_json.get("description", "").lower()

--- a/tests/integration/extract/wfs/test_wfs_extract.py
+++ b/tests/integration/extract/wfs/test_wfs_extract.py
@@ -582,3 +582,188 @@ class TestWFSResume:
         assert extract_calls[0].name == "roads"
         assert report.summary.succeeded == 2
         assert report.summary.failed == 0
+
+
+class TestWFSMetadataPropagation:
+    """Tests for Issue #369: Propagate rich WFS metadata to STAC files.
+
+    Verifies that WFS extraction --auto mode populates catalog.json and
+    collection.json with meaningful metadata from GetCapabilities and ISO 19139,
+    not generic placeholders like 'Collection: layer_name_abc123'.
+    """
+
+    def test_service_title_propagates_to_catalog(self, tmp_path: Path) -> None:
+        """WFS service title from GetCapabilities populates catalog.json title."""
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "buildings"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "buildings.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    name="buildings",
+                    output_path="buildings/buildings.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        # Discovery result with rich service metadata
+        discovery = WFSDiscoveryResult(
+            service_url="https://example.com/wfs",
+            layers=[make_layer_info("buildings", 0)],
+            service_title="INSPIRE Buildings Service",
+            service_abstract="This service provides building footprints compliant with INSPIRE directive",
+            provider="National Mapping Agency",
+            keywords=["inspire", "buildings", "cadastre"],
+            contact_name="GIS Support Team",
+            access_constraints=None,
+            fees=None,
+        )
+
+        _auto_init_catalog(output_dir, report, discovery)
+
+        catalog_json = json.loads((output_dir / "catalog.json").read_text())
+        assert catalog_json.get("title") == "INSPIRE Buildings Service", (
+            "Catalog title should be set from WFS service title"
+        )
+        assert "building footprints" in catalog_json.get("description", "").lower(), (
+            "Catalog description should contain service abstract"
+        )
+
+    def test_service_abstract_propagates_to_catalog_description(self, tmp_path: Path) -> None:
+        """WFS service abstract from GetCapabilities populates catalog.json description."""
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "roads"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "roads.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    name="roads",
+                    output_path="roads/roads.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        discovery = WFSDiscoveryResult(
+            service_url="https://example.com/wfs",
+            layers=[make_layer_info("roads", 0)],
+            service_title="Transport Network Service",
+            service_abstract="Comprehensive road network data including highways, local roads, and paths",
+            provider=None,
+            keywords=None,
+            contact_name=None,
+            access_constraints=None,
+            fees=None,
+        )
+
+        _auto_init_catalog(output_dir, report, discovery)
+
+        catalog_json = json.loads((output_dir / "catalog.json").read_text())
+        assert "road network" in catalog_json.get("description", "").lower()
+
+    def test_layer_metadata_propagates_to_collection(self, tmp_path: Path) -> None:
+        """WFS layer title/abstract from GetCapabilities populates collection.json."""
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "parcels"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "parcels.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    name="parcels",
+                    output_path="parcels/parcels.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        # Create layer with rich metadata
+        layer_info = LayerInfo(
+            name="parcels",
+            typename="ns:Parcels",
+            title="Land Parcels",
+            abstract="Cadastral parcel boundaries with ownership and land use information",
+            keywords=["cadastre", "parcels", "land use"],
+            bbox=None,
+            id=0,
+        )
+
+        discovery = WFSDiscoveryResult(
+            service_url="https://example.com/wfs",
+            layers=[layer_info],
+            service_title="Cadastre Service",
+            service_abstract="Cadastral data",
+            provider=None,
+            keywords=None,
+            contact_name=None,
+            access_constraints=None,
+            fees=None,
+        )
+
+        _auto_init_catalog(output_dir, report, discovery)
+
+        collection_json = json.loads((layer_dir / "collection.json").read_text())
+        assert collection_json.get("title") == "Land Parcels", (
+            "Collection title should be set from layer title"
+        )
+        assert "parcel boundaries" in collection_json.get("description", "").lower(), (
+            "Collection description should contain layer abstract"
+        )
+
+    def test_technical_service_title_filtered(self, tmp_path: Path) -> None:
+        """Technical service titles like 'wfs_service_v2' are filtered out."""
+        output_dir = tmp_path / "test_catalog"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "test"
+        layer_dir.mkdir()
+        fixture_path = FIXTURES_DIR / "simple.parquet"
+        output_parquet = layer_dir / "test.parquet"
+        shutil.copy(fixture_path, output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    name="test",
+                    output_path="test/test.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        # Technical/identifier-like service title should be filtered
+        discovery = WFSDiscoveryResult(
+            service_url="https://example.com/wfs",
+            layers=[make_layer_info("test", 0)],
+            service_title="wfs_service_internal_v2",  # Technical name
+            service_abstract="A meaningful service description with proper explanation",
+            provider=None,
+            keywords=None,
+            contact_name=None,
+            access_constraints=None,
+            fees=None,
+        )
+
+        _auto_init_catalog(output_dir, report, discovery)
+
+        catalog_json = json.loads((output_dir / "catalog.json").read_text())
+        # Technical title should be filtered, but description should be set
+        assert "meaningful service description" in catalog_json.get("description", "").lower()

--- a/tests/unit/test_stac_metadata_update.py
+++ b/tests/unit/test_stac_metadata_update.py
@@ -1,0 +1,331 @@
+"""Unit tests for STAC metadata update functions.
+
+Tests update_stac_metadata which patches title/description in
+catalog.json and collection.json files after initial creation.
+
+Per Issue #369: Extraction --auto mode should propagate rich metadata
+from WFS/ArcGIS services to STAC files, not leave generic placeholders.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+class TestUpdateStacMetadata:
+    """Tests for update_stac_metadata function."""
+
+    @pytest.mark.unit
+    def test_update_catalog_title_and_description(self, tmp_path: Path) -> None:
+        """update_stac_metadata updates both title and description in catalog.json."""
+        from portolan_cli.stac import update_stac_metadata
+
+        catalog_path = tmp_path / "catalog.json"
+        catalog_path.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test-catalog",
+                    "description": "A Portolan-managed STAC catalog",
+                    "stac_version": "1.1.0",
+                    "links": [],
+                }
+            )
+        )
+
+        result = update_stac_metadata(
+            catalog_path,
+            title="Bâtiments INSPIRE",
+            description="Couches de données spatiales des bâtiments",
+        )
+
+        assert result is True
+        data = json.loads(catalog_path.read_text())
+        assert data["title"] == "Bâtiments INSPIRE"
+        assert data["description"] == "Couches de données spatiales des bâtiments"
+
+    @pytest.mark.unit
+    def test_update_collection_title_and_description(self, tmp_path: Path) -> None:
+        """update_stac_metadata updates both title and description in collection.json."""
+        from portolan_cli.stac import update_stac_metadata
+
+        collection_path = tmp_path / "collection.json"
+        collection_path.write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "inspire_bu_bu_building_building_emprise_865a73",
+                    "description": "Collection: inspire_bu_bu_building_building_emprise_865a73",
+                    "stac_version": "1.1.0",
+                    "extent": {
+                        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                    "links": [],
+                    "license": "proprietary",
+                }
+            )
+        )
+
+        result = update_stac_metadata(
+            collection_path,
+            title="Building - building_emprise",
+            description="Cette série de couches de données spatiales compile les informations du thème Bâtiments",
+        )
+
+        assert result is True
+        data = json.loads(collection_path.read_text())
+        assert data["title"] == "Building - building_emprise"
+        assert (
+            data["description"]
+            == "Cette série de couches de données spatiales compile les informations du thème Bâtiments"
+        )
+
+    @pytest.mark.unit
+    def test_update_title_only(self, tmp_path: Path) -> None:
+        """update_stac_metadata can update just title, leaving description unchanged."""
+        from portolan_cli.stac import update_stac_metadata
+
+        catalog_path = tmp_path / "catalog.json"
+        catalog_path.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test",
+                    "description": "Original description",
+                    "stac_version": "1.1.0",
+                    "links": [],
+                }
+            )
+        )
+
+        result = update_stac_metadata(catalog_path, title="New Title")
+
+        assert result is True
+        data = json.loads(catalog_path.read_text())
+        assert data["title"] == "New Title"
+        assert data["description"] == "Original description"
+
+    @pytest.mark.unit
+    def test_update_description_only(self, tmp_path: Path) -> None:
+        """update_stac_metadata can update just description, leaving title unchanged."""
+        from portolan_cli.stac import update_stac_metadata
+
+        collection_path = tmp_path / "collection.json"
+        collection_path.write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "test",
+                    "title": "Original Title",
+                    "description": "Generic description",
+                    "stac_version": "1.1.0",
+                    "extent": {
+                        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                    "links": [],
+                    "license": "proprietary",
+                }
+            )
+        )
+
+        result = update_stac_metadata(
+            collection_path, description="Rich description from ISO 19139"
+        )
+
+        assert result is True
+        data = json.loads(collection_path.read_text())
+        assert data["title"] == "Original Title"
+        assert data["description"] == "Rich description from ISO 19139"
+
+    @pytest.mark.unit
+    def test_no_update_when_both_none(self, tmp_path: Path) -> None:
+        """update_stac_metadata returns False when nothing to update."""
+        from portolan_cli.stac import update_stac_metadata
+
+        catalog_path = tmp_path / "catalog.json"
+        original = {
+            "type": "Catalog",
+            "id": "test",
+            "description": "Original",
+            "stac_version": "1.1.0",
+            "links": [],
+        }
+        catalog_path.write_text(json.dumps(original))
+
+        result = update_stac_metadata(catalog_path, title=None, description=None)
+
+        assert result is False
+        # File should be unchanged
+        data = json.loads(catalog_path.read_text())
+        assert data == original
+
+    @pytest.mark.unit
+    def test_returns_false_for_missing_file(self, tmp_path: Path) -> None:
+        """update_stac_metadata returns False when file doesn't exist."""
+        from portolan_cli.stac import update_stac_metadata
+
+        nonexistent = tmp_path / "nonexistent.json"
+
+        result = update_stac_metadata(nonexistent, title="Title")
+
+        assert result is False
+
+    @pytest.mark.unit
+    def test_preserves_other_fields(self, tmp_path: Path) -> None:
+        """update_stac_metadata preserves all other JSON fields."""
+        from portolan_cli.stac import update_stac_metadata
+
+        collection_path = tmp_path / "collection.json"
+        collection_path.write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "test-collection",
+                    "description": "Old description",
+                    "stac_version": "1.1.0",
+                    "extent": {
+                        "spatial": {"bbox": [[-122.5, 37.5, -122.0, 38.0]]},
+                        "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+                    },
+                    "links": [{"rel": "self", "href": "./collection.json"}],
+                    "license": "CC-BY-4.0",
+                    "summaries": {"proj:code": ["EPSG:4326"]},
+                    "keywords": ["buildings", "inspire"],
+                }
+            )
+        )
+
+        update_stac_metadata(collection_path, title="New Title", description="New Description")
+
+        data = json.loads(collection_path.read_text())
+        # Updated fields
+        assert data["title"] == "New Title"
+        assert data["description"] == "New Description"
+        # Preserved fields
+        assert data["id"] == "test-collection"
+        assert data["stac_version"] == "1.1.0"
+        assert data["extent"]["spatial"]["bbox"] == [[-122.5, 37.5, -122.0, 38.0]]
+        assert data["links"] == [{"rel": "self", "href": "./collection.json"}]
+        assert data["license"] == "CC-BY-4.0"
+        assert data["summaries"] == {"proj:code": ["EPSG:4326"]}
+        assert data["keywords"] == ["buildings", "inspire"]
+
+    @pytest.mark.unit
+    def test_skips_technical_names_for_title(self, tmp_path: Path) -> None:
+        """update_stac_metadata skips technical-looking titles."""
+        from portolan_cli.stac import update_stac_metadata
+
+        catalog_path = tmp_path / "catalog.json"
+        catalog_path.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test",
+                    "title": "Human Readable Title",
+                    "description": "Original",
+                    "stac_version": "1.1.0",
+                    "links": [],
+                }
+            )
+        )
+
+        # Technical name should be skipped
+        result = update_stac_metadata(catalog_path, title="bu_building_emprise")
+
+        assert result is False
+        data = json.loads(catalog_path.read_text())
+        assert data["title"] == "Human Readable Title"
+
+    @pytest.mark.unit
+    def test_skips_technical_names_for_description(self, tmp_path: Path) -> None:
+        """update_stac_metadata skips technical-looking descriptions."""
+        from portolan_cli.stac import update_stac_metadata
+
+        collection_path = tmp_path / "collection.json"
+        collection_path.write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "test",
+                    "description": "Good existing description",
+                    "stac_version": "1.1.0",
+                    "extent": {
+                        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                    "links": [],
+                    "license": "proprietary",
+                }
+            )
+        )
+
+        # Technical name should be skipped
+        result = update_stac_metadata(collection_path, description="ns:layer_name_v2")
+
+        assert result is False
+        data = json.loads(collection_path.read_text())
+        assert data["description"] == "Good existing description"
+
+    @pytest.mark.unit
+    def test_accepts_good_title_with_technical_description(self, tmp_path: Path) -> None:
+        """update_stac_metadata can update title even if description is technical."""
+        from portolan_cli.stac import update_stac_metadata
+
+        catalog_path = tmp_path / "catalog.json"
+        catalog_path.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test",
+                    "description": "Original",
+                    "stac_version": "1.1.0",
+                    "links": [],
+                }
+            )
+        )
+
+        # Good title, technical description (description skipped, title applied)
+        result = update_stac_metadata(
+            catalog_path,
+            title="Buildings Dataset",
+            description="bu_building_v2",
+        )
+
+        assert result is True
+        data = json.loads(catalog_path.read_text())
+        assert data["title"] == "Buildings Dataset"
+        assert data["description"] == "Original"  # Technical description skipped
+
+    @pytest.mark.unit
+    def test_unicode_metadata(self, tmp_path: Path) -> None:
+        """update_stac_metadata handles Unicode characters correctly."""
+        from portolan_cli.stac import update_stac_metadata
+
+        catalog_path = tmp_path / "catalog.json"
+        catalog_path.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test",
+                    "description": "Original",
+                    "stac_version": "1.1.0",
+                    "links": [],
+                }
+            )
+        )
+
+        result = update_stac_metadata(
+            catalog_path,
+            title="Données géographiques françaises",
+            description="Cette couche contient les données des bâtiments avec caractères spéciaux: éàüö",
+        )
+
+        assert result is True
+        data = json.loads(catalog_path.read_text())
+        assert data["title"] == "Données géographiques françaises"
+        assert "caractères spéciaux: éàüö" in data["description"]


### PR DESCRIPTION
## Summary

Fixes #369: WFS/ArcGIS extraction `--auto` mode now populates `catalog.json` and `collection.json` with meaningful metadata from the source service, instead of generic placeholders like `"Collection: layer_name_abc123"`.

**Before:** STAC files had generic/technical names
```json
{
  "title": null,
  "description": "Collection: inspire_bu_bu_building_building_emprise_865a73"
}
```

**After:** STAC files have rich metadata from service
```json
{
  "title": "Building - building_emprise",
  "description": "Cette série de couches de données spatiales compile les informations du thème Bâtiments..."
}
```

## Changes

- Add `update_stac_metadata()` helper in `stac.py` to patch STAC files with title/description
- Update WFS orchestrator to pass `service_title` and `service_abstract` from GetCapabilities to `catalog.json`
- Update ArcGIS orchestrator to pass service description to `catalog.json`  
- Update `_seed_collection_from_iso()` to propagate ISO 19139 title/abstract to `collection.json`
- Update `seed_collection_metadata()` to propagate layer title/description to `collection.json`
- Filter technical names (underscore identifiers, namespace prefixes) to avoid replacing human-readable content

## Test Plan

- [x] Unit tests for `update_stac_metadata()` (11 tests)
- [x] Integration tests for ArcGIS metadata propagation (4 tests)
- [x] Integration tests for WFS metadata propagation (4 tests)
- [x] All existing tests pass
- [x] mypy passes
- [x] ruff passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * STAC catalog and collection title/description are now reliably populated from rich source metadata (ArcGIS, WFS, ISO), with seeded collections receiving propagated metadata.
  * New metadata utilities improve detection of technical identifiers and ensure meaningful metadata is written without overwriting human-friendly values.

* **Tests**
  * Added comprehensive unit and integration tests validating metadata propagation, filtering and partial updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->