### PR TITLE
fix(config): resolve dotted keys from nested YAML

### DIFF
--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -303,10 +303,26 @@ def get_setting(
     if catalog_path is None:
         return None
 
+    # Helper to traverse nested dicts for dotted keys like "pmtiles.src_crs"
+    def _get_nested(cfg: dict[str, Any], k: str) -> Any | None:
+        parts = k.split(".")
+        current: Any = cfg
+        for part in parts:
+            if not isinstance(current, dict) or part not in current:
+                return None
+            current = current[part]
+        return current
+
     # Helper to check key and its aliases in a config dict
     def _get_with_aliases(cfg: dict[str, Any], k: str) -> Any | None:
+        # Try direct key lookup first (flat key)
         if k in cfg:
             return cfg[k]
+        # Try nested traversal for dotted keys
+        if "." in k:
+            nested_val = _get_nested(cfg, k)
+            if nested_val is not None:
+                return nested_val
         # Check aliases (e.g., aws_profile -> profile)
         for alias in SETTING_ALIASES.get(k, []):
             if alias in cfg:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -369,6 +369,86 @@ class TestGetSetting:
         # Should fall back to catalog-level statistics.enabled
         assert result is True
 
+    @pytest.mark.unit
+    def test_dotted_key_resolves_nested_yaml(self, tmp_path: Path) -> None:
+        """Dotted keys like 'pmtiles.src_crs' should traverse nested YAML."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        save_config(tmp_path, {"pmtiles": {"src_crs": "EPSG:3035"}})
+
+        coll_path = tmp_path / "my_collection"
+        coll_path.mkdir()
+
+        result = get_setting(
+            "pmtiles.src_crs",
+            catalog_path=tmp_path,
+            collection="my_collection",
+            collection_path=coll_path,
+        )
+
+        assert result == "EPSG:3035"
+
+    @pytest.mark.unit
+    def test_dotted_key_resolves_deeply_nested_yaml(self, tmp_path: Path) -> None:
+        """Dotted keys should work at arbitrary depth."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        save_config(tmp_path, {"a": {"b": {"c": "deep_value"}}})
+
+        coll_path = tmp_path / "coll"
+        coll_path.mkdir()
+
+        result = get_setting(
+            "a.b.c",
+            catalog_path=tmp_path,
+            collection="coll",
+            collection_path=coll_path,
+        )
+
+        assert result == "deep_value"
+
+    @pytest.mark.unit
+    def test_dotted_key_returns_none_for_missing_path(self, tmp_path: Path) -> None:
+        """Dotted key should return None if any part of path is missing."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        save_config(tmp_path, {"pmtiles": {"min_zoom": 4}})
+
+        coll_path = tmp_path / "coll"
+        coll_path.mkdir()
+
+        result = get_setting(
+            "pmtiles.src_crs",
+            catalog_path=tmp_path,
+            collection="coll",
+            collection_path=coll_path,
+        )
+
+        assert result is None
+
+    @pytest.mark.unit
+    def test_dotted_key_returns_none_for_nonexistent_parent(self, tmp_path: Path) -> None:
+        """Dotted key should return None if parent key doesn't exist."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        save_config(tmp_path, {"remote": "s3://bucket/"})
+
+        coll_path = tmp_path / "coll"
+        coll_path.mkdir()
+
+        result = get_setting(
+            "pmtiles.src_crs",
+            catalog_path=tmp_path,
+            collection="coll",
+            collection_path=coll_path,
+        )
+
+        assert result is None
+
 
 class TestSetSetting:
     """Tests for set_setting function."""
@@ -1084,3 +1164,27 @@ class TestPMTilesConfigSettings:
         assert get_setting("pmtiles.include_cols", catalog_path=tmp_path) == "name,geometry"
         assert get_setting("pmtiles.attribution", catalog_path=tmp_path) == "© Test"
         assert get_setting("pmtiles.src_crs", catalog_path=tmp_path) == "EPSG:3857"
+
+    @pytest.mark.unit
+    def test_pmtiles_nested_yaml_structure(self, tmp_path: Path) -> None:
+        """PMTiles settings work with nested YAML (how users actually write config)."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        # This is how users write config.yaml (nested, not flat keys)
+        save_config(
+            tmp_path,
+            {
+                "pmtiles": {
+                    "enabled": True,
+                    "src_crs": "EPSG:3035",
+                    "min_zoom": 4,
+                    "max_zoom": 14,
+                }
+            },
+        )
+
+        assert get_setting("pmtiles.enabled", catalog_path=tmp_path) is True
+        assert get_setting("pmtiles.src_crs", catalog_path=tmp_path) == "EPSG:3035"
+        assert get_setting("pmtiles.min_zoom", catalog_path=tmp_path) == 4
+        assert get_setting("pmtiles.max_zoom", catalog_path=tmp_path) == 14

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -449,6 +449,46 @@ class TestGetSetting:
 
         assert result is None
 
+    @pytest.mark.unit
+    def test_dotted_key_returns_false_boolean(self, tmp_path: Path) -> None:
+        """Dotted key should correctly return False (not None) for disabled settings."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        save_config(tmp_path, {"pmtiles": {"enabled": False}})
+
+        coll_path = tmp_path / "coll"
+        coll_path.mkdir()
+
+        result = get_setting(
+            "pmtiles.enabled",
+            catalog_path=tmp_path,
+            collection="coll",
+            collection_path=coll_path,
+        )
+
+        assert result is False
+
+    @pytest.mark.unit
+    def test_dotted_key_returns_zero_integer(self, tmp_path: Path) -> None:
+        """Dotted key should correctly return 0 (not None) for zero values."""
+        from portolan_cli.config import get_setting, save_config
+
+        (tmp_path / ".portolan").mkdir()
+        save_config(tmp_path, {"pmtiles": {"min_zoom": 0}})
+
+        coll_path = tmp_path / "coll"
+        coll_path.mkdir()
+
+        result = get_setting(
+            "pmtiles.min_zoom",
+            catalog_path=tmp_path,
+            collection="coll",
+            collection_path=coll_path,
+        )
+
+        assert result == 0
+
 
 class TestSetSetting:
     """Tests for set_setting function."""


### PR DESCRIPTION
## Summary

- Fixes `pmtiles.src_crs` config not being passed through to gpio-pmtiles
- Root cause: `get_setting()` did flat dict lookup, but nested YAML creates `{"pmtiles": {"src_crs": ...}}`
- Added `_get_nested()` helper that splits dotted keys and traverses dict hierarchy

## Test plan

- [x] 4 new unit tests for dotted key resolution (nested, deep, missing path, missing parent)
- [x] 1 new test for pmtiles nested YAML structure (actual user config format)
- [x] 78 config tests pass, no regressions

Closes #378

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration settings now support dotted-key access to retrieve values from nested YAML structures (e.g., `pmtiles.src_crs`), while maintaining backward compatibility with direct key lookup.

* **Tests**
  * Added comprehensive unit tests validating dotted-key resolution across nested configurations, including deep nesting scenarios and proper handling of missing configuration paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->