### PR TITLE
feat(partition): add STAC partition extension support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests (unit + integration, no network)
-        run: uv run pytest tests/ -v --tb=short -m "not network and not slow and not benchmark" --cov=portolan_cli --cov-report=term-missing --cov-report=xml
+        run: uv run pytest tests/ -v --tb=short -m "not network and not slow and not benchmark" -n auto --dist loadscope --cov=portolan_cli --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -182,6 +182,33 @@ jobs:
             --timeout=120 \
             -v
 
+  slow-tests:
+    name: Slow Tests (Stress/Scale)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run slow tests (stress/scale scenarios)
+        run: |
+          uv run pytest tests/ \
+            -m slow \
+            --timeout=300 \
+            -v
+
   dependency-check:
     name: Dependency Audit
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0039](context/shared/adr/0039-hierarchical-portolan-folders.md) | Hierarchical .portolan/ at collection/subcatalog levels |
 | [0040](context/shared/adr/0040-unified-progress-output.md) | Progress + summary model: Rich progress bars, immediate errors, batched warnings |
 | [0041](context/shared/adr/0041-stac-manifest-as-canonical-scan-source.md) | STAC manifest as canonical scan source for metadata_fresh; unifies check/--fix; adds ORPHANED status |
+| [0042](context/shared/adr/0042-partition-stac-extension.md) | Standalone `partition:` STAC extension for Hive-style partitioned datasets |
 
 ## Common Commands
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,7 +36,7 @@ Validate a Portolan catalog or check files for cloud-native status.
 portolan check                        # Validate all (metadata + geo-assets)
 portolan check --metadata             # Validate metadata only
 portolan check --geo-assets           # Check geo-assets only
-portolan check --thorough             # Include partition validation
+portolan check --fix                  # Fix both metadata and geo-assets
 ```
 
 ### `portolan clean`

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,7 +36,7 @@ Validate a Portolan catalog or check files for cloud-native status.
 portolan check                        # Validate all (metadata + geo-assets)
 portolan check --metadata             # Validate metadata only
 portolan check --geo-assets           # Check geo-assets only
-portolan check --fix                  # Fix both metadata and geo-assets
+portolan check --thorough             # Include partition validation
 ```
 
 ### `portolan clean`

--- a/context/shared/adr/0042-partition-stac-extension.md
+++ b/context/shared/adr/0042-partition-stac-extension.md
@@ -1,0 +1,141 @@
+# ADR-0042: Partition STAC Extension
+
+## Status
+Proposed
+
+## Context
+
+Portolan supports spatial partitioning of large GeoParquet files (PR #399) using Hive-style directory structures:
+
+```
+buildings/
+├── kdtree_cell=0/data.parquet
+├── kdtree_cell=1/data.parquet
+└── kdtree_cell=2/data.parquet
+```
+
+However, the STAC output lacks machine-readable partition metadata. Consumers cannot programmatically discover:
+- Which columns are partition keys
+- What partitioning strategy was used (kdtree, h3, s2, quadkey)
+- How to construct efficient queries
+
+The STAC Table Extension (v1.2.0) does not define partition metadata—it describes table schemas, not physical organization.
+
+We consulted m-mohr (table extension maintainer), who [commented](https://github.com/portolan-sdi/portolan-cli/issues/232#issuecomment-4129148114):
+
+> "As long as partitioning strategies are format-specific, they should probably live in a separate extension."
+
+This aligns with our existing `stac-iceberg-extension` pattern—format-specific metadata in dedicated extensions.
+
+## Decision
+
+**Create a standalone `stac-partition-extension`** with the `partition:` namespace.
+
+### Extension Schema
+
+```json
+{
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+    "https://portolan.org/stac-extensions/partition/v1.0.0/schema.json"
+  ],
+  "partition:scheme": "hive",
+  "partition:strategy": "kdtree",
+  "partition:keys": [
+    {"name": "kdtree_cell", "type": "string"}
+  ],
+  "partition:file_count": 42,
+  "assets": {
+    "data": {
+      "href": "./kdtree_cell=*/*.parquet",
+      "partition:glob": "s3://bucket/buildings/kdtree_cell=*/*.parquet"
+    }
+  }
+}
+```
+
+### Field Definitions
+
+| Field | Scope | Type | Required | Description |
+|-------|-------|------|----------|-------------|
+| `partition:scheme` | Collection/Item | string | Yes | Partitioning scheme: `hive`, `directory` |
+| `partition:strategy` | Collection/Item | string | No | Algorithm: `kdtree`, `h3`, `s2`, `quadkey`, `a5` |
+| `partition:keys` | Collection/Item | array | Yes | Partition key definitions |
+| `partition:file_count` | Collection/Item | integer | No | Number of partition files |
+| `partition:glob` | Asset | string | No | Absolute glob URL for bulk access |
+
+### Migration from `portolan:glob`
+
+Current implementation uses `portolan:glob`. Migration path:
+
+| Version | Behavior |
+|---------|----------|
+| v0.x | Both `portolan:glob` and `partition:glob` emitted |
+| v1.0 | Deprecation warning for `portolan:glob` |
+| v2.0 | Only `partition:glob` (breaking) |
+
+## Consequences
+
+### Positive
+
+- **Machine-readable**: Consumers can programmatically discover partition structure
+- **Standard pattern**: Follows existing `stac-iceberg-extension` approach
+- **Composable**: Works alongside table extension (schema) and iceberg extension (lakehouse)
+- **Upstream-friendly**: Can propose to STAC ecosystem if adoption grows
+
+### Negative
+
+- **Maintenance burden**: Another extension to maintain
+- **Namespace proliferation**: `partition:` joins `portolan:`, `table:`, `iceberg:`
+- **Not upstream**: Won't auto-validate in generic STAC tools without extension
+
+### Neutral
+
+- Partition pruning remains consumer responsibility (DuckDB, PyArrow)
+- Per-partition statistics deferred (can derive from Parquet metadata)
+
+## Alternatives Considered
+
+### A. Extend STAC Table Extension upstream
+
+Add `table:partitioning` to the table extension.
+
+**Rejected because:**
+- Table extension maintainer advised against it (format-specific)
+- Would require upstream approval process
+- Table extension is "Pilot" maturity (evolving)
+
+### B. Use `portolan:` namespace
+
+Keep partition metadata in `portolan:partition_*` fields.
+
+**Rejected because:**
+- `portolan:` is for Portolan-specific operational metadata (e.g., `datetime_provisional`)
+- Partition metadata is semantically about data organization, not Portolan internals
+- Harder for other tools to adopt
+
+### C. Inline in table extension fields
+
+Encode partitioning in `table:columns` descriptions or custom properties.
+
+**Rejected because:**
+- Not machine-readable
+- Violates single-responsibility (columns describe schema, not storage)
+- Would require parsing free-text
+
+### D. No metadata, rely on directory conventions
+
+Consumers detect Hive partitioning from directory structure.
+
+**Rejected because:**
+- Requires filesystem access (doesn't work for HTTP STAC catalogs)
+- Can't distinguish intentional partitioning from coincidental directory structure
+- No way to document partition strategy or validate consistency
+
+## References
+
+- Issue #232: Hive Partitioning Metadata Design for STAC
+- PR #399: Spatial partitioning implementation
+- m-mohr comment: https://github.com/portolan-sdi/portolan-cli/issues/232#issuecomment-4129148114
+- stac-iceberg-extension: https://github.com/portolan-sdi/stac-iceberg-extension
+- STAC Table Extension: https://github.com/stac-extensions/table

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -1,0 +1,369 @@
+# Partition STAC Extension Implementation Plan
+
+**Date**: 2026-05-06
+**Status**: Draft
+**Issues**: #232 (Hive Partitioning Metadata Design)
+**Depends On**: PR #399 (spatial partitioning), PR #404 (vector settings)
+
+## Problem Statement
+
+Portolan now supports spatial partitioning of large GeoParquet files (PR #399), but the STAC output lacks machine-readable partition metadata. Consumers cannot programmatically discover:
+
+- Which columns are partition keys
+- What partitioning strategy was used
+- How to construct efficient queries
+
+The STAC Table Extension does not define partition metadata. Per m-mohr (table extension maintainer): partitioning is format-specific and should live in a separate extension.
+
+## Goals
+
+1. **Create `stac-partition-extension`** — standalone STAC extension for partition metadata
+2. **Emit partition metadata** in portolan's STAC output
+3. **Detect partitions** in `portolan scan` for existing partitioned datasets
+4. **Integrate auto-partitioning** into `portolan add` workflow
+5. **Validate partition consistency** across files
+
+## Non-Goals
+
+- Partition pruning optimization (DuckDB/PyArrow handle this)
+- Partition evolution (complex, defer to future)
+- Iceberg integration (separate `stac-iceberg-extension` exists)
+
+## Design
+
+### Extension Schema
+
+Repository: `github.com/portolan-sdi/stac-partition-extension`
+
+```json
+{
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+    "https://portolan.org/stac-extensions/partition/v1.0.0/schema.json"
+  ],
+  "partition:scheme": "hive",
+  "partition:strategy": "kdtree",
+  "partition:keys": [
+    {
+      "name": "kdtree_cell",
+      "type": "string",
+      "description": "KD-tree spatial partition cell identifier"
+    }
+  ],
+  "partition:file_count": 42,
+  "assets": {
+    "data": {
+      "href": "./kdtree_cell=*/*.parquet",
+      "partition:glob": "s3://bucket/collection/kdtree_cell=*/*.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    }
+  }
+}
+```
+
+#### Field Definitions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `partition:scheme` | string | Yes | Partitioning scheme: `hive`, `directory` |
+| `partition:strategy` | string | No | Algorithm used: `kdtree`, `h3`, `s2`, `quadkey`, `a5` |
+| `partition:keys` | array | Yes | Partition key definitions |
+| `partition:keys[].name` | string | Yes | Column name |
+| `partition:keys[].type` | string | Yes | Data type |
+| `partition:keys[].description` | string | No | Human description |
+| `partition:file_count` | integer | No | Number of partition files |
+| `partition:glob` | string | No | Asset-level: absolute glob URL for bulk access |
+
+#### Relationship to `portolan:glob`
+
+Current implementation uses `portolan:glob`. Migration path:
+1. v1.0.0: Support both `portolan:glob` and `partition:glob`
+2. v1.1.0: Deprecate `portolan:glob` for partitioned assets
+3. v2.0.0: Remove `portolan:glob` (breaking)
+
+### Module Changes
+
+```
+portolan_cli/
+├── partitioning.py          # Existing: partition_geoparquet(), build_glob_pattern()
+│                            # Add: get_partition_metadata() -> dict
+├── stac.py                  # Add partition:* fields when partitioned
+├── dataset.py               # Wire partition metadata through scan/add
+├── validation/
+│   └── rules.py             # Add: PartitionConsistencyRule
+└── scan.py                  # Detect existing partitions in directories
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Extension Repository (External)
+
+**Deliverable**: `stac-partition-extension` repo with v1.0.0 release
+
+- [ ] Create repo from STAC extension template
+- [ ] Write JSON Schema for `partition:*` fields
+- [ ] Add examples (kdtree, h3, multi-key)
+- [ ] Add validation test fixtures
+- [ ] README with consumer code examples (DuckDB, PyArrow)
+- [ ] Tag v1.0.0 release
+
+**Files to create**:
+```
+stac-partition-extension/
+├── README.md
+├── json-schema/
+│   └── schema.json
+├── examples/
+│   ├── collection-kdtree.json
+│   ├── collection-h3.json
+│   └── collection-multikey.json
+└── tests/
+    └── test_validation.py
+```
+
+**Exit criteria**: Extension passes STAC validator, examples render in STAC Browser
+
+---
+
+### Phase 2: ADR Documentation
+
+**Deliverable**: ADR-0042 documenting extension design decisions
+
+- [ ] Create `context/shared/adr/0042-partition-stac-extension.md`
+- [ ] Document: why separate extension (m-mohr feedback)
+- [ ] Document: relationship to table extension
+- [ ] Document: `portolan:glob` → `partition:glob` migration
+- [ ] Update CLAUDE.md ADR index
+
+**Exit criteria**: ADR reviewed and merged
+
+---
+
+### Phase 3: Emit Partition Metadata
+
+**Deliverable**: Portolan STAC output includes `partition:*` fields
+
+- [ ] Add `get_partition_metadata(output_dir, strategy)` to `partitioning.py`
+  - Returns dict with scheme, strategy, keys, file_count
+  - Parses Hive directory structure
+- [ ] Update `_create_collection_stac()` in `stac.py`
+  - Accept optional partition_metadata parameter
+  - Add `partition:*` fields to collection properties
+  - Add extension URL to `stac_extensions`
+- [ ] Wire through from `partition_geoparquet()` result
+- [ ] Update `portolan:glob` → `partition:glob` in `push.py`
+- [ ] Unit tests for metadata emission
+
+**Key code changes**:
+
+```python
+# partitioning.py
+def get_partition_metadata(output_dir: Path, strategy: str) -> dict:
+    """Extract partition metadata from Hive-style output directory."""
+    partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
+    partition_dirs = list(output_dir.glob(f"{partition_col}=*"))
+
+    return {
+        "partition:scheme": "hive",
+        "partition:strategy": strategy,
+        "partition:keys": [
+            {"name": partition_col, "type": "string"}
+        ],
+        "partition:file_count": sum(
+            len(list(d.glob("*.parquet"))) for d in partition_dirs
+        ),
+    }
+```
+
+**Exit criteria**: `portolan add` on partitioned data produces valid STAC with partition extension
+
+---
+
+### Phase 4: Partition Detection in Scan
+
+**Deliverable**: `portolan scan` detects and reports existing partitions
+
+- [ ] Add `detect_partitioning(directory: Path)` to `partitioning.py`
+  - Detect Hive-style directories (`column=value/`)
+  - Extract partition keys from directory names
+  - Return `PartitionInfo` dataclass or None
+- [ ] Update `portolan scan` output to show partition info
+  - "Detected: Hive-partitioned (keys: kdtree_cell, 42 partitions)"
+- [ ] Handle edge cases:
+  - Mixed partition depths
+  - Non-Hive directory structures
+  - Empty partition directories
+- [ ] Unit tests for detection
+
+**Exit criteria**: `portolan scan` on partitioned directory shows partition summary
+
+---
+
+### Phase 5: Auto-Partition in Add Workflow
+
+**Deliverable**: Large files auto-partition during `portolan add`
+
+- [ ] Add `partitioning.auto_partition` config option (default: true)
+- [ ] Add `partitioning.prompt` config option (default: true for interactive)
+- [ ] In `portolan add`, check `should_partition()` after file analysis
+- [ ] If interactive + prompt enabled: ask user
+- [ ] If `--auto` or non-interactive: use config threshold
+- [ ] Wire partitioned output through to STAC generation
+- [ ] Update `--help` and docs
+
+**UX flow**:
+```
+$ portolan add large-dataset.parquet
+
+Analyzing: large-dataset.parquet (4.2 GB, 12M rows)
+⚠ File exceeds 2.0 GB threshold
+
+Partition into ~100 spatial chunks? [Y/n] y
+
+Partitioning: large-dataset.parquet
+  Strategy: kdtree (data-driven spatial)
+  Target: ~120,000 rows per partition
+  ████████████████████████████████████████ 100%
+
+✓ Created 98 partitions in large-dataset/
+✓ Added to collection: default
+```
+
+**Exit criteria**: `portolan add bigfile.parquet` partitions and catalogs in one command
+
+---
+
+### Phase 6: Partition Validation Rules
+
+**Deliverable**: `portolan check` validates partition consistency
+
+- [ ] Add `PartitionSchemaConsistencyRule` to `validation/rules.py`
+  - All partition files have same Parquet schema
+  - Partition key column exists in schema
+- [ ] Add `PartitionRowCountRule`
+  - `table:row_count` matches sum of partition row counts
+- [ ] Add `PartitionStructureRule`
+  - All partition directories follow same key pattern
+  - No orphan files outside partition structure
+- [ ] Wire into `portolan check` with `--thorough` flag (expensive)
+- [ ] Unit tests for each rule
+
+**Exit criteria**: `portolan check --thorough` catches partition inconsistencies
+
+---
+
+### Phase 7: Documentation
+
+**Deliverable**: User-facing partitioning guide
+
+- [ ] Add `docs/guides/partitioning.md`
+  - When to partition (thresholds, use cases)
+  - Configuration options
+  - Consumer code examples
+- [ ] Update `docs/reference/configuration.md` with partition settings
+- [ ] Update `docs/reference/cli.md` with `portolan partition` command
+- [ ] Add partitioning to "Getting Started" if appropriate
+
+**Exit criteria**: User can learn partitioning from docs alone
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (Extension Repo)
+    │
+    ├──► Phase 2 (ADR) ──────────────────────────────────┐
+    │                                                     │
+    └──► Phase 3 (Emit Metadata) ◄────────────────────────┘
+              │
+              ├──► Phase 4 (Scan Detection)
+              │         │
+              │         └──► Phase 5 (Auto-Partition in Add)
+              │
+              └──► Phase 6 (Validation Rules)
+                        │
+                        └──► Phase 7 (Documentation)
+```
+
+**Critical path**: 1 → 3 → 5 (extension → emit → add integration)
+
+---
+
+## Testing Strategy
+
+| Phase | Test Type | Coverage |
+|-------|-----------|----------|
+| 1 | STAC validation | Extension schema validity |
+| 3 | Unit | Metadata extraction, STAC emission |
+| 4 | Unit + Integration | Detection on various directory structures |
+| 5 | Integration | End-to-end add workflow |
+| 6 | Unit | Each validation rule |
+| 7 | Manual | Docs accuracy |
+
+**Real-world test data**: Use existing `tests/fixtures/realdata/` or create synthetic partitioned fixture.
+
+---
+
+## Migration Notes
+
+### `portolan:glob` → `partition:glob`
+
+Existing catalogs using `portolan:glob` remain valid. The extension supports both during transition:
+
+```python
+# push.py - during transition period
+if "*" in href:
+    # Support both for backwards compatibility
+    asset_data["portolan:glob"] = remote_glob  # Legacy
+    asset_data["partition:glob"] = remote_glob  # New
+```
+
+Deprecation timeline:
+- **v0.x**: Both supported, no warning
+- **v1.0**: Both supported, deprecation warning for `portolan:glob`
+- **v2.0**: Only `partition:glob` (breaking change)
+
+---
+
+## Open Questions
+
+1. **Multi-key partitioning**: Should we support `year=2020/state=CA/` (multiple keys)?
+   - Current implementation: single key only (spatial)
+   - Future consideration: temporal + spatial compound keys
+
+2. **Partition statistics**: Should we store per-partition row counts?
+   - Pro: Enables smarter query planning
+   - Con: Maintenance burden, can derive from Parquet metadata
+
+3. **Non-Hive schemes**: Should we support directory-based (no `=`) partitioning?
+   - Some datasets use `2020/CA/data.parquet` without Hive syntax
+   - Lower priority, can add later
+
+---
+
+## Success Criteria
+
+Issue #232 is complete when:
+
+- [ ] `stac-partition-extension` v1.0.0 released
+- [ ] ADR-0042 merged
+- [ ] `portolan add` emits `partition:*` metadata for partitioned datasets
+- [ ] `portolan scan` detects and reports existing partitions
+- [ ] `portolan check` validates partition consistency
+- [ ] Documentation covers partitioning workflow
+- [ ] Issue #232 closed with summary comment
+
+---
+
+## References
+
+- Issue #232: Hive Partitioning Metadata Design for STAC
+- PR #399: feat(partition): add spatial partitioning for large GeoParquet files
+- PR #404: feat(convert): add configurable vector spatial optimization
+- m-mohr comment: https://github.com/portolan-sdi/portolan-cli/issues/232#issuecomment-4129148114
+- cayetanobv Iceberg analysis: https://github.com/portolan-sdi/portolan-cli/issues/232#issuecomment-4091450081
+- Existing Iceberg extension: https://github.com/portolan-sdi/stac-iceberg-extension

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -153,7 +153,10 @@ stac-partition-extension/
   - Accept optional partition_metadata parameter
   - Add `partition:*` fields to collection properties
   - Add extension URL to `stac_extensions`
-- [ ] Wire through from `partition_geoparquet()` result
+- [x] Wire through from `partition_geoparquet()` result
+  - Added `partition_metadata` field to `PreparedDataset`
+  - `_maybe_partition_large_file()` extracts and stores partition metadata
+  - `finalize_datasets()` applies partition metadata to collection via `add_partition_metadata_to_collection()`
 - [x] Update `portolan:glob` → `partition:glob` in `push.py`
 - [x] Unit tests for metadata emission
 
@@ -190,12 +193,14 @@ def get_partition_metadata(output_dir: Path, strategy: str) -> dict:
   - Detect Hive-style directories (`column=value/`)
   - Extract partition keys from directory names
   - Return `PartitionInfo` dataclass or None
-- [ ] Update `portolan scan` output to show partition info
+- [x] Update `portolan scan` output to show partition info
   - "Detected: Hive-partitioned (keys: kdtree_cell, 42 partitions)"
-- [ ] Handle edge cases:
-  - Mixed partition depths
-  - Non-Hive directory structures
-  - Empty partition directories
+  - Added `_format_special_formats()` in scan_output.py
+  - Integrates with `detect_partitioning()` for rich metadata
+- [x] Handle edge cases:
+  - Mixed partition depths (detected at first level)
+  - Non-Hive directory structures (returns None, uses fallback display)
+  - Empty partition directories (handled gracefully)
 - [x] Unit tests for detection
 
 **Exit criteria**: `portolan scan` on partitioned directory shows partition summary

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -103,12 +103,12 @@ portolan_cli/
 
 **Deliverable**: `stac-partition-extension` repo with v1.0.0 release
 
-- [ ] Create repo from STAC extension template
-- [ ] Write JSON Schema for `partition:*` fields
-- [ ] Add examples (kdtree, h3, multi-key)
-- [ ] Add validation test fixtures
-- [ ] README with consumer code examples (DuckDB, PyArrow)
-- [ ] Tag v1.0.0 release
+- [x] Create repo from STAC extension template
+- [x] Write JSON Schema for `partition:*` fields
+- [x] Add examples (kdtree, h3, multi-key)
+- [x] Add validation test fixtures
+- [x] README with consumer code examples (DuckDB, PyArrow)
+- [x] Tag v1.0.0 release
 
 **Files to create**:
 ```
@@ -132,11 +132,11 @@ stac-partition-extension/
 
 **Deliverable**: ADR-0042 documenting extension design decisions
 
-- [ ] Create `context/shared/adr/0042-partition-stac-extension.md`
-- [ ] Document: why separate extension (m-mohr feedback)
-- [ ] Document: relationship to table extension
-- [ ] Document: `portolan:glob` → `partition:glob` migration
-- [ ] Update CLAUDE.md ADR index
+- [x] Create `context/shared/adr/0042-partition-stac-extension.md`
+- [x] Document: why separate extension (m-mohr feedback)
+- [x] Document: relationship to table extension
+- [x] Document: `portolan:glob` → `partition:glob` migration
+- [x] Update CLAUDE.md ADR index
 
 **Exit criteria**: ADR reviewed and merged
 
@@ -146,16 +146,16 @@ stac-partition-extension/
 
 **Deliverable**: Portolan STAC output includes `partition:*` fields
 
-- [ ] Add `get_partition_metadata(output_dir, strategy)` to `partitioning.py`
+- [x] Add `get_partition_metadata(output_dir, strategy)` to `partitioning.py`
   - Returns dict with scheme, strategy, keys, file_count
   - Parses Hive directory structure
-- [ ] Update `_create_collection_stac()` in `stac.py`
+- [x] Update `_create_collection_stac()` in `stac.py`
   - Accept optional partition_metadata parameter
   - Add `partition:*` fields to collection properties
   - Add extension URL to `stac_extensions`
 - [ ] Wire through from `partition_geoparquet()` result
-- [ ] Update `portolan:glob` → `partition:glob` in `push.py`
-- [ ] Unit tests for metadata emission
+- [x] Update `portolan:glob` → `partition:glob` in `push.py`
+- [x] Unit tests for metadata emission
 
 **Key code changes**:
 
@@ -186,7 +186,7 @@ def get_partition_metadata(output_dir: Path, strategy: str) -> dict:
 
 **Deliverable**: `portolan scan` detects and reports existing partitions
 
-- [ ] Add `detect_partitioning(directory: Path)` to `partitioning.py`
+- [x] Add `detect_partitioning(directory: Path)` to `partitioning.py`
   - Detect Hive-style directories (`column=value/`)
   - Extract partition keys from directory names
   - Return `PartitionInfo` dataclass or None
@@ -196,7 +196,7 @@ def get_partition_metadata(output_dir: Path, strategy: str) -> dict:
   - Mixed partition depths
   - Non-Hive directory structures
   - Empty partition directories
-- [ ] Unit tests for detection
+- [x] Unit tests for detection
 
 **Exit criteria**: `portolan scan` on partitioned directory shows partition summary
 

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -222,7 +222,7 @@ def get_partition_metadata(output_dir: Path, strategy: str) -> dict:
 - [x] Wire `skip_partitioning` through dataset.py call chain
   - `add_files()` → `prepare_single_file()` → `_maybe_partition_large_file()`
 - [x] Wire partitioned output through to STAC generation (done in Phase 3)
-- [ ] Update `--help` and docs
+- [x] Update `--help` docstring with partitioning configuration section
 
 **UX flow**:
 ```

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -211,12 +211,17 @@ def get_partition_metadata(output_dir: Path, strategy: str) -> dict:
 
 **Deliverable**: Large files auto-partition during `portolan add`
 
-- [ ] Add `partitioning.auto_partition` config option (default: true)
-- [ ] Add `partitioning.prompt` config option (default: true for interactive)
-- [ ] In `portolan add`, check `should_partition()` after file analysis
-- [ ] If interactive + prompt enabled: ask user
-- [ ] If `--auto` or non-interactive: use config threshold
-- [ ] Wire partitioned output through to STAC generation
+- [x] Add `partitioning.prompt` config option (default: true for interactive)
+  - Added to `config.py` KNOWN_SETTINGS and DEFAULT_SETTINGS
+- [x] In `portolan add`, pre-scan files with `should_partition()` before processing
+  - CLI pre-scans .parquet files against threshold before calling `add_files`
+- [x] If interactive + prompt enabled: ask user
+  - `click.confirm("Partition large files into spatial chunks?")` prompt added
+- [x] If non-interactive (JSON mode/no-TTY): use config threshold silently
+  - Prompt logic only runs when `not use_json and sys.stderr.isatty()`
+- [x] Wire `skip_partitioning` through dataset.py call chain
+  - `add_files()` → `prepare_single_file()` → `_maybe_partition_large_file()`
+- [x] Wire partitioned output through to STAC generation (done in Phase 3)
 - [ ] Update `--help` and docs
 
 **UX flow**:

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -271,13 +271,17 @@ Partitioning: large-dataset.parquet
 
 **Deliverable**: User-facing partitioning guide
 
-- [ ] Add `docs/guides/partitioning.md`
+- [x] Add `docs/guides/partitioning.md`
   - When to partition (thresholds, use cases)
-  - Configuration options
-  - Consumer code examples
-- [ ] Update `docs/reference/configuration.md` with partition settings
-- [ ] Update `docs/reference/cli.md` with `portolan partition` command
-- [ ] Add partitioning to "Getting Started" if appropriate
+  - Configuration options (all settings documented)
+  - Consumer code examples (DuckDB, PyArrow, GDAL)
+  - Validation with `portolan check --thorough`
+- [x] Update `docs/reference/configuration.md` with partition settings
+  - Added `partitioning.prompt` setting
+  - Updated Settings Reference table
+  - Added auto-partition example output
+- [ ] Update `docs/reference/cli.md` with `portolan partition` command (already documented)
+- [ ] Add partitioning to "Getting Started" if appropriate (deferred - not essential for MVP)
 
 **Exit criteria**: User can learn partitioning from docs alone
 

--- a/context/shared/plans/2026-05-06-partition-stac-extension.md
+++ b/context/shared/plans/2026-05-06-partition-stac-extension.md
@@ -250,16 +250,18 @@ Partitioning: large-dataset.parquet
 
 **Deliverable**: `portolan check` validates partition consistency
 
-- [ ] Add `PartitionSchemaConsistencyRule` to `validation/rules.py`
-  - All partition files have same Parquet schema
-  - Partition key column exists in schema
-- [ ] Add `PartitionRowCountRule`
-  - `table:row_count` matches sum of partition row counts
-- [ ] Add `PartitionStructureRule`
+- [x] Add `PartitionStructureRule` to `validation/rules.py`
   - All partition directories follow same key pattern
   - No orphan files outside partition structure
-- [ ] Wire into `portolan check` with `--thorough` flag (expensive)
-- [ ] Unit tests for each rule
+  - Warns if partition:scheme missing from collection.json
+- [x] Add `PartitionSchemaConsistencyRule` to `validation/rules.py`
+  - All partition files have same Parquet schema
+  - Reports number of different schemas detected
+- [x] Wire into `portolan check` with `--thorough` flag (expensive)
+  - Added THOROUGH_RULES tuple in runner.py
+  - `--thorough` flag added to check command
+  - Updated check command docstring
+- [x] Unit tests for each rule (9 tests)
 
 **Exit criteria**: `portolan check --thorough` catches partition inconsistencies
 

--- a/docs/guides/partitioning.md
+++ b/docs/guides/partitioning.md
@@ -45,7 +45,7 @@ Configure partitioning in `.portolan/config.yaml`:
 
 ```yaml
 partitioning:
-  enabled: true           # Enable auto-partitioning (default: false)
+  enabled: true           # Enable auto-partitioning (default: true)
   prompt: true            # Ask before partitioning in interactive mode (default: true)
   threshold_gb: 2.0       # Size threshold in GB (default: 2.0)
   strategy: kdtree        # Partitioning strategy (default: kdtree)
@@ -56,7 +56,7 @@ partitioning:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `partitioning.enabled` | bool | `false` | Enable automatic partitioning during `portolan add` |
+| `partitioning.enabled` | bool | `true` | Enable automatic partitioning during `portolan add` |
 | `partitioning.prompt` | bool | `true` | Prompt user before partitioning (interactive mode) |
 | `partitioning.threshold_gb` | float | `2.0` | File size threshold in GB |
 | `partitioning.strategy` | string | `kdtree` | Partitioning strategy |

--- a/docs/guides/partitioning.md
+++ b/docs/guides/partitioning.md
@@ -1,0 +1,167 @@
+# Partitioning Large GeoParquet Files
+
+Portolan automatically partitions large GeoParquet files into smaller, spatially-organized chunks. This improves query performance and enables efficient cloud access patterns.
+
+## When to Partition
+
+Partition GeoParquet files when:
+
+- **File size exceeds 2GB** (OGC best practices threshold)
+- **Row count exceeds millions** of features
+- **Spatial queries are common** (partitioning enables spatial pruning)
+
+Portolan uses the 2GB threshold by default, matching [OGC GeoParquet best practices](https://geoparquet.org/).
+
+## How It Works
+
+When you add a large GeoParquet file, Portolan:
+
+1. **Detects** the file exceeds the threshold
+2. **Prompts** for confirmation (in interactive mode)
+3. **Partitions** using KD-tree spatial indexing
+4. **Stores** as Hive-style directories: `kdtree_cell=0/`, `kdtree_cell=1/`, etc.
+5. **Emits** `partition:*` STAC extension metadata
+
+```
+$ portolan add large-dataset.parquet
+
+Found 1 file(s) exceeding 2.0 GB threshold:
+  large-dataset.parquet (4.23 GB)
+
+Partition large files into spatial chunks? [Y/n] y
+
+Partitioning: large-dataset.parquet
+  Strategy: kdtree (data-driven spatial)
+  Target: ~120,000 rows per partition
+  ████████████████████████████████████████ 100%
+
+✓ Created 98 partitions in large-dataset/
+✓ Added to collection: default
+```
+
+## Configuration
+
+Configure partitioning in `.portolan/config.yaml`:
+
+```yaml
+partitioning:
+  enabled: true           # Enable auto-partitioning (default: false)
+  prompt: true            # Ask before partitioning in interactive mode (default: true)
+  threshold_gb: 2.0       # Size threshold in GB (default: 2.0)
+  strategy: kdtree        # Partitioning strategy (default: kdtree)
+  target_rows: 120000     # Target rows per partition (default: 120,000)
+```
+
+### Configuration Options
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `partitioning.enabled` | bool | `false` | Enable automatic partitioning during `portolan add` |
+| `partitioning.prompt` | bool | `true` | Prompt user before partitioning (interactive mode) |
+| `partitioning.threshold_gb` | float | `2.0` | File size threshold in GB |
+| `partitioning.strategy` | string | `kdtree` | Partitioning strategy |
+| `partitioning.target_rows` | int | `120000` | Target rows per partition |
+
+### Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `kdtree` | KD-tree spatial partitioning (default, data-driven) |
+| `h3` | H3 hexagonal grid partitioning (planned) |
+| `s2` | S2 cell partitioning (planned) |
+| `quadkey` | Quadkey partitioning (planned) |
+
+Currently only `kdtree` is implemented. Other strategies are planned for future releases.
+
+## STAC Metadata
+
+Partitioned collections include `partition:*` extension fields:
+
+```json
+{
+  "stac_extensions": [
+    "https://portolan.org/stac-extensions/partition/v1.0.0/schema.json"
+  ],
+  "partition:scheme": "hive",
+  "partition:strategy": "kdtree",
+  "partition:keys": [
+    {"name": "kdtree_cell", "type": "string"}
+  ],
+  "partition:file_count": 98,
+  "assets": {
+    "data": {
+      "href": "./kdtree_cell=*/data.parquet",
+      "partition:glob": "s3://bucket/collection/kdtree_cell=*/data.parquet"
+    }
+  }
+}
+```
+
+## Consuming Partitioned Data
+
+### DuckDB
+
+DuckDB can query partitioned data directly using the glob pattern:
+
+```sql
+SELECT *
+FROM read_parquet('s3://bucket/collection/kdtree_cell=*/data.parquet')
+WHERE ST_Intersects(geometry, ST_GeomFromText('POLYGON(...)'))
+```
+
+DuckDB automatically prunes partitions based on the Hive directory structure.
+
+### PyArrow
+
+```python
+import pyarrow.parquet as pq
+import pyarrow.dataset as ds
+
+# Read as dataset with partition pruning
+dataset = ds.dataset(
+    "s3://bucket/collection/",
+    partitioning="hive"
+)
+
+# Query with partition filtering
+table = dataset.to_table(
+    filter=ds.field("kdtree_cell").isin(["0", "1", "2"])
+)
+```
+
+### GDAL/OGR
+
+```bash
+ogrinfo -al "/vsicurl/s3://bucket/collection/kdtree_cell=0/data.parquet"
+```
+
+## Validation
+
+Use `portolan check --thorough` to validate partition consistency:
+
+```bash
+$ portolan check --thorough
+
+Checking partition structure...
+✓ All partitions use consistent key: kdtree_cell
+✓ All partition files have consistent schema
+✓ No orphan files outside partition structure
+```
+
+This checks:
+- All partition directories use the same key pattern
+- All parquet files have identical schemas
+- No files exist outside the partition structure
+
+## Manual Partitioning
+
+For more control, use the standalone `portolan partition` command:
+
+```bash
+portolan partition large.parquet \
+  --output-dir ./partitioned/ \
+  --strategy kdtree \
+  --target-rows 100000
+```
+
+See `portolan partition --help` for all options.

--- a/docs/guides/partitioning.md
+++ b/docs/guides/partitioning.md
@@ -80,7 +80,7 @@ Partitioned collections include `partition:*` extension fields:
 ```json
 {
   "stac_extensions": [
-    "https://portolan.org/stac-extensions/partition/v1.0.0/schema.json"
+    "https://portolan-sdi.github.io/stac-partition-extension/v1.0.0/schema.json"
   ],
   "partition:scheme": "hive",
   "partition:strategy": "kdtree",

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -378,7 +378,7 @@ Split large GeoParquet files into spatially-organized partitions for better quer
 
 ```yaml
 # .portolan/config.yaml
-partitioning.enabled: true       # Enable auto-partitioning during add (default: false)
+partitioning.enabled: true       # Enable auto-partitioning during add (default: true)
 partitioning.prompt: true        # Ask before partitioning in interactive mode (default: true)
 partitioning.threshold_gb: 2     # Size threshold in GB (default: 2.0)
 partitioning.strategy: kdtree    # Partitioning strategy (default: kdtree)
@@ -436,7 +436,7 @@ collection/
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `partitioning.enabled` | `false` | Enable auto-partitioning during `portolan add` |
+| `partitioning.enabled` | `true` | Enable auto-partitioning during `portolan add` |
 | `partitioning.prompt` | `true` | Ask before partitioning in interactive mode |
 | `partitioning.threshold_gb` | `2.0` | File size threshold in GB |
 | `partitioning.strategy` | `kdtree` | Spatial partitioning strategy |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -378,14 +378,25 @@ Split large GeoParquet files into spatially-organized partitions for better quer
 
 ```yaml
 # .portolan/config.yaml
-partitioning.enabled: true       # Enable partitioning features (default: false)
-partitioning.threshold_gb: 2     # Size threshold in GB for --preview (default: 2.0)
+partitioning.enabled: true       # Enable auto-partitioning during add (default: false)
+partitioning.prompt: true        # Ask before partitioning in interactive mode (default: true)
+partitioning.threshold_gb: 2     # Size threshold in GB (default: 2.0)
 partitioning.strategy: kdtree    # Partitioning strategy (default: kdtree)
 partitioning.target_rows: 120000 # Target rows per partition (default: 120,000)
 ```
 
-!!! note "Standalone command"
-    Partitioning is performed via `portolan partition`, not automatically during `add`. Use the command below to partition large files before or after tracking.
+With `partitioning.enabled: true`, large files are automatically partitioned during `portolan add`:
+
+```
+$ portolan add large-dataset.parquet
+
+Found 1 file(s) exceeding 2.0 GB threshold:
+  large-dataset.parquet (4.23 GB)
+
+Partition large files into spatial chunks? [Y/n] y
+```
+
+Set `partitioning.prompt: false` to partition without asking.
 
 ### Commands
 
@@ -425,8 +436,9 @@ collection/
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `partitioning.enabled` | `false` | Enable partitioning features |
-| `partitioning.threshold_gb` | `2.0` | Size threshold for `--preview` recommendation |
+| `partitioning.enabled` | `false` | Enable auto-partitioning during `portolan add` |
+| `partitioning.prompt` | `true` | Ask before partitioning in interactive mode |
+| `partitioning.threshold_gb` | `2.0` | File size threshold in GB |
 | `partitioning.strategy` | `kdtree` | Spatial partitioning strategy |
 | `partitioning.target_rows` | `120000` | Target rows per partition |
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -2747,7 +2747,9 @@ def _check_partition_prompt(
     from portolan_cli.config import get_setting
     from portolan_cli.partitioning import should_partition
 
-    part_enabled = get_setting("partitioning.enabled", catalog_root) or False
+    part_enabled = get_setting("partitioning.enabled", catalog_root)
+    if part_enabled is None:
+        part_enabled = True  # Default: enabled (prompt before partitioning large files)
     part_prompt = get_setting("partitioning.prompt", catalog_root)
     if part_prompt is None:
         part_prompt = True  # Default: prompt in interactive mode
@@ -3180,7 +3182,7 @@ def add_cmd(
         spatial chunks using KD-tree partitioning. In interactive mode,
         you'll be prompted before partitioning. Configure via:
 
-            partitioning.enabled: true/false (default: false)
+            partitioning.enabled: true/false (default: true)
             partitioning.prompt: true/false (default: true)
             partitioning.threshold_gb: size in GB (default: 2.0)
     """

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -71,6 +71,7 @@ from portolan_cli.validation import (
     Severity,
 )
 from portolan_cli.validation import check as validate_catalog
+from portolan_cli.validation.runner import DEFAULT_RULES, THOROUGH_RULES
 
 
 def format_size(size_bytes: int) -> str:
@@ -1180,6 +1181,11 @@ def _output_combined_check_json(
     is_flag=True,
     help="Only check/fix geospatial assets (cloud-native status, convertibility)",
 )
+@click.option(
+    "--thorough",
+    is_flag=True,
+    help="Run expensive validation (partition schema consistency, file content checks)",
+)
 @click.pass_context
 def check(
     ctx: click.Context,
@@ -1191,6 +1197,7 @@ def check(
     remove_legacy: bool,
     metadata: bool,
     geo_assets: bool,
+    thorough: bool,
 ) -> None:
     """Validate a Portolan catalog or check files for cloud-native status.
 
@@ -1204,6 +1211,10 @@ def check(
     - --geo-assets: Only check/fix geospatial assets (cloud-native status)
     - Neither: Check/fix both (default)
 
+    Use --thorough for expensive validation (reads file contents):
+    - Partition structure consistency (Hive-style directories)
+    - Partition schema consistency (all parquet files match)
+
     Examples:
 
         portolan check                        # Validate all (metadata + geo-assets)
@@ -1211,6 +1222,8 @@ def check(
         portolan check --metadata             # Validate metadata only
 
         portolan check --geo-assets           # Check geo-assets only
+
+        portolan check --thorough             # Include partition validation
 
         portolan check --fix                  # Fix both metadata and geo-assets
 
@@ -1248,6 +1261,7 @@ def check(
         remove_legacy=remove_legacy,
         use_json=use_json,
         verbose=verbose,
+        thorough=thorough,
     )
 
 
@@ -1399,13 +1413,18 @@ def _execute_check_workflow(
     remove_legacy: bool,
     use_json: bool,
     verbose: bool,
+    thorough: bool = False,
 ) -> None:
     """Execute the check workflow based on flags.
 
     The workflow varies based on scope (--metadata, --geo-assets) and --fix:
     - Without --fix: run validation and report issues
     - With --fix: run validation AND apply fixes for the selected scope
+    - With --thorough: also run expensive partition validation rules
     """
+    # Build rules list based on --thorough flag
+    rules = DEFAULT_RULES + THOROUGH_RULES if thorough else DEFAULT_RULES
+
     # Handle fix workflows (may exit early)
     if fix:
         _run_fix_workflow(
@@ -1423,14 +1442,14 @@ def _execute_check_workflow(
     # Check-only workflows (no --fix)
     if run_metadata and not run_geo_assets:
         # Metadata only
-        metadata_report = validate_catalog(path)
+        metadata_report = validate_catalog(path, rules=rules)
         _output_metadata_only(metadata_report, mode, use_json, verbose)
     elif run_geo_assets and not run_metadata:
         # Geo-assets only
         _output_format_only(path, mode, use_json, verbose)
     else:
         # Both (combined)
-        metadata_report = validate_catalog(path)
+        metadata_report = validate_catalog(path, rules=rules)
         _output_combined(path, metadata_report, mode, use_json, verbose)
 
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -71,7 +71,7 @@ from portolan_cli.validation import (
     Severity,
 )
 from portolan_cli.validation import check as validate_catalog
-from portolan_cli.validation.runner import DEFAULT_RULES, THOROUGH_RULES
+from portolan_cli.validation.runner import DEFAULT_RULES
 
 
 def format_size(size_bytes: int) -> str:
@@ -1181,11 +1181,6 @@ def _output_combined_check_json(
     is_flag=True,
     help="Only check/fix geospatial assets (cloud-native status, convertibility)",
 )
-@click.option(
-    "--thorough",
-    is_flag=True,
-    help="Run expensive validation (partition schema consistency, file content checks)",
-)
 @click.pass_context
 def check(
     ctx: click.Context,
@@ -1197,7 +1192,6 @@ def check(
     remove_legacy: bool,
     metadata: bool,
     geo_assets: bool,
-    thorough: bool,
 ) -> None:
     """Validate a Portolan catalog or check files for cloud-native status.
 
@@ -1211,10 +1205,6 @@ def check(
     - --geo-assets: Only check/fix geospatial assets (cloud-native status)
     - Neither: Check/fix both (default)
 
-    Use --thorough for expensive validation (reads file contents):
-    - Partition structure consistency (Hive-style directories)
-    - Partition schema consistency (all parquet files match)
-
     Examples:
 
         portolan check                        # Validate all (metadata + geo-assets)
@@ -1222,8 +1212,6 @@ def check(
         portolan check --metadata             # Validate metadata only
 
         portolan check --geo-assets           # Check geo-assets only
-
-        portolan check --thorough             # Include partition validation
 
         portolan check --fix                  # Fix both metadata and geo-assets
 
@@ -1261,7 +1249,6 @@ def check(
         remove_legacy=remove_legacy,
         use_json=use_json,
         verbose=verbose,
-        thorough=thorough,
     )
 
 
@@ -1413,17 +1400,14 @@ def _execute_check_workflow(
     remove_legacy: bool,
     use_json: bool,
     verbose: bool,
-    thorough: bool = False,
 ) -> None:
     """Execute the check workflow based on flags.
 
     The workflow varies based on scope (--metadata, --geo-assets) and --fix:
     - Without --fix: run validation and report issues
     - With --fix: run validation AND apply fixes for the selected scope
-    - With --thorough: also run expensive partition validation rules
     """
-    # Build rules list based on --thorough flag
-    rules = DEFAULT_RULES + THOROUGH_RULES if thorough else DEFAULT_RULES
+    rules = DEFAULT_RULES
 
     # Handle fix workflows (may exit early)
     if fix:

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -2731,13 +2731,13 @@ def _check_partition_prompt(
     from portolan_cli.config import get_setting
     from portolan_cli.partitioning import should_partition
 
-    part_enabled = get_setting("partitioning.enabled", catalog_root)
+    part_enabled = get_setting("partitioning.enabled", catalog_path=catalog_root)
     if part_enabled is None:
         part_enabled = True  # Default: enabled (prompt before partitioning large files)
-    part_prompt = get_setting("partitioning.prompt", catalog_root)
+    part_prompt = get_setting("partitioning.prompt", catalog_path=catalog_root)
     if part_prompt is None:
         part_prompt = True  # Default: prompt in interactive mode
-    threshold_gb = get_setting("partitioning.threshold_gb", catalog_root) or 2.0
+    threshold_gb = get_setting("partitioning.threshold_gb", catalog_path=catalog_root) or 2.0
 
     if not (part_enabled and part_prompt and sys.stderr.isatty()):
         return False
@@ -2745,15 +2745,23 @@ def _check_partition_prompt(
     # Pre-scan for large files that would trigger partitioning
     large_files: list[tuple[Path, float]] = []
     for p in resolved_paths:
-        if p.is_file() and p.suffix.lower() == ".parquet":
-            if should_partition(p, threshold_gb=threshold_gb, enabled=True):
-                size_gb = p.stat().st_size / (1024 * 1024 * 1024)
-                large_files.append((p, size_gb))
-        elif p.is_dir():
-            for pq in p.rglob("*.parquet"):
-                if should_partition(pq, threshold_gb=threshold_gb, enabled=True):
-                    size_gb = pq.stat().st_size / (1024 * 1024 * 1024)
-                    large_files.append((pq, size_gb))
+        try:
+            if p.is_file() and p.suffix.lower() == ".parquet":
+                if should_partition(p, threshold_gb=threshold_gb, enabled=True):
+                    size_gb = p.stat().st_size / (1024 * 1024 * 1024)
+                    large_files.append((p, size_gb))
+            elif p.is_dir():
+                for pq in p.rglob("*.parquet"):
+                    try:
+                        if should_partition(pq, threshold_gb=threshold_gb, enabled=True):
+                            size_gb = pq.stat().st_size / (1024 * 1024 * 1024)
+                            large_files.append((pq, size_gb))
+                    except OSError:
+                        # Skip files with permission errors or broken symlinks
+                        continue
+        except OSError:
+            # Skip paths with permission errors or broken symlinks
+            continue
 
     if not large_files:
         return False

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -2709,6 +2709,63 @@ def _validate_item_id_usage(
         raise SystemExit(1)
 
 
+def _check_partition_prompt(
+    resolved_paths: list[Path],
+    catalog_root: Path,
+) -> bool:
+    """Check if user wants to skip partitioning for large files.
+
+    Pre-scans files against partition threshold and prompts user in interactive
+    mode. Returns True if partitioning should be skipped.
+
+    Args:
+        resolved_paths: List of resolved paths to check.
+        catalog_root: Path to catalog root for config lookup.
+
+    Returns:
+        True if user declined partitioning, False otherwise.
+    """
+    from portolan_cli.config import get_setting
+    from portolan_cli.partitioning import should_partition
+
+    part_enabled = get_setting("partitioning.enabled", catalog_root) or False
+    part_prompt = get_setting("partitioning.prompt", catalog_root)
+    if part_prompt is None:
+        part_prompt = True  # Default: prompt in interactive mode
+    threshold_gb = get_setting("partitioning.threshold_gb", catalog_root) or 2.0
+
+    if not (part_enabled and part_prompt and sys.stderr.isatty()):
+        return False
+
+    # Pre-scan for large files that would trigger partitioning
+    large_files: list[tuple[Path, float]] = []
+    for p in resolved_paths:
+        if p.is_file() and p.suffix.lower() == ".parquet":
+            if should_partition(p, threshold_gb=threshold_gb, enabled=True):
+                size_gb = p.stat().st_size / (1024 * 1024 * 1024)
+                large_files.append((p, size_gb))
+        elif p.is_dir():
+            for pq in p.rglob("*.parquet"):
+                if should_partition(pq, threshold_gb=threshold_gb, enabled=True):
+                    size_gb = pq.stat().st_size / (1024 * 1024 * 1024)
+                    large_files.append((pq, size_gb))
+
+    if not large_files:
+        return False
+
+    warn(f"Found {len(large_files)} file(s) exceeding {threshold_gb} GB threshold:")
+    for lf, size in large_files[:5]:  # Show first 5
+        detail(f"  {lf.name} ({size:.2f} GB)")
+    if len(large_files) > 5:
+        detail(f"  ... and {len(large_files) - 5} more")
+
+    if not click.confirm("Partition large files into spatial chunks?", default=True):
+        info_output("Skipping partitioning (files will be added as-is)")
+        return True
+
+    return False
+
+
 def _handle_parquet_after_add(
     catalog_root: Path,
     affected_collections: set[str],
@@ -3097,6 +3154,16 @@ def add_cmd(
     - Changed files are re-extracted with new metadata
     - Sidecar files (.dbf, .shx, .prj for shapefiles) are auto-detected
     - All files in the item directory are tracked, not just geo files (ADR-0028)
+
+    \b
+    Large file partitioning:
+        GeoParquet files exceeding 2GB are automatically partitioned into
+        spatial chunks using KD-tree partitioning. In interactive mode,
+        you'll be prompted before partitioning. Configure via:
+
+            partitioning.enabled: true/false (default: false)
+            partitioning.prompt: true/false (default: true)
+            partitioning.threshold_gb: size in GB (default: 2.0)
     """
     use_json = should_output_json(ctx, json_output)
 
@@ -3163,6 +3230,11 @@ def add_cmd(
         if should_show_progress:
             progress_reporter.advance()
 
+    # Check if user wants to skip partitioning for large files (Phase 5: auto-partition UX)
+    skip_partitioning = (
+        _check_partition_prompt(resolved_paths, catalog_root) if not use_json else False
+    )
+
     # item_datetime is parsed by Click via FLEXIBLE_DATETIME type (ADR-0035)
     try:
         with progress_reporter:
@@ -3178,6 +3250,7 @@ def add_cmd(
                 json_mode=use_json,
                 force=force,
                 reconvert=reconvert,
+                skip_partitioning=skip_partitioning,
             )
     except (ValueError, FileNotFoundError) as err:
         err_type = type(err).__name__

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -82,7 +82,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "statistics.raster_mode": "approx",
     "parquet.enabled": False,  # Disabled by default (100% optional per issue #319)
     "parquet.threshold": 100,  # Suggest parquet generation when items > threshold
-    "partitioning.enabled": False,  # Partitioning features disabled by default
+    "partitioning.enabled": True,  # Auto-partition large GeoParquet files (>2GB)
     "partitioning.prompt": True,  # Prompt before partitioning in interactive mode
     "partitioning.threshold_gb": 2.0,  # 2GB per OGC best practices
     "partitioning.strategy": "kdtree",  # KD-tree: data-driven, auto-balancing

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -53,6 +53,7 @@ KNOWN_SETTINGS: frozenset[str] = frozenset(
         "parquet.enabled",  # Generate items.parquet for large collections
         "parquet.threshold",  # Item count threshold to suggest parquet generation
         "partitioning.enabled",  # Auto-partition large GeoParquet files (Issue #352)
+        "partitioning.prompt",  # Prompt before partitioning in interactive mode (default: true)
         "partitioning.threshold_gb",  # Size threshold in GB (default: 2.0)
         "partitioning.strategy",  # Spatial partitioning strategy (default: kdtree)
         "partitioning.target_rows",  # Target rows per partition (default: 120000)
@@ -82,6 +83,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "parquet.enabled": False,  # Disabled by default (100% optional per issue #319)
     "parquet.threshold": 100,  # Suggest parquet generation when items > threshold
     "partitioning.enabled": False,  # Partitioning features disabled by default
+    "partitioning.prompt": True,  # Prompt before partitioning in interactive mode
     "partitioning.threshold_gb": 2.0,  # 2GB per OGC best practices
     "partitioning.strategy": "kdtree",  # KD-tree: data-driven, auto-balancing
     "partitioning.target_rows": 120_000,  # geoparquet-io default

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -427,6 +427,7 @@ def _maybe_partition_large_file(
     prepared: PreparedDataset,
     catalog_root: Path,
     item_datetime: datetime | None,
+    skip_partitioning: bool = False,
 ) -> list[PreparedDataset]:
     """Partition a large GeoParquet file if it exceeds the size threshold.
 
@@ -437,6 +438,8 @@ def _maybe_partition_large_file(
         prepared: The prepared dataset to potentially partition.
         catalog_root: Root directory of the catalog.
         item_datetime: Optional datetime for created items.
+        skip_partitioning: If True, skip partitioning even if file exceeds threshold.
+            Used when user declines interactive prompt.
 
     Returns:
         List of PreparedDatasets. If partitioning occurred, contains multiple
@@ -452,6 +455,10 @@ def _maybe_partition_large_file(
 
     # Only partition vector formats (GeoParquet)
     if prepared.format_type != FormatType.VECTOR:
+        return [prepared]
+
+    # Skip if user declined interactive prompt
+    if skip_partitioning:
         return [prepared]
 
     # Only partition item-level assets (collection-level means single file < 2GB)
@@ -2791,6 +2798,7 @@ def add_files(
     json_mode: bool = False,
     force: bool = False,
     reconvert: bool = False,
+    skip_partitioning: bool = False,
 ) -> tuple[list[DatasetInfo], list[Path], list[AddFailure]]:
     """Add files to a Portolan catalog.
 
@@ -2953,6 +2961,7 @@ def add_files(
                 prepared=prepared,
                 catalog_root=catalog_root,
                 item_datetime=item_datetime,
+                skip_partitioning=skip_partitioning,
             )
             return (partitioned, [], None)
 

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -71,6 +71,7 @@ from portolan_cli.stac import (
     add_collection_extensions_from_summaries,
     add_collection_properties_from_metadata,
     add_item_to_collection,
+    add_partition_metadata_to_collection,
     add_projection_extension,
     add_raster_extension,
     add_table_extension,
@@ -406,6 +407,7 @@ class PreparedDataset:
         stac_item: The PySTAC Item object (None for collection-level vector assets).
         stac_assets: Assets to add to collection.json (for collection-level assets).
         metadata: Extracted metadata (GeoParquet or COG) for table extension (Issue #304).
+        partition_metadata: Partition extension fields from get_partition_metadata() (Issue #232).
     """
 
     item_id: str
@@ -418,6 +420,7 @@ class PreparedDataset:
     stac_item: pystac.Item | None = None
     stac_assets: dict[str, pystac.Asset] | None = None  # For collection-level addition
     metadata: AllMetadata | None = None
+    partition_metadata: dict[str, object] | None = None
 
 
 def _maybe_partition_large_file(
@@ -442,6 +445,7 @@ def _maybe_partition_large_file(
     from portolan_cli.config import get_setting
     from portolan_cli.partitioning import (
         build_glob_pattern,
+        get_partition_metadata,
         partition_geoparquet,
         should_partition,
     )
@@ -556,6 +560,9 @@ def _maybe_partition_large_file(
         # portolan:glob will be populated on push with remote URL
     )
 
+    # Extract partition metadata for STAC partition extension (Issue #232)
+    partition_meta = get_partition_metadata(partition_output_dir, str(strategy))
+
     # Create a PreparedDataset for the glob asset (collection-level)
     # Use original item_id as base to avoid collisions across collections
     glob_item_id = f"{prepared.item_id}_partitioned"
@@ -570,6 +577,7 @@ def _maybe_partition_large_file(
         stac_item=None,
         stac_assets={glob_item_id: glob_asset},
         metadata=None,
+        partition_metadata=partition_meta,
     )
     partitioned_datasets.append(glob_prepared)
 
@@ -1485,6 +1493,12 @@ def finalize_datasets(
                 vector_metadata.insert(0, existing_meta)
             aggregated = aggregate_table_metadata(vector_metadata)
             add_table_extension(collection, aggregated)
+
+        # Add partition extension if any items have partition metadata (Issue #232)
+        for p in items:
+            if p.partition_metadata is not None:
+                add_partition_metadata_to_collection(collection, p.partition_metadata)
+                break  # Only one partition metadata per collection
 
         # Compute collection summaries from items (per ADR-0036)
         # Moved here from push.py for separation of concerns - summaries are now

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -2923,7 +2923,14 @@ def add_files(
                                 force=force,
                                 reconvert=reconvert,
                             )
-                            prepared_list.append(prepared)
+                            # Apply partitioning to each layer (Issue #352)
+                            partitioned = _maybe_partition_large_file(
+                                prepared=prepared,
+                                catalog_root=catalog_root,
+                                item_datetime=item_datetime,
+                                skip_partitioning=skip_partitioning,
+                            )
+                            prepared_list.extend(partitioned)
                         except Exception as err:
                             failure_list.append(
                                 AddFailure(

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -288,9 +288,9 @@ def detect_partitioning(directory: Path) -> dict[str, object] | None:
 
     # Try to detect strategy from column name
     strategy = None
-    for strat, col in PARTITION_COLUMNS.items():
+    for strategy_name, col in PARTITION_COLUMNS.items():
         if col in partition_keys:
-            strategy = strat
+            strategy = strategy_name
             break
 
     result: dict[str, object] = {

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -293,9 +293,12 @@ def detect_partitioning(directory: Path) -> dict[str, object] | None:
             strategy = strat
             break
 
-    return {
+    result: dict[str, object] = {
         "partition:scheme": "hive",
-        "partition:strategy": strategy,
         "partition:keys": [{"name": key, "type": "string"} for key in partition_keys],
         "partition:file_count": file_count,
     }
+    # Only include strategy if detected (avoid null in JSON output)
+    if strategy is not None:
+        result["partition:strategy"] = strategy
+    return result

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -211,3 +211,91 @@ def build_remote_glob(
     base = remote_base.rstrip("/")
     partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
     return f"{base}/{collection_id}/{partition_col}=*/*.parquet"
+
+
+def get_partition_metadata(output_dir: Path, strategy: str = DEFAULT_STRATEGY) -> dict[str, object]:
+    """Extract partition metadata from Hive-style output directory.
+
+    Returns metadata conforming to the STAC Partition Extension schema:
+    https://portolan-sdi.github.io/stac-partition-extension/v1.0.0/schema.json
+
+    Args:
+        output_dir: Directory containing Hive-style partitioned output.
+        strategy: Partitioning strategy used (kdtree, h3, etc.).
+
+    Returns:
+        Dict with partition extension fields:
+        - partition:scheme: "hive"
+        - partition:strategy: The strategy used
+        - partition:keys: List of partition key definitions
+        - partition:file_count: Total number of partition files
+    """
+    partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
+    partition_dirs = list(output_dir.glob(f"{partition_col}=*"))
+
+    file_count = sum(len(list(d.glob("*.parquet"))) for d in partition_dirs)
+
+    return {
+        "partition:scheme": "hive",
+        "partition:strategy": strategy,
+        "partition:keys": [
+            {
+                "name": partition_col,
+                "type": "string",
+                "description": f"{strategy.upper()} spatial partition cell identifier",
+            }
+        ],
+        "partition:file_count": file_count,
+    }
+
+
+def detect_partitioning(directory: Path) -> dict[str, object] | None:
+    """Detect existing Hive-style partitioning in a directory.
+
+    Scans for directories matching the pattern "column=value/" and extracts
+    partition metadata if found.
+
+    Args:
+        directory: Directory to scan for partitions.
+
+    Returns:
+        Partition metadata dict if partitioning detected, None otherwise.
+    """
+    import re
+
+    # Look for Hive-style directories: column=value
+    hive_pattern = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)=.+$")
+
+    partition_keys: list[str] = []
+    partition_dirs: list[Path] = []
+
+    for item in directory.iterdir():
+        if item.is_dir():
+            match = hive_pattern.match(item.name)
+            if match:
+                key_name = match.group(1)
+                if key_name not in partition_keys:
+                    partition_keys.append(key_name)
+                partition_dirs.append(item)
+
+    if not partition_keys:
+        return None
+
+    # Count total files
+    file_count = 0
+    for pdir in partition_dirs:
+        file_count += len(list(pdir.glob("*.parquet")))
+
+    # Try to detect strategy from column name
+    strategy = None
+    for strat, col in PARTITION_COLUMNS.items():
+        if col in partition_keys:
+            strategy = strat
+            break
+
+    return {
+        "partition:scheme": "hive",
+        "partition:strategy": strategy,
+        "partition:keys": [{"name": key, "type": "string"} for key in partition_keys],
+        "partition:file_count": file_count,
+    }

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -307,10 +307,11 @@ def _transform_collection_glob_assets(
             remote_glob = f"{base}/{collection_path}/{glob_pattern}"
 
             # Emit both fields during transition (ADR-0042)
-            if "partition:glob" not in asset_data:
+            # Always overwrite to keep both fields in sync with current remote
+            if asset_data.get("partition:glob") != remote_glob:
                 asset_data["partition:glob"] = remote_glob
                 modified = True
-            if "portolan:glob" not in asset_data:
+            if asset_data.get("portolan:glob") != remote_glob:
                 asset_data["portolan:glob"] = remote_glob
                 modified = True
 

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -268,11 +268,15 @@ def _transform_collection_glob_assets(
     prefix: str,
     collection_path: str,
 ) -> bytes:
-    """Transform collection.json to populate portolan:glob fields.
+    """Transform collection.json to populate glob fields for partitioned assets.
 
     Per Issue #351: Partitioned GeoParquet datasets expose a glob pattern in
-    collection-level assets. On push, we populate the portolan:glob field with
-    the full remote URL.
+    collection-level assets. On push, we populate glob fields with the full
+    remote URL.
+
+    Emits both fields during transition period (per ADR-0042):
+    - partition:glob (new, per STAC Partition Extension)
+    - portolan:glob (legacy, for backwards compatibility)
 
     Args:
         content: Original collection.json bytes.
@@ -280,7 +284,7 @@ def _transform_collection_glob_assets(
         collection_path: Relative path to collection (e.g., "buildings").
 
     Returns:
-        Transformed collection.json bytes with portolan:glob populated.
+        Transformed collection.json bytes with glob fields populated.
     """
     try:
         data = json.loads(content)
@@ -293,16 +297,22 @@ def _transform_collection_glob_assets(
     for _asset_key, asset_data in assets.items():
         href = asset_data.get("href", "")
         # Check if this is a glob pattern (contains *)
-        if "*" in href and "portolan:glob" not in asset_data:
+        if "*" in href:
             # Build full remote glob URL
-            # href is relative to collection.json (e.g., "./*/data.parquet")
+            # href is relative to collection.json (e.g., "./kdtree_cell=*/*.parquet")
             # We need to convert to absolute remote URL
             glob_pattern = href.lstrip("./")
             # Build URL preserving protocol separator
             base = prefix.rstrip("/")
             remote_glob = f"{base}/{collection_path}/{glob_pattern}"
-            asset_data["portolan:glob"] = remote_glob
-            modified = True
+
+            # Emit both fields during transition (ADR-0042)
+            if "partition:glob" not in asset_data:
+                asset_data["partition:glob"] = remote_glob
+                modified = True
+            if "portolan:glob" not in asset_data:
+                asset_data["portolan:glob"] = remote_glob
+                modified = True
 
     if modified:
         return json.dumps(data, indent=2).encode("utf-8")

--- a/portolan_cli/scan_output.py
+++ b/portolan_cli/scan_output.py
@@ -734,6 +734,63 @@ def _format_manual_only(result: ScanResult) -> str:
     return "\n".join(lines)
 
 
+def _format_special_formats(result: ScanResult) -> list[str]:
+    """Format detected special formats (Hive partitions, etc.) for display.
+
+    For Hive partitions, uses detect_partitioning() from partitioning.py
+    to get rich metadata (scheme, strategy, file_count).
+
+    Args:
+        result: The scan result containing special_formats.
+
+    Returns:
+        List of formatted lines to display.
+    """
+    if not result.special_formats:
+        return []
+
+    from portolan_cli.partitioning import detect_partitioning
+
+    lines: list[str] = []
+    lines.append("")
+    lines.append("Detected special formats:")
+
+    for sf in result.special_formats:
+        if sf.format_type == "hive_partition":
+            # Get rich partition metadata (handle missing directories gracefully)
+            partition_meta = None
+            if sf.path.exists():
+                partition_meta = detect_partitioning(sf.path)
+            if partition_meta:
+                keys_raw = partition_meta.get("partition:keys", [])
+                keys = keys_raw if isinstance(keys_raw, list) else []
+                key_names = [k.get("name", "unknown") for k in keys if isinstance(k, dict)]
+                file_count = partition_meta.get("partition:file_count", 0)
+                strategy = partition_meta.get("partition:strategy")
+
+                strategy_str = f" ({strategy})" if strategy else ""
+                keys_str = ", ".join(key_names) if key_names else "unknown"
+                lines.append(f"  ✓ Hive-partitioned{strategy_str}: {sf.relative_path}")
+                lines.append(f"      Keys: {keys_str}, {file_count} partitions")
+            else:
+                # Fallback to basic info from SpecialFormat
+                keys = sf.details.get("partition_keys", [])
+                keys_str = ", ".join(keys) if keys else "unknown"
+                lines.append(f"  ✓ Hive-partitioned: {sf.relative_path}")
+                lines.append(f"      Keys: {keys_str}")
+        elif sf.format_type == "filegdb":
+            gdbtable_count = sf.details.get("gdbtable_count", 0)
+            lines.append(f"  ✓ FileGDB: {sf.relative_path} ({gdbtable_count} tables)")
+        elif sf.format_type == "stac_catalog":
+            lines.append(f"  ℹ Existing STAC catalog: {sf.relative_path}")
+        elif sf.format_type == "stac_collection":
+            lines.append(f"  ℹ Existing STAC collection: {sf.relative_path}")
+        else:
+            lines.append(f"  • {sf.format_type}: {sf.relative_path}")
+
+    return lines
+
+
 def format_scan_output(
     result: ScanResult,
     show_tree: bool = False,
@@ -776,6 +833,9 @@ def format_scan_output(
             mark = "\u2713" if check.passed else "\u2717"
             msg = f" ({check.message})" if check.message else ""
             lines.append(f"  [{mark}] {check.description}{msg}")
+
+    # Special formats (Hive partitions, FileGDB, etc.)
+    lines.extend(_format_special_formats(result))
 
     # Issues, skipped, suggestions, next steps
     lines.extend(_format_issues(result))

--- a/portolan_cli/scan_output.py
+++ b/portolan_cli/scan_output.py
@@ -749,22 +749,20 @@ def _format_special_formats(result: ScanResult) -> list[str]:
     if not result.special_formats:
         return []
 
-    from portolan_cli.partitioning import detect_partitioning
-
     lines: list[str] = []
     lines.append("")
     lines.append("Detected special formats:")
 
     for sf in result.special_formats:
         if sf.format_type == "hive_partition":
-            # Get rich partition metadata (handle missing directories gracefully)
-            partition_meta = None
-            if sf.path.exists():
-                partition_meta = detect_partitioning(sf.path)
-            if partition_meta:
-                keys_raw = partition_meta.get("partition:keys", [])
-                keys = keys_raw if isinstance(keys_raw, list) else []
-                key_names = [k.get("name", "unknown") for k in keys if isinstance(k, dict)]
+            # Use scan-time snapshot from sf.details instead of re-scanning filesystem
+            partition_meta = getattr(sf, "details", None) or {}
+
+            # Check for new format (partition:keys) first, then legacy (partition_keys)
+            keys_raw = partition_meta.get("partition:keys", [])
+            if keys_raw and isinstance(keys_raw, list) and isinstance(keys_raw[0], dict):
+                # New format: [{"name": "x", "type": "string"}, ...]
+                key_names = [k.get("name", "unknown") for k in keys_raw]
                 file_count = partition_meta.get("partition:file_count", 0)
                 strategy = partition_meta.get("partition:strategy")
 
@@ -773,9 +771,9 @@ def _format_special_formats(result: ScanResult) -> list[str]:
                 lines.append(f"  ✓ Hive-partitioned{strategy_str}: {sf.relative_path}")
                 lines.append(f"      Keys: {keys_str}, {file_count} partitions")
             else:
-                # Fallback to basic info from SpecialFormat
-                keys = sf.details.get("partition_keys", [])
-                keys_str = ", ".join(keys) if keys else "unknown"
+                # Legacy format: {"partition_keys": ["x", "y"]}
+                legacy_keys = partition_meta.get("partition_keys", [])
+                keys_str = ", ".join(legacy_keys) if legacy_keys else "unknown"
                 lines.append(f"  ✓ Hive-partitioned: {sf.relative_path}")
                 lines.append(f"      Keys: {keys_str}")
         elif sf.format_type == "filegdb":

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -297,6 +297,32 @@ def add_collection_properties_from_metadata(
             collection.stac_extensions.append(proj_ext_url)
 
 
+def add_partition_metadata_to_collection(
+    collection: pystac.Collection,
+    partition_metadata: dict[str, object],
+) -> None:
+    """Add partition extension fields to a collection.
+
+    Adds partition:* fields from the provided metadata dict and registers
+    the partition extension URL in stac_extensions.
+
+    Args:
+        collection: The collection to add partition metadata to.
+        partition_metadata: Dict with partition:* fields from get_partition_metadata().
+    """
+    # Add partition:* fields to collection extra_fields
+    for key, value in partition_metadata.items():
+        if key.startswith("partition:"):
+            collection.extra_fields[key] = value
+
+    # Register partition extension
+    ext_url = EXTENSION_URLS["partition"]
+    if collection.stac_extensions is None:
+        collection.stac_extensions = []
+    if ext_url not in collection.stac_extensions:
+        collection.stac_extensions.append(ext_url)
+
+
 def _update_collection_extent_from_bbox(
     collection: pystac.Collection,
     bbox: list[float],
@@ -390,6 +416,7 @@ EXTENSION_URLS = {
     "raster": "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "file": "https://stac-extensions.github.io/file/v2.1.0/schema.json",  # Reserved for future
     "vector": "https://stac-extensions.github.io/vector/v0.1.0/schema.json",  # Proposal maturity
+    "partition": "https://portolan-sdi.github.io/stac-partition-extension/v1.0.0/schema.json",
 }
 
 
@@ -427,6 +454,10 @@ def build_stac_extensions(properties: dict[str, object]) -> list[str]:
     # Check for vector extension fields
     if any(k.startswith("vector:") for k in properties):
         extensions.append(EXTENSION_URLS["vector"])
+
+    # Check for partition extension fields
+    if any(k.startswith("partition:") for k in properties):
+        extensions.append(EXTENSION_URLS["partition"])
 
     return extensions
 

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -500,11 +500,11 @@ class PartitionStructureRule(ValidationRule):
                 issues.append(f"{coll_dir.name}: {len(orphan_files)} orphan .parquet at root")
 
             # Check collection.json has partition:* fields
+            # STAC Collections store extension fields at top level, not in "properties"
             try:
                 with open(coll_json) as f:
                     coll_data = json.load(f)
-                props = coll_data.get("properties", coll_data)
-                if "partition:scheme" not in props:
+                if "partition:scheme" not in coll_data:
                     issues.append(f"{coll_dir.name}: missing partition:scheme in collection.json")
             except (json.JSONDecodeError, OSError):
                 pass

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -446,3 +446,141 @@ class ProvisionalDatetimeRule(ValidationRule):
             f"{len(provisional_items)} item(s) have provisional datetime: {item_list}",
             fix_hint="Use 'portolan add --datetime YYYY-MM-DD' to set explicit datetime",
         )
+
+
+# --- Thorough rules (expensive, run with --thorough) ---
+
+
+class PartitionStructureRule(ValidationRule):
+    """Check that partitioned collections have consistent Hive-style structure.
+
+    Validates:
+    - All partition directories follow same key=value pattern
+    - No orphan files outside partition structure
+    - partition:* extension fields are present when partitions detected
+    """
+
+    name = "partition_structure"
+    severity = Severity.WARNING
+    description = "Verify partition directory structure consistency"
+
+    def check(self, catalog_path: Path) -> ValidationResult:
+        """Check partition structure for all collections."""
+        issues: list[str] = []
+
+        # Find all collection.json files
+        for coll_json in catalog_path.rglob("collection.json"):
+            coll_dir = coll_json.parent
+
+            # Look for Hive-style partition directories (key=value pattern)
+            partition_dirs = [
+                d
+                for d in coll_dir.iterdir()
+                if d.is_dir() and "=" in d.name and not d.name.startswith(".")
+            ]
+
+            if not partition_dirs:
+                continue
+
+            # Extract partition key from first directory
+            first_key = partition_dirs[0].name.split("=")[0]
+
+            # Check all partition dirs use same key
+            for pdir in partition_dirs:
+                if "=" not in pdir.name:
+                    issues.append(f"{coll_dir.name}: orphan dir '{pdir.name}'")
+                    continue
+                key = pdir.name.split("=")[0]
+                if key != first_key:
+                    issues.append(f"{coll_dir.name}: mixed keys '{first_key}' and '{key}'")
+
+            # Check for orphan parquet files at collection level
+            orphan_files = list(coll_dir.glob("*.parquet"))
+            if orphan_files and partition_dirs:
+                issues.append(f"{coll_dir.name}: {len(orphan_files)} orphan .parquet at root")
+
+            # Check collection.json has partition:* fields
+            try:
+                with open(coll_json) as f:
+                    coll_data = json.load(f)
+                props = coll_data.get("properties", coll_data)
+                if "partition:scheme" not in props:
+                    issues.append(f"{coll_dir.name}: missing partition:scheme in collection.json")
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        if not issues:
+            return self._pass("All partitioned collections have consistent structure")
+
+        issue_list = "; ".join(issues[:5])
+        if len(issues) > 5:
+            issue_list += f" (+{len(issues) - 5} more)"
+
+        return self._fail(
+            f"Partition structure issues: {issue_list}",
+            fix_hint="Ensure all partition directories use same key pattern",
+        )
+
+
+class PartitionSchemaConsistencyRule(ValidationRule):
+    """Check that all parquet files in a partition have consistent schema.
+
+    This is an expensive check that reads parquet metadata from all files.
+    Only runs with --thorough flag.
+    """
+
+    name = "partition_schema_consistency"
+    severity = Severity.ERROR
+    description = "Verify all partition files have same Parquet schema"
+
+    def check(self, catalog_path: Path) -> ValidationResult:
+        """Check schema consistency across partition files."""
+        try:
+            import pyarrow.parquet as pq
+        except ImportError:
+            return self._pass("PyArrow not available, skipping schema check")
+
+        issues: list[str] = []
+
+        for coll_json in catalog_path.rglob("collection.json"):
+            coll_dir = coll_json.parent
+
+            # Find Hive-style partition directories
+            partition_dirs = [
+                d
+                for d in coll_dir.iterdir()
+                if d.is_dir() and "=" in d.name and not d.name.startswith(".")
+            ]
+
+            if not partition_dirs:
+                continue
+
+            # Collect schemas from all parquet files
+            schemas: dict[str, list[str]] = {}
+            for pdir in partition_dirs:
+                for pq_file in pdir.glob("*.parquet"):
+                    try:
+                        schema = pq.read_schema(pq_file)
+                        schema_key = str(sorted(schema.names))
+                        if schema_key not in schemas:
+                            schemas[schema_key] = []
+                        schemas[schema_key].append(str(pq_file.relative_to(coll_dir)))
+                    except Exception:
+                        issues.append(f"{coll_dir.name}: unreadable {pq_file.name}")
+
+            if len(schemas) > 1:
+                issues.append(
+                    f"{coll_dir.name}: {len(schemas)} different schemas across partitions"
+                )
+
+        if not issues:
+            return self._pass("All partition files have consistent schema")
+
+        issue_list = "; ".join(issues[:3])
+        if len(issues) > 3:
+            issue_list += f" (+{len(issues) - 3} more)"
+
+        return self._fail(
+            f"Schema inconsistency: {issue_list}",
+            fix_hint="Re-partition with consistent source data",
+        )

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -223,8 +223,6 @@ class PMTilesRecommendedRule(ValidationRule):
         Returns:
             ValidationResult with warning if any GeoParquet lacks PMTiles.
         """
-        import json
-
         # Find all collection.json files
         collection_files = list(catalog_path.rglob("collection.json"))
 
@@ -525,8 +523,8 @@ class PartitionStructureRule(ValidationRule):
 class PartitionSchemaConsistencyRule(ValidationRule):
     """Check that all parquet files in a partition have consistent schema.
 
-    This is an expensive check that reads parquet metadata from all files.
-    Only runs with --thorough flag.
+    Reads parquet metadata (footer only) from all partition files to verify
+    they share the same schema.
     """
 
     name = "partition_schema_consistency"
@@ -537,8 +535,14 @@ class PartitionSchemaConsistencyRule(ValidationRule):
         """Check schema consistency across partition files."""
         try:
             import pyarrow.parquet as pq
+            from pyarrow import ArrowInvalid
         except ImportError:
-            return self._pass("PyArrow not available, skipping schema check")
+            return ValidationResult(
+                rule_name=self.name,
+                passed=True,
+                severity=Severity.WARNING,
+                message="PyArrow not available, schema consistency not checked",
+            )
 
         issues: list[str] = []
 
@@ -565,8 +569,8 @@ class PartitionSchemaConsistencyRule(ValidationRule):
                         if schema_key not in schemas:
                             schemas[schema_key] = []
                         schemas[schema_key].append(str(pq_file.relative_to(coll_dir)))
-                    except Exception:
-                        issues.append(f"{coll_dir.name}: unreadable {pq_file.name}")
+                    except (OSError, ArrowInvalid) as e:
+                        issues.append(f"{coll_dir.name}: unreadable {pq_file.name} ({e})")
 
             if len(schemas) > 1:
                 issues.append(

--- a/portolan_cli/validation/runner.py
+++ b/portolan_cli/validation/runner.py
@@ -18,7 +18,7 @@ from portolan_cli.validation.rules import (
     ValidationRule,
 )
 
-# Default rules for v0.4 (catalog structure + metadata freshness)
+# Default rules for v0.4 (catalog structure + metadata freshness + partitions)
 # Immutable tuple to prevent accidental mutation
 DEFAULT_RULES: tuple[ValidationRule, ...] = (
     CatalogExistsRule(),
@@ -27,11 +27,6 @@ DEFAULT_RULES: tuple[ValidationRule, ...] = (
     PMTilesRecommendedRule(),
     MetadataFreshRule(),
     ProvisionalDatetimeRule(),
-)
-
-# Thorough rules (expensive, require reading file contents)
-# Run with --thorough flag
-THOROUGH_RULES: tuple[ValidationRule, ...] = (
     PartitionStructureRule(),
     PartitionSchemaConsistencyRule(),
 )

--- a/portolan_cli/validation/runner.py
+++ b/portolan_cli/validation/runner.py
@@ -10,6 +10,8 @@ from portolan_cli.validation.rules import (
     CatalogExistsRule,
     CatalogJsonValidRule,
     MetadataFreshRule,
+    PartitionSchemaConsistencyRule,
+    PartitionStructureRule,
     PMTilesRecommendedRule,
     ProvisionalDatetimeRule,
     StacFieldsRule,
@@ -25,6 +27,13 @@ DEFAULT_RULES: tuple[ValidationRule, ...] = (
     PMTilesRecommendedRule(),
     MetadataFreshRule(),
     ProvisionalDatetimeRule(),
+)
+
+# Thorough rules (expensive, require reading file contents)
+# Run with --thorough flag
+THOROUGH_RULES: tuple[ValidationRule, ...] = (
+    PartitionStructureRule(),
+    PartitionSchemaConsistencyRule(),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,7 @@ dev = [
     "numpy>=2.2.6",
     "pylint>=4.0.5",
     "pytest-asyncio>=1.3.0",
+    "pytest-xdist>=3.8.0",
     "types-pyyaml>=6.0.12.20250915",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 # =============================================================================
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fixtures_dir() -> Path:
     """Return the path to the test fixtures directory."""
     return Path(__file__).parent / "fixtures"
@@ -27,37 +27,37 @@ def fixtures_dir() -> Path:
 # =============================================================================
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_points_geojson(fixtures_dir: Path) -> Path:
     """Path to valid points GeoJSON fixture (10 point features)."""
     return fixtures_dir / "vector" / "valid" / "points.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_polygons_geojson(fixtures_dir: Path) -> Path:
     """Path to valid polygons GeoJSON fixture (5 polygon features)."""
     return fixtures_dir / "vector" / "valid" / "polygons.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_lines_geojson(fixtures_dir: Path) -> Path:
     """Path to valid lines GeoJSON fixture (5 linestring features)."""
     return fixtures_dir / "vector" / "valid" / "lines.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_multigeom_geojson(fixtures_dir: Path) -> Path:
     """Path to valid mixed geometry GeoJSON fixture."""
     return fixtures_dir / "vector" / "valid" / "multigeom.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_large_properties_geojson(fixtures_dir: Path) -> Path:
     """Path to valid GeoJSON with 20+ property columns."""
     return fixtures_dir / "vector" / "valid" / "large_properties.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_points_parquet(fixtures_dir: Path) -> Path:
     """Path to valid GeoParquet fixture (real-world Open Buildings data).
 
@@ -67,7 +67,7 @@ def valid_points_parquet(fixtures_dir: Path) -> Path:
     return fixtures_dir / "realdata" / "open-buildings.parquet"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def projected_parquet(fixtures_dir: Path) -> Path:
     """Path to GeoParquet with projected CRS (EPSG:32631 UTM Zone 31N)."""
     return fixtures_dir / "vector" / "open-buildings-utm31n.parquet"
@@ -76,25 +76,25 @@ def projected_parquet(fixtures_dir: Path) -> Path:
 # Invalid vector fixtures
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def invalid_no_geometry_json(fixtures_dir: Path) -> Path:
     """Path to JSON file with no geometry field."""
     return fixtures_dir / "vector" / "invalid" / "no_geometry.json"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def invalid_malformed_geojson(fixtures_dir: Path) -> Path:
     """Path to malformed (truncated) GeoJSON file."""
     return fixtures_dir / "vector" / "invalid" / "malformed.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def invalid_empty_geojson(fixtures_dir: Path) -> Path:
     """Path to empty FeatureCollection GeoJSON file."""
     return fixtures_dir / "vector" / "invalid" / "empty.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def invalid_null_geometries_geojson(fixtures_dir: Path) -> Path:
     """Path to GeoJSON with null geometry features."""
     return fixtures_dir / "vector" / "invalid" / "null_geometries.geojson"
@@ -105,7 +105,7 @@ def invalid_null_geometries_geojson(fixtures_dir: Path) -> Path:
 # =============================================================================
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_rgb_cog(fixtures_dir: Path) -> Path:
     """Path to valid COG fixture (real-world RapidAI4EO satellite imagery).
 
@@ -115,19 +115,19 @@ def valid_rgb_cog(fixtures_dir: Path) -> Path:
     return fixtures_dir / "realdata" / "rapidai4eo-sample.tif"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_singleband_cog(fixtures_dir: Path) -> Path:
     """Path to valid single-band COG fixture (64x64)."""
     return fixtures_dir / "raster" / "valid" / "singleband.tif"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_float32_cog(fixtures_dir: Path) -> Path:
     """Path to valid float32 COG fixture (elevation-like data)."""
     return fixtures_dir / "raster" / "valid" / "float32.tif"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_nodata_cog(fixtures_dir: Path) -> Path:
     """Path to valid COG with nodata value set."""
     return fixtures_dir / "raster" / "valid" / "nodata.tif"
@@ -136,19 +136,19 @@ def valid_nodata_cog(fixtures_dir: Path) -> Path:
 # Invalid raster fixtures
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def invalid_not_georeferenced_tif(fixtures_dir: Path) -> Path:
     """Path to TIFF without CRS or geotransform."""
     return fixtures_dir / "raster" / "invalid" / "not_georeferenced.tif"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def invalid_truncated_tif(fixtures_dir: Path) -> Path:
     """Path to truncated (corrupted) TIFF file."""
     return fixtures_dir / "raster" / "invalid" / "truncated.tif"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def non_cog_tif(fixtures_dir: Path) -> Path:
     """Path to non-cloud-optimized GeoTIFF (Natural Earth data)."""
     return fixtures_dir / "raster" / "natural-earth-non-cog.tif"
@@ -159,19 +159,19 @@ def non_cog_tif(fixtures_dir: Path) -> Path:
 # =============================================================================
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def edge_unicode_geojson(fixtures_dir: Path) -> Path:
     """Path to GeoJSON with Unicode property values."""
     return fixtures_dir / "edge" / "unicode_properties.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def edge_special_filename_geojson(fixtures_dir: Path) -> Path:
     """Path to GeoJSON with spaces in filename."""
     return fixtures_dir / "edge" / "special_filename spaces.geojson"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def edge_antimeridian_geojson(fixtures_dir: Path) -> Path:
     """Path to GeoJSON crossing the antimeridian."""
     return fixtures_dir / "edge" / "antimeridian.geojson"
@@ -182,31 +182,31 @@ def edge_antimeridian_geojson(fixtures_dir: Path) -> Path:
 # =============================================================================
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def nwi_wetlands_path(fixtures_dir: Path) -> Path:
     """NWI Wetlands - complex polygons with holes (1,000 features)."""
     return fixtures_dir / "realdata" / "nwi-wetlands.parquet"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def open_buildings_path(fixtures_dir: Path) -> Path:
     """Open Buildings - bulk polygon ingestion (1,000 features)."""
     return fixtures_dir / "realdata" / "open-buildings.parquet"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def road_detections_path(fixtures_dir: Path) -> Path:
     """Road Detections - LineString geometries (1,000 features)."""
     return fixtures_dir / "realdata" / "road-detections.parquet"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fieldmaps_boundaries_path(fixtures_dir: Path) -> Path:
     """FieldMaps Boundaries - antimeridian crossing (3 features)."""
     return fixtures_dir / "realdata" / "fieldmaps-boundaries.parquet"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def rapidai4eo_path(fixtures_dir: Path) -> Path:
     """RapidAI4EO - Cloud-Optimized GeoTIFF raster."""
     return fixtures_dir / "realdata" / "rapidai4eo-sample.tif"

--- a/tests/integration/test_versioning_stress.py
+++ b/tests/integration/test_versioning_stress.py
@@ -1183,6 +1183,8 @@ class TestCatalogVersionsEdgeCases:
 # =============================================================================
 
 
+@pytest.mark.slow
+@pytest.mark.integration
 class TestScaleAt1000Files:
     """Test at scale matching original issue #339 (1900 files).
 

--- a/tests/unit/test_cli_add_rm.py
+++ b/tests/unit/test_cli_add_rm.py
@@ -997,3 +997,96 @@ class TestRmJsonOutput:
                 envelope = json.loads(result.output)
                 assert envelope["success"] is True
                 assert envelope["data"]["dry_run"] is True
+
+
+class TestCheckPartitionPrompt:
+    """Tests for _check_partition_prompt helper function."""
+
+    @pytest.mark.unit
+    def test_returns_false_when_partitioning_disabled(self, tmp_path: Path) -> None:
+        """When partitioning.enabled is False, should return False (no skip)."""
+        from portolan_cli.cli import _check_partition_prompt
+
+        setup_catalog(tmp_path)
+
+        # Create config with partitioning disabled
+        config_path = tmp_path / ".portolan" / "config.yaml"
+        config_path.write_text("partitioning:\n  enabled: false\n")
+
+        # Create a "large" parquet file (mocked size)
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        result = _check_partition_prompt([parquet_file], tmp_path)
+
+        assert result is False
+
+    @pytest.mark.unit
+    def test_returns_false_when_no_large_files(self, tmp_path: Path) -> None:
+        """When no files exceed threshold, should return False."""
+        from portolan_cli.cli import _check_partition_prompt
+
+        setup_catalog(tmp_path)
+
+        # Create a small parquet file
+        parquet_file = tmp_path / "small.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        result = _check_partition_prompt([parquet_file], tmp_path)
+
+        assert result is False
+
+    @pytest.mark.unit
+    def test_returns_false_when_not_tty(self, tmp_path: Path) -> None:
+        """When not running in TTY, should return False (non-interactive)."""
+        from portolan_cli.cli import _check_partition_prompt
+
+        setup_catalog(tmp_path)
+
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        # Mock should_partition to return True (imported inside function from partitioning module)
+        with patch("portolan_cli.partitioning.should_partition", return_value=True):
+            # sys.stderr.isatty() returns False in test environment
+            result = _check_partition_prompt([parquet_file], tmp_path)
+
+        assert result is False
+
+    @pytest.mark.unit
+    def test_returns_false_when_prompt_disabled(self, tmp_path: Path) -> None:
+        """When partitioning.prompt is False, should not prompt."""
+        from portolan_cli.cli import _check_partition_prompt
+
+        setup_catalog(tmp_path)
+
+        # Create config with prompt disabled
+        config_path = tmp_path / ".portolan" / "config.yaml"
+        config_path.write_text("partitioning:\n  enabled: true\n  prompt: false\n")
+
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        with patch("portolan_cli.partitioning.should_partition", return_value=True):
+            result = _check_partition_prompt([parquet_file], tmp_path)
+
+        assert result is False
+
+    @pytest.mark.unit
+    def test_scans_directories_recursively(self, tmp_path: Path) -> None:
+        """Should scan directories for parquet files."""
+        from portolan_cli.cli import _check_partition_prompt
+
+        setup_catalog(tmp_path)
+
+        # Create nested parquet file
+        subdir = tmp_path / "data" / "nested"
+        subdir.mkdir(parents=True)
+        parquet_file = subdir / "deep.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        # Pass directory, not file
+        result = _check_partition_prompt([tmp_path / "data"], tmp_path)
+
+        # Should return False (no TTY, no large files without mock)
+        assert result is False

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -278,8 +278,8 @@ class TestGlobTransformation:
         assert "portolan:glob" not in thumbnail
 
     @pytest.mark.unit
-    def test_transform_skips_assets_with_existing_glob(self) -> None:
-        """_transform_collection_glob_assets doesn't overwrite existing portolan:glob."""
+    def test_transform_overwrites_existing_glob_for_sync(self) -> None:
+        """_transform_collection_glob_assets overwrites existing globs to keep in sync."""
         import json
 
         from portolan_cli.push import _transform_collection_glob_assets
@@ -291,7 +291,7 @@ class TestGlobTransformation:
                 "partitioned_data": {
                     "href": "./kdtree_cell=*/*.parquet",
                     "type": "application/vnd.apache.parquet",
-                    "portolan:glob": "s3://existing/path/*/*.parquet",
+                    "portolan:glob": "s3://old-bucket/old-path/*/*.parquet",
                 },
             },
         }
@@ -300,10 +300,10 @@ class TestGlobTransformation:
         result = _transform_collection_glob_assets(content, "s3://bucket/catalog", "buildings")
         result_json = json.loads(result)
 
-        # Should preserve existing value
+        # Should overwrite with current remote URL to keep in sync
         assert (
             result_json["assets"]["partitioned_data"]["portolan:glob"]
-            == "s3://existing/path/*/*.parquet"
+            == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
         )
 
     @pytest.mark.unit
@@ -519,8 +519,8 @@ class TestDetectPartitioning:
         assert result["partition:strategy"] == "h3"
 
     @pytest.mark.unit
-    def test_detect_partitioning_unknown_column_returns_none_strategy(self, tmp_path: Path) -> None:
-        """detect_partitioning returns None strategy for unknown column names."""
+    def test_detect_partitioning_unknown_column_omits_strategy(self, tmp_path: Path) -> None:
+        """detect_partitioning omits strategy key for unknown column names."""
         from portolan_cli.partitioning import detect_partitioning
 
         (tmp_path / "custom_partition=value1").mkdir()
@@ -529,7 +529,8 @@ class TestDetectPartitioning:
         result = detect_partitioning(tmp_path)
 
         assert result is not None
-        assert result["partition:strategy"] is None
+        # Strategy key should be omitted (not null) for unknown columns
+        assert "partition:strategy" not in result
         assert result["partition:keys"][0]["name"] == "custom_partition"
 
 
@@ -700,8 +701,8 @@ class TestGlobTransformationPartitionExtension:
         assert asset["portolan:glob"] == expected_glob
 
     @pytest.mark.unit
-    def test_transform_respects_existing_partition_glob(self) -> None:
-        """_transform_collection_glob_assets doesn't overwrite existing partition:glob."""
+    def test_transform_syncs_both_glob_fields(self) -> None:
+        """_transform_collection_glob_assets syncs both partition:glob and portolan:glob."""
         import json
 
         from portolan_cli.push import _transform_collection_glob_assets
@@ -712,7 +713,7 @@ class TestGlobTransformationPartitionExtension:
             "assets": {
                 "partitioned_data": {
                     "href": "./kdtree_cell=*/*.parquet",
-                    "partition:glob": "s3://existing/path/*/*.parquet",
+                    "partition:glob": "s3://old-bucket/old-path/*/*.parquet",
                 },
             },
         }
@@ -721,7 +722,8 @@ class TestGlobTransformationPartitionExtension:
         result = _transform_collection_glob_assets(content, "s3://bucket/catalog", "buildings")
         result_json = json.loads(result)
 
-        # partition:glob preserved, portolan:glob added
+        # Both fields should be updated to current remote URL
         asset = result_json["assets"]["partitioned_data"]
-        assert asset["partition:glob"] == "s3://existing/path/*/*.parquet"
-        assert asset["portolan:glob"] == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
+        expected_glob = "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
+        assert asset["partition:glob"] == expected_glob
+        assert asset["portolan:glob"] == expected_glob

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -604,6 +604,69 @@ class TestPartitionExtensionInStac:
         assert EXTENSION_URLS["partition"] in extensions
 
 
+class TestFinalizeDatasetPartitionWiring:
+    """Tests for partition metadata wiring through finalize_datasets (Issue #232 Phase 3)."""
+
+    @pytest.mark.unit
+    def test_finalize_datasets_applies_partition_metadata_to_collection(
+        self, tmp_path: Path
+    ) -> None:
+        """finalize_datasets applies partition_metadata from PreparedDataset to collection."""
+        import pystac
+
+        from portolan_cli.dataset import PreparedDataset, finalize_datasets
+        from portolan_cli.formats import FormatType
+        from portolan_cli.stac import EXTENSION_URLS
+
+        # Initialize catalog structure
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+
+        catalog = pystac.Catalog(id="test-catalog", description="Test")
+        catalog.normalize_hrefs(f"{catalog_root}/")
+        catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
+
+        # Create PreparedDataset with partition_metadata
+        partition_metadata = {
+            "partition:scheme": "hive",
+            "partition:strategy": "kdtree",
+            "partition:keys": [{"name": "kdtree_cell", "type": "string"}],
+            "partition:file_count": 42,
+        }
+
+        glob_asset = pystac.Asset(
+            href="./kdtree_cell=*/*.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+        )
+
+        prepared = PreparedDataset(
+            item_id="test_partitioned",
+            collection_id="test-collection",
+            format_type=FormatType.VECTOR,
+            bbox=[-180, -90, 180, 90],
+            asset_files={},
+            item_json_path=None,
+            is_collection_level_asset=True,
+            stac_assets={"test_partitioned": glob_asset},
+            partition_metadata=partition_metadata,
+        )
+
+        # Finalize
+        finalize_datasets(catalog_root, [prepared])
+
+        # Verify collection has partition metadata
+        collection_path = catalog_root / "test-collection" / "collection.json"
+        assert collection_path.exists()
+
+        collection = pystac.Collection.from_file(str(collection_path))
+
+        assert collection.extra_fields.get("partition:scheme") == "hive"
+        assert collection.extra_fields.get("partition:strategy") == "kdtree"
+        assert collection.extra_fields.get("partition:file_count") == 42
+        assert EXTENSION_URLS["partition"] in (collection.stac_extensions or [])
+
+
 class TestGlobTransformationPartitionExtension:
     """Tests for partition:glob field emission (ADR-0042 transition)."""
 

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -418,3 +418,247 @@ class TestPartitionGeoparquetUnsupportedStrategy:
                 output_dir=output_dir,
                 strategy="h3",
             )
+
+
+class TestGetPartitionMetadata:
+    """Tests for get_partition_metadata function (Phase 3: STAC Partition Extension)."""
+
+    @pytest.mark.unit
+    def test_get_partition_metadata_returns_extension_fields(self, tmp_path: Path) -> None:
+        """get_partition_metadata returns dict with partition:* fields."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        # Create Hive-style partition structure
+        (tmp_path / "kdtree_cell=001").mkdir()
+        (tmp_path / "kdtree_cell=001" / "data.parquet").write_bytes(b"x")
+        (tmp_path / "kdtree_cell=002").mkdir()
+        (tmp_path / "kdtree_cell=002" / "data.parquet").write_bytes(b"x")
+
+        result = get_partition_metadata(tmp_path, strategy="kdtree")
+
+        assert result["partition:scheme"] == "hive"
+        assert result["partition:strategy"] == "kdtree"
+        assert result["partition:file_count"] == 2
+        assert len(result["partition:keys"]) == 1
+        assert result["partition:keys"][0]["name"] == "kdtree_cell"
+        assert result["partition:keys"][0]["type"] == "string"
+
+    @pytest.mark.unit
+    def test_get_partition_metadata_counts_files_correctly(self, tmp_path: Path) -> None:
+        """get_partition_metadata correctly counts files across partitions."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        # Create partitions with multiple files each
+        (tmp_path / "kdtree_cell=001").mkdir()
+        (tmp_path / "kdtree_cell=001" / "part1.parquet").write_bytes(b"x")
+        (tmp_path / "kdtree_cell=001" / "part2.parquet").write_bytes(b"x")
+        (tmp_path / "kdtree_cell=002").mkdir()
+        (tmp_path / "kdtree_cell=002" / "part1.parquet").write_bytes(b"x")
+
+        result = get_partition_metadata(tmp_path, strategy="kdtree")
+
+        assert result["partition:file_count"] == 3
+
+    @pytest.mark.unit
+    def test_get_partition_metadata_uses_strategy_column(self, tmp_path: Path) -> None:
+        """get_partition_metadata uses correct partition column per strategy."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        (tmp_path / "h3_cell=abc").mkdir()
+        (tmp_path / "h3_cell=abc" / "data.parquet").write_bytes(b"x")
+
+        result = get_partition_metadata(tmp_path, strategy="h3")
+
+        assert result["partition:keys"][0]["name"] == "h3_cell"
+        assert "H3" in result["partition:keys"][0]["description"]
+
+
+class TestDetectPartitioning:
+    """Tests for detect_partitioning function (Phase 4 prep)."""
+
+    @pytest.mark.unit
+    def test_detect_partitioning_finds_hive_structure(self, tmp_path: Path) -> None:
+        """detect_partitioning detects Hive-style partitioning."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        (tmp_path / "kdtree_cell=001").mkdir()
+        (tmp_path / "kdtree_cell=001" / "data.parquet").write_bytes(b"x")
+        (tmp_path / "kdtree_cell=002").mkdir()
+        (tmp_path / "kdtree_cell=002" / "data.parquet").write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is not None
+        assert result["partition:scheme"] == "hive"
+        assert result["partition:strategy"] == "kdtree"
+        assert result["partition:file_count"] == 2
+
+    @pytest.mark.unit
+    def test_detect_partitioning_returns_none_for_flat_directory(self, tmp_path: Path) -> None:
+        """detect_partitioning returns None for non-partitioned directories."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        (tmp_path / "data.parquet").write_bytes(b"x")
+        (tmp_path / "other.parquet").write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is None
+
+    @pytest.mark.unit
+    def test_detect_partitioning_identifies_strategy_from_column_name(self, tmp_path: Path) -> None:
+        """detect_partitioning identifies strategy from known column names."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        (tmp_path / "h3_cell=8928308280fffff").mkdir()
+        (tmp_path / "h3_cell=8928308280fffff" / "data.parquet").write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is not None
+        assert result["partition:strategy"] == "h3"
+
+    @pytest.mark.unit
+    def test_detect_partitioning_unknown_column_returns_none_strategy(self, tmp_path: Path) -> None:
+        """detect_partitioning returns None strategy for unknown column names."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        (tmp_path / "custom_partition=value1").mkdir()
+        (tmp_path / "custom_partition=value1" / "data.parquet").write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is not None
+        assert result["partition:strategy"] is None
+        assert result["partition:keys"][0]["name"] == "custom_partition"
+
+
+class TestPartitionExtensionInStac:
+    """Tests for partition extension integration in stac.py."""
+
+    @pytest.mark.unit
+    def test_add_partition_metadata_to_collection_adds_fields(self) -> None:
+        """add_partition_metadata_to_collection adds partition:* fields."""
+        import pystac
+
+        from portolan_cli.stac import add_partition_metadata_to_collection
+
+        collection = pystac.Collection(
+            id="test",
+            description="Test",
+            extent=pystac.Extent(
+                spatial=pystac.SpatialExtent(bboxes=[[-180, -90, 180, 90]]),
+                temporal=pystac.TemporalExtent(intervals=[[None, None]]),
+            ),
+        )
+
+        partition_metadata = {
+            "partition:scheme": "hive",
+            "partition:strategy": "kdtree",
+            "partition:keys": [{"name": "kdtree_cell", "type": "string"}],
+            "partition:file_count": 42,
+        }
+
+        add_partition_metadata_to_collection(collection, partition_metadata)
+
+        assert collection.extra_fields["partition:scheme"] == "hive"
+        assert collection.extra_fields["partition:strategy"] == "kdtree"
+        assert collection.extra_fields["partition:file_count"] == 42
+        assert len(collection.extra_fields["partition:keys"]) == 1
+
+    @pytest.mark.unit
+    def test_add_partition_metadata_registers_extension(self) -> None:
+        """add_partition_metadata_to_collection adds extension URL."""
+        import pystac
+
+        from portolan_cli.stac import EXTENSION_URLS, add_partition_metadata_to_collection
+
+        collection = pystac.Collection(
+            id="test",
+            description="Test",
+            extent=pystac.Extent(
+                spatial=pystac.SpatialExtent(bboxes=[[-180, -90, 180, 90]]),
+                temporal=pystac.TemporalExtent(intervals=[[None, None]]),
+            ),
+        )
+
+        partition_metadata = {"partition:scheme": "hive", "partition:keys": []}
+
+        add_partition_metadata_to_collection(collection, partition_metadata)
+
+        assert EXTENSION_URLS["partition"] in collection.stac_extensions
+
+    @pytest.mark.unit
+    def test_build_stac_extensions_includes_partition(self) -> None:
+        """build_stac_extensions detects partition:* fields."""
+        from portolan_cli.stac import EXTENSION_URLS, build_stac_extensions
+
+        properties = {
+            "partition:scheme": "hive",
+            "partition:strategy": "kdtree",
+            "partition:keys": [],
+        }
+
+        extensions = build_stac_extensions(properties)
+
+        assert EXTENSION_URLS["partition"] in extensions
+
+
+class TestGlobTransformationPartitionExtension:
+    """Tests for partition:glob field emission (ADR-0042 transition)."""
+
+    @pytest.mark.unit
+    def test_transform_adds_both_glob_fields(self) -> None:
+        """_transform_collection_glob_assets adds both partition:glob and portolan:glob."""
+        import json
+
+        from portolan_cli.push import _transform_collection_glob_assets
+
+        collection_json = {
+            "type": "Collection",
+            "id": "buildings",
+            "assets": {
+                "partitioned_data": {
+                    "href": "./kdtree_cell=*/*.parquet",
+                    "type": "application/vnd.apache.parquet",
+                },
+            },
+        }
+
+        content = json.dumps(collection_json).encode("utf-8")
+        result = _transform_collection_glob_assets(content, "s3://bucket/catalog", "buildings")
+        result_json = json.loads(result)
+
+        asset = result_json["assets"]["partitioned_data"]
+        expected_glob = "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
+
+        # Both fields should be populated
+        assert asset["partition:glob"] == expected_glob
+        assert asset["portolan:glob"] == expected_glob
+
+    @pytest.mark.unit
+    def test_transform_respects_existing_partition_glob(self) -> None:
+        """_transform_collection_glob_assets doesn't overwrite existing partition:glob."""
+        import json
+
+        from portolan_cli.push import _transform_collection_glob_assets
+
+        collection_json = {
+            "type": "Collection",
+            "id": "buildings",
+            "assets": {
+                "partitioned_data": {
+                    "href": "./kdtree_cell=*/*.parquet",
+                    "partition:glob": "s3://existing/path/*/*.parquet",
+                },
+            },
+        }
+
+        content = json.dumps(collection_json).encode("utf-8")
+        result = _transform_collection_glob_assets(content, "s3://bucket/catalog", "buildings")
+        result_json = json.loads(result)
+
+        # partition:glob preserved, portolan:glob added
+        asset = result_json["assets"]["partitioned_data"]
+        assert asset["partition:glob"] == "s3://existing/path/*/*.parquet"
+        assert asset["portolan:glob"] == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"

--- a/tests/unit/test_scan_output.py
+++ b/tests/unit/test_scan_output.py
@@ -1760,3 +1760,92 @@ class TestScanOutputIntegration:
                 assert file_dict["inferred_collection_id"] is not None, (
                     f"Expected collection ID for nested file {file_dict['relative_path']}"
                 )
+
+
+class TestPartitionOutputFormatting:
+    """Tests for partition metadata display in scan output (Issue #232 Phase 4)."""
+
+    @pytest.mark.unit
+    def test_format_special_formats_shows_hive_partition_with_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        """_format_special_formats displays Hive partitions with rich metadata."""
+        from portolan_cli.scan_detect import SpecialFormat
+        from portolan_cli.scan_output import _format_special_formats
+
+        # Create Hive-style partition structure
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "kdtree_cell=0001").mkdir()
+        (data_dir / "kdtree_cell=0001" / "data.parquet").touch()
+        (data_dir / "kdtree_cell=0002").mkdir()
+        (data_dir / "kdtree_cell=0002" / "data.parquet").touch()
+
+        sf = SpecialFormat(
+            path=data_dir,
+            relative_path="data",
+            format_type="hive_partition",
+            details={"partition_keys": ["kdtree_cell"]},
+        )
+
+        result = ScanResult(
+            root=tmp_path,
+            ready=[],
+            issues=[],
+            skipped=[],
+            directories_scanned=1,
+            special_formats=[sf],
+        )
+
+        lines = _format_special_formats(result)
+        output = "\n".join(lines)
+
+        assert "Detected special formats:" in output
+        assert "Hive-partitioned" in output
+        assert "kdtree" in output.lower()
+        assert "2 partitions" in output
+
+    @pytest.mark.unit
+    def test_format_special_formats_fallback_without_rich_metadata(self) -> None:
+        """_format_special_formats falls back to basic info when path doesn't exist."""
+        from portolan_cli.scan_detect import SpecialFormat
+        from portolan_cli.scan_output import _format_special_formats
+
+        sf = SpecialFormat(
+            path=Path("/nonexistent/path"),
+            relative_path="nonexistent",
+            format_type="hive_partition",
+            details={"partition_keys": ["year", "state"]},
+        )
+
+        result = ScanResult(
+            root=Path("/tmp"),
+            ready=[],
+            issues=[],
+            skipped=[],
+            directories_scanned=1,
+            special_formats=[sf],
+        )
+
+        lines = _format_special_formats(result)
+        output = "\n".join(lines)
+
+        assert "Hive-partitioned" in output
+        assert "year, state" in output
+
+    @pytest.mark.unit
+    def test_format_special_formats_empty_returns_empty(self) -> None:
+        """_format_special_formats returns empty list when no special formats."""
+        from portolan_cli.scan_output import _format_special_formats
+
+        result = ScanResult(
+            root=Path("/tmp"),
+            ready=[],
+            issues=[],
+            skipped=[],
+            directories_scanned=1,
+            special_formats=[],
+        )
+
+        lines = _format_special_formats(result)
+        assert lines == []

--- a/tests/unit/test_scan_output.py
+++ b/tests/unit/test_scan_output.py
@@ -1769,23 +1769,24 @@ class TestPartitionOutputFormatting:
     def test_format_special_formats_shows_hive_partition_with_metadata(
         self, tmp_path: Path
     ) -> None:
-        """_format_special_formats displays Hive partitions with rich metadata."""
+        """_format_special_formats displays Hive partitions with rich metadata from details."""
         from portolan_cli.scan_detect import SpecialFormat
         from portolan_cli.scan_output import _format_special_formats
 
-        # Create Hive-style partition structure
         data_dir = tmp_path / "data"
         data_dir.mkdir()
-        (data_dir / "kdtree_cell=0001").mkdir()
-        (data_dir / "kdtree_cell=0001" / "data.parquet").touch()
-        (data_dir / "kdtree_cell=0002").mkdir()
-        (data_dir / "kdtree_cell=0002" / "data.parquet").touch()
 
+        # Provide full partition metadata in sf.details (scan-time snapshot)
         sf = SpecialFormat(
             path=data_dir,
             relative_path="data",
             format_type="hive_partition",
-            details={"partition_keys": ["kdtree_cell"]},
+            details={
+                "partition:scheme": "hive",
+                "partition:strategy": "kdtree",
+                "partition:keys": [{"name": "kdtree_cell", "type": "string"}],
+                "partition:file_count": 2,
+            },
         )
 
         result = ScanResult(
@@ -1807,10 +1808,11 @@ class TestPartitionOutputFormatting:
 
     @pytest.mark.unit
     def test_format_special_formats_fallback_without_rich_metadata(self) -> None:
-        """_format_special_formats falls back to basic info when path doesn't exist."""
+        """_format_special_formats falls back to basic info from partition_keys."""
         from portolan_cli.scan_detect import SpecialFormat
         from portolan_cli.scan_output import _format_special_formats
 
+        # Provide minimal details with just partition_keys (fallback format)
         sf = SpecialFormat(
             path=Path("/nonexistent/path"),
             relative_path="nonexistent",

--- a/tests/unit/test_validation_rules.py
+++ b/tests/unit/test_validation_rules.py
@@ -1215,3 +1215,198 @@ class TestMetadataFreshRule:
 
         assert result.passed is False
         assert "missing" in result.message.lower()
+
+
+# --- Partition validation rules (thorough) ---
+
+
+class TestPartitionStructureRule:
+    """Tests for PartitionStructureRule."""
+
+    @pytest.mark.unit
+    def test_passes_when_no_partitions(self, tmp_path: Path) -> None:
+        """Rule passes when collection has no Hive-style partitions."""
+        from portolan_cli.validation.rules import PartitionStructureRule
+
+        # Setup catalog with non-partitioned collection
+        (tmp_path / ".portolan").mkdir()
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        rule = PartitionStructureRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is True
+
+    @pytest.mark.unit
+    def test_passes_with_consistent_partition_keys(self, tmp_path: Path) -> None:
+        """Rule passes when all partition dirs use same key."""
+        from portolan_cli.validation.rules import PartitionStructureRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","partition:scheme":"hive","partition:keys":[{"name":"kdtree_cell"}]}'
+        )
+
+        # Create consistent Hive partitions
+        (coll / "kdtree_cell=0").mkdir()
+        (coll / "kdtree_cell=1").mkdir()
+
+        rule = PartitionStructureRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is True
+
+    @pytest.mark.unit
+    def test_fails_with_mixed_partition_keys(self, tmp_path: Path) -> None:
+        """Rule fails when partition dirs use different keys."""
+        from portolan_cli.validation.rules import PartitionStructureRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        # Create mixed partition keys
+        (coll / "kdtree_cell=0").mkdir()
+        (coll / "h3_cell=abc").mkdir()  # Different key!
+
+        rule = PartitionStructureRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is False
+        assert "mixed keys" in result.message
+
+    @pytest.mark.unit
+    def test_fails_with_orphan_parquet_at_root(self, tmp_path: Path) -> None:
+        """Rule fails when parquet files exist at collection root alongside partitions."""
+        from portolan_cli.validation.rules import PartitionStructureRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        # Create partition dir AND orphan parquet at root
+        (coll / "kdtree_cell=0").mkdir()
+        (coll / "orphan.parquet").write_text("fake")
+
+        rule = PartitionStructureRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is False
+        assert "orphan" in result.message
+
+    @pytest.mark.unit
+    def test_warns_missing_partition_scheme_field(self, tmp_path: Path) -> None:
+        """Rule fails when partitions exist but partition:scheme missing."""
+        from portolan_cli.validation.rules import PartitionStructureRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        # Collection JSON missing partition:scheme
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        (coll / "kdtree_cell=0").mkdir()
+
+        rule = PartitionStructureRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is False
+        assert "partition:scheme" in result.message
+
+
+class TestPartitionSchemaConsistencyRule:
+    """Tests for PartitionSchemaConsistencyRule."""
+
+    @pytest.mark.unit
+    def test_passes_when_no_partitions(self, tmp_path: Path) -> None:
+        """Rule passes when no Hive-style partitions exist."""
+        from portolan_cli.validation.rules import PartitionSchemaConsistencyRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        rule = PartitionSchemaConsistencyRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is True
+
+    @pytest.mark.unit
+    def test_passes_with_consistent_schemas(self, tmp_path: Path) -> None:
+        """Rule passes when all partition files have same schema."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        from portolan_cli.validation.rules import PartitionSchemaConsistencyRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        # Create partitions with same schema
+        p1 = coll / "kdtree_cell=0"
+        p1.mkdir()
+        p2 = coll / "kdtree_cell=1"
+        p2.mkdir()
+
+        table = pa.table({"id": [1], "name": ["test"]})
+        pq.write_table(table, p1 / "data.parquet")
+        pq.write_table(table, p2 / "data.parquet")
+
+        rule = PartitionSchemaConsistencyRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is True
+
+    @pytest.mark.unit
+    def test_fails_with_inconsistent_schemas(self, tmp_path: Path) -> None:
+        """Rule fails when partition files have different schemas."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        from portolan_cli.validation.rules import PartitionSchemaConsistencyRule
+
+        coll = tmp_path / "test-collection"
+        coll.mkdir()
+        (coll / "collection.json").write_text(
+            '{"type":"Collection","stac_version":"1.0.0","id":"test"}'
+        )
+
+        p1 = coll / "kdtree_cell=0"
+        p1.mkdir()
+        p2 = coll / "kdtree_cell=1"
+        p2.mkdir()
+
+        # Different schemas!
+        table1 = pa.table({"id": [1], "name": ["test"]})
+        table2 = pa.table({"id": [2], "value": [42]})  # Different columns
+        pq.write_table(table1, p1 / "data.parquet")
+        pq.write_table(table2, p2 / "data.parquet")
+
+        rule = PartitionSchemaConsistencyRule()
+        result = rule.check(tmp_path)
+
+        assert result.passed is False
+        assert "different schemas" in result.message.lower()
+
+    @pytest.mark.unit
+    def test_has_error_severity(self) -> None:
+        """Schema inconsistency is an ERROR (data corruption)."""
+        from portolan_cli.validation.rules import PartitionSchemaConsistencyRule
+
+        rule = PartitionSchemaConsistencyRule()
+        assert rule.severity == Severity.ERROR

--- a/tests/unit/test_validation_runner.py
+++ b/tests/unit/test_validation_runner.py
@@ -88,7 +88,7 @@ class TestCheck:
         # No .portolan dir = first rule fails
         report = check(tmp_path)
 
-        # Should have run all 6 default rules even though the first one failed
-        # (Added ProvisionalDatetimeRule per ADR-0035)
+        # Should have run all 8 default rules even though the first one failed
+        # (6 original + 2 partition rules: PartitionStructureRule, PartitionSchemaConsistencyRule)
         # This verifies the runner doesn't short-circuit on failure
-        assert len(report.results) == 6
+        assert len(report.results) == 8

--- a/uv.lock
+++ b/uv.lock
@@ -1211,6 +1211,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastembed"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4090,6 +4099,7 @@ dev = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pylint" },
     { name = "pytest-asyncio" },
+    { name = "pytest-xdist" },
     { name = "types-pyyaml" },
 ]
 
@@ -4157,6 +4167,7 @@ dev = [
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
@@ -4931,6 +4942,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Implement standalone `partition:` STAC extension for Hive-style partitioned datasets
- Add partition metadata emission, detection, auto-partitioning, and validation rules
- Enable partitioning by default with configurable thresholds

## Key Features

- **Partition detection**: Automatically detect Hive-style partitions (e.g., `year=2024/month=01/`)
- **Auto-partitioning**: Interactive prompt for large files (>2GB) with `portolan add`
- **Metadata emission**: Populate `partition:scheme`, `partition:keys`, `partition:file_count`, `partition:strategy`
- **Validation rules**: `PartitionSchemaConsistencyRule` and `PMTilesRecommendedRule` run by default
- **Scan output**: Display partition information in scan results

## Configuration

```yaml
# .portolan/config.yaml
partitioning:
  enabled: true          # Default: true
  prompt: true           # Interactive prompt for large files
  threshold_gb: 2.0      # Size threshold for auto-partition prompt
```

## STAC Extension Fields

| Field | Description |
|-------|-------------|
| `partition:scheme` | Always "hive" for Hive-style partitioning |
| `partition:keys` | Array of `{name, type}` objects for partition columns |
| `partition:file_count` | Number of partition files |
| `partition:strategy` | Optional: how partitions were created (e.g., "h3") |
| `partition:glob` | Glob pattern matching partition files |

## Test Plan

- [x] Unit tests for partitioning module
- [x] Unit tests for scan output formatting
- [x] Unit tests for validation rules
- [x] Integration tests for add workflow partitioning
- [x] All pre-commit hooks pass
- [x] mypy strict mode passes

Closes #232

🤖 Generated with [Claude Code](https://claude.ai/claude-code)