### PR TITLE
fix(add): detect file changes within mtime tolerance

### DIFF
--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -2368,17 +2368,21 @@ def is_current(
         current_checksum = compute_dir_checksum(path)
         return current_checksum == asset.sha256
 
-    # Fast path: check mtime (2s tolerance for NFS/CIFS compatibility)
-    if asset.mtime is not None:
-        if abs(file_stat.st_mtime - asset.mtime) < MTIME_TOLERANCE_SECONDS:
-            return True
+    # Fast path: mtime unchanged AND size unchanged → file is current
+    # Both conditions must hold; size check catches fast overwrites within mtime tolerance
+    mtime_unchanged = (
+        asset.mtime is not None and abs(file_stat.st_mtime - asset.mtime) < MTIME_TOLERANCE_SECONDS
+    )
+    size_unchanged = asset.size_bytes is not None and file_stat.st_size == asset.size_bytes
 
-    # Medium path: size check before expensive SHA256
-    # If size differs, file definitely changed - skip checksum
+    if mtime_unchanged and size_unchanged:
+        return True
+
+    # Medium path: size differs → definitely changed
     if asset.size_bytes is not None and file_stat.st_size != asset.size_bytes:
         return False
 
-    # Slow path: compare sha256 (only if mtime changed but size matches)
+    # Slow path: mtime changed but size matches → check sha256
     current_checksum = compute_checksum(path)
     return current_checksum == asset.sha256
 

--- a/tests/integration/test_crs_change_detection.py
+++ b/tests/integration/test_crs_change_detection.py
@@ -1,0 +1,195 @@
+"""Reproduction test for issue #388: CRS change not detected after reprojection.
+
+This test verifies that when a GeoParquet file is reprojected externally,
+`portolan add` detects the change and updates the collection metadata.
+
+See: https://github.com/portolan-sdi/portolan-cli/issues/388
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from click.testing import CliRunner
+from shapely.geometry import Point
+
+from portolan_cli.cli import cli
+from portolan_cli.dataset import add_files, is_current
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def catalog_with_3857_geoparquet(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create a catalog with a GeoParquet file in EPSG:3857.
+
+    Uses collection-level asset (file directly in collection dir) per ADR-0031.
+
+    Returns:
+        Tuple of (catalog_root, collection_dir, geoparquet_path).
+    """
+    catalog_root = tmp_path / "catalog"
+    catalog_root.mkdir()
+
+    # Initialize catalog via CLI
+    result = CliRunner().invoke(cli, ["init", str(catalog_root), "--auto"])
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+
+    # Create collection directory (file goes directly here, no item subdir)
+    collection_dir = catalog_root / "test-collection"
+    collection_dir.mkdir(parents=True)
+
+    # Create a simple GeoDataFrame in EPSG:3857 (Web Mercator)
+    gdf = gpd.GeoDataFrame(
+        {"name": ["point1", "point2"]},
+        geometry=[
+            Point(-8238310, 4970072),  # ~NYC in EPSG:3857
+            Point(-8237000, 4971000),
+        ],
+        crs="EPSG:3857",
+    )
+
+    # Save as GeoParquet directly in collection (collection-level asset)
+    parquet_path = collection_dir / "data.parquet"
+    gdf.to_parquet(parquet_path)
+
+    return catalog_root, collection_dir, parquet_path
+
+
+class TestCRSChangeDetection:
+    """Tests for issue #388: CRS change detection after reprojection."""
+
+    @pytest.mark.integration
+    def test_is_current_detects_reprojected_file(
+        self, catalog_with_3857_geoparquet: tuple[Path, Path, Path]
+    ) -> None:
+        """Verify is_current() returns False for a reprojected file.
+
+        This tests the detection layer: after reprojection, the file
+        should be detected as changed (not current).
+        """
+        catalog_root, collection_dir, parquet_path = catalog_with_3857_geoparquet
+
+        # Add the file initially
+        added, skipped, failures = add_files(
+            paths=[parquet_path],
+            catalog_root=catalog_root,
+        )
+        assert len(added) == 1, f"Expected 1 added, got {len(added)}"
+        assert len(failures) == 0, f"Unexpected failures: {failures}"
+
+        # Verify file is now "current" (tracked)
+        versions_path = collection_dir / "versions.json"
+        assert versions_path.exists(), f"versions.json should exist at {versions_path}"
+        assert is_current(parquet_path, versions_path), "File should be current after add"
+
+        # Simulate external reprojection: read, reproject, overwrite
+        gdf = gpd.read_parquet(parquet_path)
+        assert gdf.crs.to_epsg() == 3857, f"Expected EPSG:3857, got {gdf.crs}"
+
+        # Reproject to EPSG:4326
+        gdf_4326 = gdf.to_crs("EPSG:4326")
+        assert gdf_4326.crs.to_epsg() == 4326
+
+        # Overwrite the original file (simulating gpio convert + mv)
+        gdf_4326.to_parquet(parquet_path)
+
+        # Verify CRS actually changed in file
+        gdf_check = gpd.read_parquet(parquet_path)
+        assert gdf_check.crs.to_epsg() == 4326, "File should now be EPSG:4326"
+
+        # THE KEY TEST: is_current() should return False (file changed)
+        assert not is_current(parquet_path, versions_path), (
+            "is_current() should detect reprojected file as changed"
+        )
+
+    @pytest.mark.integration
+    def test_readd_reprocesses_reprojected_file(
+        self, catalog_with_3857_geoparquet: tuple[Path, Path, Path]
+    ) -> None:
+        """Verify re-adding a reprojected file reprocesses it (not skipped).
+
+        This is the core fix for issue #388: after external reprojection,
+        `portolan add` must detect the change and reprocess the file.
+
+        Note: CRS propagation to collection.json is a separate concern.
+        GeoParquetMetadata.to_stac_properties() currently doesn't include CRS,
+        so proj:epsg/proj:code won't appear in collection.json for collection-level
+        GeoParquet assets. That's a potential enhancement for a future issue.
+        """
+        catalog_root, collection_dir, parquet_path = catalog_with_3857_geoparquet
+
+        # Add the collection-level file
+        added, skipped, failures = add_files(
+            paths=[parquet_path],
+            catalog_root=catalog_root,
+        )
+        assert len(added) == 1
+
+        # Reproject the file
+        gdf = gpd.read_parquet(parquet_path)
+        gdf_4326 = gdf.to_crs("EPSG:4326")
+        gdf_4326.to_parquet(parquet_path)
+
+        # Re-add
+        added2, skipped2, failures2 = add_files(
+            paths=[parquet_path],
+            catalog_root=catalog_root,
+        )
+
+        # THE KEY TEST: file should NOT be skipped (issue #388 fix)
+        assert len(skipped2) == 0, (
+            f"File should NOT be skipped after reprojection, but was: {skipped2}"
+        )
+        assert len(added2) == 1, f"Expected 1 added, got {len(added2)}"
+        assert len(failures2) == 0, f"Unexpected failures: {failures2}"
+
+    @pytest.mark.integration
+    def test_versions_json_tracks_reprojection(
+        self, catalog_with_3857_geoparquet: tuple[Path, Path, Path]
+    ) -> None:
+        """Verify versions.json sha256 changes after reprojection.
+
+        This confirms the detection mechanism: sha256 should differ for
+        the reprojected file, triggering reprocessing on re-add.
+        """
+        catalog_root, collection_dir, parquet_path = catalog_with_3857_geoparquet
+
+        # Add the file
+        add_files(paths=[parquet_path], catalog_root=catalog_root)
+
+        # Get initial sha256 from versions.json
+        versions_path = collection_dir / "versions.json"
+        versions_data = json.loads(versions_path.read_text())
+        initial_assets = versions_data["versions"][-1]["assets"]
+        initial_sha256 = initial_assets.get("data.parquet", {}).get("sha256")
+
+        print(f"Initial sha256: {initial_sha256}")
+        assert initial_sha256 is not None, "Asset should have sha256"
+
+        # Reproject the file
+        gdf = gpd.read_parquet(parquet_path)
+        gdf_4326 = gdf.to_crs("EPSG:4326")
+        gdf_4326.to_parquet(parquet_path)
+
+        # Re-add
+        add_files(paths=[parquet_path], catalog_root=catalog_root)
+
+        # Get final sha256
+        versions_data_after = json.loads(versions_path.read_text())
+        final_assets = versions_data_after["versions"][-1]["assets"]
+        final_sha256 = final_assets.get("data.parquet", {}).get("sha256")
+
+        print(f"Final sha256: {final_sha256}")
+
+        # sha256 MUST differ for reprojected file
+        assert final_sha256 != initial_sha256, (
+            "sha256 should change after reprojection — file content is different"
+        )

--- a/tests/integration/test_crs_change_detection.py
+++ b/tests/integration/test_crs_change_detection.py
@@ -9,6 +9,7 @@ See: https://github.com/portolan-sdi/portolan-cli/issues/388
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import geopandas as gpd
@@ -94,6 +95,9 @@ class TestCRSChangeDetection:
         gdf = gpd.read_parquet(parquet_path)
         assert gdf.crs.to_epsg() == 3857, f"Expected EPSG:3857, got {gdf.crs}"
 
+        # Capture original mtime before reprojection
+        orig_mtime = os.path.getmtime(parquet_path)
+
         # Reproject to EPSG:4326
         gdf_4326 = gdf.to_crs("EPSG:4326")
         assert gdf_4326.crs.to_epsg() == 4326
@@ -101,11 +105,16 @@ class TestCRSChangeDetection:
         # Overwrite the original file (simulating gpio convert + mv)
         gdf_4326.to_parquet(parquet_path)
 
+        # Force mtime back to original to exercise mtime-tolerance branch
+        # Without this, test might pass via sha256 path on slow systems
+        os.utime(parquet_path, (orig_mtime, orig_mtime))
+
         # Verify CRS actually changed in file
         gdf_check = gpd.read_parquet(parquet_path)
         assert gdf_check.crs.to_epsg() == 4326, "File should now be EPSG:4326"
 
         # THE KEY TEST: is_current() should return False (file changed)
+        # With same mtime, only the size check (the fix) catches this
         assert not is_current(parquet_path, versions_path), (
             "is_current() should detect reprojected file as changed"
         )
@@ -134,9 +143,11 @@ class TestCRSChangeDetection:
         assert len(added) == 1
 
         # Reproject the file
+        orig_mtime = os.path.getmtime(parquet_path)
         gdf = gpd.read_parquet(parquet_path)
         gdf_4326 = gdf.to_crs("EPSG:4326")
         gdf_4326.to_parquet(parquet_path)
+        os.utime(parquet_path, (orig_mtime, orig_mtime))  # Force mtime within tolerance
 
         # Re-add
         added2, skipped2, failures2 = add_files(
@@ -175,9 +186,11 @@ class TestCRSChangeDetection:
         assert initial_sha256 is not None, "Asset should have sha256"
 
         # Reproject the file
+        orig_mtime = os.path.getmtime(parquet_path)
         gdf = gpd.read_parquet(parquet_path)
         gdf_4326 = gdf.to_crs("EPSG:4326")
         gdf_4326.to_parquet(parquet_path)
+        os.utime(parquet_path, (orig_mtime, orig_mtime))  # Force mtime within tolerance
 
         # Re-add
         add_files(paths=[parquet_path], catalog_root=catalog_root)


### PR DESCRIPTION
## Summary

Fixes #388: Files reprojected externally (e.g., via `gpio convert`) were incorrectly skipped on re-add because `is_current()` only checked mtime, not file size.

- **Root cause:** The mtime fast-path (2s tolerance for NFS/CIFS) returned True immediately without checking file size. Files overwritten within 2 seconds were marked "unchanged".
- **Fix:** Fast-path now requires BOTH mtime unchanged AND size unchanged before returning True early. If size differs, proceeds to sha256 check.

## Test plan

- [x] New integration tests in `tests/integration/test_crs_change_detection.py`:
  - `test_is_current_detects_reprojected_file` — verifies `is_current()` returns False after reprojection
  - `test_readd_reprocesses_reprojected_file` — verifies file is re-added (not skipped)
  - `test_versions_json_tracks_reprojection` — verifies sha256 updates in versions.json
- [x] All 3934 existing unit tests pass
- [x] Lint/type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset change detection by validating both file modification timestamp and size concurrently, ensuring more accurate identification of externally modified files requiring reprocessing.

* **Tests**
  * Added integration tests for coordinate system change detection, verifying that reprojected GeoParquet files are correctly identified as modified and properly reprocessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->