### PR TITLE
fix(partition): correct path mismatch in versions.json and glob patterns

### DIFF
--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -545,7 +545,7 @@ def _maybe_partition_large_file(
 
     # Add collection-level glob asset for bulk access (Issue #351)
     # This provides a single glob URL for DuckDB/PyArrow/GDAL to read all partitions
-    glob_pattern = build_glob_pattern(prepared.collection_id, str(strategy))
+    glob_pattern = build_glob_pattern(str(strategy))
     glob_asset = pystac.Asset(
         href=glob_pattern,
         media_type="application/vnd.apache.parquet",

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -441,7 +441,6 @@ def _maybe_partition_large_file(
     from portolan_cli.config import get_setting
     from portolan_cli.partitioning import (
         build_glob_pattern,
-        get_partition_info,
         partition_geoparquet,
         should_partition,
     )
@@ -534,15 +533,12 @@ def _maybe_partition_large_file(
     partitioned_datasets: list[PreparedDataset] = []
 
     for partition_path in partition_files:
-        partition_info = get_partition_info(partition_path)
-        partition_id = f"{prepared.item_id}_{partition_info['cell_id']}"
-
         # Create STAC item for this partition
+        # item_id auto-derived from partition_path.parent.name (e.g., "kdtree_cell=0000000000")
         partition_prepared = prepare_dataset(
             path=partition_path,
             catalog_root=catalog_root,
             collection_id=prepared.collection_id,
-            item_id=partition_id,
             item_datetime=item_datetime,
         )
         partitioned_datasets.append(partition_prepared)

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -174,20 +174,22 @@ def get_partition_info(partition_path: Path) -> dict[str, str]:
     }
 
 
-def build_glob_pattern(collection_id: str, strategy: str = DEFAULT_STRATEGY) -> str:
+def build_glob_pattern(strategy: str = DEFAULT_STRATEGY) -> str:
     """Build glob pattern for collection-level asset href.
 
     Per Issue #351, partitioned datasets expose a glob URL for bulk access.
 
     Args:
-        collection_id: The collection identifier.
         strategy: Partitioning strategy used.
 
     Returns:
         Relative glob pattern like "./kdtree_cell=*/*.parquet" for Hive-style partitions.
+
+    Note:
+        The pattern matches ALL .parquet files in partition directories.
+        geoparquet-io creates files named by cell ID (e.g., "0000000000.parquet").
+        Do not place additional parquet files in partition directories.
     """
-    # Hive-style: each partition is in its own directory named by partition column
-    # Files are named by cell ID (e.g., "0000000000.parquet"), not "data.parquet"
     partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
     return f"./{partition_col}=*/*.parquet"
 

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -184,11 +184,12 @@ def build_glob_pattern(collection_id: str, strategy: str = DEFAULT_STRATEGY) -> 
         strategy: Partitioning strategy used.
 
     Returns:
-        Relative glob pattern like "./kdtree_cell=*/data.parquet" for Hive-style partitions.
+        Relative glob pattern like "./kdtree_cell=*/*.parquet" for Hive-style partitions.
     """
     # Hive-style: each partition is in its own directory named by partition column
+    # Files are named by cell ID (e.g., "0000000000.parquet"), not "data.parquet"
     partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
-    return f"./{partition_col}=*/data.parquet"
+    return f"./{partition_col}=*/*.parquet"
 
 
 def build_remote_glob(
@@ -202,9 +203,9 @@ def build_remote_glob(
         strategy: Partitioning strategy used.
 
     Returns:
-        Absolute glob URL like "s3://bucket/collection/kdtree_cell=*/data.parquet".
+        Absolute glob URL like "s3://bucket/collection/kdtree_cell=*/*.parquet".
     """
     # Normalize: ensure no trailing slash on base
     base = remote_base.rstrip("/")
     partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
-    return f"{base}/{collection_id}/{partition_col}=*/data.parquet"
+    return f"{base}/{collection_id}/{partition_col}=*/*.parquet"

--- a/tests/integration/test_partition_paths.py
+++ b/tests/integration/test_partition_paths.py
@@ -1,0 +1,261 @@
+"""Integration tests for spatial partitioning path handling.
+
+Per Issue #349/#399: Partitioned GeoParquet files should:
+1. Use Hive-style directory names (kdtree_cell=XXXX/)
+2. Have versions.json paths match actual filesystem structure
+3. Have glob patterns that work with DuckDB/PyArrow
+
+These tests verify the fix for the path mismatch bug where:
+- versions.json recorded "data_XXXX/XXXX.parquet"
+- But actual files were "kdtree_cell=XXXX/XXXX.parquet"
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def initialized_catalog(tmp_path: Path) -> Path:
+    """Create an initialized Portolan catalog using CLI."""
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+    return tmp_path
+
+
+@pytest.fixture
+def large_geoparquet(initialized_catalog: Path) -> Path:
+    """Create a GeoParquet file large enough to trigger partitioning."""
+    import geopandas as gpd
+    import numpy as np
+    from shapely.geometry import Point
+
+    collection_dir = initialized_catalog / "points"
+    collection_dir.mkdir()
+
+    # Create 100k points - enough to meet minimum rows per partition (512 partitions * 100 rows)
+    n = 100000
+    gdf = gpd.GeoDataFrame(
+        {"id": range(n), "val": np.random.rand(n)},
+        geometry=[
+            Point(np.random.uniform(-180, 180), np.random.uniform(-90, 90)) for _ in range(n)
+        ],
+        crs="EPSG:4326",
+    )
+    parquet_path = collection_dir / "data.parquet"
+    gdf.to_parquet(parquet_path)
+    return parquet_path
+
+
+def _set_partitioning_config(catalog_root: Path, threshold_gb: float = 0.00001) -> None:
+    """Enable partitioning with low threshold via direct config file manipulation."""
+    config_path = catalog_root / ".portolan" / "config.yaml"
+    config_content = f"""# Portolan configuration
+partitioning.enabled: true
+partitioning.threshold_gb: {threshold_gb}
+"""
+    config_path.write_text(config_content)
+
+
+@pytest.mark.integration
+class TestPartitionPathConsistency:
+    """Tests for partition path consistency between filesystem and versions.json."""
+
+    def test_versions_json_paths_match_hive_structure(
+        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+    ) -> None:
+        """versions.json paths should match actual Hive-style directory structure."""
+        # Enable partitioning with very low threshold via direct config
+        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
+
+        # Add the file (should trigger partitioning)
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--force",
+                "--portolan-dir",
+                str(initialized_catalog),
+                str(large_geoparquet.parent),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+        assert "Added" in result.output
+
+        # Check versions.json
+        versions_path = large_geoparquet.parent / "versions.json"
+        assert versions_path.exists(), "versions.json not created"
+
+        versions_data = json.loads(versions_path.read_text())
+        assets = versions_data["versions"][0]["assets"]
+
+        # Get actual partition directories
+        partition_dirs = list(large_geoparquet.parent.glob("kdtree_cell=*"))
+        assert len(partition_dirs) > 0, "No partition directories created"
+
+        # Verify each partition directory has a corresponding entry in versions.json
+        for partition_dir in partition_dirs:
+            dir_name = partition_dir.name  # e.g., "kdtree_cell=0000000000"
+            parquet_files = list(partition_dir.glob("*.parquet"))
+            assert len(parquet_files) == 1, f"Expected 1 parquet in {dir_name}"
+
+            filename = parquet_files[0].name
+            expected_key = f"{dir_name}/{filename}"
+
+            assert expected_key in assets, (
+                f"versions.json missing entry for {expected_key}. "
+                f"Keys: {list(assets.keys())[:5]}..."
+            )
+
+    def test_glob_pattern_matches_actual_files(
+        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+    ) -> None:
+        """Glob pattern in collection.json should match actual partition files."""
+        # Enable partitioning via direct config
+        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
+
+        # Add the file
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--force",
+                "--portolan-dir",
+                str(initialized_catalog),
+                str(large_geoparquet.parent),
+            ],
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Check collection.json for glob asset
+        collection_path = large_geoparquet.parent / "collection.json"
+        collection_data = json.loads(collection_path.read_text())
+
+        # Find glob asset
+        glob_asset = None
+        for _key, asset in collection_data.get("assets", {}).items():
+            if "*" in asset.get("href", ""):
+                glob_asset = asset
+                break
+
+        assert glob_asset is not None, "No glob asset found in collection.json"
+
+        # Extract glob pattern and verify it matches actual files
+        href = glob_asset["href"]  # e.g., "./kdtree_cell=*/*.parquet"
+        assert href == "./kdtree_cell=*/*.parquet", f"Unexpected glob pattern: {href}"
+
+        # Verify glob actually matches files
+
+        collection_dir = large_geoparquet.parent
+        # Convert glob pattern to pathlib pattern
+        pattern = href.lstrip("./")  # "kdtree_cell=*/*.parquet"
+        matched_files = list(collection_dir.glob(pattern))
+
+        assert len(matched_files) > 0, f"Glob pattern {pattern} matched no files"
+
+    def test_duckdb_can_read_via_glob(
+        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+    ) -> None:
+        """DuckDB should be able to read partitioned data via glob pattern."""
+        pytest.importorskip("duckdb")
+        import duckdb
+
+        # Enable partitioning via direct config
+        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
+
+        # Add the file
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--force",
+                "--portolan-dir",
+                str(initialized_catalog),
+                str(large_geoparquet.parent),
+            ],
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Read collection.json to get glob pattern
+        collection_path = large_geoparquet.parent / "collection.json"
+        collection_data = json.loads(collection_path.read_text())
+
+        # Find glob asset
+        glob_href = None
+        for asset in collection_data.get("assets", {}).values():
+            if "*" in asset.get("href", ""):
+                glob_href = asset["href"]
+                break
+
+        assert glob_href is not None, "No glob asset found"
+
+        # Convert to absolute path for DuckDB
+        collection_dir = large_geoparquet.parent
+        glob_path = str(collection_dir / glob_href.lstrip("./"))
+
+        # Query via DuckDB
+        result = duckdb.sql(f"SELECT count(*) as cnt FROM '{glob_path}'").fetchone()
+        assert result is not None
+        row_count = result[0]
+
+        # Should have all 10k rows
+        assert row_count == 100000, f"Expected 100000 rows, got {row_count}"
+
+
+@pytest.mark.integration
+class TestPushGlobTransformation:
+    """Tests for portolan:glob field transformation during push."""
+
+    def test_push_dryrun_shows_correct_glob_url(
+        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+    ) -> None:
+        """Push dry-run should show correct glob URL transformation."""
+        # Enable partitioning via direct config
+        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
+
+        # Add the file
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--force",
+                "--portolan-dir",
+                str(initialized_catalog),
+                str(large_geoparquet.parent),
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Verify transformation function works correctly
+        from portolan_cli.push import _transform_collection_glob_assets
+
+        collection_path = large_geoparquet.parent / "collection.json"
+        content = collection_path.read_bytes()
+
+        transformed = _transform_collection_glob_assets(content, "s3://bucket/catalog", "points")
+        transformed_data = json.loads(transformed)
+
+        # Find glob asset and verify portolan:glob
+        for asset in transformed_data.get("assets", {}).values():
+            if "*" in asset.get("href", ""):
+                assert "portolan:glob" in asset, "portolan:glob not added"
+                glob_url = asset["portolan:glob"]
+                assert glob_url == "s3://bucket/catalog/points/kdtree_cell=*/*.parquet", (
+                    f"Wrong glob URL: {glob_url}"
+                )
+                break
+        else:
+            pytest.fail("No glob asset found in transformed collection")

--- a/tests/integration/test_partition_paths.py
+++ b/tests/integration/test_partition_paths.py
@@ -45,8 +45,8 @@ def large_geoparquet(initialized_catalog: Path) -> Path:
     collection_dir = initialized_catalog / "points"
     collection_dir.mkdir()
 
-    # Create 100k points - enough to meet minimum rows per partition (512 partitions * 100 rows)
-    n = 100000
+    # Create 100k points - exceeds minimum (512 partitions * 100 rows = 51,200 minimum)
+    n = 100_000
     gdf = gpd.GeoDataFrame(
         {"id": range(n), "val": np.random.rand(n)},
         geometry=[
@@ -153,9 +153,11 @@ class TestPartitionPathConsistency:
 
         assert glob_asset is not None, "No glob asset found in collection.json"
 
-        # Extract glob pattern and verify it matches actual files
+        # Extract glob pattern and verify structure (not exact match - allows strategy changes)
         href = glob_asset["href"]  # e.g., "./kdtree_cell=*/*.parquet"
-        assert href == "./kdtree_cell=*/*.parquet", f"Unexpected glob pattern: {href}"
+        assert href.startswith("./"), f"Glob should be relative: {href}"
+        assert "*" in href, f"Glob should contain wildcard: {href}"
+        assert href.endswith("/*.parquet"), f"Glob should match parquet files: {href}"
 
         # Verify glob actually matches files
 
@@ -165,6 +167,45 @@ class TestPartitionPathConsistency:
         matched_files = list(collection_dir.glob(pattern))
 
         assert len(matched_files) > 0, f"Glob pattern {pattern} matched no files"
+
+    def test_glob_excludes_non_parquet_files(
+        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+    ) -> None:
+        """Glob pattern should NOT match non-parquet files in partition directories."""
+        # Enable partitioning via direct config
+        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
+
+        # Add the file
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--force",
+                "--portolan-dir",
+                str(initialized_catalog),
+                str(large_geoparquet.parent),
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Add a non-parquet file to a partition directory
+        partition_dirs = list(large_geoparquet.parent.glob("kdtree_cell=*"))
+        assert len(partition_dirs) > 0
+        decoy_file = partition_dirs[0] / "metadata.json"
+        decoy_file.write_text('{"decoy": true}')
+
+        # Get glob pattern and verify it doesn't match the decoy
+        collection_dir = large_geoparquet.parent
+        pattern = "kdtree_cell=*/*.parquet"
+        matched_files = list(collection_dir.glob(pattern))
+
+        # Verify decoy is NOT in matches
+        matched_names = [f.name for f in matched_files]
+        assert "metadata.json" not in matched_names, "Glob incorrectly matched non-parquet file"
+
+        # All matches should be .parquet
+        for f in matched_files:
+            assert f.suffix == ".parquet", f"Non-parquet file matched: {f}"
 
     def test_duckdb_can_read_via_glob(
         self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
@@ -211,8 +252,8 @@ class TestPartitionPathConsistency:
         assert result is not None
         row_count = result[0]
 
-        # Should have all 10k rows
-        assert row_count == 100000, f"Expected 100000 rows, got {row_count}"
+        # Should have all 100k rows
+        assert row_count == 100_000, f"Expected 100000 rows, got {row_count}"
 
 
 @pytest.mark.integration
@@ -248,14 +289,17 @@ class TestPushGlobTransformation:
         transformed = _transform_collection_glob_assets(content, "s3://bucket/catalog", "points")
         transformed_data = json.loads(transformed)
 
-        # Find glob asset and verify portolan:glob
+        # Find glob asset and verify portolan:glob structure (not exact match)
         for asset in transformed_data.get("assets", {}).values():
             if "*" in asset.get("href", ""):
                 assert "portolan:glob" in asset, "portolan:glob not added"
                 glob_url = asset["portolan:glob"]
-                assert glob_url == "s3://bucket/catalog/points/kdtree_cell=*/*.parquet", (
-                    f"Wrong glob URL: {glob_url}"
+                # Verify URL structure without hardcoding exact pattern
+                assert glob_url.startswith("s3://bucket/catalog/points/"), (
+                    f"Wrong base URL: {glob_url}"
                 )
+                assert "*" in glob_url, f"Missing wildcard in glob URL: {glob_url}"
+                assert glob_url.endswith("/*.parquet"), f"Wrong suffix: {glob_url}"
                 break
         else:
             pytest.fail("No glob asset found in transformed collection")

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -202,7 +202,7 @@ class TestGlobPatterns:
         """build_glob_pattern returns relative glob with strategy-specific partition column."""
         from portolan_cli.partitioning import build_glob_pattern
 
-        result = build_glob_pattern("buildings", strategy="kdtree")
+        result = build_glob_pattern(strategy="kdtree")
 
         assert result == "./kdtree_cell=*/*.parquet"
 
@@ -211,10 +211,10 @@ class TestGlobPatterns:
         """build_glob_pattern uses correct partition column for each strategy."""
         from portolan_cli.partitioning import build_glob_pattern
 
-        assert build_glob_pattern("x", "kdtree") == "./kdtree_cell=*/*.parquet"
-        assert build_glob_pattern("x", "h3") == "./h3_cell=*/*.parquet"
-        assert build_glob_pattern("x", "s2") == "./s2_cell=*/*.parquet"
-        assert build_glob_pattern("x", "quadkey") == "./quadkey=*/*.parquet"
+        assert build_glob_pattern("kdtree") == "./kdtree_cell=*/*.parquet"
+        assert build_glob_pattern("h3") == "./h3_cell=*/*.parquet"
+        assert build_glob_pattern("s2") == "./s2_cell=*/*.parquet"
+        assert build_glob_pattern("quadkey") == "./quadkey=*/*.parquet"
 
     @pytest.mark.unit
     def test_build_remote_glob_creates_absolute_url(self) -> None:

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -204,17 +204,17 @@ class TestGlobPatterns:
 
         result = build_glob_pattern("buildings", strategy="kdtree")
 
-        assert result == "./kdtree_cell=*/data.parquet"
+        assert result == "./kdtree_cell=*/*.parquet"
 
     @pytest.mark.unit
     def test_build_glob_pattern_uses_correct_partition_column(self) -> None:
         """build_glob_pattern uses correct partition column for each strategy."""
         from portolan_cli.partitioning import build_glob_pattern
 
-        assert build_glob_pattern("x", "kdtree") == "./kdtree_cell=*/data.parquet"
-        assert build_glob_pattern("x", "h3") == "./h3_cell=*/data.parquet"
-        assert build_glob_pattern("x", "s2") == "./s2_cell=*/data.parquet"
-        assert build_glob_pattern("x", "quadkey") == "./quadkey=*/data.parquet"
+        assert build_glob_pattern("x", "kdtree") == "./kdtree_cell=*/*.parquet"
+        assert build_glob_pattern("x", "h3") == "./h3_cell=*/*.parquet"
+        assert build_glob_pattern("x", "s2") == "./s2_cell=*/*.parquet"
+        assert build_glob_pattern("x", "quadkey") == "./quadkey=*/*.parquet"
 
     @pytest.mark.unit
     def test_build_remote_glob_creates_absolute_url(self) -> None:
@@ -223,7 +223,7 @@ class TestGlobPatterns:
 
         result = build_remote_glob("s3://bucket/catalog", "buildings", "kdtree")
 
-        assert result == "s3://bucket/catalog/buildings/kdtree_cell=*/data.parquet"
+        assert result == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
 
     @pytest.mark.unit
     def test_build_remote_glob_handles_trailing_slash(self) -> None:
@@ -232,7 +232,7 @@ class TestGlobPatterns:
 
         result = build_remote_glob("s3://bucket/catalog/", "buildings", "kdtree")
 
-        assert result == "s3://bucket/catalog/buildings/kdtree_cell=*/data.parquet"
+        assert result == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
 
 
 class TestGlobTransformation:
@@ -250,7 +250,7 @@ class TestGlobTransformation:
             "id": "buildings",
             "assets": {
                 "partitioned_data": {
-                    "href": "./kdtree_cell=*/data.parquet",
+                    "href": "./kdtree_cell=*/*.parquet",
                     "type": "application/vnd.apache.parquet",
                     "roles": ["data"],
                 },
@@ -270,8 +270,7 @@ class TestGlobTransformation:
         partitioned = result_json["assets"]["partitioned_data"]
         assert "portolan:glob" in partitioned
         assert (
-            partitioned["portolan:glob"]
-            == "s3://bucket/catalog/buildings/kdtree_cell=*/data.parquet"
+            partitioned["portolan:glob"] == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
         )
 
         # Non-glob asset should be unchanged
@@ -290,9 +289,9 @@ class TestGlobTransformation:
             "id": "buildings",
             "assets": {
                 "partitioned_data": {
-                    "href": "./kdtree_cell=*/data.parquet",
+                    "href": "./kdtree_cell=*/*.parquet",
                     "type": "application/vnd.apache.parquet",
-                    "portolan:glob": "s3://existing/path/*/data.parquet",
+                    "portolan:glob": "s3://existing/path/*/*.parquet",
                 },
             },
         }
@@ -304,7 +303,7 @@ class TestGlobTransformation:
         # Should preserve existing value
         assert (
             result_json["assets"]["partitioned_data"]["portolan:glob"]
-            == "s3://existing/path/*/data.parquet"
+            == "s3://existing/path/*/*.parquet"
         )
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Fix partition item_id derivation to use Hive-style directory names (`kdtree_cell=XXXX`) instead of constructing `{stem}_{cell}` paths
- Fix glob patterns to use `*.parquet` instead of hardcoded `data.parquet` (matches geoparquet-io output)
- Add integration tests for partition path consistency, glob matching, and DuckDB compatibility

## Problem
After `portolan add` with auto-partitioning:
- `versions.json` recorded paths like `data_0000000000/0000000000.parquet`
- But actual files were at `kdtree_cell=0000000000/0000000000.parquet`
- This caused `portolan push` to fail with "file not found" errors
- Glob patterns also used `data.parquet` but files are named `{cell_id}.parquet`

## Test plan
- [x] Unit tests pass (`uv run pytest tests/unit/test_partitioning.py`)
- [x] New integration tests verify path consistency
- [x] DuckDB can read partitioned data via glob pattern
- [x] Push transformation creates correct `portolan:glob` URLs

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partitioning of large GeoParquet datasets with Hive-style directory structures and flexible file pattern matching.
  * Fixed glob pattern generation to correctly match files within partition directories instead of hard-coded filenames.

* **Tests**
  * Added integration tests validating spatial partitioning path consistency, glob pattern matching, and remote query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->