### PR TITLE
fix(pmtiles): clean up partial output files on generation failure

### DIFF
--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -484,8 +484,14 @@ def generate_pmtiles_for_collection(
             result.generated.append(pmtiles_path)
 
         except PMTilesGenerationError as e:
+            # Clean up partial output file to prevent phantom assets (Issue #385)
+            if pmtiles_path.exists():
+                pmtiles_path.unlink()
             result.failed.append((parquet_path, str(e)))
         except Exception as e:
+            # Clean up partial output file to prevent phantom assets (Issue #385)
+            if pmtiles_path.exists():
+                pmtiles_path.unlink()
             result.failed.append((parquet_path, f"Unexpected error: {e}"))
 
     return result

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from portolan_cli.errors import PortolanError
+from portolan_cli.output import warn
 
 # MIME type for PMTiles (matches dataset.py)
 PMTILES_MEDIA_TYPE = "application/vnd.pmtiles"
@@ -455,6 +456,9 @@ def generate_pmtiles_for_collection(
             result.skipped.append(pmtiles_path)
             continue
 
+        # Track success to clean up partial files on any failure (Issue #385)
+        # Using finally ensures cleanup even on KeyboardInterrupt/SystemExit
+        generation_succeeded = False
         try:
             # Delete existing file if forcing regeneration
             # (tippecanoe requires this since it doesn't have a --force option)
@@ -482,16 +486,17 @@ def generate_pmtiles_for_collection(
             track_pmtiles_in_versions(collection_path, pmtiles_path, catalog_root)
 
             result.generated.append(pmtiles_path)
+            generation_succeeded = True
 
         except PMTilesGenerationError as e:
-            # Clean up partial output file to prevent phantom assets (Issue #385)
-            if pmtiles_path.exists():
-                pmtiles_path.unlink()
             result.failed.append((parquet_path, str(e)))
         except Exception as e:
-            # Clean up partial output file to prevent phantom assets (Issue #385)
-            if pmtiles_path.exists():
-                pmtiles_path.unlink()
             result.failed.append((parquet_path, f"Unexpected error: {e}"))
+        finally:
+            # Clean up partial output to prevent phantom assets (Issue #385)
+            # missing_ok=True avoids TOCTOU race condition
+            if not generation_succeeded and pmtiles_path.exists():
+                pmtiles_path.unlink(missing_ok=True)
+                warn(f"Cleaned up partial file after failure: {pmtiles_path.name}")
 
     return result

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -540,6 +540,49 @@ class TestGeneratePMTilesForCollection:
         assert len(result.failed) == 1
         assert not pmtiles_path.exists(), "Partial file should be cleaned up on any error"
 
+    @pytest.mark.unit
+    def test_cleans_up_partial_file_on_keyboard_interrupt(self, tmp_path: Path) -> None:
+        """Partial PMTiles file is deleted even on KeyboardInterrupt (Issue #385).
+
+        KeyboardInterrupt inherits from BaseException, not Exception.
+        The finally block ensures cleanup even when user hits Ctrl+C.
+        """
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+
+        collection_dir = tmp_path / "collection"
+        collection_dir.mkdir()
+
+        collection_json = {
+            "type": "Collection",
+            "assets": {
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                }
+            },
+        }
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json))
+        (collection_dir / "data.parquet").write_bytes(b"PAR1")
+
+        pmtiles_path = collection_dir / "data.pmtiles"
+
+        def mock_generate_interrupted(*args: object, **kwargs: object) -> None:
+            pmtiles_path.write_bytes(b"partial")
+            raise KeyboardInterrupt()
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                with patch("portolan_cli.pmtiles.generate_pmtiles", mock_generate_interrupted):
+                    with pytest.raises(KeyboardInterrupt):
+                        generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        # KEY ASSERTION: Partial file cleaned up even on KeyboardInterrupt
+        assert not pmtiles_path.exists(), (
+            "Partial file must be cleaned up on KeyboardInterrupt. "
+            "finally block handles BaseException subclasses."
+        )
+
 
 # Integration tests that require tippecanoe
 @pytest.mark.skipif(

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -451,6 +451,95 @@ class TestGeneratePMTilesForCollection:
         assert call_kwargs["attribution"] == "© Me"
         assert call_kwargs["src_crs"] == "EPSG:4326"
 
+    @pytest.mark.unit
+    def test_cleans_up_partial_file_on_failure(self, tmp_path: Path) -> None:
+        """Partial PMTiles file is deleted when generation fails (Issue #385).
+
+        When gpio-pmtiles/tippecanoe fails mid-generation, it may leave a
+        partial output file. This test verifies that such files are cleaned
+        up to prevent phantom assets in versions.json on subsequent add runs.
+        """
+        from portolan_cli.pmtiles import (
+            PMTilesGenerationError,
+            generate_pmtiles_for_collection,
+        )
+
+        collection_dir = tmp_path / "collection"
+        collection_dir.mkdir()
+
+        # Create collection with parquet asset
+        collection_json = {
+            "type": "Collection",
+            "assets": {
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                }
+            },
+        }
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json))
+        (collection_dir / "data.parquet").write_bytes(b"PAR1")
+
+        pmtiles_path = collection_dir / "data.pmtiles"
+
+        # Mock generate_pmtiles to create partial file then raise
+        def mock_generate_raises(*args: object, **kwargs: object) -> None:
+            # Simulate: gpio-pmtiles creates file, then fails mid-processing
+            pmtiles_path.write_bytes(b"partial content")
+            raise PMTilesGenerationError("data.parquet", ValueError("Non-geospatial"))
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                with patch("portolan_cli.pmtiles.generate_pmtiles", mock_generate_raises):
+                    result = generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        # Verify failure was recorded
+        assert len(result.failed) == 1
+        assert "data.parquet" in str(result.failed[0][0])
+
+        # KEY ASSERTION: Partial file should be cleaned up (Issue #385)
+        assert not pmtiles_path.exists(), (
+            "Partial PMTiles file should be deleted on generation failure. "
+            "Leaving it causes phantom assets in versions.json on next add."
+        )
+
+    @pytest.mark.unit
+    def test_cleans_up_partial_file_on_unexpected_error(self, tmp_path: Path) -> None:
+        """Partial PMTiles file is deleted on unexpected errors too (Issue #385)."""
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+
+        collection_dir = tmp_path / "collection"
+        collection_dir.mkdir()
+
+        collection_json = {
+            "type": "Collection",
+            "assets": {
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                }
+            },
+        }
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json))
+        (collection_dir / "data.parquet").write_bytes(b"PAR1")
+
+        pmtiles_path = collection_dir / "data.pmtiles"
+
+        # Mock to create partial file then raise unexpected exception
+        def mock_generate_unexpected(*args: object, **kwargs: object) -> None:
+            pmtiles_path.write_bytes(b"partial")
+            raise RuntimeError("Unexpected tippecanoe crash")
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                with patch("portolan_cli.pmtiles.generate_pmtiles", mock_generate_unexpected):
+                    result = generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        assert len(result.failed) == 1
+        assert not pmtiles_path.exists(), "Partial file should be cleaned up on any error"
+
 
 # Integration tests that require tippecanoe
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

Fixes #385 - Phantom assets in versions.json after failed PMTiles generation.

- Clean up partial .pmtiles files when generation fails mid-process
- Prevents orphaned files from being picked up by `_scan_item_assets` on subsequent `add` runs
- Avoids phantom entries in versions.json that cause warnings during push

## Root cause

When PMTiles generation fails (e.g., non-geospatial parquet or tippecanoe crash), gpio-pmtiles may leave partial output files on disk. These orphaned files get picked up by `_scan_item_assets` on subsequent `add` runs, causing phantom entries in versions.json that reference non-existent or corrupt files.

## Changes

- Added cleanup logic in `generate_pmtiles_for_collection()` using `finally` block
- Handles `KeyboardInterrupt`/`SystemExit` (BaseException subclasses) - not just Exception
- Uses `missing_ok=True` on unlink to avoid TOCTOU race condition
- Adds `warn()` call for observability when cleanup occurs
- Three unit tests verifying cleanup for PMTilesGenerationError, unexpected exceptions, and KeyboardInterrupt

## Test plan

- [x] `test_cleans_up_partial_file_on_failure` - PMTilesGenerationError
- [x] `test_cleans_up_partial_file_on_unexpected_error` - RuntimeError
- [x] `test_cleans_up_partial_file_on_keyboard_interrupt` - Ctrl+C scenario
- [x] All existing pmtiles tests pass (23 passed, 1 skipped)
- [x] Pre-commit hooks pass (ruff, mypy, vulture, xenon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)