### PR TITLE
feat(stac): normalize asset keys and titles for well-known roles

### DIFF
--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -161,6 +161,29 @@ _MEDIA_TYPE_MAP: dict[str, str] = {
     ".html": "text/html",
 }
 
+# Default titles for well-known STAC asset roles. Matches the convention
+# used by Element 84 Earth Search (e.g. Sentinel-2 items always carry a
+# "title" on every asset). Used by _scan_item_assets when no explicit title
+# is set.
+_ROLE_TITLES: dict[str, str] = {
+    "data": "Data",
+    "thumbnail": "Thumbnail",
+    "metadata": "Metadata",
+    "documentation": "Documentation",
+}
+
+# Asset keys reserved for well-known roles. _scan_item_assets prefers these
+# keys over filename-derived stems so STAC consumers can find assets by role
+# without inspecting file paths. Order matters for collision priority: an
+# asset with role "thumbnail" prefers key "thumbnail"; if it's already taken
+# (e.g. by a user-named thumbnail.png), the second asset falls back to its
+# stem.
+_ROLE_KEYS: dict[str, str] = {
+    "thumbnail": "thumbnail",
+    "metadata": "metadata",
+    "documentation": "documentation",
+}
+
 # Extension-to-role mapping for asset files.
 # Data formats get "data", images get "thumbnail", metadata gets "metadata".
 _ROLE_MAP: dict[str, str] = {
@@ -269,16 +292,21 @@ def _scan_item_assets(
             # Skip special files (sockets, devices, etc.)
             continue
 
-        # Primary geo file gets "data" key, others use stem with disambiguation
+        # Primary geo file gets "data" key. Other files prefer the well-known
+        # role-keyed name ("thumbnail", "metadata", "documentation") so STAC
+        # consumers can find them by role; on collision, fall back to stem,
+        # then to filename.
         if file_path == primary_file:
             asset_key = "data"
         else:
-            # Use stem, but disambiguate on collision (e.g., metadata.json vs metadata.xml)
-            base_key = file_path.stem
-            asset_key = base_key
-            if asset_key in stac_assets or asset_key == "data":
-                # Collision: use full filename instead
-                asset_key = file_path.name
+            role_key = _ROLE_KEYS.get(file_role)
+            if role_key and role_key not in stac_assets and role_key != "data":
+                asset_key = role_key
+            else:
+                # Use stem, but disambiguate on collision (e.g. metadata.json vs metadata.xml)
+                asset_key = file_path.stem
+                if asset_key in stac_assets or asset_key == "data":
+                    asset_key = file_path.name
         # Asset href must be relative to item JSON location.
         # PySTAC places item JSON at: {collection_dir}/{item_id}/{item_id}.json
         #
@@ -307,6 +335,7 @@ def _scan_item_assets(
             href=asset_href,
             media_type=file_media_type,
             roles=[file_role],
+            title=_ROLE_TITLES.get(file_role),
         )
         asset_files[file_path.name] = (file_path, file_checksum)
         asset_paths.append(str(file_path))

--- a/tests/unit/test_asset_key_normalization.py
+++ b/tests/unit/test_asset_key_normalization.py
@@ -1,0 +1,185 @@
+"""Tests for STAC asset key normalization and titles.
+
+When _scan_item_assets builds STAC asset entries, well-known roles
+(thumbnail, metadata, documentation) should:
+- Use the role name as the asset key (e.g., "thumbnail" not "preview")
+  so STAC consumers can find the asset by role without inspecting paths.
+- Carry a default title matching the convention used by Element 84
+  Earth Search (every asset has a title).
+
+Falls back to stem on collision so a user with two thumbnails or two
+metadata files still gets stable keys.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.dataset import _scan_item_assets
+
+
+@pytest.fixture
+def item_dir_with_data(tmp_path: Path, valid_points_parquet: Path) -> tuple[Path, Path]:
+    """Item directory with a parquet primary data file."""
+    item_dir = tmp_path / "collection" / "item-id"
+    item_dir.mkdir(parents=True)
+    data_file = item_dir / "data.parquet"
+    shutil.copy(valid_points_parquet, data_file)
+    return item_dir, data_file
+
+
+class TestAssetKeyNormalization:
+    """Well-known roles get stable, role-keyed asset keys."""
+
+    @pytest.mark.unit
+    def test_thumbnail_uses_role_name_as_key(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """A preview.png with role thumbnail is keyed as "thumbnail"."""
+        item_dir, data_file = item_dir_with_data
+        # File named preview.png (not "thumbnail.png") to prove key is
+        # derived from role, not from filename.
+        (item_dir / "preview.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert "thumbnail" in assets
+        assert assets["thumbnail"].roles == ["thumbnail"]
+        assert assets["thumbnail"].href == "preview.png"
+
+    @pytest.mark.unit
+    def test_metadata_uses_role_name_as_key(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """A sidecar XML is keyed as "metadata"."""
+        item_dir, data_file = item_dir_with_data
+        (item_dir / "iso19139.xml").write_text("<gmd:MD_Metadata/>")
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert "metadata" in assets
+        assert assets["metadata"].roles == ["metadata"]
+
+    @pytest.mark.unit
+    def test_documentation_uses_role_name_as_key(
+        self, item_dir_with_data: tuple[Path, Path]
+    ) -> None:
+        """A README.md is keyed as "documentation"."""
+        item_dir, data_file = item_dir_with_data
+        (item_dir / "README.md").write_text("# Hello")
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert "documentation" in assets
+        assert assets["documentation"].roles == ["documentation"]
+
+    @pytest.mark.unit
+    def test_collision_falls_back_to_stem(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """Two thumbnails: first wins the role key, second uses its stem."""
+        item_dir, data_file = item_dir_with_data
+        (item_dir / "preview.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+        (item_dir / "overview.jpg").write_bytes(b"\xff\xd8\xff" + b"\x00" * 100)
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        # Exactly one of them claims the role key, the other falls back.
+        thumbnail_assets = {k: v for k, v in assets.items() if v.roles == ["thumbnail"]}
+        assert len(thumbnail_assets) == 2
+        assert "thumbnail" in thumbnail_assets
+        # Second thumbnail keyed by stem (preview or overview, whichever lost the race)
+        other_keys = set(thumbnail_assets) - {"thumbnail"}
+        assert other_keys.issubset({"preview", "overview"})
+        assert len(other_keys) == 1
+
+    @pytest.mark.unit
+    def test_primary_data_still_keyed_data(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """Primary file remains keyed as "data" (unchanged behavior)."""
+        item_dir, data_file = item_dir_with_data
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert "data" in assets
+        assert assets["data"].roles == ["data"]
+
+
+class TestAssetTitles:
+    """Well-known roles carry a default title."""
+
+    @pytest.mark.unit
+    def test_thumbnail_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        item_dir, data_file = item_dir_with_data
+        (item_dir / "preview.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert assets["thumbnail"].title == "Thumbnail"
+
+    @pytest.mark.unit
+    def test_metadata_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        item_dir, data_file = item_dir_with_data
+        (item_dir / "iso.xml").write_text("<x/>")
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert assets["metadata"].title == "Metadata"
+
+    @pytest.mark.unit
+    def test_documentation_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        item_dir, data_file = item_dir_with_data
+        (item_dir / "README.md").write_text("# Hi")
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert assets["documentation"].title == "Documentation"
+
+    @pytest.mark.unit
+    def test_data_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        item_dir, data_file = item_dir_with_data
+
+        assets, _, _ = _scan_item_assets(
+            item_dir=item_dir,
+            item_id="item-id",
+            primary_file=data_file,
+            collection_dir=item_dir.parent,
+        )
+
+        assert assets["data"].title == "Data"


### PR DESCRIPTION
## Summary

- In `_scan_item_assets` (`portolan_cli/dataset.py:216`), prefer the role name (`thumbnail`, `metadata`, `documentation`) as the asset key over the filename stem so STAC consumers can look an asset up by role without inspecting paths. Falls back to the stem on collision (e.g., two thumbnails in one item).
- Set a default `title` on every asset based on its role (`Data`, `Thumbnail`, `Metadata`, `Documentation`), matching the convention used by Element 84 Earth Search (verified via curl, every Sentinel-2 / Landsat asset has a title).

Closes #374. Independent of #373, branched off `main`.

## Why

Today a user-supplied `preview.png` is keyed `preview` and a `iso19139.xml` is keyed `iso19139`. STAC consumers that lookup `assets["thumbnail"]` (the well-known role) miss it. Earth Search keeps role and key aligned, this PR brings Portolan in line.

## Test plan

- [x] `tests/unit/test_asset_key_normalization.py` , 9 new tests:
  - Thumbnail / metadata / documentation files keyed by role name (not stem)
  - Two thumbnails: one wins the role key, the other falls back to its stem
  - Primary `data` key unchanged
  - Each well-known role gets the expected default title
- [x] Full unit suite, 3,883 passing, 0 regressions in `test_dataset.py`, `test_stac_links_regression.py`, `test_add_rm_hypothesis.py`, `test_stac_extensions.py`
- [x] `ruff check`, `ruff format`, `mypy --strict` clean

## Backward compat note

Existing catalogs may have assets keyed by stem. Re-running `portolan add` will normalize them to role-keyed names. No data loss.
