### PR TITLE
docs: end-to-end tutorial and quickstart command

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -29,6 +29,14 @@ portolan add imagery/                      # Add all files in directory
 portolan add .                             # Add all files in catalog
 ```
 
+### `portolan agent-instructions`
+Alias for quickstart command.
+
+```bash
+portolan agent-instructions
+portolan agent-instructions --json
+```
+
 ### `portolan check`
 Validate a Portolan catalog or check files for cloud-native status.
 
@@ -141,6 +149,14 @@ portolan push s3://mybucket/catalog --collection demographics
 portolan push gs://mybucket/catalog -c imagery --dry-run
 portolan push s3://mybucket/catalog
 portolan push --dry-run  # Uses configured remote
+```
+
+### `portolan quickstart`
+Print agent quickstart instructions.
+
+```bash
+portolan quickstart
+portolan quickstart --json
 ```
 
 ### `portolan readme`

--- a/context/shared/plans/end-to-end-tutorial-quickstart.md
+++ b/context/shared/plans/end-to-end-tutorial-quickstart.md
@@ -1,0 +1,273 @@
+# End-to-End Tutorial + Quickstart Command Plan
+
+**Status:** Ready for implementation
+**Created:** 2026-05-06
+**Context:** PRs #380 and #367 were too WFS-focused. This replaces them with a single clean end-to-end example.
+
+## Goal
+
+Two outputs from one effort:
+1. **Human-facing docs** (`docs/tutorials/end-to-end.md`) — narrative walkthrough in mkdocs
+2. **Agent quickstart command** (`portolan quickstart`) — dense, actionable reference for AI coding tools (kata-style)
+
+## Data Source
+
+**Belgium Buildings WFS:**
+- Endpoint: `https://geoservices.wallonie.be/geoserver/inspire_bu/ows`
+- Layer: `inspire_bu:BU.Building_building_emprise`
+- Extract without limit to measure actual size
+- Push to existing bucket: `s3://us-west-2.opendata.source.coop/nlebovits/belgium-buildings/`
+
+**Note:** Partitioning triggers at 2GB. If data < 2GB, document the threshold but don't force artificial data.
+
+## Workflow Scope
+
+Full MVP demonstration:
+- `portolan extract wfs` (pull without limit)
+- `portolan init`
+- `portolan add`
+- `portolan scan`
+- `portolan check --fix`
+- Partitioning (auto-detected at 2GB+)
+- Style generation
+- Thumbnail generation
+- `portolan readme --recursive`
+- Configure remote (`.env`)
+- Clear existing bucket
+- `portolan push`
+
+**Excluded:** COG conversion (separate tutorial, same mechanics).
+
+## Implementation Steps
+
+### Step 1: Workspace Setup
+
+```bash
+cd ~/Documents/dev/portolan/portolan-test-data
+mkdir belgium-buildings-mvp && cd belgium-buildings-mvp
+showboat init WORKFLOW.md "Belgium Buildings MVP Demo"
+```
+
+### Step 2: Extract Without Limit
+
+```bash
+showboat exec WORKFLOW.md bash \
+  "uv run portolan extract wfs \
+    https://geoservices.wallonie.be/geoserver/inspire_bu/ows \
+    buildings \
+    --layers 'inspire_bu:BU.Building_building_emprise' \
+    --auto"
+```
+
+Measure resulting GeoParquet size.
+
+### Step 3: Full Workflow (showboat captures each)
+
+Execute and capture with showboat:
+1. `portolan init`
+2. `portolan add`
+3. `portolan scan`
+4. `portolan check --fix`
+5. Observe partitioning behavior
+6. Style generation
+7. Thumbnail generation
+8. `portolan readme --recursive`
+9. Configure `.env` with:
+   ```
+   PORTOLAN_REMOTE=s3://us-west-2.opendata.source.coop/nlebovits/belgium-buildings/
+   PORTOLAN_PROFILE=source-coop
+   ```
+10. Clear bucket: `aws s3 rm s3://us-west-2.opendata.source.coop/nlebovits/belgium-buildings/ --recursive`
+11. `portolan push`
+
+### Step 4: Verify Reproducibility
+
+```bash
+showboat verify WORKFLOW.md
+```
+
+### Step 5: Port to portolan-cli Docs
+
+- Copy WORKFLOW.md content → `docs/tutorials/end-to-end.md`
+- Add human narrative between code blocks
+- Add to mkdocs.yml nav
+
+### Step 6: Create Quickstart Command
+
+**File:** `portolan_cli/quickstart_content.py`
+
+Follow kata's pattern (https://github.com/wesm/kata):
+
+```python
+QUICKSTART = """
+# Portolan Agent Quickstart
+
+This is the short version to give any coding agent. Also available via CLI:
+
+    portolan quickstart
+    portolan agent-instructions   # alias
+
+## Session Setup
+
+- Run from catalog root, or pass --catalog-root <path>
+- Use --format=json for all reads when parsing output
+- Set PORTOLAN_REMOTE and PORTOLAN_PROFILE for push/pull
+
+## Per-Task Guidelines
+
+- Never add files without initializing first (portolan init)
+- Scan before check: scan detects, check validates
+- Use --fix to auto-remediate, --dry-run to preview
+- Prefer --auto for non-interactive workflows
+- Search/list before creating; avoid duplicates
+
+## STAC Terminology
+
+| Term | Meaning |
+|------|---------|
+| Catalog | Root container (catalog.json) |
+| Collection | Group of related items |
+| Item | Single spatiotemporal entity |
+| Asset | Actual data file |
+
+## Example Session
+
+```bash
+# Initialize catalog
+portolan init --auto --format=json
+
+# Add data files
+portolan add data/*.parquet --format=json
+
+# Scan for metadata
+portolan scan --format=json
+
+# Validate and fix issues
+portolan check --fix --format=json
+
+# Generate documentation
+portolan readme --recursive --format=json
+
+# Push to remote
+portolan push --format=json
+```
+
+## Command Patterns
+
+For agent parsing, always use --format=json:
+
+```bash
+portolan --format=json list
+portolan --format=json status
+portolan --format=json info <path>
+```
+
+JSON envelope structure:
+```json
+{
+  "success": true,
+  "command": "command_name",
+  "data": { ... },
+  "errors": [ ... ]
+}
+```
+"""
+```
+
+**CLI command:** Add to `cli.py`:
+
+```python
+@cli.command()
+def quickstart():
+    """Print agent quickstart instructions."""
+    from portolan_cli.quickstart_content import QUICKSTART
+    click.echo(QUICKSTART)
+
+@cli.command("agent-instructions")
+def agent_instructions():
+    """Alias for quickstart."""
+    from portolan_cli.quickstart_content import QUICKSTART
+    click.echo(QUICKSTART)
+```
+
+### Step 7: DRY Integration
+
+**Script:** `scripts/generate_quickstart.py`
+
+- Validates quickstart content syntax
+- Could inject into docs via markers if needed
+- Three modes: `--dry-run`, `--update`, `--check`
+
+**Pre-commit hook in prek.toml:**
+
+```toml
+{
+  id = "validate-quickstart",
+  entry = "uv run python scripts/generate_quickstart.py --check",
+  files = { glob = ["portolan_cli/quickstart_content.py"] },
+  pass_filenames = false,
+  language = "system",
+}
+```
+
+### Step 8: CI Integration
+
+- mkdocs build validates tutorial renders
+- `portolan quickstart > /dev/null` syntax check
+- Optional: extract and run code blocks from tutorial
+
+## Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| Showboat workflow (one-time) | `portolan-test-data/belgium-buildings-mvp/WORKFLOW.md` |
+| Human tutorial | `portolan-cli/docs/tutorials/end-to-end.md` |
+| Agent quickstart content | `portolan-cli/portolan_cli/quickstart_content.py` |
+| CLI commands | `portolan quickstart`, `portolan agent-instructions` |
+| Validation script | `portolan-cli/scripts/generate_quickstart.py` |
+
+## Research Findings
+
+### JSON Output Coverage
+
+97% coverage (30/31 commands). Only `partition` missing `--json` flag. Global `--format=json` available.
+
+**Gap to fix:** Add `--json` to `partition` command.
+
+### Showboat CLI
+
+- Installed: `~/.local/bin/showboat` v0.6.1
+- Commands: `init`, `note`, `exec`, `image`, `pop`, `verify`, `extract`
+- `showboat verify` re-runs code blocks, compares outputs
+- Existing tutorials in portolan-test-data have showboat IDs
+
+### DRY Patterns in Repo
+
+Marker-based replacement: `<!-- BEGIN GENERATED: section -->` / `<!-- END GENERATED: section -->`
+
+Scripts:
+- `scripts/generate_skill_md.py` — Click CLI introspection
+- `scripts/generate_claude_md_sections.py` — Multi-source generation
+- `scripts/validate_claude_md.py` — Validation
+- `scripts/update_freshness.py` — Freshness tracking
+
+Three-mode pattern: `--dry-run`, `--update`, `--check`
+
+Pre-commit integration via prek.toml.
+
+### Belgium Buildings Tutorial (Existing)
+
+- WFS: `https://geoservices.wallonie.be/geoserver/inspire_bu/ows`
+- Layer: `inspire_bu:BU.Building_building_emprise`
+- Bucket: `s3://us-west-2.opendata.source.coop/nlebovits/belgium-buildings/`
+- Profile: `source-coop`
+- Current examples use 100k features
+
+## Notes for Implementer
+
+1. **Start with showboat workflow** — run actual commands, capture outputs
+2. **Measure data size** — if < 2GB, partitioning won't trigger; document threshold
+3. **Clear bucket before push** — `aws s3 rm ... --recursive`
+4. **Port showboat output to docs** — add narrative, don't just copy
+5. **Quickstart follows kata pattern** — session setup, guidelines, example, terminology
+6. **Test both outputs** — `portolan quickstart` prints cleanly, mkdocs builds

--- a/docs/tutorials/end-to-end.md
+++ b/docs/tutorials/end-to-end.md
@@ -15,17 +15,15 @@ portolan extract wfs \
   --auto
 ```
 
-This creates `buildings/` with GeoParquet (Hilbert-ordered for spatial queries), STAC catalog/collection JSON, and metadata seeded from the service's ISO 19139 records. The full dataset is 3.8M features (~750MB).
+Creates `buildings/` with GeoParquet (Hilbert-ordered), STAC catalog/collection JSON, and metadata seeded from ISO 19139 records. The full dataset is 3.8M features (~750MB).
 
 ## Generate PMTiles
 
 ```bash
-portolan add buildings/**/*.parquet \
-  --pmtiles \
-  --workers 4
+portolan add buildings/**/*.parquet --pmtiles --workers 4
 ```
 
-The `--pmtiles` flag generates vector tiles, a Mapbox GL style, and a PNG thumbnail for each GeoParquet. The `--workers` flag parallelizes metadata extraction across files.
+Generates vector tiles (`.pmtiles`), a Mapbox GL style (embedded in STAC as `pmtiles:style`), and a thumbnail (`.thumb.jpg`). The `--workers` flag parallelizes metadata extraction.
 
 ## Validate and Fix
 
@@ -34,7 +32,7 @@ portolan scan --tree
 portolan check --fix
 ```
 
-The `--tree` flag shows directory structure with status markers. The `--fix` flag converts non-cloud-native formats, updates stale STAC metadata, and generates missing bbox/temporal extents. Add `--dry-run` to preview changes.
+Scan shows directory structure with status markers. Check validates STAC and converts non-cloud-native formats. The `--fix` flag updates stale metadata and generates missing bbox/temporal extents. Add `--dry-run` to preview.
 
 ## Generate READMEs
 
@@ -42,7 +40,7 @@ The `--tree` flag shows directory structure with status markers. The `--fix` fla
 portolan readme --recursive
 ```
 
-READMEs are generated from STAC metadata plus `.portolan/metadata.yaml` (human enrichment layer). Edit `metadata.yaml` to add descriptions, licenses, and attribution—never edit README.md directly.
+Generates from STAC metadata plus `.portolan/metadata.yaml`. Edit `metadata.yaml` for descriptions, licenses, attribution—never edit README.md directly.
 
 ## Configure Remote
 
@@ -59,8 +57,8 @@ EOF
 portolan push --workers 4 --concurrency 16
 ```
 
-The `--workers` flag parallelizes across collections (each gets its own upload thread). The `--concurrency` flag controls parallel file uploads within each collection. With 4 workers and 16 concurrency, you get up to 64 simultaneous uploads.
+Parallelizes across collections (`--workers`) and files within each collection (`--concurrency`). With 4 workers and 16 concurrency: up to 64 simultaneous uploads.
 
 ## Result
 
-The published catalog includes GeoParquet, PMTiles, style.json, thumbnail.png, and READMEs—all accessible via HTTP range requests without a tile server.
+Published catalog includes GeoParquet, PMTiles with inline style, thumbnails, and READMEs—all accessible via HTTP range requests.

--- a/docs/tutorials/end-to-end.md
+++ b/docs/tutorials/end-to-end.md
@@ -1,43 +1,11 @@
-# End-to-End Tutorial: Belgium Buildings
+# End-to-End: Belgium Buildings
 
-This tutorial walks through the complete Portolan workflow using real-world data: Belgium INSPIRE building footprints from a WFS service.
+Published catalog: [source.coop/nlebovits/belgium-buildings](https://source.coop/nlebovits/belgium-buildings)
+Browse in STAC Browser: [radiantearth.github.io/stac-browser](https://radiantearth.github.io/stac-browser/#/external/us-west-2.opendata.source.coop/nlebovits/belgium-buildings/catalog.json)
 
-**You'll learn:**
+## Extract from WFS
 
-- Extracting data from WFS services
-- Initializing and managing a Portolan catalog
-- Generating PMTiles with automatic styles and thumbnails
-- Validating and fixing metadata
-- Generating documentation
-- Publishing to cloud storage
-
-## Prerequisites
-
-- Portolan CLI installed (`pipx install portolan-cli`)
-- AWS credentials configured (for S3 push)
-
-## Step 1: Create a Workspace
-
-```bash
-mkdir belgium-buildings && cd belgium-buildings
-```
-
-## Step 2: Extract from WFS
-
-Belgium's Wallonia region publishes INSPIRE-compliant building footprints via WFS. First, explore what's available:
-
-```bash
-portolan extract wfs \
-  "https://geoservices.wallonie.be/geoserver/inspire_bu/ows" \
-  --dry-run
-```
-
-Output shows two layers:
-
-- `inspire_bu:BU.Building_building_emprise` — building footprints
-- `inspire_bu:BU.Building_building_lod1` — 3D building models
-
-Extract the building footprints:
+Wallonia publishes INSPIRE building footprints via WFS at `https://geoservices.wallonie.be/geoserver/inspire_bu/ows`. The `--dry-run` flag shows available layers without fetching data.
 
 ```bash
 portolan extract wfs \
@@ -47,145 +15,52 @@ portolan extract wfs \
   --auto
 ```
 
-This creates a catalog structure in `buildings/` with:
+This creates `buildings/` with GeoParquet (Hilbert-ordered for spatial queries), STAC catalog/collection JSON, and metadata seeded from the service's ISO 19139 records. The full dataset is 3.8M features (~750MB).
 
-- GeoParquet data file (cloud-optimized, Hilbert-ordered)
-- STAC catalog and collection metadata
-- Metadata seeded from the WFS service's ISO 19139 records
-
-!!! note "Full extract vs. limited"
-    Remove `--limit` for production use. The full Belgium buildings dataset is ~750MB with 3.8M features.
-
-## Step 3: Explore the Catalog
-
-Check what was created:
+## Generate PMTiles
 
 ```bash
-portolan list
+portolan add buildings/**/*.parquet \
+  --pmtiles \
+  --workers 4
 ```
 
-View collection details:
+The `--pmtiles` flag generates vector tiles, a Mapbox GL style, and a PNG thumbnail for each GeoParquet. The `--workers` flag parallelizes metadata extraction across files.
+
+## Validate and Fix
 
 ```bash
-portolan info buildings/inspire_bu_bu_building_building_emprise
-```
-
-## Step 4: Generate PMTiles
-
-PMTiles are cloud-optimized vector tiles that enable web mapping without a tile server. Generate them with automatic style and thumbnail:
-
-```bash
-portolan add buildings/**/*.parquet --pmtiles
-```
-
-This generates three assets per GeoParquet file:
-
-| Asset | Purpose |
-|-------|---------|
-| `.pmtiles` | Vector tiles for web maps |
-| `style.json` | Mapbox GL style (auto-generated colors) |
-| `thumbnail.png` | Preview image with basemap |
-
-## Step 5: Scan and Validate
-
-Scan for metadata extraction:
-
-```bash
-portolan scan
-```
-
-Validate the catalog structure and auto-fix issues:
-
-```bash
+portolan scan --tree
 portolan check --fix
 ```
 
-Common auto-fixes include:
+The `--tree` flag shows directory structure with status markers. The `--fix` flag converts non-cloud-native formats, updates stale STAC metadata, and generates missing bbox/temporal extents. Add `--dry-run` to preview changes.
 
-- Adding missing bbox from geometry
-- Setting temporal extent to null (unknown dates)
-- Generating STAC item IDs
-
-## Step 6: Generate Documentation
-
-Create README files from STAC metadata:
+## Generate READMEs
 
 ```bash
 portolan readme --recursive
 ```
 
-This generates `README.md` at both catalog and collection levels, combining:
+READMEs are generated from STAC metadata plus `.portolan/metadata.yaml` (human enrichment layer). Edit `metadata.yaml` to add descriptions, licenses, and attribution—never edit README.md directly.
 
-- STAC metadata (machine-extracted)
-- Human enrichment from `.portolan/metadata.yaml`
-
-!!! tip "Edit metadata.yaml, not README.md"
-    The README is always regenerated. Add descriptions, licenses, and attribution to `metadata.yaml`.
-
-## Step 7: Configure Remote
-
-Create a `.env` file with your remote storage:
+## Configure Remote
 
 ```bash
 cat > .env << 'EOF'
-PORTOLAN_REMOTE=s3://your-bucket/belgium-buildings/
-PORTOLAN_PROFILE=your-aws-profile
+PORTOLAN_REMOTE=s3://us-west-2.opendata.source.coop/nlebovits/belgium-buildings/
+PORTOLAN_PROFILE=source-coop
 EOF
 ```
 
-## Step 8: Push to Cloud
-
-Push the catalog:
+## Push
 
 ```bash
-portolan push
+portolan push --workers 4 --concurrency 16
 ```
 
-Portolan uploads:
+The `--workers` flag parallelizes across collections (each gets its own upload thread). The `--concurrency` flag controls parallel file uploads within each collection. With 4 workers and 16 concurrency, you get up to 64 simultaneous uploads.
 
-- STAC catalog and collection JSON
-- GeoParquet data files
-- PMTiles, styles, and thumbnails
-- READMEs
+## Result
 
-## Verify Publication
-
-Your data is now available at the S3 URL. The PMTiles can be loaded directly in web mapping libraries:
-
-```javascript
-import maplibregl from "maplibre-gl";
-import { Protocol } from "pmtiles";
-
-const protocol = new Protocol();
-maplibregl.addProtocol("pmtiles", protocol.tile);
-
-const map = new maplibregl.Map({
-  container: "map",
-  style: "https://your-bucket.s3.amazonaws.com/belgium-buildings/.../style.json",
-});
-```
-
-## Summary
-
-| Step | Command | Purpose |
-|------|---------|---------|
-| 1 | `extract wfs` | Pull data from WFS service |
-| 2 | `list`, `info` | Explore catalog contents |
-| 3 | `add --pmtiles` | Generate vector tiles + style + thumbnail |
-| 4 | `scan` | Extract metadata |
-| 5 | `check --fix` | Validate and auto-fix |
-| 6 | `readme --recursive` | Generate documentation |
-| 7 | `.env` config | Configure remote storage |
-| 8 | `push` | Publish to cloud |
-
-## Agent Usage
-
-For AI agents working with Portolan, use `--json` for machine-parseable output:
-
-```bash
-portolan quickstart  # Dense agent reference
-portolan list --json
-portolan check --fix --json
-```
-
-See `portolan quickstart` for the complete agent reference.
+The published catalog includes GeoParquet, PMTiles, style.json, thumbnail.png, and READMEs—all accessible via HTTP range requests without a tile server.

--- a/docs/tutorials/end-to-end.md
+++ b/docs/tutorials/end-to-end.md
@@ -1,0 +1,191 @@
+# End-to-End Tutorial: Belgium Buildings
+
+This tutorial walks through the complete Portolan workflow using real-world data: Belgium INSPIRE building footprints from a WFS service.
+
+**You'll learn:**
+
+- Extracting data from WFS services
+- Initializing and managing a Portolan catalog
+- Generating PMTiles with automatic styles and thumbnails
+- Validating and fixing metadata
+- Generating documentation
+- Publishing to cloud storage
+
+## Prerequisites
+
+- Portolan CLI installed (`pipx install portolan-cli`)
+- AWS credentials configured (for S3 push)
+
+## Step 1: Create a Workspace
+
+```bash
+mkdir belgium-buildings && cd belgium-buildings
+```
+
+## Step 2: Extract from WFS
+
+Belgium's Wallonia region publishes INSPIRE-compliant building footprints via WFS. First, explore what's available:
+
+```bash
+portolan extract wfs \
+  "https://geoservices.wallonie.be/geoserver/inspire_bu/ows" \
+  --dry-run
+```
+
+Output shows two layers:
+
+- `inspire_bu:BU.Building_building_emprise` — building footprints
+- `inspire_bu:BU.Building_building_lod1` — 3D building models
+
+Extract the building footprints:
+
+```bash
+portolan extract wfs \
+  "https://geoservices.wallonie.be/geoserver/inspire_bu/ows" \
+  buildings \
+  --layers "inspire_bu:BU.Building_building_emprise" \
+  --auto
+```
+
+This creates a catalog structure in `buildings/` with:
+
+- GeoParquet data file (cloud-optimized, Hilbert-ordered)
+- STAC catalog and collection metadata
+- Metadata seeded from the WFS service's ISO 19139 records
+
+!!! note "Full extract vs. limited"
+    Remove `--limit` for production use. The full Belgium buildings dataset is ~750MB with 3.8M features.
+
+## Step 3: Explore the Catalog
+
+Check what was created:
+
+```bash
+portolan list
+```
+
+View collection details:
+
+```bash
+portolan info buildings/inspire_bu_bu_building_building_emprise
+```
+
+## Step 4: Generate PMTiles
+
+PMTiles are cloud-optimized vector tiles that enable web mapping without a tile server. Generate them with automatic style and thumbnail:
+
+```bash
+portolan add buildings/**/*.parquet --pmtiles
+```
+
+This generates three assets per GeoParquet file:
+
+| Asset | Purpose |
+|-------|---------|
+| `.pmtiles` | Vector tiles for web maps |
+| `style.json` | Mapbox GL style (auto-generated colors) |
+| `thumbnail.png` | Preview image with basemap |
+
+## Step 5: Scan and Validate
+
+Scan for metadata extraction:
+
+```bash
+portolan scan
+```
+
+Validate the catalog structure and auto-fix issues:
+
+```bash
+portolan check --fix
+```
+
+Common auto-fixes include:
+
+- Adding missing bbox from geometry
+- Setting temporal extent to null (unknown dates)
+- Generating STAC item IDs
+
+## Step 6: Generate Documentation
+
+Create README files from STAC metadata:
+
+```bash
+portolan readme --recursive
+```
+
+This generates `README.md` at both catalog and collection levels, combining:
+
+- STAC metadata (machine-extracted)
+- Human enrichment from `.portolan/metadata.yaml`
+
+!!! tip "Edit metadata.yaml, not README.md"
+    The README is always regenerated. Add descriptions, licenses, and attribution to `metadata.yaml`.
+
+## Step 7: Configure Remote
+
+Create a `.env` file with your remote storage:
+
+```bash
+cat > .env << 'EOF'
+PORTOLAN_REMOTE=s3://your-bucket/belgium-buildings/
+PORTOLAN_PROFILE=your-aws-profile
+EOF
+```
+
+## Step 8: Push to Cloud
+
+Push the catalog:
+
+```bash
+portolan push
+```
+
+Portolan uploads:
+
+- STAC catalog and collection JSON
+- GeoParquet data files
+- PMTiles, styles, and thumbnails
+- READMEs
+
+## Verify Publication
+
+Your data is now available at the S3 URL. The PMTiles can be loaded directly in web mapping libraries:
+
+```javascript
+import maplibregl from "maplibre-gl";
+import { Protocol } from "pmtiles";
+
+const protocol = new Protocol();
+maplibregl.addProtocol("pmtiles", protocol.tile);
+
+const map = new maplibregl.Map({
+  container: "map",
+  style: "https://your-bucket.s3.amazonaws.com/belgium-buildings/.../style.json",
+});
+```
+
+## Summary
+
+| Step | Command | Purpose |
+|------|---------|---------|
+| 1 | `extract wfs` | Pull data from WFS service |
+| 2 | `list`, `info` | Explore catalog contents |
+| 3 | `add --pmtiles` | Generate vector tiles + style + thumbnail |
+| 4 | `scan` | Extract metadata |
+| 5 | `check --fix` | Validate and auto-fix |
+| 6 | `readme --recursive` | Generate documentation |
+| 7 | `.env` config | Configure remote storage |
+| 8 | `push` | Publish to cloud |
+
+## Agent Usage
+
+For AI agents working with Portolan, use `--json` for machine-parseable output:
+
+```bash
+portolan quickstart  # Dense agent reference
+portolan list --json
+portolan check --fix --json
+```
+
+See `portolan quickstart` for the complete agent reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Tutorials:
+    - End-to-End: tutorials/end-to-end.md
   - Guides:
     - Version Management: guides/version-management.md
     - AI Skills: guides/skills.md
@@ -83,6 +85,7 @@ nav:
     - Extracting from WFS: guides/extract-wfs.md
     - Metadata Defaults: guides/metadata-defaults.md
     - Nested Catalogs: guides/nested-catalogs.md
+    - Partitioning: guides/partitioning.md
   - Reference:
     - CLI: reference/cli.md
     - Configuration: reference/configuration.md

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -7656,3 +7656,52 @@ def skills_show_cmd(ctx: click.Context, name: str, json_output: bool) -> None:
     else:
         # Print raw content for AI agents to ingest
         click.echo(content)
+
+
+@cli.command()
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def quickstart(ctx: click.Context, json_output: bool) -> None:
+    """Print agent quickstart instructions.
+
+    Dense, actionable reference for AI coding agents (kata-style).
+    Includes STAC terminology, example session, and command patterns.
+
+    \b
+    Examples:
+        portolan quickstart
+        portolan quickstart --json
+    """
+    from portolan_cli.quickstart_content import QUICKSTART
+
+    use_json = should_output_json(ctx, json_output)
+
+    if use_json:
+        envelope = success_envelope("quickstart", {"content": QUICKSTART})
+        output_json_envelope(envelope)
+    else:
+        click.echo(QUICKSTART)
+
+
+@cli.command("agent-instructions")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def agent_instructions(ctx: click.Context, json_output: bool) -> None:
+    """Alias for quickstart command.
+
+    Print agent quickstart instructions for AI coding agents.
+
+    \b
+    Examples:
+        portolan agent-instructions
+        portolan agent-instructions --json
+    """
+    from portolan_cli.quickstart_content import QUICKSTART
+
+    use_json = should_output_json(ctx, json_output)
+
+    if use_json:
+        envelope = success_envelope("agent-instructions", {"content": QUICKSTART})
+        output_json_envelope(envelope)
+    else:
+        click.echo(QUICKSTART)

--- a/portolan_cli/quickstart_content.py
+++ b/portolan_cli/quickstart_content.py
@@ -1,0 +1,137 @@
+"""Agent quickstart content for Portolan CLI.
+
+This module contains the kata-style instructions for AI coding agents.
+The content is designed to be dense, actionable, and parseable.
+
+Reference: https://github.com/wesm/kata
+"""
+
+QUICKSTART = """# Portolan Agent Quickstart
+
+Dense reference for AI coding agents. Also available via CLI:
+
+    portolan quickstart
+    portolan agent-instructions   # alias
+
+## Session Setup
+
+- Run from catalog root, or pass --catalog-root <path>
+- Use --format=json (global) or --json (per-command) for machine parsing
+- Set PORTOLAN_REMOTE and PORTOLAN_PROFILE in .env for push/pull
+
+## Per-Task Guidelines
+
+- Never add files without initializing first (portolan init)
+- Use --pmtiles with add to generate vector tiles, styles, and thumbnails
+- Scan extracts metadata; check validates STAC structure
+- Use --fix to auto-remediate, --dry-run to preview
+- Prefer --auto for non-interactive workflows
+
+## STAC Terminology
+
+| Term | Meaning |
+|------|---------|
+| Catalog | Root container (catalog.json) |
+| Collection | Group of related items |
+| Item | Single spatiotemporal entity |
+| Asset | Actual data file |
+
+Do NOT use "dataset" — use STAC terms.
+
+## Full Workflow Example
+
+```bash
+# 1. Extract from WFS (or start with local GeoParquet)
+portolan extract wfs "https://example.com/wfs" output_dir \\
+  --layers "layer_name" --auto --json
+
+# 2. Initialize catalog (if not using extract)
+portolan init --auto --json
+
+# 3. Add files with PMTiles generation (creates tiles + style + thumbnail)
+portolan add data/*.parquet --pmtiles --json
+
+# 4. Scan for metadata extraction
+portolan scan --json
+
+# 5. Validate and auto-fix issues
+portolan check --fix --json
+
+# 6. Generate documentation
+portolan readme --recursive --json
+
+# 7. Configure remote
+echo "PORTOLAN_REMOTE=s3://bucket/path/" >> .env
+echo "PORTOLAN_PROFILE=aws-profile-name" >> .env
+
+# 8. Push to cloud storage
+portolan push --json
+```
+
+## Key Commands
+
+| Command | Purpose |
+|---------|---------|
+| init | Create catalog in current directory |
+| add | Track files (--pmtiles generates vector tiles + style + thumbnail) |
+| scan | Extract metadata from assets |
+| check | Validate STAC structure (--fix auto-remediates) |
+| push | Upload to remote storage |
+| pull | Download from remote storage |
+| list | Show catalog contents |
+| status | Show sync status |
+| info | Show detailed item/collection info |
+| readme | Generate README.md (--recursive for all collections) |
+| extract wfs | Pull data from WFS service |
+| partition | Split large GeoParquet (>2GB) into Hive-partitioned structure |
+
+## PMTiles Generation
+
+Use `--pmtiles` with `add` for vector data:
+
+```bash
+portolan add buildings.parquet --pmtiles --json
+```
+
+This generates:
+- PMTiles vector tiles (web-optimized)
+- Mapbox GL style.json (auto-generated color scheme)
+- PNG thumbnail (preview image)
+
+All three are registered as STAC assets automatically.
+
+## JSON Output
+
+Both forms work:
+```bash
+portolan --format=json list      # Global flag
+portolan list --json             # Per-command flag
+```
+
+Envelope structure:
+```json
+{
+  "success": true,
+  "command": "list",
+  "data": { ... },
+  "errors": []
+}
+```
+
+On failure, check `errors` array:
+```json
+{
+  "success": false,
+  "errors": [{"type": "ErrorType", "message": "description"}]
+}
+```
+
+## Partitioning
+
+Large vector files (>2GB) trigger partitioning prompts during add/scan.
+Use `--auto` to accept defaults, or pre-partition:
+
+```bash
+portolan partition large_file.parquet --column region --json
+```
+"""

--- a/portolan_cli/quickstart_content.py
+++ b/portolan_cli/quickstart_content.py
@@ -94,11 +94,11 @@ portolan add buildings.parquet --pmtiles --json
 ```
 
 This generates:
-- PMTiles vector tiles (web-optimized)
-- Mapbox GL style.json (auto-generated color scheme)
-- PNG thumbnail (preview image)
+- PMTiles vector tiles (.pmtiles)
+- Mapbox GL style (inline in STAC as `pmtiles:style`)
+- Thumbnail (.thumb.jpg)
 
-All three are registered as STAC assets automatically.
+PMTiles and thumbnail are registered as STAC assets.
 
 ## JSON Output
 

--- a/prek.toml
+++ b/prek.toml
@@ -151,6 +151,14 @@ hooks = [
     pass_filenames = false,
   },
   {
+    id = "validate-quickstart",
+    name = "validate quickstart content",
+    entry = "uv run python scripts/validate_quickstart.py",
+    language = "system",
+    files = { glob = ["portolan_cli/quickstart_content.py"] },
+    pass_filenames = false,
+  },
+  {
     id = "mypy",
     name = "mypy",
     entry = "uv run mypy",

--- a/scripts/validate_quickstart.py
+++ b/scripts/validate_quickstart.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Validate quickstart content for required sections and syntax.
+
+This script ensures the agent quickstart content includes all required
+sections and has valid markdown structure.
+
+Usage:
+    python scripts/validate_quickstart.py           # Validate (exit 1 if invalid)
+    python scripts/validate_quickstart.py --check   # Same as above (for prek hook)
+
+Exit codes:
+    0: Valid
+    1: Invalid or missing required content
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Required sections that must be present in quickstart content
+REQUIRED_SECTIONS = [
+    "# Portolan Agent Quickstart",
+    "## Session Setup",
+    "## STAC Terminology",
+    "## Full Workflow Example",
+    "## Key Commands",
+    "## JSON Output",
+]
+
+# Required terminology (STAC terms must be documented)
+REQUIRED_TERMS = ["Catalog", "Collection", "Item", "Asset"]
+
+# Required commands in example session
+REQUIRED_COMMANDS = [
+    "portolan init",
+    "portolan add",
+    "portolan scan",
+    "portolan check",
+]
+
+
+def get_project_root() -> Path:
+    """Find project root by looking for pyproject.toml."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "pyproject.toml").exists():
+            return current
+        current = current.parent
+    return Path.cwd()
+
+
+def validate_quickstart() -> list[str]:
+    """Validate quickstart content and return list of errors."""
+    errors: list[str] = []
+
+    # Import the quickstart content
+    root = get_project_root()
+    sys.path.insert(0, str(root))
+
+    try:
+        from portolan_cli.quickstart_content import QUICKSTART
+    except ImportError as e:
+        return [f"Could not import quickstart content: {e}"]
+
+    # Check required sections
+    for section in REQUIRED_SECTIONS:
+        if section not in QUICKSTART:
+            errors.append(f"Missing required section: {section}")
+
+    # Check STAC terminology
+    for term in REQUIRED_TERMS:
+        if term not in QUICKSTART:
+            errors.append(f"Missing STAC term: {term}")
+
+    # Check example commands
+    for cmd in REQUIRED_COMMANDS:
+        if cmd not in QUICKSTART:
+            errors.append(f"Missing example command: {cmd}")
+
+    # Check for JSON format mention (agent parsing)
+    if "--format=json" not in QUICKSTART and "--json" not in QUICKSTART:
+        errors.append("Missing JSON format documentation for agent parsing")
+
+    # Check markdown code blocks are balanced
+    code_block_count = QUICKSTART.count("```")
+    if code_block_count % 2 != 0:
+        errors.append(f"Unbalanced code blocks: {code_block_count} backtick sequences")
+
+    return errors
+
+
+def main() -> int:
+    """Run validation and print results."""
+    errors = validate_quickstart()
+
+    if errors:
+        print("Quickstart validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("Quickstart content valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_cli_quickstart.py
+++ b/tests/unit/test_cli_quickstart.py
@@ -1,0 +1,102 @@
+"""Tests for `portolan quickstart` and `portolan agent-instructions` CLI commands.
+
+These commands print agent-friendly instructions for AI coding tools (kata-style).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+class TestQuickstartCommand:
+    """Tests for the `portolan quickstart` command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.unit
+    def test_quickstart_prints_content(self, runner: CliRunner) -> None:
+        """portolan quickstart should print agent instructions."""
+        result = runner.invoke(cli, ["quickstart"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert "Portolan Agent Quickstart" in result.output
+
+    @pytest.mark.unit
+    def test_quickstart_contains_stac_terminology(self, runner: CliRunner) -> None:
+        """Quickstart should include STAC terminology table."""
+        result = runner.invoke(cli, ["quickstart"])
+
+        assert result.exit_code == 0
+        assert "Catalog" in result.output
+        assert "Collection" in result.output
+        assert "Item" in result.output
+        assert "Asset" in result.output
+
+    @pytest.mark.unit
+    def test_quickstart_contains_example_session(self, runner: CliRunner) -> None:
+        """Quickstart should include example commands."""
+        result = runner.invoke(cli, ["quickstart"])
+
+        assert result.exit_code == 0
+        assert "portolan init" in result.output
+        assert "portolan add" in result.output
+        assert "portolan scan" in result.output
+        assert "portolan check" in result.output
+
+    @pytest.mark.unit
+    def test_quickstart_mentions_json_format(self, runner: CliRunner) -> None:
+        """Quickstart should mention --format=json for agent parsing."""
+        result = runner.invoke(cli, ["quickstart"])
+
+        assert result.exit_code == 0
+        assert "--format=json" in result.output or "--json" in result.output
+
+    @pytest.mark.unit
+    def test_quickstart_json_output(self, runner: CliRunner) -> None:
+        """portolan quickstart --json should return structured JSON."""
+        result = runner.invoke(cli, ["quickstart", "--json"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        data = json.loads(result.output)
+        assert data["success"] is True
+        assert data["command"] == "quickstart"
+        assert "content" in data["data"]
+        assert "Portolan Agent Quickstart" in data["data"]["content"]
+
+
+class TestAgentInstructionsCommand:
+    """Tests for the `portolan agent-instructions` alias command."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.unit
+    def test_agent_instructions_is_alias_for_quickstart(self, runner: CliRunner) -> None:
+        """portolan agent-instructions should produce same output as quickstart."""
+        quickstart_result = runner.invoke(cli, ["quickstart"])
+        alias_result = runner.invoke(cli, ["agent-instructions"])
+
+        assert quickstart_result.exit_code == 0
+        assert alias_result.exit_code == 0
+        assert quickstart_result.output == alias_result.output
+
+    @pytest.mark.unit
+    def test_agent_instructions_json_output(self, runner: CliRunner) -> None:
+        """portolan agent-instructions --json should work like quickstart --json."""
+        result = runner.invoke(cli, ["agent-instructions", "--json"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        data = json.loads(result.output)
+        assert data["success"] is True
+        # Command name reflects the alias used
+        assert data["command"] == "agent-instructions"


### PR DESCRIPTION
## Summary

- Adds plan for end-to-end tutorial using Belgium buildings WFS
- Defines `portolan quickstart` command (kata-style agent instructions)
- Documents DRY patterns for single-source-of-truth content generation

## Deliverables (for implementer)

| Output | Location |
|--------|----------|
| Human tutorial | `docs/tutorials/end-to-end.md` |
| Agent quickstart | `portolan quickstart` CLI command |
| Quickstart content | `portolan_cli/quickstart_content.py` |
| Validation script | `scripts/generate_quickstart.py` |

## Workflow Scope

Full MVP demonstration:
- Extract Belgium buildings (no limit, measure size)
- Init → Add → Scan → Check → Partitioning → Style → Thumbnail → Push
- Clear existing bucket, push to Source Cooperative

## Replaces

- #380 (too WFS-focused)
- #367 (too WFS-focused)

## Test plan

- [ ] Run showboat workflow end-to-end
- [ ] Verify `portolan quickstart` prints cleanly
- [ ] mkdocs builds with new tutorial
- [ ] Pre-commit hooks validate content freshness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive End-to-End Tutorial and Quickstart Command Plan documentation with step-by-step implementation guidance covering workspace setup, data extraction, full workflow, verification, and CI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->