### PR TITLE
Fix CRS mismatch false positive for geographic CRSes (ETRS89, NAD83)

### DIFF
--- a/portolan_cli/crs.py
+++ b/portolan_cli/crs.py
@@ -218,16 +218,20 @@ def validate_bbox_crs(
     if crs is None:
         return None
 
-    # Check if CRS is WGS84 (no mismatch possible)
+    # Check if CRS is WGS84 or another geographic CRS (no mismatch possible)
     try:
         parsed_crs = CRS.from_user_input(crs)
         if _is_wgs84(parsed_crs):
+            return None
+        # Geographic CRSes like ETRS89 (EPSG:4258) naturally have coordinates
+        # in the same lon/lat range as WGS84 — not a mismatch.
+        if parsed_crs.is_geographic:
             return None
     except (CRSError, TypeError):
         # Invalid CRS, can't validate
         return None
 
-    # CRS is NOT WGS84 - check if coordinates look like WGS84
+    # CRS is projected - check if coordinates look like WGS84
     if is_likely_wgs84_bbox(bbox):
         return CRSMismatchWarning(
             declared_crs=crs,

--- a/tests/unit/test_crs_validation.py
+++ b/tests/unit/test_crs_validation.py
@@ -141,6 +141,19 @@ class TestValidateBboxCrs:
             result = validate_bbox_crs(bbox, crs)
             assert result is None, f"Unexpected warning for CRS {crs}"
 
+    def test_no_warning_when_geographic_crs_with_lonlat_coords(self) -> None:
+        """No warning for non-WGS84 geographic CRSes like ETRS89.
+
+        Geographic CRSes (ETRS89, NAD83, etc.) naturally have coordinates in
+        the same lon/lat range as WGS84. This is not a mismatch — unlike
+        projected CRSes (EPSG:28992) where lon/lat-range coordinates indicate
+        the data was mislabeled.
+        """
+        bbox = (3.16, 50.75, 7.23, 53.54)  # Netherlands in ETRS89
+        for crs in ["EPSG:4258", "EPSG:4269"]:  # ETRS89, NAD83
+            result = validate_bbox_crs(bbox, crs)
+            assert result is None, f"Unexpected warning for geographic CRS {crs}"
+
 
 class TestTransformBboxToWgs84WithValidation:
     """Tests for CRS mismatch detection during bbox transformation."""


### PR DESCRIPTION
## Summary

- Skip CRS mismatch validation when the declared CRS is a geographic CRS (e.g., ETRS89/EPSG:4258, NAD83/EPSG:4269)
- The mismatch heuristic was designed for projected CRSes (EPSG:28992) where lon/lat-range coordinates indicate mislabeled data
- Geographic CRSes naturally have coordinates in the same range as WGS84, so the check produces false positives
- This blocks `portolan add` for all EU INSPIRE-harmonized datasets, which use ETRS89

## Context

Discovered while adding PDOK's INSPIRE Buildings dataset (24M Dutch building footprints in EPSG:4258) to a Portolan catalog. `portolan add` rejected the GeoParquet file with:

```
✗ [PRTLN-CNV004] CRS mismatch: declares EPSG:4258 but coordinates (3.16, 50.75, 7.23, 53.54)
  appear to be EPSG:4326.
```

ETRS89 and WGS84 differ by sub-meter amounts — the coordinates *should* look the same.

## Test plan

- [x] New test: `test_no_warning_when_geographic_crs_with_lonlat_coords` covers EPSG:4258 (ETRS89) and EPSG:4269 (NAD83)
- [x] All 21 existing CRS validation tests still pass
- [x] Projected CRS mismatch detection (the original ArcGIS bug) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved coordinate reference system validation to correctly recognize geographic CRS types and prevent false mismatch warnings when using standard longitude/latitude coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->