### PR TITLE
feat(version): add git-like version management UX (closes #389)

### DIFF
--- a/docs/guides/version-management.md
+++ b/docs/guides/version-management.md
@@ -1,0 +1,197 @@
+# Version Management
+
+Portolan tracks data versions in `versions.json`, enabling git-like workflows for your geospatial data.
+
+## Quick Start
+
+```bash
+# Check what's changed since the last version
+portolan status
+
+# Create a new version after modifying files
+portolan version bump my-collection 1.1.0 -m "Updated source data"
+
+# View version history
+portolan version list my-collection
+```
+
+## Understanding Status
+
+The `portolan status` command shows the state of your collections:
+
+```bash
+$ portolan status
+→ Collection: demographics
+→   Local version: 1.0.0
+    Remote version: (offline or not configured)
+→
+→   Modified files:
+⚠     census-data.parquet (checksum changed)
+→
+→   Deleted files:
+✗     old-data.parquet (missing from disk)
+```
+
+### Status Categories
+
+| Category | Meaning |
+|----------|---------|
+| **Modified** | File checksum differs from `versions.json` |
+| **Deleted** | File in `versions.json` but missing from disk |
+| **Untracked** | Data file on disk but not in `versions.json` |
+
+!!! note "Managed Files"
+    STAC metadata files (`collection.json`, `*.json` items), `README.md`, and `metadata.yaml` are **not** shown as untracked. These are managed by Portolan separately from data versioning.
+
+### Sync State
+
+When connected to a remote, status shows whether you're in sync:
+
+- **in_sync**: Local and remote versions match
+- **ahead**: Local has unpushed versions
+- **behind**: Remote has versions you haven't pulled
+- **unknown**: Remote not configured or offline
+
+Use `--offline` to skip the remote check:
+
+```bash
+portolan status --offline
+```
+
+## Creating Versions
+
+Use `portolan version bump` to create a new version:
+
+```bash
+portolan version bump <collection> <version> [options]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-m, --notes` | Version message (like a commit message) |
+| `--breaking` | Mark as a breaking change |
+| `-y, --yes` | Skip confirmation prompt |
+| `--json` | JSON output for automation |
+
+### Examples
+
+```bash
+# Simple version bump with message
+portolan version bump demographics 1.2.0 -m "Added 2024 census data"
+
+# Breaking change (schema modified)
+portolan version bump demographics 2.0.0 --breaking -m "Changed column names"
+
+# Non-interactive (for CI/CD)
+portolan version bump demographics 1.2.0 -y --json
+```
+
+### Version Format
+
+Versions must be valid [semver](https://semver.org/) strings:
+
+- ✅ `1.0.0`, `2.1.3`, `1.0.0-beta.1`, `1.0.0+build.123`
+- ❌ `1.0`, `v1.0.0`, `latest`, `bad-version`
+
+### Validation
+
+The bump command validates:
+
+1. **Semver format** - Rejects invalid version strings
+2. **Uniqueness** - Rejects versions that already exist
+
+## Viewing History
+
+### Current Version
+
+```bash
+$ portolan version current demographics
+→ demographics: 1.2.0  2026-05-06 10:30:00 — Added 2024 census data
+    3 asset(s)
+```
+
+### All Versions
+
+```bash
+$ portolan version list demographics
+→ Versions for 'demographics' (3 total):
+
+→   1.0.0  2026-01-15 08:00:00 — Initial release
+      census-data.parquet
+→   1.1.0  2026-03-20 14:30:00 — Updated boundaries
+      census-data.parquet
+→   1.2.0  2026-05-06 10:30:00 — Added 2024 census data
+      census-data.parquet
+      demographics-2024.parquet
+```
+
+## JSON Output
+
+All commands support `--json` for machine-readable output:
+
+```bash
+$ portolan status --json
+{
+  "success": true,
+  "command": "status",
+  "data": {
+    "collections": [
+      {
+        "collection": "demographics",
+        "local_version": "1.2.0",
+        "remote_version": "1.2.0",
+        "sync_state": "in_sync",
+        "modified_files": [],
+        "untracked_files": [],
+        "deleted_files": []
+      }
+    ]
+  }
+}
+```
+
+## Workflow Example
+
+A typical workflow:
+
+```bash
+# 1. Check current state
+portolan status
+
+# 2. Make changes to your data files
+# ... edit parquet files, add new files, etc.
+
+# 3. Review what changed
+portolan status
+
+# 4. Create a new version
+portolan version bump my-collection 1.3.0 -m "Monthly data update"
+
+# 5. Push to remote
+portolan push
+```
+
+## What Gets Versioned?
+
+### Tracked in versions.json
+
+- Data files (`.parquet`, `.tif`, `.csv`, etc.)
+- Checksums (SHA256) for change detection
+- File sizes and modification times
+
+### NOT Tracked (Managed Separately)
+
+- `collection.json` - STAC collection metadata
+- `*.json` item files - STAC item metadata
+- `README.md` - Generated documentation
+- `metadata.yaml` - Human enrichment layer
+- `versions.json` - The version file itself
+
+These files are synced with `portolan push` but aren't versioned—they're derived from or supplement the data.
+
+## See Also
+
+- [Configuration](../reference/configuration.md) - Configure remote settings
+- [CLI Reference](../reference/cli.md) - Full command reference

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Guides:
+    - Version Management: guides/version-management.md
     - AI Skills: guides/skills.md
     - Extracting from ArcGIS: guides/extract-arcgis.md
     - Extracting from WFS: guides/extract-wfs.md

--- a/portolan_cli/backends/json_file.py
+++ b/portolan_cli/backends/json_file.py
@@ -127,6 +127,7 @@ class JsonFileBackend:
         breaking: bool,
         message: str,
         removed: set[str] | None = None,
+        version: str | None = None,
     ) -> Version:
         """Publish a new version of a collection.
 
@@ -139,6 +140,7 @@ class JsonFileBackend:
             schema: Schema fingerprint for change detection (CRITICAL #1).
             breaking: Whether this is a breaking change.
             message: Human-readable description of the change (MAJOR #6).
+            version: Explicit version string. If None, auto-compute next version.
 
         Returns:
             The newly created Version object.
@@ -158,8 +160,8 @@ class JsonFileBackend:
                 versions=[],
             )
 
-        # Compute next version
-        next_version = self._compute_next_version(versions_file, breaking)
+        # Use explicit version if provided, otherwise auto-compute
+        next_version = version if version else self._compute_next_version(versions_file, breaking)
 
         # Build asset objects with checksums
         asset_objects: dict[str, Asset] = {}

--- a/portolan_cli/backends/protocol.py
+++ b/portolan_cli/backends/protocol.py
@@ -150,6 +150,7 @@ class VersioningBackend(Protocol):
         breaking: bool,
         message: str,
         removed: set[str] | None = None,
+        version: str | None = None,
     ) -> Version:
         """Publish a new version of a collection.
 
@@ -160,6 +161,7 @@ class VersioningBackend(Protocol):
             breaking: Whether this is a breaking change.
             message: Human-readable description of the change.
             removed: Set of asset keys to remove from the version.
+            version: Explicit version string. If None, auto-compute next version.
 
         Returns:
             The newly created Version object.

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -65,6 +65,7 @@ from portolan_cli.scan_output import (
     render_tree_view,
 )
 from portolan_cli.scan_progress import ScanProgressReporter, count_directories
+from portolan_cli.status import CollectionStatus, get_collection_status
 from portolan_cli.temporal import FLEXIBLE_DATETIME
 from portolan_cli.validation import (
     Severity,
@@ -728,6 +729,154 @@ def list_cmd(
             return
 
         _list_tree_output_with_status(result)
+
+
+# =============================================================================
+# Status command (Issue #389 - git-like version management)
+# =============================================================================
+
+
+@cli.command("status")
+@click.option(
+    "--collection",
+    "-c",
+    help="Show status for a specific collection only.",
+)
+@click.option(
+    "--catalog",
+    "catalog_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to catalog root (default: auto-detect).",
+)
+@click.option(
+    "--offline",
+    is_flag=True,
+    help="Skip remote version check (show local state only).",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def status_cmd(
+    ctx: click.Context,
+    collection: str | None,
+    catalog_path: Path | None,
+    offline: bool,
+    json_output: bool,
+) -> None:
+    """Show local vs remote version state for collections.
+
+    Git-style status showing version sync state, modified files, and
+    untracked files for each collection in the catalog.
+
+    \b
+    Status information:
+        Local version   Current version in local versions.json
+        Remote version  Current version on remote (unless --offline)
+        Sync state      in_sync, ahead, behind, or unknown
+        Modified        Files changed since last version
+        Untracked       Files on disk not in versions.json
+        Deleted         Files in versions.json but missing from disk
+
+    \b
+    Examples:
+        portolan status                    # Status for all collections
+        portolan status -c demographics    # Status for one collection
+        portolan status --offline          # Skip remote check
+        portolan status --json             # JSON output for agents
+    """
+    use_json = should_output_json(ctx, json_output)
+
+    if catalog_path is None:
+        catalog_path = require_catalog_root(use_json, "status")
+
+    # Load remote URL from config (if not offline)
+    remote_url: str | None = None
+    if not offline:
+        remote_url = resolve_remote(None, catalog_path, collection)
+
+    # Discover collections
+    from portolan_cli.push import discover_collections
+
+    if collection:
+        collections = [collection]
+    else:
+        collections = discover_collections(catalog_path)
+
+    if not collections:
+        if use_json:
+            envelope = success_envelope("status", {"collections": []})
+            output_json_envelope(envelope)
+        else:
+            info_output("No collections found")
+        return
+
+    # Get status for each collection
+    statuses: list[CollectionStatus] = []
+    for coll in collections:
+        status = get_collection_status(
+            catalog_root=catalog_path,
+            collection=coll,
+            offline=offline,
+            remote_url=remote_url,
+        )
+        statuses.append(status)
+
+    if use_json:
+        envelope = success_envelope(
+            "status",
+            {"collections": [s.to_dict() for s in statuses]},
+        )
+        output_json_envelope(envelope)
+    else:
+        _output_status_human(statuses)
+
+
+def _output_status_human(statuses: list[CollectionStatus]) -> None:
+    """Format status output for human consumption."""
+    for status in statuses:
+        info_output(f"Collection: {status.collection}")
+
+        # Version info
+        local_str = status.local_version or "(not initialized)"
+        info_output(f"  Local version: {local_str}")
+
+        if status.remote_version is not None:
+            sync_indicator = ""
+            if status.sync_state == "behind":
+                sync_indicator = "  ⚠ behind remote"
+            elif status.sync_state == "ahead":
+                sync_indicator = "  ↑ ahead of remote"
+            info_output(f"  Remote version: {status.remote_version}{sync_indicator}")
+        elif status.sync_state == "unknown":
+            detail("  Remote version: (offline or not configured)")
+
+        # Modified files
+        if status.modified_files:
+            info_output("")
+            info_output("  Modified files:")
+            for f in status.modified_files:
+                warn(f"    {f} (checksum changed)")
+
+        # Deleted files
+        if status.deleted_files:
+            info_output("")
+            info_output("  Deleted files:")
+            for f in status.deleted_files:
+                error(f"    {f} (missing from disk)")
+
+        # Untracked files
+        if status.untracked_files:
+            info_output("")
+            info_output("  Untracked files:")
+            for f in status.untracked_files:
+                detail(f"    {f}")
+
+        # Clean state message
+        if not status.modified_files and not status.deleted_files and not status.untracked_files:
+            if status.local_version:
+                success("  No local changes")
+
+        info_output("")
 
 
 # =============================================================================
@@ -6523,14 +6672,17 @@ def _require_iceberg_backend(
 
 @cli.group()
 def version() -> None:
-    """Iceberg version management commands.
+    """Version management commands.
+
+    Works with any versioning backend (file, iceberg). Backend is auto-detected
+    from catalog configuration.
 
     \b
     Subcommands:
         current   Show current version of a collection
         list      List all versions of a collection
-        rollback  Rollback to a previous version
-        prune     Remove old versions
+        rollback  Rollback to a previous version (iceberg only)
+        prune     Remove old versions (iceberg only)
     """
 
 
@@ -6553,20 +6705,22 @@ def current(
 ) -> None:
     """Show the current version of a collection.
 
+    Works with any versioning backend (auto-detected from config).
+
     \b
     Examples:
         portolan version current boundaries
         portolan version current boundaries --json
     """
+    from portolan_cli.version_ops import get_current_version
+
     use_json = should_output_json(ctx, json_output)
 
     if catalog_path is None:
         catalog_path = require_catalog_root(use_json, "version current")
 
-    backend = _require_iceberg_backend(catalog_path, use_json, "current")
-
     try:
-        ver = backend.get_current_version(collection)
+        ver = get_current_version(collection, catalog_root=catalog_path)
     except (FileNotFoundError, Exception) as e:
         if use_json:
             envelope = error_envelope(
@@ -6620,20 +6774,22 @@ def version_list_cmd(
 ) -> None:
     """List all versions of a collection.
 
+    Works with any versioning backend (auto-detected from config).
+
     \b
     Examples:
         portolan version list boundaries
         portolan version list boundaries --json
     """
+    from portolan_cli.version_ops import list_versions
+
     use_json = should_output_json(ctx, json_output)
 
     if catalog_path is None:
         catalog_path = require_catalog_root(use_json, "version list")
 
-    backend = _require_iceberg_backend(catalog_path, use_json, "list")
-
     try:
-        versions = backend.list_versions(collection)
+        versions = list_versions(collection, catalog_root=catalog_path)
     except (FileNotFoundError, Exception) as e:
         if use_json:
             envelope = error_envelope(
@@ -6676,6 +6832,192 @@ def version_list_cmd(
             if v.changes:
                 for change in v.changes:
                     detail(f"    {change}")
+
+
+def _bump_show_changes(
+    collection: str,
+    new_version: str,
+    current_version: str | None,
+    modified: list[str],
+    deleted: list[str],
+) -> bool:
+    """Show changes and get confirmation for version bump."""
+    info_output(f"Creating version {new_version} for '{collection}'")
+    info_output(f"  Current version: {current_version}")
+    info_output("")
+
+    if modified:
+        info_output("Modified files:")
+        for f in modified:
+            warn(f"  {f}")
+
+    if deleted:
+        info_output("Deleted files:")
+        for f in deleted:
+            error(f"  {f}")
+
+    info_output("")
+    return click.confirm("Create this version?")
+
+
+@version.command()
+@click.argument("collection")
+@click.argument("new_version")
+@click.option(
+    "--notes",
+    "-m",
+    help="Version notes/message describing the change.",
+)
+@click.option(
+    "--breaking",
+    is_flag=True,
+    help="Mark this version as having breaking changes.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip confirmation prompt.",
+)
+@click.option(
+    "--catalog",
+    "catalog_path",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Path to catalog root (default: auto-detect).",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def bump(
+    ctx: click.Context,
+    collection: str,
+    new_version: str,
+    notes: str | None,
+    breaking: bool,
+    yes: bool,
+    catalog_path: Path | None,
+    json_output: bool,
+) -> None:
+    """Create a new version from current file state.
+
+    Detects modified files by comparing checksums, computes new checksums,
+    and creates a new version entry in versions.json.
+
+    NEW_VERSION must be an explicit semver string (e.g., "1.2.0").
+
+    \b
+    Examples:
+        portolan version bump demographics 1.4.0 -m "Updated source data"
+        portolan version bump demographics 2.0.0 --breaking -m "Schema change"
+        portolan version bump demographics 1.4.0 -y  # Skip confirmation
+    """
+    from portolan_cli.status import detect_deleted_files, detect_modified_files
+    from portolan_cli.version_ops import publish_version
+    from portolan_cli.versions import read_versions
+
+    use_json = should_output_json(ctx, json_output)
+
+    if catalog_path is None:
+        catalog_path = require_catalog_root(use_json, "version bump")
+
+    collection_path = catalog_path / collection
+    versions_path = collection_path / "versions.json"
+
+    # Read current versions
+    if not versions_path.exists():
+        if use_json:
+            envelope = error_envelope(
+                "version bump",
+                [ErrorDetail(type="NotFoundError", message=f"No versions.json in {collection}")],
+            )
+            output_json_envelope(envelope)
+        else:
+            error(f"Collection '{collection}' has no versions.json")
+        raise SystemExit(1)
+
+    try:
+        versions_file = read_versions(versions_path)
+    except ValueError as e:
+        if use_json:
+            envelope = error_envelope(
+                "version bump",
+                [ErrorDetail(type="ParseError", message=str(e))],
+            )
+            output_json_envelope(envelope)
+        else:
+            error(f"Invalid versions.json: {e}")
+        raise SystemExit(1) from None
+
+    current_version = versions_file.current_version
+
+    # Detect changes
+    modified = detect_modified_files(collection_path, versions_file)
+    deleted = detect_deleted_files(collection_path, versions_file)
+
+    if not modified and not deleted:
+        if use_json:
+            envelope = success_envelope(
+                "version bump",
+                {"collection": collection, "message": "No changes detected", "created": False},
+            )
+            output_json_envelope(envelope)
+        else:
+            info_output(f"No changes detected in '{collection}'")
+        return
+
+    # Show what will be versioned and get confirmation
+    if not use_json and not yes:
+        if not _bump_show_changes(collection, new_version, current_version, modified, deleted):
+            info_output("Aborted")
+            return
+
+    # Compute checksums for modified files
+    assets: dict[str, str] = {}
+    for filename in modified:
+        file_path = collection_path / filename
+        if file_path.exists():
+            assets[filename] = str(file_path)
+
+    # Publish the version
+    try:
+        ver = publish_version(
+            collection,
+            assets=assets,
+            breaking=breaking,
+            message=notes or "",
+            removed=set(deleted) if deleted else None,
+            catalog_root=catalog_path,
+        )
+    except Exception as e:
+        if use_json:
+            envelope = error_envelope(
+                "version bump",
+                [ErrorDetail(type=type(e).__name__, message=str(e))],
+            )
+            output_json_envelope(envelope)
+        else:
+            error(f"Failed to create version: {e}")
+        raise SystemExit(1) from None
+
+    if use_json:
+        envelope = success_envelope(
+            "version bump",
+            {
+                "collection": collection,
+                "version": ver.version,
+                "previous_version": current_version,
+                "created": ver.created.isoformat(),
+                "breaking": ver.breaking,
+                "message": ver.message,
+                "modified_files": modified,
+                "deleted_files": deleted,
+            },
+        )
+        output_json_envelope(envelope)
+    else:
+        success(f"Created version {ver.version}")
+        if ver.message:
+            detail(f"  {ver.message}")
 
 
 @version.command()

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -6860,6 +6860,27 @@ def _bump_show_changes(
     return click.confirm("Create this version?")
 
 
+def _bump_error(use_json: bool, error_type: str, message: str) -> None:
+    """Output a version bump error and exit."""
+    if use_json:
+        envelope = error_envelope(
+            "version bump",
+            [ErrorDetail(type=error_type, message=message)],
+        )
+        output_json_envelope(envelope)
+    else:
+        error(message)
+    raise SystemExit(1)
+
+
+def _validate_semver(version: str) -> bool:
+    """Validate semver format (major.minor.patch with optional prerelease/build)."""
+    import re
+
+    semver_pattern = r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$"
+    return bool(re.match(semver_pattern, version))
+
+
 @version.command()
 @click.argument("collection")
 @click.argument("new_version")
@@ -6917,6 +6938,11 @@ def bump(
 
     use_json = should_output_json(ctx, json_output)
 
+    # Validate semver format
+    if not _validate_semver(new_version):
+        msg = f"Invalid semver: '{new_version}'. Expected format: MAJOR.MINOR.PATCH (e.g., '1.2.0')"
+        _bump_error(use_json, "ValidationError", msg)
+
     if catalog_path is None:
         catalog_path = require_catalog_root(use_json, "version bump")
 
@@ -6925,30 +6951,19 @@ def bump(
 
     # Read current versions
     if not versions_path.exists():
-        if use_json:
-            envelope = error_envelope(
-                "version bump",
-                [ErrorDetail(type="NotFoundError", message=f"No versions.json in {collection}")],
-            )
-            output_json_envelope(envelope)
-        else:
-            error(f"Collection '{collection}' has no versions.json")
-        raise SystemExit(1)
+        _bump_error(use_json, "NotFoundError", f"No versions.json in {collection}")
 
     try:
         versions_file = read_versions(versions_path)
     except ValueError as e:
-        if use_json:
-            envelope = error_envelope(
-                "version bump",
-                [ErrorDetail(type="ParseError", message=str(e))],
-            )
-            output_json_envelope(envelope)
-        else:
-            error(f"Invalid versions.json: {e}")
-        raise SystemExit(1) from None
+        _bump_error(use_json, "ParseError", f"Invalid versions.json: {e}")
 
     current_version = versions_file.current_version
+
+    # Check for duplicate version
+    existing_versions = {v.version for v in versions_file.versions}
+    if new_version in existing_versions:
+        _bump_error(use_json, "DuplicateVersionError", f"Version '{new_version}' already exists")
 
     # Detect changes
     modified = detect_modified_files(collection_path, versions_file)
@@ -6986,18 +7001,11 @@ def bump(
             breaking=breaking,
             message=notes or "",
             removed=set(deleted) if deleted else None,
+            version=new_version,
             catalog_root=catalog_path,
         )
     except Exception as e:
-        if use_json:
-            envelope = error_envelope(
-                "version bump",
-                [ErrorDetail(type=type(e).__name__, message=str(e))],
-            )
-            output_json_envelope(envelope)
-        else:
-            error(f"Failed to create version: {e}")
-        raise SystemExit(1) from None
+        _bump_error(use_json, type(e).__name__, f"Failed to create version: {e}")
 
     if use_json:
         envelope = success_envelope(

--- a/portolan_cli/status.py
+++ b/portolan_cli/status.py
@@ -1,0 +1,264 @@
+"""Status module - shows local vs remote version state (Issue #389).
+
+Provides git-like status output showing:
+- Current local and remote versions
+- Modified files (checksum changed since last version)
+- Untracked files (on disk but not in versions.json)
+- Deleted files (in versions.json but missing from disk)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from portolan_cli.dataset import compute_checksum
+from portolan_cli.versions import VersionsFile, read_versions
+
+
+@dataclass
+class CollectionStatus:
+    """Status of a single collection.
+
+    Attributes:
+        collection: Collection ID/path.
+        local_version: Current local version string, or None if uninitialized.
+        remote_version: Current remote version string, or None if offline/unknown.
+        modified_files: Files with checksums different from versions.json.
+        untracked_files: Files on disk not in versions.json.
+        deleted_files: Files in versions.json but missing from disk.
+    """
+
+    collection: str
+    local_version: str | None
+    remote_version: str | None
+    modified_files: list[str] = field(default_factory=list)
+    untracked_files: list[str] = field(default_factory=list)
+    deleted_files: list[str] = field(default_factory=list)
+
+    @property
+    def sync_state(self) -> str:
+        """Compute sync state relative to remote.
+
+        Returns:
+            'in_sync': Local and remote versions match.
+            'ahead': Local version is newer than remote.
+            'behind': Remote version is newer than local.
+            'diverged': Versions differ but neither is clearly ahead.
+            'unknown': Remote version is unavailable.
+        """
+        if self.remote_version is None:
+            return "unknown"
+
+        if self.local_version is None:
+            return "behind" if self.remote_version else "unknown"
+
+        if self.local_version == self.remote_version:
+            return "in_sync"
+
+        # Simple semver comparison for common cases
+        local_parts = self._parse_version(self.local_version)
+        remote_parts = self._parse_version(self.remote_version)
+
+        if local_parts > remote_parts:
+            return "ahead"
+        elif local_parts < remote_parts:
+            return "behind"
+        else:
+            return "diverged"
+
+    @staticmethod
+    def _parse_version(version: str) -> tuple[int, int, int]:
+        """Parse semver string to comparable tuple."""
+        try:
+            parts = version.split("-")[0].split("+")[0].split(".")
+            return (int(parts[0]), int(parts[1]), int(parts[2]))
+        except (IndexError, ValueError):
+            return (0, 0, 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict for JSON output."""
+        return {
+            "collection": self.collection,
+            "local_version": self.local_version,
+            "remote_version": self.remote_version,
+            "sync_state": self.sync_state,
+            "modified_files": self.modified_files,
+            "untracked_files": self.untracked_files,
+            "deleted_files": self.deleted_files,
+        }
+
+
+def detect_modified_files(
+    collection_path: Path,
+    versions_file: VersionsFile,
+) -> list[str]:
+    """Detect files modified since last versioned state.
+
+    Compares current file checksums against the checksums stored in
+    the latest version entry of versions.json.
+
+    Args:
+        collection_path: Path to the collection directory.
+        versions_file: Parsed versions.json content.
+
+    Returns:
+        List of filenames that have different checksums than versions.json.
+    """
+    if not versions_file.versions:
+        return []
+
+    current_version = versions_file.versions[-1]
+    modified = []
+
+    for asset_name, asset in current_version.assets.items():
+        file_path = collection_path / asset_name
+        if not file_path.exists():
+            # Missing files are handled by detect_deleted_files
+            continue
+
+        try:
+            current_checksum = compute_checksum(file_path)
+            if current_checksum != asset.sha256:
+                modified.append(asset_name)
+        except OSError:
+            # Can't compute checksum, treat as modified
+            modified.append(asset_name)
+
+    return sorted(modified)
+
+
+def detect_deleted_files(
+    collection_path: Path,
+    versions_file: VersionsFile,
+) -> list[str]:
+    """Detect files deleted since last versioned state.
+
+    Finds files that exist in versions.json but are missing from disk.
+
+    Args:
+        collection_path: Path to the collection directory.
+        versions_file: Parsed versions.json content.
+
+    Returns:
+        List of filenames that are in versions.json but missing from disk.
+    """
+    if not versions_file.versions:
+        return []
+
+    current_version = versions_file.versions[-1]
+    deleted = []
+
+    for asset_name in current_version.assets:
+        file_path = collection_path / asset_name
+        if not file_path.exists():
+            deleted.append(asset_name)
+
+    return sorted(deleted)
+
+
+def detect_untracked_files(
+    collection_path: Path,
+    versions_file: VersionsFile,
+) -> list[str]:
+    """Detect files on disk not tracked in versions.json.
+
+    Args:
+        collection_path: Path to the collection directory.
+        versions_file: Parsed versions.json content.
+
+    Returns:
+        List of filenames on disk but not in versions.json.
+    """
+    if not versions_file.versions:
+        # No versions = everything is untracked
+        tracked: set[str] = set()
+    else:
+        tracked = set(versions_file.versions[-1].assets.keys())
+
+    untracked = []
+    for file_path in collection_path.iterdir():
+        if file_path.is_file() and file_path.name != "versions.json":
+            if file_path.name not in tracked:
+                untracked.append(file_path.name)
+
+    return sorted(untracked)
+
+
+def get_collection_status(
+    catalog_root: Path,
+    collection: str,
+    *,
+    offline: bool = False,
+    remote_url: str | None = None,
+) -> CollectionStatus:
+    """Get status for a single collection.
+
+    Args:
+        catalog_root: Path to catalog root directory.
+        collection: Collection ID/path relative to catalog root.
+        offline: If True, skip remote version check.
+        remote_url: Optional remote URL for fetching remote versions.json.
+
+    Returns:
+        CollectionStatus with local/remote versions and file changes.
+    """
+    collection_path = catalog_root / collection
+    versions_path = collection_path / "versions.json"
+
+    # Read local versions.json
+    local_version: str | None = None
+    versions_file: VersionsFile | None = None
+
+    if versions_path.exists():
+        try:
+            versions_file = read_versions(versions_path)
+            local_version = versions_file.current_version
+        except (ValueError, FileNotFoundError):
+            pass
+
+    # Detect file changes
+    modified_files: list[str] = []
+    deleted_files: list[str] = []
+    untracked_files: list[str] = []
+
+    if versions_file is not None:
+        modified_files = detect_modified_files(collection_path, versions_file)
+        deleted_files = detect_deleted_files(collection_path, versions_file)
+        untracked_files = detect_untracked_files(collection_path, versions_file)
+
+    # Fetch remote version (unless offline)
+    remote_version: str | None = None
+    if not offline and remote_url:
+        remote_version = _fetch_remote_version(remote_url, collection)
+
+    return CollectionStatus(
+        collection=collection,
+        local_version=local_version,
+        remote_version=remote_version,
+        modified_files=modified_files,
+        untracked_files=untracked_files,
+        deleted_files=deleted_files,
+    )
+
+
+def _fetch_remote_version(remote_url: str, collection: str) -> str | None:
+    """Fetch current version from remote versions.json.
+
+    Args:
+        remote_url: Base URL of remote catalog.
+        collection: Collection ID.
+
+    Returns:
+        Remote version string, or None if fetch fails.
+    """
+    # Import here to avoid circular dependency
+    from portolan_cli.pull import PullError, _fetch_remote_versions
+
+    try:
+        # Reuse existing remote fetch logic
+        remote_versions = _fetch_remote_versions(remote_url, collection)
+        return remote_versions.current_version
+    except (PullError, Exception):
+        return None

--- a/portolan_cli/status.py
+++ b/portolan_cli/status.py
@@ -158,18 +158,46 @@ def detect_deleted_files(
     return sorted(deleted)
 
 
+# Files managed by Portolan that should not appear as "untracked"
+MANAGED_FILES = frozenset(
+    {
+        "versions.json",
+        "collection.json",
+        "catalog.json",
+        "README.md",
+        "metadata.yaml",
+    }
+)
+
+
+def _is_stac_item(file_path: Path) -> bool:
+    """Check if a JSON file is a STAC item (has type: Feature)."""
+    if file_path.suffix != ".json":
+        return False
+    try:
+        import json
+
+        data = json.loads(file_path.read_text())
+        return bool(data.get("type") == "Feature")
+    except (json.JSONDecodeError, OSError, KeyError):
+        return False
+
+
 def detect_untracked_files(
     collection_path: Path,
     versions_file: VersionsFile,
 ) -> list[str]:
-    """Detect files on disk not tracked in versions.json.
+    """Detect data files on disk not tracked in versions.json.
+
+    Excludes Portolan-managed files (STAC metadata, versions.json, README.md)
+    since those are derived/generated and managed separately from data versioning.
 
     Args:
         collection_path: Path to the collection directory.
         versions_file: Parsed versions.json content.
 
     Returns:
-        List of filenames on disk but not in versions.json.
+        List of data filenames on disk but not in versions.json.
     """
     if not versions_file.versions:
         # No versions = everything is untracked
@@ -179,9 +207,22 @@ def detect_untracked_files(
 
     untracked = []
     for file_path in collection_path.iterdir():
-        if file_path.is_file() and file_path.name != "versions.json":
-            if file_path.name not in tracked:
-                untracked.append(file_path.name)
+        if not file_path.is_file():
+            continue
+
+        name = file_path.name
+
+        # Skip Portolan-managed files
+        if name in MANAGED_FILES:
+            continue
+
+        # Skip STAC item files (*.json with type: Feature)
+        if _is_stac_item(file_path):
+            continue
+
+        # Report as untracked if not in versions.json
+        if name not in tracked:
+            untracked.append(name)
 
     return sorted(untracked)
 

--- a/portolan_cli/version_ops.py
+++ b/portolan_cli/version_ops.py
@@ -68,16 +68,34 @@ def publish_version(
     breaking: bool = False,
     message: str = "",
     removed: set[str] | None = None,
+    version: str | None = None,
     backend_name: str | None = None,
     catalog_root: Path | None = None,
 ) -> Version:
-    """Publish a new version of a collection."""
+    """Publish a new version of a collection.
+
+    Args:
+        collection: Collection identifier/path.
+        assets: Mapping of asset names to asset paths/URIs.
+        schema: Schema fingerprint for change detection.
+        breaking: Whether this is a breaking change.
+        message: Human-readable description of the change.
+        removed: Set of asset keys to remove from the version.
+        version: Explicit version string. If None, auto-compute next version.
+        backend_name: Backend to use. If None, resolved from config.
+        catalog_root: Path to catalog root for config lookup.
+
+    Returns:
+        The newly created Version object.
+    """
     from portolan_cli.backends import get_backend
 
     name = _resolve_backend_name(backend_name, catalog_root)
     backend = get_backend(name, catalog_root=catalog_root)
     schema = schema or {"columns": [], "types": {}, "hash": "unknown"}
-    return backend.publish(collection, assets, schema, breaking, message, removed=removed)
+    return backend.publish(
+        collection, assets, schema, breaking, message, removed=removed, version=version
+    )
 
 
 def rollback_version(

--- a/tests/integration/test_list_status_integration.py
+++ b/tests/integration/test_list_status_integration.py
@@ -152,30 +152,6 @@ class TestListStatusIntegration:
             assert "scan" in result.output.lower() or "add" in result.output.lower()
 
 
-class TestStatusCommandRemovalIntegration:
-    """Integration tests verifying status command is removed."""
-
-    @pytest.mark.integration
-    def test_status_command_no_longer_exists(self, runner: CliRunner) -> None:
-        """The status command should not be available."""
-        result = runner.invoke(cli, ["status"])
-
-        # Should fail because command doesn't exist
-        assert result.exit_code != 0 or "no such command" in result.output.lower()
-
-    @pytest.mark.integration
-    def test_help_does_not_mention_status(self, runner: CliRunner) -> None:
-        """Help output should not mention the status command."""
-        result = runner.invoke(cli, ["--help"])
-
-        assert result.exit_code == 0
-        # "status" should not appear as a command
-        # (may appear in other contexts, but not as "status  " which indicates a command)
-        lines = result.output.lower().split("\n")
-        command_lines = [line for line in lines if line.strip().startswith("status")]
-        assert len(command_lines) == 0, f"status command still listed: {command_lines}"
-
-
 class TestListOutputFormatIntegration:
     """Integration tests for list output formatting."""
 

--- a/tests/integration/test_status_cli.py
+++ b/tests/integration/test_status_cli.py
@@ -1,0 +1,153 @@
+"""Integration tests for portolan status CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def initialized_catalog(tmp_path: Path) -> Path:
+    """Create an initialized catalog with a collection and versions.json."""
+    # Create .portolan/config.yaml (catalog marker)
+    portolan_dir = tmp_path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("version: 1\n")
+
+    # Create a collection with versions.json
+    collection = tmp_path / "demographics"
+    collection.mkdir()
+
+    # Create versions.json
+    versions_data = {
+        "spec_version": "1.0.0",
+        "current_version": "1.2.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2024-01-15T10:30:00Z",
+                "breaking": False,
+                "assets": {},
+                "changes": [],
+            },
+            {
+                "version": "1.2.0",
+                "created": "2024-02-01T10:30:00Z",
+                "breaking": False,
+                "assets": {
+                    "data.parquet": {
+                        "sha256": "abc123",
+                        "size_bytes": 1024,
+                        "href": "demographics/data.parquet",
+                    }
+                },
+                "changes": ["data.parquet"],
+            },
+        ],
+    }
+    (collection / "versions.json").write_text(json.dumps(versions_data))
+
+    return tmp_path
+
+
+class TestStatusCLI:
+    """Integration tests for portolan status command."""
+
+    @pytest.mark.integration
+    def test_status_shows_local_version(self, initialized_catalog: Path, tmp_path: Path) -> None:
+        """Status command shows local version from versions.json."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["status", "--catalog", str(initialized_catalog), "--offline"],
+        )
+
+        assert result.exit_code == 0
+        assert "demographics" in result.output
+        assert "1.2.0" in result.output
+
+    @pytest.mark.integration
+    def test_status_json_output(self, initialized_catalog: Path, tmp_path: Path) -> None:
+        """Status command outputs valid JSON with --json flag."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["status", "--catalog", str(initialized_catalog), "--offline", "--json"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert "collections" in data["data"]
+        assert len(data["data"]["collections"]) == 1
+        assert data["data"]["collections"][0]["collection"] == "demographics"
+        assert data["data"]["collections"][0]["local_version"] == "1.2.0"
+
+    @pytest.mark.integration
+    def test_status_collection_filter(self, initialized_catalog: Path, tmp_path: Path) -> None:
+        """Status command filters by collection with -c flag."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "status",
+                "--catalog",
+                str(initialized_catalog),
+                "-c",
+                "demographics",
+                "--offline",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "demographics" in result.output
+
+    @pytest.mark.integration
+    def test_status_no_collections(self, tmp_path: Path) -> None:
+        """Status command handles empty catalog gracefully."""
+        # Create empty catalog
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("version: 1\n")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["status", "--catalog", str(tmp_path), "--offline"],
+        )
+
+        assert result.exit_code == 0
+        assert "No collections found" in result.output
+
+    @pytest.mark.integration
+    def test_status_detects_deleted_files(self, initialized_catalog: Path, tmp_path: Path) -> None:
+        """Status shows files in versions.json but missing from disk."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["status", "--catalog", str(initialized_catalog), "--offline", "--json"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # data.parquet is in versions.json but doesn't exist on disk
+        assert "data.parquet" in data["data"]["collections"][0]["deleted_files"]
+
+    @pytest.mark.integration
+    def test_status_offline_skips_remote(self, initialized_catalog: Path, tmp_path: Path) -> None:
+        """Offline mode sets remote_version to None."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["status", "--catalog", str(initialized_catalog), "--offline", "--json"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["data"]["collections"][0]["remote_version"] is None
+        assert data["data"]["collections"][0]["sync_state"] == "unknown"

--- a/tests/integration/test_version_bump.py
+++ b/tests/integration/test_version_bump.py
@@ -1,0 +1,274 @@
+"""Integration tests for portolan version bump command."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+def _sha256(content: bytes) -> str:
+    """Compute SHA256 hash of content."""
+    return hashlib.sha256(content).hexdigest()
+
+
+@pytest.fixture
+def catalog_with_tracked_file(tmp_path: Path) -> Path:
+    """Create a catalog with a tracked file that can be modified."""
+    # Create .portolan/config.yaml (catalog marker)
+    portolan_dir = tmp_path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("version: 1\n")
+
+    # Create a collection with a file
+    collection = tmp_path / "demographics"
+    collection.mkdir()
+
+    # Create the actual file
+    data_file = collection / "data.parquet"
+    original_content = b"original content"
+    data_file.write_bytes(original_content)
+
+    # Create versions.json tracking this file
+    checksum = _sha256(original_content)
+    versions_data = {
+        "spec_version": "1.0.0",
+        "current_version": "1.0.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2024-01-15T10:30:00Z",
+                "breaking": False,
+                "assets": {
+                    "data.parquet": {
+                        "sha256": checksum,
+                        "size_bytes": len(original_content),
+                        "href": "demographics/data.parquet",
+                    }
+                },
+                "changes": ["data.parquet"],
+                "message": "Initial release",
+            }
+        ],
+    }
+    (collection / "versions.json").write_text(json.dumps(versions_data))
+
+    return tmp_path
+
+
+class TestVersionBump:
+    """Integration tests for 'portolan version bump'."""
+
+    @pytest.mark.integration
+    def test_bump_detects_no_changes(self, catalog_with_tracked_file: Path) -> None:
+        """Bump reports no changes when file is unchanged."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "No changes detected" in result.output
+
+    @pytest.mark.integration
+    def test_bump_detects_modified_file(self, catalog_with_tracked_file: Path) -> None:
+        """Bump detects when a tracked file has changed."""
+        # Modify the file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+                "-m",
+                "Updated data",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created version 1.1.0" in result.output
+
+    @pytest.mark.integration
+    def test_bump_json_output(self, catalog_with_tracked_file: Path) -> None:
+        """Bump outputs valid JSON with --json flag."""
+        # Modify the file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["version"] == "1.1.0"
+        assert data["data"]["previous_version"] == "1.0.0"
+        assert "data.parquet" in data["data"]["modified_files"]
+
+    @pytest.mark.integration
+    def test_bump_with_breaking_flag(self, catalog_with_tracked_file: Path) -> None:
+        """Bump records breaking change flag."""
+        # Modify the file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"breaking change content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "2.0.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+                "--breaking",
+                "-m",
+                "Schema change",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["data"]["breaking"] is True
+        assert data["data"]["message"] == "Schema change"
+
+    @pytest.mark.integration
+    def test_bump_detects_deleted_file(self, catalog_with_tracked_file: Path) -> None:
+        """Bump detects when a tracked file has been deleted."""
+        # Delete the tracked file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.unlink()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "data.parquet" in data["data"]["deleted_files"]
+
+    @pytest.mark.integration
+    def test_bump_requires_versions_json(self, tmp_path: Path) -> None:
+        """Bump fails if collection has no versions.json."""
+        # Create minimal catalog without versions.json
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("version: 1\n")
+        (tmp_path / "empty_collection").mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "empty_collection",
+                "1.0.0",
+                "--catalog",
+                str(tmp_path),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "no versions.json" in result.output.lower()
+
+
+class TestVersionBumpConfirmation:
+    """Tests for bump confirmation prompt."""
+
+    @pytest.mark.integration
+    def test_bump_aborts_on_no(self, catalog_with_tracked_file: Path) -> None:
+        """Bump aborts when user says no to confirmation."""
+        # Modify the file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+            ],
+            input="n\n",  # Answer "no" to confirmation
+        )
+
+        assert result.exit_code == 0
+        assert "Aborted" in result.output
+
+    @pytest.mark.integration
+    def test_bump_proceeds_with_yes_flag(self, catalog_with_tracked_file: Path) -> None:
+        """Bump skips confirmation with -y flag."""
+        # Modify the file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created version 1.1.0" in result.output

--- a/tests/integration/test_version_bump.py
+++ b/tests/integration/test_version_bump.py
@@ -272,3 +272,158 @@ class TestVersionBumpConfirmation:
 
         assert result.exit_code == 0
         assert "Created version 1.1.0" in result.output
+
+
+class TestVersionBumpValidation:
+    """Tests for version bump validation."""
+
+    @pytest.mark.integration
+    def test_bump_uses_explicit_version(self, catalog_with_tracked_file: Path) -> None:
+        """Bump creates the exact version specified, not auto-computed."""
+        # Modify the file
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "9.8.7",  # Explicit version that differs from auto-computed
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        # Critical: verify the ACTUAL version created matches what user specified
+        assert data["data"]["version"] == "9.8.7"
+
+        # Double-check by reading versions.json directly
+        versions_data = json.loads(
+            (catalog_with_tracked_file / "demographics" / "versions.json").read_text()
+        )
+        assert versions_data["current_version"] == "9.8.7"
+
+    @pytest.mark.integration
+    def test_bump_rejects_invalid_semver(self, catalog_with_tracked_file: Path) -> None:
+        """Bump rejects invalid semver strings."""
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "not-a-version",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid semver" in result.output
+
+    @pytest.mark.integration
+    def test_bump_rejects_partial_version(self, catalog_with_tracked_file: Path) -> None:
+        """Bump rejects partial version strings like '1.2'."""
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.2",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid semver" in result.output
+
+    @pytest.mark.integration
+    def test_bump_accepts_prerelease_version(self, catalog_with_tracked_file: Path) -> None:
+        """Bump accepts valid semver with prerelease tag."""
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.1.0-beta.1",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created version 1.1.0-beta.1" in result.output
+
+    @pytest.mark.integration
+    def test_bump_rejects_duplicate_version(self, catalog_with_tracked_file: Path) -> None:
+        """Bump rejects creating a version that already exists."""
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "1.0.0",  # Same as existing version in fixture
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "already exists" in result.output
+
+    @pytest.mark.integration
+    def test_bump_invalid_semver_json_output(self, catalog_with_tracked_file: Path) -> None:
+        """Bump returns proper JSON error for invalid semver."""
+        data_file = catalog_with_tracked_file / "demographics" / "data.parquet"
+        data_file.write_bytes(b"modified content")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "version",
+                "bump",
+                "demographics",
+                "bad",
+                "--catalog",
+                str(catalog_with_tracked_file),
+                "-y",
+                "--json",
+            ],
+        )
+
+        assert result.exit_code == 1
+        data = json.loads(result.output)
+        assert data["success"] is False
+        assert data["errors"][0]["type"] == "ValidationError"

--- a/tests/integration/test_version_file_backend.py
+++ b/tests/integration/test_version_file_backend.py
@@ -1,0 +1,188 @@
+"""Integration tests for version commands with file backend."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def catalog_with_versions(tmp_path: Path) -> Path:
+    """Create a catalog with versions.json for testing."""
+    # Create .portolan/config.yaml (catalog marker)
+    portolan_dir = tmp_path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("version: 1\n")
+
+    # Create a collection with versions.json
+    collection = tmp_path / "boundaries"
+    collection.mkdir()
+
+    versions_data = {
+        "spec_version": "1.0.0",
+        "current_version": "2.1.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2024-01-15T10:30:00Z",
+                "breaking": False,
+                "assets": {
+                    "data.parquet": {
+                        "sha256": "abc",
+                        "size_bytes": 100,
+                        "href": "boundaries/data.parquet",
+                    }
+                },
+                "changes": ["data.parquet"],
+                "message": "Initial release",
+            },
+            {
+                "version": "2.0.0",
+                "created": "2024-02-01T10:30:00Z",
+                "breaking": True,
+                "assets": {
+                    "data.parquet": {
+                        "sha256": "def",
+                        "size_bytes": 200,
+                        "href": "boundaries/data.parquet",
+                    }
+                },
+                "changes": ["data.parquet"],
+                "message": "Schema change",
+            },
+            {
+                "version": "2.1.0",
+                "created": "2024-03-01T10:30:00Z",
+                "breaking": False,
+                "assets": {
+                    "data.parquet": {
+                        "sha256": "ghi",
+                        "size_bytes": 300,
+                        "href": "boundaries/data.parquet",
+                    }
+                },
+                "changes": ["data.parquet"],
+                "message": "Data update",
+            },
+        ],
+    }
+    (collection / "versions.json").write_text(json.dumps(versions_data))
+
+    return tmp_path
+
+
+class TestVersionCurrentFileBackend:
+    """Tests for 'portolan version current' with file backend."""
+
+    @pytest.mark.integration
+    def test_current_shows_version(self, catalog_with_versions: Path) -> None:
+        """version current shows the current version."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "current", "boundaries", "--catalog", str(catalog_with_versions)],
+        )
+
+        assert result.exit_code == 0
+        assert "2.1.0" in result.output
+        assert "boundaries" in result.output
+
+    @pytest.mark.integration
+    def test_current_json_output(self, catalog_with_versions: Path) -> None:
+        """version current outputs valid JSON."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "current", "boundaries", "--catalog", str(catalog_with_versions), "--json"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["version"] == "2.1.0"
+        assert data["data"]["collection"] == "boundaries"
+
+
+class TestVersionListFileBackend:
+    """Tests for 'portolan version list' with file backend."""
+
+    @pytest.mark.integration
+    def test_list_shows_all_versions(self, catalog_with_versions: Path) -> None:
+        """version list shows all versions in history."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "list", "boundaries", "--catalog", str(catalog_with_versions)],
+        )
+
+        assert result.exit_code == 0
+        assert "1.0.0" in result.output
+        assert "2.0.0" in result.output
+        assert "2.1.0" in result.output
+        assert "3 total" in result.output
+
+    @pytest.mark.integration
+    def test_list_json_output(self, catalog_with_versions: Path) -> None:
+        """version list outputs valid JSON with all versions."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "list", "boundaries", "--catalog", str(catalog_with_versions), "--json"],
+        )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert len(data["data"]["versions"]) == 3
+        versions = [v["version"] for v in data["data"]["versions"]]
+        assert "1.0.0" in versions
+        assert "2.0.0" in versions
+        assert "2.1.0" in versions
+
+    @pytest.mark.integration
+    def test_list_shows_breaking_flag(self, catalog_with_versions: Path) -> None:
+        """version list indicates breaking changes."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "list", "boundaries", "--catalog", str(catalog_with_versions)],
+        )
+
+        assert result.exit_code == 0
+        assert "[BREAKING]" in result.output
+
+
+class TestVersionErrorHandling:
+    """Tests for error handling in version commands."""
+
+    @pytest.mark.integration
+    def test_current_missing_collection(self, catalog_with_versions: Path) -> None:
+        """version current handles missing collection gracefully."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "current", "nonexistent", "--catalog", str(catalog_with_versions)],
+        )
+
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower() or "error" in result.output.lower()
+
+    @pytest.mark.integration
+    def test_list_missing_collection_json(self, catalog_with_versions: Path) -> None:
+        """version list returns empty versions for nonexistent collection."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["version", "list", "nonexistent", "--catalog", str(catalog_with_versions), "--json"],
+        )
+
+        # File backend returns empty list for nonexistent collection (valid state)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["data"]["versions"] == []

--- a/tests/unit/test_cli_version_commands.py
+++ b/tests/unit/test_cli_version_commands.py
@@ -74,65 +74,6 @@ def runner() -> CliRunner:
 
 
 # ---------------------------------------------------------------------------
-# _require_iceberg_backend — backend guard
-# ---------------------------------------------------------------------------
-
-
-class TestRequireIcebergBackend:
-    """Tests for the _require_iceberg_backend guard used by version sub-commands."""
-
-    @pytest.mark.unit
-    def test_wrong_backend_exits_with_error(self, runner: CliRunner, tmp_path: Path) -> None:
-        """version current errors out when the active backend is not iceberg."""
-        catalog_root = _make_file_catalog(tmp_path)
-
-        with patch(
-            "portolan_cli.config.get_setting",
-            return_value=None,  # no backend → defaults to 'file'
-        ):
-            result = runner.invoke(
-                cli,
-                [
-                    "version",
-                    "current",
-                    "boundaries",
-                    "--catalog",
-                    str(catalog_root),
-                ],
-            )
-
-        assert result.exit_code == 1
-        assert "iceberg" in result.output.lower()
-
-    @pytest.mark.unit
-    def test_wrong_backend_json_error(self, runner: CliRunner, tmp_path: Path) -> None:
-        """version current emits a JSON error when backend is not iceberg and --json is set."""
-        catalog_root = _make_file_catalog(tmp_path)
-
-        with patch(
-            "portolan_cli.config.get_setting",
-            return_value=None,
-        ):
-            result = runner.invoke(
-                cli,
-                [
-                    "--format",
-                    "json",
-                    "version",
-                    "current",
-                    "boundaries",
-                    "--catalog",
-                    str(catalog_root),
-                ],
-            )
-
-        assert result.exit_code == 1
-        data = json.loads(result.output)
-        assert data["success"] is False
-        assert "iceberg" in data["errors"][0]["message"].lower()
-
-
-# ---------------------------------------------------------------------------
 # version current
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -235,6 +235,191 @@ class TestDetectDeletedFiles:
         assert deleted == []
 
 
+class TestDetectUntrackedFiles:
+    """Tests for detecting untracked files."""
+
+    @pytest.mark.unit
+    def test_detects_untracked_file(self, tmp_path: Path) -> None:
+        """Files on disk but not in versions.json are reported as untracked."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "untracked.parquet").write_bytes(b"content")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert untracked == ["untracked.parquet"]
+
+    @pytest.mark.unit
+    def test_no_untracked_when_all_tracked(self, tmp_path: Path) -> None:
+        """No untracked files when all files are in versions.json."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "data.parquet").write_bytes(b"content")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={
+                        "data.parquet": Asset(
+                            sha256=_sha256("content"),
+                            size_bytes=100,
+                            href="collection/data.parquet",
+                        )
+                    },
+                    changes=["data.parquet"],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert untracked == []
+
+    @pytest.mark.unit
+    def test_excludes_versions_json(self, tmp_path: Path) -> None:
+        """versions.json itself is never reported as untracked."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "versions.json").write_text("{}")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert "versions.json" not in untracked
+
+    @pytest.mark.unit
+    def test_ignores_subdirectories(self, tmp_path: Path) -> None:
+        """Subdirectories are not reported as untracked files."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "subdir").mkdir()
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert untracked == []
+
+    @pytest.mark.unit
+    def test_all_files_untracked_with_no_versions(self, tmp_path: Path) -> None:
+        """All files are untracked when versions list is empty."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "file1.parquet").write_bytes(b"a")
+        (collection_path / "file2.parquet").write_bytes(b"b")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version=None,
+            versions=[],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert sorted(untracked) == ["file1.parquet", "file2.parquet"]
+
+
+class TestParseVersion:
+    """Tests for semver parsing in sync_state calculation."""
+
+    @pytest.mark.unit
+    def test_parses_standard_semver(self) -> None:
+        """Standard semver strings are parsed correctly."""
+        from portolan_cli.status import CollectionStatus
+
+        result = CollectionStatus._parse_version("1.2.3")
+        assert result == (1, 2, 3)
+
+    @pytest.mark.unit
+    def test_parses_semver_with_prerelease(self) -> None:
+        """Prerelease tags are stripped before parsing."""
+        from portolan_cli.status import CollectionStatus
+
+        result = CollectionStatus._parse_version("1.2.3-beta.1")
+        assert result == (1, 2, 3)
+
+    @pytest.mark.unit
+    def test_parses_semver_with_build_metadata(self) -> None:
+        """Build metadata is stripped before parsing."""
+        from portolan_cli.status import CollectionStatus
+
+        result = CollectionStatus._parse_version("1.2.3+build.456")
+        assert result == (1, 2, 3)
+
+    @pytest.mark.unit
+    def test_handles_invalid_version(self) -> None:
+        """Invalid version strings return (0, 0, 0)."""
+        from portolan_cli.status import CollectionStatus
+
+        result = CollectionStatus._parse_version("not-a-version")
+        assert result == (0, 0, 0)
+
+    @pytest.mark.unit
+    def test_handles_partial_version(self) -> None:
+        """Partial version strings return (0, 0, 0)."""
+        from portolan_cli.status import CollectionStatus
+
+        result = CollectionStatus._parse_version("1.2")
+        assert result == (0, 0, 0)
+
+    @pytest.mark.unit
+    def test_handles_empty_string(self) -> None:
+        """Empty string returns (0, 0, 0)."""
+        from portolan_cli.status import CollectionStatus
+
+        result = CollectionStatus._parse_version("")
+        assert result == (0, 0, 0)
+
+
 class TestCollectionStatus:
     """Tests for the main get_collection_status function."""
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -367,6 +367,116 @@ class TestDetectUntrackedFiles:
         untracked = detect_untracked_files(collection_path, versions_file)
         assert sorted(untracked) == ["file1.parquet", "file2.parquet"]
 
+    @pytest.mark.unit
+    def test_excludes_collection_json(self, tmp_path: Path) -> None:
+        """collection.json is a managed file and never reported as untracked."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "collection.json").write_text('{"type": "Collection"}')
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert "collection.json" not in untracked
+
+    @pytest.mark.unit
+    def test_excludes_readme(self, tmp_path: Path) -> None:
+        """README.md is a managed file and never reported as untracked."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "README.md").write_text("# Collection")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert "README.md" not in untracked
+
+    @pytest.mark.unit
+    def test_excludes_stac_item_files(self, tmp_path: Path) -> None:
+        """STAC item JSON files (type: Feature) are not reported as untracked."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        # Create a STAC item file
+        (collection_path / "item-2020.json").write_text(
+            '{"type": "Feature", "id": "item-2020", "geometry": null, "properties": {}}'
+        )
+        # Create a non-STAC JSON file (should be reported as untracked)
+        (collection_path / "config.json").write_text('{"setting": "value"}')
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert "item-2020.json" not in untracked
+        assert "config.json" in untracked
+
+    @pytest.mark.unit
+    def test_excludes_metadata_yaml(self, tmp_path: Path) -> None:
+        """metadata.yaml is a managed file and never reported as untracked."""
+        from portolan_cli.status import detect_untracked_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "metadata.yaml").write_text("title: My Collection")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={},
+                    changes=[],
+                )
+            ],
+        )
+
+        untracked = detect_untracked_files(collection_path, versions_file)
+        assert "metadata.yaml" not in untracked
+
 
 class TestParseVersion:
     """Tests for semver parsing in sync_state calculation."""

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,400 @@
+"""Unit tests for portolan status command.
+
+Tests the status module which shows local vs remote version state,
+modified files, and untracked files (Issue #389).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.versions import Asset, Version, VersionsFile
+
+
+def _sha256(data: str) -> str:
+    """Generate valid SHA256 hash from string."""
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+def _create_versions_file(
+    version: str = "1.0.0",
+    assets: dict[str, tuple[str, int]] | None = None,
+) -> VersionsFile:
+    """Create a VersionsFile for testing.
+
+    Args:
+        version: Version string.
+        assets: Dict of filename -> (content_for_hash, size_bytes).
+    """
+    if assets is None:
+        assets = {"data.parquet": ("content1", 1024)}
+
+    asset_objs = {
+        name: Asset(
+            sha256=_sha256(content),
+            size_bytes=size,
+            href=f"collection/{name}",
+        )
+        for name, (content, size) in assets.items()
+    }
+
+    ver = Version(
+        version=version,
+        created=datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc),
+        breaking=False,
+        assets=asset_objs,
+        changes=list(asset_objs.keys()),
+    )
+
+    return VersionsFile(
+        spec_version="1.0.0",
+        current_version=version,
+        versions=[ver],
+    )
+
+
+class TestDetectModifiedFiles:
+    """Tests for detecting files modified since last version."""
+
+    @pytest.mark.unit
+    def test_no_modifications_when_checksums_match(self, tmp_path: Path) -> None:
+        """Files with matching checksums are not reported as modified."""
+        from portolan_cli.status import detect_modified_files
+
+        # Create a file with known content
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        data_file = collection_path / "data.parquet"
+        content = b"test content"
+        data_file.write_bytes(content)
+
+        # Create versions.json with matching checksum
+        checksum = hashlib.sha256(content).hexdigest()
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={
+                        "data.parquet": Asset(
+                            sha256=checksum,
+                            size_bytes=len(content),
+                            href="collection/data.parquet",
+                        )
+                    },
+                    changes=["data.parquet"],
+                )
+            ],
+        )
+
+        modified = detect_modified_files(collection_path, versions_file)
+        assert modified == []
+
+    @pytest.mark.unit
+    def test_detects_modified_file(self, tmp_path: Path) -> None:
+        """Files with different checksums are reported as modified."""
+        from portolan_cli.status import detect_modified_files
+
+        # Create a file with content different from versions.json
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        data_file = collection_path / "data.parquet"
+        data_file.write_bytes(b"new content")
+
+        # Create versions.json with OLD checksum
+        old_checksum = hashlib.sha256(b"old content").hexdigest()
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={
+                        "data.parquet": Asset(
+                            sha256=old_checksum,
+                            size_bytes=100,
+                            href="collection/data.parquet",
+                        )
+                    },
+                    changes=["data.parquet"],
+                )
+            ],
+        )
+
+        modified = detect_modified_files(collection_path, versions_file)
+        assert modified == ["data.parquet"]
+
+    @pytest.mark.unit
+    def test_deleted_file_not_reported_as_modified(self, tmp_path: Path) -> None:
+        """Files in versions.json but missing from disk are not in modified list."""
+        from portolan_cli.status import detect_modified_files
+
+        # Create collection without the file
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+
+        # Create versions.json referencing a file that doesn't exist
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={
+                        "missing.parquet": Asset(
+                            sha256=_sha256("content"),
+                            size_bytes=100,
+                            href="collection/missing.parquet",
+                        )
+                    },
+                    changes=["missing.parquet"],
+                )
+            ],
+        )
+
+        modified = detect_modified_files(collection_path, versions_file)
+        assert modified == []
+
+
+class TestDetectDeletedFiles:
+    """Tests for detecting files deleted since last version."""
+
+    @pytest.mark.unit
+    def test_detects_deleted_file(self, tmp_path: Path) -> None:
+        """Files in versions.json but missing from disk are reported as deleted."""
+        from portolan_cli.status import detect_deleted_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={
+                        "deleted.parquet": Asset(
+                            sha256=_sha256("content"),
+                            size_bytes=100,
+                            href="collection/deleted.parquet",
+                        )
+                    },
+                    changes=["deleted.parquet"],
+                )
+            ],
+        )
+
+        deleted = detect_deleted_files(collection_path, versions_file)
+        assert deleted == ["deleted.parquet"]
+
+    @pytest.mark.unit
+    def test_no_deleted_when_all_files_exist(self, tmp_path: Path) -> None:
+        """No deleted files when all versioned files exist on disk."""
+        from portolan_cli.status import detect_deleted_files
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        (collection_path / "data.parquet").write_bytes(b"content")
+
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version="1.0.0",
+            versions=[
+                Version(
+                    version="1.0.0",
+                    created=datetime.now(timezone.utc),
+                    breaking=False,
+                    assets={
+                        "data.parquet": Asset(
+                            sha256=_sha256("content"),
+                            size_bytes=100,
+                            href="collection/data.parquet",
+                        )
+                    },
+                    changes=["data.parquet"],
+                )
+            ],
+        )
+
+        deleted = detect_deleted_files(collection_path, versions_file)
+        assert deleted == []
+
+
+class TestCollectionStatus:
+    """Tests for the main get_collection_status function."""
+
+    @pytest.mark.unit
+    def test_returns_local_version(self, tmp_path: Path) -> None:
+        """Status includes the current local version."""
+        from portolan_cli.status import CollectionStatus, get_collection_status
+
+        # Set up collection with versions.json
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+        versions_path = collection_path / "versions.json"
+
+        versions_path.write_text(
+            json.dumps(
+                {
+                    "spec_version": "1.0.0",
+                    "current_version": "2.1.0",
+                    "versions": [
+                        {
+                            "version": "2.1.0",
+                            "created": "2024-01-15T10:30:00Z",
+                            "breaking": False,
+                            "assets": {},
+                            "changes": [],
+                        }
+                    ],
+                }
+            )
+        )
+
+        status = get_collection_status(
+            catalog_root=tmp_path,
+            collection="collection",
+            offline=True,
+        )
+
+        assert isinstance(status, CollectionStatus)
+        assert status.local_version == "2.1.0"
+
+    @pytest.mark.unit
+    def test_no_versions_json_returns_none_version(self, tmp_path: Path) -> None:
+        """Status returns None for local_version when no versions.json exists."""
+        from portolan_cli.status import get_collection_status
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+
+        status = get_collection_status(
+            catalog_root=tmp_path,
+            collection="collection",
+            offline=True,
+        )
+
+        assert status.local_version is None
+
+    @pytest.mark.unit
+    def test_offline_mode_skips_remote_check(self, tmp_path: Path) -> None:
+        """Offline mode does not attempt to fetch remote versions."""
+        from portolan_cli.status import get_collection_status
+
+        collection_path = tmp_path / "collection"
+        collection_path.mkdir()
+
+        # Should not raise even without remote configured
+        status = get_collection_status(
+            catalog_root=tmp_path,
+            collection="collection",
+            offline=True,
+        )
+
+        assert status.remote_version is None
+
+
+class TestStatusOutput:
+    """Tests for status output formatting."""
+
+    @pytest.mark.unit
+    def test_status_to_dict_for_json_output(self) -> None:
+        """CollectionStatus can be serialized to dict for JSON output."""
+        from portolan_cli.status import CollectionStatus
+
+        status = CollectionStatus(
+            collection="demographics",
+            local_version="1.3.0",
+            remote_version="1.3.1",
+            modified_files=["census-data.parquet"],
+            untracked_files=["notes.txt"],
+            deleted_files=[],
+        )
+
+        data = status.to_dict()
+
+        assert data["collection"] == "demographics"
+        assert data["local_version"] == "1.3.0"
+        assert data["remote_version"] == "1.3.1"
+        assert data["modified_files"] == ["census-data.parquet"]
+        assert data["untracked_files"] == ["notes.txt"]
+        assert data["deleted_files"] == []
+
+    @pytest.mark.unit
+    def test_sync_state_behind(self) -> None:
+        """Sync state is 'behind' when remote is ahead."""
+        from portolan_cli.status import CollectionStatus
+
+        status = CollectionStatus(
+            collection="test",
+            local_version="1.0.0",
+            remote_version="1.1.0",
+            modified_files=[],
+            untracked_files=[],
+            deleted_files=[],
+        )
+
+        assert status.sync_state == "behind"
+
+    @pytest.mark.unit
+    def test_sync_state_ahead(self) -> None:
+        """Sync state is 'ahead' when local has unpushed versions."""
+        from portolan_cli.status import CollectionStatus
+
+        status = CollectionStatus(
+            collection="test",
+            local_version="1.2.0",
+            remote_version="1.0.0",
+            modified_files=[],
+            untracked_files=[],
+            deleted_files=[],
+        )
+
+        assert status.sync_state == "ahead"
+
+    @pytest.mark.unit
+    def test_sync_state_in_sync(self) -> None:
+        """Sync state is 'in_sync' when versions match."""
+        from portolan_cli.status import CollectionStatus
+
+        status = CollectionStatus(
+            collection="test",
+            local_version="1.0.0",
+            remote_version="1.0.0",
+            modified_files=[],
+            untracked_files=[],
+            deleted_files=[],
+        )
+
+        assert status.sync_state == "in_sync"
+
+    @pytest.mark.unit
+    def test_sync_state_unknown_when_offline(self) -> None:
+        """Sync state is 'unknown' when remote version is None."""
+        from portolan_cli.status import CollectionStatus
+
+        status = CollectionStatus(
+            collection="test",
+            local_version="1.0.0",
+            remote_version=None,
+            modified_files=[],
+            untracked_files=[],
+            deleted_files=[],
+        )
+
+        assert status.sync_state == "unknown"

--- a/tests/unit/test_version_ops.py
+++ b/tests/unit/test_version_ops.py
@@ -92,7 +92,7 @@ class TestPublishVersion:
             result = publish_version("col", assets={"a": "/path"}, schema=schema, message="test")
 
         mock_backend.publish.assert_called_once_with(
-            "col", {"a": "/path"}, schema, False, "test", removed=None
+            "col", {"a": "/path"}, schema, False, "test", removed=None, version=None
         )
         assert result is mock_version
 
@@ -112,7 +112,7 @@ class TestPublishVersion:
             )
 
         mock_backend.publish.assert_called_once_with(
-            "col", {}, schema, False, "remove", removed={"old.parquet"}
+            "col", {}, schema, False, "remove", removed={"old.parquet"}, version=None
         )
 
 


### PR DESCRIPTION
## Summary
- Add `portolan status` command showing local vs remote state, modified/deleted/untracked files
- Add `portolan version bump` command to create new versions from file changes without manual JSON editing
- Enable `portolan version current/list` for file backend (previously Iceberg-only)
- Auto-detect versioning backend instead of requiring explicit Iceberg

## Test plan
- [x] Unit tests for status module (13 → 28 tests)
- [x] Integration tests for status CLI (6 tests)
- [x] Integration tests for version file backend (7 tests)
- [x] Integration tests for version bump (8 → 15 tests)
- [x] All pre-commit hooks pass (ruff, mypy, xenon, vulture)
- [x] Manual testing with real data from portolan-test-data

## Changes

### Core Features
- `portolan status` - Git-like status showing version sync state and file changes
- `portolan version bump <collection> <version>` - Create versions from file changes
- `portolan version current/list` - Now works with file backend (not just Iceberg)

### Adversarial Review Fixes
- **Critical bug fixed:** `version bump` now uses the user-provided version (was auto-computing)
- **Validation added:** Semver format validation, duplicate version rejection
- **Managed file filtering:** STAC files (`collection.json`, items) no longer show as "untracked"

### Documentation
- Added comprehensive mkdocs guide: `docs/guides/version-management.md`
- CLI reference auto-updates via mkdocs-click

### Test Coverage
- 55 tests total (was 34 at initial PR)
- Covers: modified/deleted/untracked detection, version validation, managed file filtering

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)