### PR TITLE
fix(extract): clean collection names and filter boilerplate

### DIFF
--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -105,12 +105,14 @@ class ExtractionProgress:
     status: str
 
 
-def _slugify(name: str, disambiguate: bool = False) -> str:
+def _slugify(name: str, disambiguate: bool = False, unique_id: int | None = None) -> str:
     """Convert a name to a filesystem-safe slug.
 
     Args:
         name: Original name (e.g., "ns:FeatureType")
         disambiguate: If True, append a short hash to prevent collisions.
+        unique_id: Unique identifier to include in hash (required when disambiguating
+            identical names that would otherwise produce identical hashes).
 
     Returns:
         Slugified name (e.g., "ns_featuretype" or "ns_featuretype_a1b2c3")
@@ -124,7 +126,8 @@ def _slugify(name: str, disambiguate: bool = False) -> str:
     slug = slug or "unnamed"
 
     if disambiguate:
-        name_hash = hashlib.sha256(name.encode()).hexdigest()[:6]
+        hash_input = f"{name}:{unique_id}" if unique_id is not None else name
+        name_hash = hashlib.sha256(hash_input.encode()).hexdigest()[:6]
         slug = f"{slug}_{name_hash}"
 
     return slug
@@ -148,7 +151,7 @@ def _assign_slugs(layers: list[LayerInfo]) -> dict[int, str]:
     for layer in layers:
         base_slug = base_slugs[layer.id]
         if slug_counts[base_slug] > 1:
-            result[layer.id] = _slugify(layer.name, disambiguate=True)
+            result[layer.id] = _slugify(layer.name, disambiguate=True, unique_id=layer.id)
         else:
             result[layer.id] = base_slug
 

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -130,6 +130,31 @@ def _slugify(name: str, disambiguate: bool = False) -> str:
     return slug
 
 
+def _assign_slugs(layers: list[LayerInfo]) -> dict[int, str]:
+    """Pre-compute slugs for all layers, disambiguating only on collision.
+
+    Args:
+        layers: List of layers to assign slugs to.
+
+    Returns:
+        Dict mapping layer id to assigned slug.
+    """
+    from collections import Counter
+
+    base_slugs = {layer.id: _slugify(layer.name, disambiguate=False) for layer in layers}
+    slug_counts = Counter(base_slugs.values())
+
+    result: dict[int, str] = {}
+    for layer in layers:
+        base_slug = base_slugs[layer.id]
+        if slug_counts[base_slug] > 1:
+            result[layer.id] = _slugify(layer.name, disambiguate=True)
+        else:
+            result[layer.id] = base_slug
+
+    return result
+
+
 def _build_wfs_url(base_url: str, params: dict[str, str]) -> str:
     """Build a WFS URL by merging params into base_url.
 
@@ -365,6 +390,81 @@ def _negotiate_version(url: str, wfs_version: str) -> str:
         return "1.1.0"
 
 
+def _extract_layers_parallel(
+    url: str,
+    layers_to_extract: list[tuple[int, LayerInfo]],
+    output_dir: Path,
+    options: ExtractionOptions,
+    negotiated_version: str,
+    total: int,
+    layer_slugs: dict[int, str],
+    on_progress: Callable[[ExtractionProgress], None] | None,
+) -> list[LayerResult]:
+    """Extract multiple layers in parallel using ThreadPoolExecutor."""
+    actual_workers = min(options.workers, len(layers_to_extract))
+    logger.info("Extracting %d layers with %d workers", len(layers_to_extract), actual_workers)
+    results: list[LayerResult] = []
+
+    with ThreadPoolExecutor(max_workers=actual_workers) as executor:
+        future_to_layer = {
+            executor.submit(
+                _extract_layer_task,
+                url,
+                layer,
+                output_dir,
+                options,
+                negotiated_version,
+                i,
+                total,
+                layer_slugs[layer.id],
+            ): (i, layer)
+            for i, layer in layers_to_extract
+        }
+
+        for future in as_completed(future_to_layer):
+            i, layer = future_to_layer[future]
+            try:
+                result = future.result(timeout=options.timeout)
+                results.append(result)
+                status = "success" if result.status == "success" else "failed"
+                _emit_progress(on_progress, i, total, layer.name, status)
+            except TimeoutError:
+                logger.error("Layer %s timed out after %ds", layer.name, options.timeout)
+                _emit_progress(on_progress, i, total, layer.name, "failed")
+                results.append(
+                    LayerResult(
+                        id=layer.id,
+                        name=layer.name,
+                        status="failed",
+                        features=0,
+                        size_bytes=0,
+                        duration_seconds=options.timeout,
+                        output_path="",
+                        warnings=[],
+                        error=f"Timeout after {options.timeout}s",
+                        attempts=1,
+                    )
+                )
+            except Exception as e:
+                logger.error("Layer %s failed: %s", layer.name, e)
+                _emit_progress(on_progress, i, total, layer.name, "failed")
+                results.append(
+                    LayerResult(
+                        id=layer.id,
+                        name=layer.name,
+                        status="failed",
+                        features=0,
+                        size_bytes=0,
+                        duration_seconds=0.0,
+                        output_path="",
+                        warnings=[],
+                        error=str(e),
+                        attempts=1,
+                    )
+                )
+    return results
+
+
 def _extract_layer_task(
     url: str,
     layer: LayerInfo,
@@ -373,12 +473,12 @@ def _extract_layer_task(
     negotiated_version: str,
     layer_index: int,
     total_layers: int,
+    layer_slug: str,
 ) -> LayerResult:
     """Extract a single layer (task for parallel execution).
 
     Returns LayerResult with success or failure status.
     """
-    layer_slug = _slugify(layer.name, disambiguate=True)
     collection_dir = output_dir / layer_slug
     output_path = collection_dir / f"{layer_slug}.parquet"
 
@@ -510,70 +610,22 @@ def extract_wfs_catalog(
             )
         layers_to_extract.append((i, layer))
 
+    # Pre-compute slugs: only disambiguate on collision (Issue #379)
+    layer_slugs = _assign_slugs([layer for _, layer in layers_to_extract])
+
     # Extract layers - parallel if workers > 1, sequential otherwise
     extracted_results: list[LayerResult] = []
-
     if options.workers > 1 and len(layers_to_extract) > 1:
-        # Parallel extraction
-        actual_workers = min(options.workers, len(layers_to_extract))
-        logger.info("Extracting %d layers with %d workers", len(layers_to_extract), actual_workers)
-
-        with ThreadPoolExecutor(max_workers=actual_workers) as executor:
-            future_to_layer = {
-                executor.submit(
-                    _extract_layer_task,
-                    url,
-                    layer,
-                    output_dir,
-                    options,
-                    negotiated_version,
-                    i,
-                    total,
-                ): (i, layer)
-                for i, layer in layers_to_extract
-            }
-
-            for future in as_completed(future_to_layer):
-                i, layer = future_to_layer[future]
-                try:
-                    result = future.result(timeout=options.timeout)
-                    extracted_results.append(result)
-                    status = "success" if result.status == "success" else "failed"
-                    _emit_progress(on_progress, i, total, layer.name, status)
-                except TimeoutError:
-                    logger.error("Layer %s timed out after %ds", layer.name, options.timeout)
-                    _emit_progress(on_progress, i, total, layer.name, "failed")
-                    extracted_results.append(
-                        LayerResult(
-                            id=layer.id,
-                            name=layer.name,
-                            status="failed",
-                            features=0,
-                            size_bytes=0,
-                            duration_seconds=options.timeout,
-                            output_path="",
-                            warnings=[],
-                            error=f"Timeout after {options.timeout}s",
-                            attempts=1,
-                        )
-                    )
-                except Exception as e:
-                    logger.error("Layer %s failed: %s", layer.name, e)
-                    _emit_progress(on_progress, i, total, layer.name, "failed")
-                    extracted_results.append(
-                        LayerResult(
-                            id=layer.id,
-                            name=layer.name,
-                            status="failed",
-                            features=0,
-                            size_bytes=0,
-                            duration_seconds=0.0,
-                            output_path="",
-                            warnings=[],
-                            error=str(e),
-                            attempts=1,
-                        )
-                    )
+        extracted_results = _extract_layers_parallel(
+            url,
+            layers_to_extract,
+            output_dir,
+            options,
+            negotiated_version,
+            total,
+            layer_slugs,
+            on_progress,
+        )
     else:
         # Sequential extraction
         for i, layer in layers_to_extract:
@@ -581,7 +633,14 @@ def extract_wfs_catalog(
             _emit_progress(on_progress, i, total, layer.name, "extracting")
 
             result = _extract_layer_task(
-                url, layer, output_dir, options, negotiated_version, i, total
+                url,
+                layer,
+                output_dir,
+                options,
+                negotiated_version,
+                i,
+                total,
+                layer_slugs[layer.id],
             )
             extracted_results.append(result)
 
@@ -635,19 +694,22 @@ def _auto_init_catalog(
     service_title = discovery_result.service_title if discovery_result else None
     service_description = discovery_result.service_abstract if discovery_result else None
 
-    # Filter technical names BEFORE init_catalog to avoid writing them
-    # (update_stac_metadata can't overwrite if init_catalog already wrote them)
+    # Filter technical names AND boilerplate (Issue #376)
+    from portolan_cli.extract.wfs.metadata import is_boilerplate_description
     from portolan_cli.stac import is_technical_name
 
-    filtered_title = None if is_technical_name(service_title) else service_title
-    filtered_description = None if is_technical_name(service_description) else service_description
+    def _should_filter(text: str | None) -> bool:
+        return is_technical_name(text) or is_boilerplate_description(text)
+
+    filtered_title = None if _should_filter(service_title) else service_title
+    filtered_description = None if _should_filter(service_description) else service_description
 
     init_catalog(output_dir, title=filtered_title, description=filtered_description)
 
     # Per Issue #369: Update catalog.json with rich metadata
-    # This handles cases where init_catalog used defaults
+    # Per Issue #376: Use filtered values to avoid overwriting with boilerplate
     catalog_path = output_dir / "catalog.json"
-    update_stac_metadata(catalog_path, title=service_title, description=service_description)
+    update_stac_metadata(catalog_path, title=filtered_title, description=filtered_description)
 
     add_files(
         paths=parquet_files,

--- a/tests/unit/extract/wfs/test_orchestrator.py
+++ b/tests/unit/extract/wfs/test_orchestrator.py
@@ -635,6 +635,12 @@ class TestSlugify:
         result = _slugify("MyLayer", disambiguate=False)
         assert result == "mylayer"
 
+    def test_slug_unique_id_differentiates(self) -> None:
+        """Same name with different unique_ids produces different slugs."""
+        slug1 = _slugify("same_name", disambiguate=True, unique_id=0)
+        slug2 = _slugify("same_name", disambiguate=True, unique_id=1)
+        assert slug1 != slug2
+
 
 class TestAssignSlugs:
     """Tests for _assign_slugs function (Issue #379)."""
@@ -686,4 +692,20 @@ class TestAssignSlugs:
         # layer:a and layer_a: collision, both get hash
         assert len(slugs[0].split("_")[-1]) == 6
         assert len(slugs[1].split("_")[-1]) == 6
+        assert slugs[0] != slugs[1]
+
+    def test_identical_names_different_ids(self) -> None:
+        """Identical names with different IDs produce different slugs."""
+        # Edge case: exact same name but different layer IDs
+        # (could happen with bad WFS data or duplicate entries)
+        layers = [
+            make_layer_info("buildings", 0),
+            make_layer_info("buildings", 1),
+        ]
+        slugs = _assign_slugs(layers)
+
+        # Both should have hash suffixes
+        assert len(slugs[0].split("_")[-1]) == 6
+        assert len(slugs[1].split("_")[-1]) == 6
+        # Critical: they must be DIFFERENT despite identical names
         assert slugs[0] != slugs[1]

--- a/tests/unit/extract/wfs/test_orchestrator.py
+++ b/tests/unit/extract/wfs/test_orchestrator.py
@@ -14,6 +14,8 @@ import pytest
 from portolan_cli.extract.wfs.discovery import LayerInfo, WFSDiscoveryResult
 from portolan_cli.extract.wfs.orchestrator import (
     ExtractionOptions,
+    _assign_slugs,
+    _slugify,
     extract_wfs_catalog,
 )
 
@@ -605,3 +607,83 @@ class TestWFSMetadataSeeding:
         assert metadata_path.exists()
         content = metadata_path.read_text()
         assert "Layer in nested structure" in content
+
+
+class TestSlugify:
+    """Tests for _slugify function (Issue #379)."""
+
+    def test_basic_slug(self) -> None:
+        """Basic name is slugified without hash."""
+        result = _slugify("my_layer", disambiguate=False)
+        assert result == "my_layer"
+        assert len(result.split("_")) == 2  # No hash appended
+
+    def test_slug_with_disambiguation(self) -> None:
+        """Hash appended when disambiguate=True."""
+        result = _slugify("my_layer", disambiguate=True)
+        parts = result.split("_")
+        assert len(parts) == 3  # my, layer, hash
+        assert len(parts[-1]) == 6  # 6-char hash
+
+    def test_slug_normalizes_special_chars(self) -> None:
+        """Special characters converted to underscores."""
+        result = _slugify("ns:Feature-Type.Name", disambiguate=False)
+        assert result == "ns_feature_type_name"
+
+    def test_slug_lowercase(self) -> None:
+        """Names are lowercased."""
+        result = _slugify("MyLayer", disambiguate=False)
+        assert result == "mylayer"
+
+
+class TestAssignSlugs:
+    """Tests for _assign_slugs function (Issue #379)."""
+
+    def test_unique_names_no_hash(self) -> None:
+        """Unique layer names get slugs without hash suffixes."""
+        layers = [
+            make_layer_info("layer_a", 0),
+            make_layer_info("layer_b", 1),
+            make_layer_info("layer_c", 2),
+        ]
+        slugs = _assign_slugs(layers)
+
+        assert slugs[0] == "layer_a"
+        assert slugs[1] == "layer_b"
+        assert slugs[2] == "layer_c"
+
+    def test_collision_gets_hash(self) -> None:
+        """Colliding slugs get hash suffix."""
+        # "ns:layer" and "ns_layer" both slugify to "ns_layer"
+        layers = [
+            make_layer_info("ns:layer", 0),
+            make_layer_info("ns_layer", 1),
+        ]
+        slugs = _assign_slugs(layers)
+
+        # Both should have hash suffixes due to collision
+        assert "_" in slugs[0] and len(slugs[0].split("_")[-1]) == 6
+        assert "_" in slugs[1] and len(slugs[1].split("_")[-1]) == 6
+        # But they should be different
+        assert slugs[0] != slugs[1]
+
+    def test_partial_collision(self) -> None:
+        """Only colliding names get hash, others stay clean."""
+        # layer:a and layer_a both slugify to "layer_a" (collision)
+        # layer_b and layer_c are unique
+        layers = [
+            make_layer_info("layer:a", 0),  # Slugifies to layer_a
+            make_layer_info("layer_a", 1),  # Slugifies to layer_a (collision!)
+            make_layer_info("layer_b", 2),  # Unique
+            make_layer_info("layer_c", 3),  # Unique
+        ]
+        slugs = _assign_slugs(layers)
+
+        # layer_b and layer_c: no collision, no hash
+        assert slugs[2] == "layer_b"
+        assert slugs[3] == "layer_c"
+
+        # layer:a and layer_a: collision, both get hash
+        assert len(slugs[0].split("_")[-1]) == 6
+        assert len(slugs[1].split("_")[-1]) == 6
+        assert slugs[0] != slugs[1]


### PR DESCRIPTION
## Summary

- **#379**: Collection names no longer include hash suffixes unless there's an actual collision
- **#376**: Catalog descriptions no longer get overwritten with GeoServer boilerplate

## Changes

**Issue #379 (collection slugs):**
- Add `_assign_slugs()` to pre-compute slugs before extraction starts
- Only add hash suffix when multiple layer names slugify to the same value
- Works correctly with parallel extraction (collision detection happens upfront)

**Issue #376 (boilerplate filtering):**
- Add `is_boilerplate_description()` check to title/description filtering
- Fix `update_stac_metadata()` call to use filtered values (was overwriting with raw values)

**Refactoring:**
- Extract `_extract_layers_parallel()` helper to reduce `extract_wfs_catalog` complexity

## Test plan

- [x] Unit tests for `_slugify()` behavior
- [x] Unit tests for `_assign_slugs()` collision detection
- [x] All existing orchestrator tests pass
- [x] Lint and type checks pass

Closes #376, closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)