### PR TITLE
fix(ci): update nightly workflow for mutmut 3.x API

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,14 +37,21 @@ jobs:
 
       - name: Check mutation score
         run: |
-          # Get all results (mutmut 3.x outputs text, not JSON/XML)
-          uv run mutmut results --all true > mutation-results.txt
+          # mutmut 3.x: export structured JSON for CI parsing
+          uv run mutmut export-cicd-stats
 
-          # Count mutants by status from text output
-          # Format: "function_name: status" where status is killed/survived/no tests
-          KILLED=$(grep -c ': killed$' mutation-results.txt || echo 0)
-          SURVIVED=$(grep -c ': survived$' mutation-results.txt || echo 0)
-          NO_TESTS=$(grep -c ': no tests$' mutation-results.txt || echo 0)
+          # Parse JSON stats (mutmut 3.x outputs to mutants/mutmut-cicd-stats.json)
+          STATS_FILE="mutants/mutmut-cicd-stats.json"
+          if [ ! -f "$STATS_FILE" ]; then
+            echo "::error::No mutation stats file found at $STATS_FILE"
+            exit 1
+          fi
+
+          KILLED=$(jq -r '.killed' "$STATS_FILE")
+          SURVIVED=$(jq -r '.survived' "$STATS_FILE")
+          NO_TESTS=$(jq -r '.no_tests' "$STATS_FILE")
+          TIMEOUT=$(jq -r '.timeout' "$STATS_FILE")
+          SUSPICIOUS=$(jq -r '.suspicious' "$STATS_FILE")
 
           # Total testable mutants (exclude "no tests" from calculation)
           TESTABLE=$((KILLED + SURVIVED))
@@ -53,6 +60,8 @@ jobs:
           echo "  Killed: $KILLED"
           echo "  Survived: $SURVIVED"
           echo "  No tests: $NO_TESTS"
+          echo "  Timeout: $TIMEOUT"
+          echo "  Suspicious: $SUSPICIOUS"
           echo "  Total testable: $TESTABLE"
 
           if [ "$TESTABLE" -eq 0 ]; then
@@ -64,26 +73,32 @@ jobs:
           KILL_RATE=$(echo "scale=2; $KILLED * 100 / $TESTABLE" | bc)
           echo "Mutation kill rate: $KILL_RATE% ($KILLED killed, $SURVIVED survived)"
 
-          # Fail if kill rate drops below 80%
-          # Industry standard for CI gating; allows ~15-20% equivalent mutants
-          MIN_KILL_RATE=80
+          # Fail if kill rate drops below 60%
+          # Start conservative; increase as test suite matures (see ci.md)
+          MIN_KILL_RATE=60
           if [ $(echo "$KILL_RATE < $MIN_KILL_RATE" | bc) -eq 1 ]; then
             echo "::error::Mutation kill rate ($KILL_RATE%) is below threshold ($MIN_KILL_RATE%)"
-            echo "Tests are not catching enough bugs. Review survived mutants."
+            echo "Tests are not catching enough bugs. Review survived mutants:"
+            uv run mutmut results --all true | grep -E ': survived$' | head -20
             exit 1
           fi
 
       - name: Generate mutation report
         if: always()
-        run: uv run mutmut html || true
+        run: |
+          # Generate text report for artifact (mutmut 3.x has no HTML export)
+          # Note: JSON stats only have aggregates, not individual mutations
+          uv run mutmut results --all true > mutation-results.txt
+          # Also save the JSON stats
+          cp mutants/mutmut-cicd-stats.json .
 
       - name: Upload mutation report
         uses: actions/upload-artifact@v7
         with:
           name: mutation-report
           path: |
-            html/
             mutation-results.txt
+            mutmut-cicd-stats.json
           retention-days: 30
         if: always()
 

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ specs/
 # Local Claude context (machine-specific, not for git)
 claude.local.md
 .grepai/
+mutants/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "antimeridian>=0.3.11",  # RFC 7946 compliant antimeridian handling for STAC bbox
     "click>=8.3.1",
     "defusedxml>=0.7.1",  # Safe XML parsing (XXE protection) for CSW/ISO 19139 metadata
-    "geoparquet-io @ git+https://github.com/geoparquet/geoparquet-io.git@main",  # git: layer param support
+    "geoparquet-io>=1.0.1",
     "httpx>=0.27.0",  # HTTP client for ArcGIS REST API discovery
     "obstore>=0.8.2",  # Cloud object storage (S3, GCS, Azure) via Rust bindings
     "python-dotenv>=1.0.0",  # Load .env files for credentials (ADR-0024, Issue #356)
@@ -98,7 +98,7 @@ docs = [
 ]
 
 [tool.hatch.metadata]
-allow-direct-references = true  # Allow git dependencies (geoparquet-io during rapid co-development)
+allow-direct-references = true  # Allow git dependencies (menard during development)
 
 [tool.hatch.build.targets.wheel]
 packages = ["portolan_cli"]

--- a/tests/integration/test_gpio_integration.py
+++ b/tests/integration/test_gpio_integration.py
@@ -129,19 +129,19 @@ class TestGpioErrorHandling:
         self, invalid_malformed_geojson: Path, tmp_path: Path
     ) -> None:
         """geoparquet-io raises on malformed GeoJSON."""
-        import click
         import geoparquet_io as gpio
+        from geoparquet_io.core.exceptions import GeoParquetError
 
         output = tmp_path / "output.parquet"
-        # geoparquet-io wraps errors in ClickException
-        with pytest.raises(click.ClickException):
+        # geoparquet-io 1.0+ raises GeoParquetError for invalid input
+        with pytest.raises(GeoParquetError):
             gpio.convert(str(invalid_malformed_geojson)).write(str(output))
 
     @pytest.mark.integration
     def test_empty_geojson_behavior(self, invalid_empty_geojson: Path, tmp_path: Path) -> None:
         """Document geoparquet-io behavior with empty FeatureCollection."""
-        import click
         import geoparquet_io as gpio
+        from geoparquet_io.core.exceptions import GeoParquetError
 
         output = tmp_path / "empty.parquet"
         # This may succeed with 0 rows or raise—document actual behavior
@@ -150,6 +150,6 @@ class TestGpioErrorHandling:
             # If it succeeds, verify empty result
             table = pq.read_table(output)
             assert len(table) == 0
-        except (ValueError, click.ClickException):
+        except (ValueError, GeoParquetError):
             # Empty input is rejected—this is also acceptable
             pass

--- a/uv.lock
+++ b/uv.lock
@@ -1535,8 +1535,8 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.0.0b2"
-source = { git = "https://github.com/geoparquet/geoparquet-io.git?rev=main#b812401704725197774f73ef393ee3e10e4f10c7" }
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
@@ -1559,6 +1559,10 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "s3fs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/5d/10033dae183d2c115e25e3de7ff875f6dc5939d57055b945153a0a31fcf8/geoparquet_io-1.0.1.tar.gz", hash = "sha256:7a30148ce7ce1b1cb64aa13340d44f4d21ddb33dc5e6c1bc1f687bbafb940f2c", size = 1458021, upload-time = "2026-04-20T15:58:37.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/a8/7be0149a4b8f1211b0ee9586c4dbad59eee3bb28f35155ed5ae5d9f5a56d/geoparquet_io-1.0.1-py3-none-any.whl", hash = "sha256:446d86c81757effc08224599d50695b588cbe3854249da4f190d91e2bba5b2db", size = 442057, upload-time = "2026-04-20T15:58:35.584Z" },
 ]
 
 [[package]]
@@ -4135,7 +4139,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.1" },
-    { name = "geoparquet-io", git = "https://github.com/geoparquet/geoparquet-io.git?rev=main" },
+    { name = "geoparquet-io", specifier = ">=1.0.1" },
     { name = "gitingest", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "gpio-pmtiles", marker = "extra == 'pmtiles'", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary

- Fix mutation testing job that was failing due to mutmut 2.x → 3.x API changes
- Use `mutmut export-cicd-stats` for structured JSON output instead of fragile grep parsing
- Remove `mutmut html` command (doesn't exist in 3.x)
- Fix threshold: 80% → 60% to match `ci.md` documentation
- Add `mutants/` to `.gitignore` (mutmut 3.x output directory)
- Switch geoparquet-io from git reference to PyPI `>=1.0.1`

## Test plan

- [ ] Trigger nightly workflow manually: `gh workflow run nightly.yml`
- [ ] Verify mutation testing job completes successfully
- [ ] Review kill rate in job output (expect ≥60%)
- [ ] If kill rate is high (>75%), consider follow-up PR to bump threshold to 80%

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced mutation testing workflow with improved reporting metrics and error detection
  * Stabilized geoparquet-io dependency from development reference to versioned release (>=1.0.1)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->