### PR TITLE
feat(readme): add --verbose flag for detailed output

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -4916,10 +4916,17 @@ def metadata_validate(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+def _verbose_readme(msg: str, verbose: bool, use_json: bool) -> None:
+    """Output verbose message for readme command (if enabled and not JSON mode)."""
+    if verbose and not use_json:
+        info_output(msg)
+
+
 def _generate_readme_content(
     target_dir: Path,
     catalog_path: Path,
     use_json: bool,
+    verbose: bool = False,
 ) -> tuple[str, bool]:
     """Generate README content for a target directory.
 
@@ -4927,6 +4934,7 @@ def _generate_readme_content(
         target_dir: Directory to generate README for.
         catalog_path: Root catalog path.
         use_json: Whether to output errors as JSON.
+        verbose: Whether to show detailed output.
 
     Returns:
         Tuple of (readme_content, is_catalog_root).
@@ -4938,12 +4946,26 @@ def _generate_readme_content(
     from portolan_cli.errors import ConfigInvalidStructureError
     from portolan_cli.readme import generate_catalog_readme, generate_readme
 
+    # Compute relative path for display
+    try:
+        rel_dir = target_dir.relative_to(catalog_path)
+        display_dir = str(rel_dir) if str(rel_dir) != "." else ""
+    except ValueError:
+        display_dir = str(target_dir)
+    dir_prefix = f"{display_dir}/" if display_dir else ""
+
     # Check if at catalog root (has catalog.json, not collection.json)
     is_catalog_root = (target_dir / "catalog.json").exists() and not (
         target_dir / "collection.json"
     ).exists()
 
     if is_catalog_root:
+        _verbose_readme(
+            f"Reading catalog.json from {dir_prefix or 'catalog root'}", verbose, use_json
+        )
+        if (target_dir / ".portolan" / "metadata.yaml").exists():
+            _verbose_readme(f"Reading metadata.yaml from {dir_prefix}.portolan/", verbose, use_json)
+        _verbose_readme("Generating README.md", verbose, use_json)
         return generate_catalog_readme(target_dir), True
 
     # Load STAC (collection.json or catalog.json)
@@ -4951,11 +4973,16 @@ def _generate_readme_content(
     for stac_file in ["collection.json", "catalog.json"]:
         stac_path = target_dir / stac_file
         if stac_path.exists():
+            _verbose_readme(
+                f"Reading {stac_file} from {dir_prefix or 'catalog root'}", verbose, use_json
+            )
             stac = json.loads(stac_path.read_text())
             break
 
     # Load merged metadata
     try:
+        if (target_dir / ".portolan" / "metadata.yaml").exists():
+            _verbose_readme(f"Reading metadata.yaml from {dir_prefix}.portolan/", verbose, use_json)
         metadata_dict = load_merged_metadata(target_dir, catalog_path)
     except ConfigInvalidStructureError as err:
         if use_json:
@@ -4967,6 +4994,8 @@ def _generate_readme_content(
         else:
             error(f"Invalid YAML in metadata.yaml: {err}")
         raise SystemExit(1) from err
+
+    _verbose_readme("Generating README.md", verbose, use_json)
 
     return generate_readme(stac=stac, metadata=metadata_dict), False
 
@@ -5148,6 +5177,7 @@ def _readme_recursive(
     use_json: bool,
     check: bool,
     stdout: bool,
+    verbose: bool = False,
 ) -> None:
     """Generate READMEs for catalog and all collections recursively.
 
@@ -5160,6 +5190,7 @@ def _readme_recursive(
         use_json: Output JSON format.
         check: CI mode - check freshness only.
         stdout: Print to stdout (not supported in recursive mode).
+        verbose: Whether to show detailed output.
     """
     from portolan_cli.readme import (
         generate_catalog_readme,
@@ -5185,17 +5216,20 @@ def _readme_recursive(
         rel_path = str(rel_dir / "README.md")
 
         if (dirpath / "collection.json").exists():
+            _verbose_readme(f"Processing collection: {rel_dir}/", verbose, use_json)
             content = generate_readme_for_collection(dirpath, catalog_path)
             _process_readme_entry(
                 readme_path, content, rel_path, check, generated_paths, stale_paths
             )
         elif (dirpath / "catalog.json").exists():
+            _verbose_readme(f"Processing subcatalog: {rel_dir}/", verbose, use_json)
             content = generate_catalog_readme(dirpath)
             _process_readme_entry(
                 readme_path, content, rel_path, check, generated_paths, stale_paths
             )
 
     # Generate root catalog README
+    _verbose_readme("Processing catalog root", verbose, use_json)
     root_content = generate_catalog_readme(catalog_path)
     _process_readme_entry(
         catalog_path / "README.md", root_content, "README.md", check, generated_paths, stale_paths
@@ -5264,6 +5298,7 @@ def _readme_recursive(
     default=False,
     help="Generate READMEs for catalog and all collections.",
 )
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed output.")
 @click.pass_context
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
 def readme(
@@ -5273,6 +5308,7 @@ def readme(
     stdout: bool,
     check: bool,
     recursive: bool,
+    verbose: bool,
 ) -> None:
     """Generate README.md from STAC metadata and metadata.yaml.
 
@@ -5314,7 +5350,7 @@ def readme(
 
     # Handle recursive mode
     if recursive:
-        _readme_recursive(catalog_path, use_json, check, stdout)
+        _readme_recursive(catalog_path, use_json, check, stdout, verbose)
         return
 
     # Determine target directory
@@ -5324,7 +5360,9 @@ def readme(
         target_dir = catalog_path
 
     # Generate README content
-    readme_content, is_catalog_root = _generate_readme_content(target_dir, catalog_path, use_json)
+    readme_content, is_catalog_root = _generate_readme_content(
+        target_dir, catalog_path, use_json, verbose
+    )
 
     # Determine output path
     readme_path = target_dir / "README.md"

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -4922,6 +4922,21 @@ def _verbose_readme(msg: str, verbose: bool, use_json: bool) -> None:
         info_output(msg)
 
 
+def _verbose_readme_files(
+    dirpath: Path,
+    rel_dir: str,
+    stac_file: str,
+    verbose: bool,
+    use_json: bool,
+) -> None:
+    """Output verbose file-read messages for a STAC directory."""
+    dir_suffix = "/" if rel_dir != "catalog root" else ""
+    _verbose_readme(f"Reading {stac_file} from {rel_dir}{dir_suffix}", verbose, use_json)
+    if (dirpath / ".portolan" / "metadata.yaml").exists():
+        metadata_loc = ".portolan/" if rel_dir == "catalog root" else f"{rel_dir}/.portolan/"
+        _verbose_readme(f"Reading metadata.yaml from {metadata_loc}", verbose, use_json)
+
+
 def _generate_readme_content(
     target_dir: Path,
     catalog_path: Path,
@@ -5217,12 +5232,14 @@ def _readme_recursive(
 
         if (dirpath / "collection.json").exists():
             _verbose_readme(f"Processing collection: {rel_dir}/", verbose, use_json)
+            _verbose_readme_files(dirpath, str(rel_dir), "collection.json", verbose, use_json)
             content = generate_readme_for_collection(dirpath, catalog_path)
             _process_readme_entry(
                 readme_path, content, rel_path, check, generated_paths, stale_paths
             )
         elif (dirpath / "catalog.json").exists():
             _verbose_readme(f"Processing subcatalog: {rel_dir}/", verbose, use_json)
+            _verbose_readme_files(dirpath, str(rel_dir), "catalog.json", verbose, use_json)
             content = generate_catalog_readme(dirpath)
             _process_readme_entry(
                 readme_path, content, rel_path, check, generated_paths, stale_paths
@@ -5230,6 +5247,7 @@ def _readme_recursive(
 
     # Generate root catalog README
     _verbose_readme("Processing catalog root", verbose, use_json)
+    _verbose_readme_files(catalog_path, "catalog root", "catalog.json", verbose, use_json)
     root_content = generate_catalog_readme(catalog_path)
     _process_readme_entry(
         catalog_path / "README.md", root_content, "README.md", check, generated_paths, stale_paths

--- a/tests/integration/test_readme_recursive.py
+++ b/tests/integration/test_readme_recursive.py
@@ -163,3 +163,155 @@ class TestReadmeRecursive:
 
         assert result.exit_code == 1
         assert "stale" in result.output.lower() or "alpha" in result.output
+
+
+class TestReadmeVerbose:
+    """Integration tests for portolan readme --verbose flag."""
+
+    @pytest.fixture
+    def catalog_with_metadata(self, tmp_path: Path) -> Path:
+        """Create a catalog with collections and metadata.yaml files."""
+        # Initialize catalog structure
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text("version: '1.0'\n")
+        (tmp_path / ".portolan" / "metadata.yaml").write_text(
+            "contact:\n  name: Test\n  email: test@example.com\nlicense: MIT\n"
+        )
+
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "verbose-test",
+                    "title": "Verbose Test Catalog",
+                    "description": "Testing verbose output",
+                    "stac_version": "1.0.0",
+                }
+            )
+        )
+
+        # Create collection with metadata
+        coll_dir = tmp_path / "mydata"
+        coll_dir.mkdir()
+        (coll_dir / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "mydata",
+                    "title": "My Data Collection",
+                    "description": "Test collection",
+                    "stac_version": "1.0.0",
+                    "extent": {
+                        "spatial": {"bbox": [[0, 0, 1, 1]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                    "links": [],
+                    "license": "MIT",
+                }
+            )
+        )
+        (coll_dir / ".portolan").mkdir()
+        (coll_dir / ".portolan" / "metadata.yaml").write_text(
+            "contact:\n  name: Test\n  email: test@example.com\nlicense: MIT\n"
+        )
+
+        return tmp_path
+
+    @pytest.mark.integration
+    def test_verbose_shows_file_reads_for_collection(self, catalog_with_metadata: Path) -> None:
+        """--verbose should show which files are being read for a collection."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["readme", "mydata", "--verbose"])
+
+        assert result.exit_code == 0
+        assert "collection.json" in result.output
+        assert "metadata.yaml" in result.output
+        assert "mydata" in result.output
+
+    @pytest.mark.integration
+    def test_verbose_shows_file_reads_for_catalog(self, catalog_with_metadata: Path) -> None:
+        """--verbose should show which files are being read for catalog root."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["readme", "--verbose"])
+
+        assert result.exit_code == 0
+        assert "catalog.json" in result.output
+        assert "metadata.yaml" in result.output
+
+    @pytest.mark.integration
+    def test_verbose_recursive_shows_all_file_reads(self, catalog_with_metadata: Path) -> None:
+        """--recursive --verbose should show file reads for every entity."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["readme", "--recursive", "--verbose"])
+
+        assert result.exit_code == 0
+        # Should show processing messages
+        assert "Processing" in result.output
+        # Should show file-level reads for catalog root
+        assert "catalog.json" in result.output
+        # Should show file-level reads for collection
+        assert "collection.json" in result.output
+        # Should show metadata reads
+        assert "metadata.yaml" in result.output
+
+    @pytest.mark.integration
+    def test_verbose_with_json_produces_valid_json(self, catalog_with_metadata: Path) -> None:
+        """--verbose --json should not corrupt JSON output."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["--format", "json", "readme", "--verbose"])
+
+        assert result.exit_code == 0
+        # Must be valid JSON
+        output = json.loads(result.output)
+        assert output["success"] is True
+        # Verbose text should NOT appear in JSON output
+        assert "Reading" not in result.output
+
+    @pytest.mark.integration
+    def test_verbose_recursive_json_produces_valid_json(self, catalog_with_metadata: Path) -> None:
+        """--recursive --verbose --json should produce valid JSON."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["--format", "json", "readme", "--recursive", "--verbose"])
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert output["success"] is True
+        assert "generated" in output["data"]
+
+    @pytest.mark.integration
+    def test_default_no_verbose_is_quiet(self, catalog_with_metadata: Path) -> None:
+        """Without --verbose, file read messages should not appear."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["readme"])
+
+        assert result.exit_code == 0
+        # Should NOT show "Reading" messages
+        assert "Reading" not in result.output
+
+    @pytest.mark.integration
+    def test_verbose_check_mode_shows_reads(self, catalog_with_metadata: Path) -> None:
+        """--check --verbose should show file reads during check."""
+        runner = CliRunner()
+
+        # First generate
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            runner.invoke(cli, ["readme"])
+
+        # Then check with verbose
+        with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
+            result = runner.invoke(cli, ["readme", "--check", "--verbose"])
+
+        assert result.exit_code == 0
+        assert "catalog.json" in result.output or "metadata.yaml" in result.output

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -580,3 +580,138 @@ class TestReadmeGenerate:
             content = Path("README.md").read_text()
             assert "# STAC Title" in content
             assert "Portolan" in content  # Attribution footer
+
+    @pytest.mark.unit
+    def test_verbose_shows_file_reads(self, runner: CliRunner, tmp_path: Path) -> None:
+        """readme --verbose should show which files are being read."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("demographics").mkdir()
+            Path("demographics/collection.json").write_text(
+                json.dumps({"type": "Collection", "id": "demographics", "title": "Demographics"})
+            )
+            Path("demographics/.portolan").mkdir()
+            Path("demographics/.portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+
+            result = runner.invoke(cli, ["readme", "demographics", "--verbose"])
+
+            assert result.exit_code == 0
+            # Should show reading collection.json
+            assert "collection.json" in result.output
+            # Should show reading metadata.yaml
+            assert "metadata.yaml" in result.output
+            # Should show generating
+            assert "Generating" in result.output or "README.md" in result.output
+
+    @pytest.mark.unit
+    def test_verbose_short_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+        """readme -v should work as shorthand for --verbose."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("catalog.json").write_text(
+                json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
+            )
+            Path(".portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+
+            result = runner.invoke(cli, ["readme", "-v"])
+
+            assert result.exit_code == 0
+            # Should show verbose output
+            assert "catalog.json" in result.output or "metadata.yaml" in result.output
+
+    @pytest.mark.unit
+    def test_verbose_recursive_shows_per_collection_progress(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """readme --recursive --verbose should show progress for each collection."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("catalog.json").write_text(
+                json.dumps({"type": "Catalog", "id": "root", "title": "Root"})
+            )
+            Path(".portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+            # Create two collections
+            for name in ["demographics", "climate"]:
+                Path(name).mkdir()
+                Path(f"{name}/collection.json").write_text(
+                    json.dumps({"type": "Collection", "id": name, "title": name.title()})
+                )
+                Path(f"{name}/.portolan").mkdir()
+                Path(f"{name}/.portolan/metadata.yaml").write_text(
+                    "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+                )
+
+            result = runner.invoke(cli, ["readme", "--recursive", "--verbose"])
+
+            assert result.exit_code == 0
+            # Should mention both collections in verbose output
+            assert "demographics" in result.output
+            assert "climate" in result.output
+
+    @pytest.mark.unit
+    def test_verbose_check_shows_reads_even_when_fresh(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """readme --check --verbose should show file reads even when README is fresh."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("catalog.json").write_text(
+                json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
+            )
+            Path(".portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+            # Generate README first
+            runner.invoke(cli, ["readme"])
+
+            result = runner.invoke(cli, ["readme", "--check", "--verbose"])
+
+            assert result.exit_code == 0
+            # Should still show what was read
+            assert "catalog.json" in result.output or "metadata.yaml" in result.output
+
+    @pytest.mark.unit
+    def test_verbose_ignored_with_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
+        """readme --verbose --json should not include verbose messages in JSON."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("catalog.json").write_text(
+                json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
+            )
+            Path(".portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+
+            result = runner.invoke(cli, ["--format", "json", "readme", "--verbose"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["success"] is True
+            # JSON output should be valid JSON (verbose text not mixed in)
+            assert "command" in output
+
+    @pytest.mark.unit
+    def test_default_no_verbose_is_minimal(self, runner: CliRunner, tmp_path: Path) -> None:
+        """readme without --verbose should produce minimal output."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path("catalog.json").write_text(
+                json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
+            )
+            Path(".portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+
+            result = runner.invoke(cli, ["readme"])
+
+            assert result.exit_code == 0
+            # Should NOT show reading messages (only success)
+            assert "Reading" not in result.output
+            # Should show success message
+            assert "README.md" in result.output or "Generated" in result.output


### PR DESCRIPTION
## Summary

Closes #387

- Adds `-v/--verbose` flag to `portolan readme` command
- Shows file reads during README generation when enabled:
  - `→ Reading collection.json from path/`
  - `→ Reading metadata.yaml from path/.portolan/`
  - `→ Generating README.md`
- Works with `--check` and `--recursive` modes
- Ignored when `--json` is used (JSON output stays clean)

## Test plan

- [x] `portolan readme --verbose` shows file reads
- [x] `portolan readme -v` works as shorthand
- [x] `portolan readme --recursive --verbose` shows per-collection progress
- [x] `portolan readme --check --verbose` shows reads even when fresh
- [x] `portolan readme --verbose --json` produces valid JSON (verbose ignored)
- [x] Default behavior (no flag) remains minimal

🤖 Generated with [Claude Code](https://claude.ai/code)