### PR TITLE
feat(style): replace inline pmtiles:style with standalone style assets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0041](context/shared/adr/0041-stac-manifest-as-canonical-scan-source.md) | STAC manifest as canonical scan source for metadata_fresh; unifies check/--fix; adds ORPHANED status |
 | [0042](context/shared/adr/0042-partition-stac-extension.md) | Standalone `partition:` STAC extension for Hive-style partitioned datasets |
 | [0043](context/shared/adr/0043-style-and-thumbnail-architecture.md) | Style/thumbnail: inline in STAC, Mapbox GL spec, basemaps for vectors only |
+| [0044](context/shared/adr/0044-styles-as-stac-assets.md) | Styles as standalone STAC assets (supersedes ADR-0043 style storage) |
 
 ## Common Commands
 

--- a/context/shared/adr/0043-style-and-thumbnail-architecture.md
+++ b/context/shared/adr/0043-style-and-thumbnail-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0043: Style and Thumbnail Architecture
 
 ## Status
-Accepted
+Accepted (style storage section superseded by ADR-0044; thumbnail and basemap decisions remain active)
 
 ## Context
 

--- a/context/shared/adr/0044-styles-as-stac-assets.md
+++ b/context/shared/adr/0044-styles-as-stac-assets.md
@@ -87,7 +87,7 @@ During scan, `styles/*.json` files are discovered and registered as STAC assets.
 **Easier:**
 - Multiple styles per collection (data-driven, thematic, labeled)
 - Styles are independently addressable by URL — no STAC parsing needed
-- Complete Mapbox GL specs work directly with MapLibre/Mapbox GL
+- Complete Mapbox GL specs work directly with Mapbox GL JS; MapLibre GL requires registering a `pmtiles://` protocol handler (see [protomaps docs](https://docs.protomaps.com/pmtiles/maplibre))
 - Browser-based style picker reads `portolan:styles` for discovery
 
 **Harder:**

--- a/context/shared/adr/0044-styles-as-stac-assets.md
+++ b/context/shared/adr/0044-styles-as-stac-assets.md
@@ -1,0 +1,103 @@
+# ADR-0044: Styles as STAC Assets
+
+## Status
+Accepted (supersedes ADR-0043 style storage section)
+
+## Context
+
+ADR-0043 stored styles inline on PMTiles assets as `pmtiles:style` — a single Mapbox GL style snippet embedded in the STAC asset's extra fields. This approach:
+
+1. Only supports a single style per asset (no "buildings by age" vs "by use" alternatives)
+2. Requires parsing STAC to extract the style — it's not independently addressable
+3. Uses a partial Mapbox GL spec (layers only, no sources) requiring consumers to assemble the full style
+
+We want to support multiple named styles per collection, each independently loadable as a URL, with human-readable titles and descriptions for style picker UIs.
+
+## Decision
+
+### Style files as standalone assets
+
+Each style is a complete Mapbox GL v8 JSON file stored in `{collection}/styles/`:
+
+```
+collection/
+├── collection.json
+├── data.pmtiles
+└── styles/
+    ├── default.json
+    ├── by-age.json
+    └── by-use.json
+```
+
+Each style file is self-contained with a relative source path to the PMTiles:
+
+```json
+{
+  "version": 8,
+  "name": "Buildings by Construction Year",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../data.pmtiles"
+    }
+  },
+  "layers": [...]
+}
+```
+
+### STAC registration
+
+Style files are registered as collection-level assets with:
+- Key: `styles/{name}` (e.g., `styles/default`, `styles/by-age`)
+- Type: `application/json`
+- Roles: `["style"]`
+- Title: Short label for picker UIs
+- Description: What the style shows (colors, data mapping)
+
+### Collection manifest
+
+A `portolan:styles` array on the collection lists asset keys in display order. First entry is the default style.
+
+```json
+{
+  "portolan:styles": ["styles/default", "styles/by-age"],
+  "assets": {
+    "styles/default": {
+      "href": "./styles/default.json",
+      "type": "application/json",
+      "title": "Default",
+      "roles": ["style"]
+    }
+  }
+}
+```
+
+This starts as a Portolan convention (`portolan:` prefix) that may evolve into a standalone STAC extension.
+
+### Default style generation
+
+`portolan` auto-generates `styles/default.json` during PMTiles generation (not during scan — per ADR-0016). User-created style files are never overwritten.
+
+### Style discovery
+
+During scan, `styles/*.json` files are discovered and registered as STAC assets. `styles/default` sorts first; remaining styles are alphabetical.
+
+## Consequences
+
+**Easier:**
+- Multiple styles per collection (data-driven, thematic, labeled)
+- Styles are independently addressable by URL — no STAC parsing needed
+- Complete Mapbox GL specs work directly with MapLibre/Mapbox GL
+- Browser-based style picker reads `portolan:styles` for discovery
+
+**Harder:**
+- Style files must be kept in sync with PMTiles source paths (mitigated by relative paths)
+- Slightly more files on disk per collection
+
+## Alternatives Considered
+
+### Keep inline pmtiles:style with multiple styles
+Rejected: Would require a non-standard array-of-styles property, still not independently addressable, and bloats STAC JSON for multi-style collections.
+
+### Separate style.json without STAC registration
+Rejected: No discoverability — consumers wouldn't know styles exist without convention-based scanning.

--- a/context/shared/plans/2026-05-07-styles-as-stac-assets-plan.md
+++ b/context/shared/plans/2026-05-07-styles-as-stac-assets-plan.md
@@ -1,0 +1,1712 @@
+# Styles as STAC Assets — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace inline `pmtiles:style` with standalone Mapbox GL v8 style files stored as STAC assets, with a `portolan:styles` manifest on collections.
+
+**Architecture:** Style files live in `{collection}/styles/*.json` as complete Mapbox GL v8 specs with relative PMTiles source paths. During PMTiles generation, a default style file is auto-created. During scan, all style files are discovered and registered as STAC assets with a `portolan:styles` array on the collection (first = default). The existing `VectorStyleConfig` dataclass and config loading are preserved — only the output format changes.
+
+**Tech Stack:** Python 3.10+, Click CLI, pystac, JSON
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `portolan_cli/style.py` | Modify | Remove `build_pmtiles_style`, add `build_full_style`, `write_style_file`, `write_default_style`, `discover_styles`, `build_styles_manifest` |
+| `portolan_cli/pmtiles.py` | Modify | Remove `pmtiles:style` from `add_pmtiles_asset_to_collection` and `_build_style_for_geoparquet`; call `write_default_style` instead |
+| `portolan_cli/metadata/pmtiles.py` | Modify | Remove `style` field from `PMTilesMetadata` and `pmtiles:style` from `to_stac_properties` |
+| `portolan_cli/scan_classify.py` | Modify | Update `STYLE_FILENAMES` to recognize files inside `styles/` directories |
+| `portolan_cli/dataset.py` | Modify | Call style discovery + registration during collection building |
+| `tests/unit/test_style.py` | Modify | Replace `build_pmtiles_style` tests with `build_full_style`/`write_style_file`/`discover_styles` tests |
+| `tests/fixtures/metadata/style/valid/` | Modify | Update fixtures to full Mapbox GL style format (with `sources`) |
+| `context/shared/adr/0044-styles-as-stac-assets.md` | Create | New ADR superseding 0043's style storage decision |
+| `context/shared/adr/0043-style-and-thumbnail-architecture.md` | Modify | Add "Superseded by ADR-0044" note to style storage section |
+| `portolan_cli/skills/sourcecoop.md` | Modify | Add styles section (canonical skill location in this repo) |
+| `CLAUDE.md` | Modify | Add ADR-0044 to the ADR index |
+
+---
+
+### Task 1: Write ADR-0044
+
+**Files:**
+- Create: `context/shared/adr/0044-styles-as-stac-assets.md`
+- Modify: `context/shared/adr/0043-style-and-thumbnail-architecture.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Create ADR-0044**
+
+```markdown
+# ADR-0044: Styles as STAC Assets
+
+## Status
+Accepted (supersedes ADR-0043 style storage section)
+
+## Context
+
+ADR-0043 stored styles inline on PMTiles assets as `pmtiles:style` — a single Mapbox GL style snippet embedded in the STAC asset's extra fields. This approach:
+
+1. Only supports a single style per asset (no "buildings by age" vs "by use" alternatives)
+2. Requires parsing STAC to extract the style — it's not independently addressable
+3. Uses a partial Mapbox GL spec (layers only, no sources) requiring consumers to assemble the full style
+
+We want to support multiple named styles per collection, each independently loadable as a URL, with human-readable titles and descriptions for style picker UIs.
+
+## Decision
+
+### Style files as standalone assets
+
+Each style is a complete Mapbox GL v8 JSON file stored in `{collection}/styles/`:
+
+```
+collection/
+├── collection.json
+├── data.pmtiles
+└── styles/
+    ├── default.json
+    ├── by-age.json
+    └── by-use.json
+```
+
+Each style file is self-contained with a relative source path to the PMTiles:
+
+```json
+{
+  "version": 8,
+  "name": "Buildings by Construction Year",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../data.pmtiles"
+    }
+  },
+  "layers": [...]
+}
+```
+
+### STAC registration
+
+Style files are registered as collection-level assets with:
+- Key: `styles/{name}` (e.g., `styles/default`, `styles/by-age`)
+- Type: `application/json`
+- Roles: `["style"]`
+- Title: Short label for picker UIs
+- Description: What the style shows (colors, data mapping)
+
+### Collection manifest
+
+A `portolan:styles` array on the collection lists asset keys in display order. First entry is the default style.
+
+```json
+{
+  "portolan:styles": ["styles/default", "styles/by-age"],
+  "assets": {
+    "styles/default": {
+      "href": "./styles/default.json",
+      "type": "application/json",
+      "title": "Default",
+      "roles": ["style"]
+    }
+  }
+}
+```
+
+This starts as a Portolan convention (`portolan:` prefix) that may evolve into a standalone STAC extension.
+
+### Default style generation
+
+`portolan` auto-generates `styles/default.json` during PMTiles generation (not during scan — per ADR-0016). User-created style files are never overwritten.
+
+### Style discovery
+
+During scan, `styles/*.json` files are discovered and registered as STAC assets. `styles/default` sorts first; remaining styles are alphabetical.
+
+## Consequences
+
+**Easier:**
+- Multiple styles per collection (data-driven, thematic, labeled)
+- Styles are independently addressable by URL — no STAC parsing needed
+- Complete Mapbox GL specs work directly with MapLibre/Mapbox GL
+- Browser-based style picker reads `portolan:styles` for discovery
+
+**Harder:**
+- Style files must be kept in sync with PMTiles source paths (mitigated by relative paths)
+- Slightly more files on disk per collection
+
+## Alternatives Considered
+
+### Keep inline pmtiles:style with multiple styles
+Rejected: Would require a non-standard array-of-styles property, still not independently addressable, and bloats STAC JSON for multi-style collections.
+
+### Separate style.json without STAC registration
+Rejected: No discoverability — consumers wouldn't know styles exist without convention-based scanning.
+```
+
+- [ ] **Step 2: Update ADR-0043 status**
+
+In `context/shared/adr/0043-style-and-thumbnail-architecture.md`, change the Status section:
+
+```markdown
+## Status
+Accepted (style storage section superseded by ADR-0044; thumbnail and basemap decisions remain active)
+```
+
+- [ ] **Step 3: Add ADR-0044 to CLAUDE.md index**
+
+Add this row to the ADR index table in `CLAUDE.md`, after ADR-0043:
+
+```markdown
+| [0044](context/shared/adr/0044-styles-as-stac-assets.md) | Styles as standalone STAC assets (supersedes ADR-0043 style storage) |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add context/shared/adr/0044-styles-as-stac-assets.md context/shared/adr/0043-style-and-thumbnail-architecture.md CLAUDE.md
+git commit -m "docs(adr): add ADR-0044 styles as STAC assets
+
+Supersedes ADR-0043's inline pmtiles:style approach with standalone
+Mapbox GL v8 style files registered as STAC assets."
+```
+
+---
+
+### Task 2: Update style fixtures to full Mapbox GL format
+
+**Files:**
+- Modify: `tests/fixtures/metadata/style/valid/style_polygon.json`
+- Modify: `tests/fixtures/metadata/style/valid/style_line.json`
+- Modify: `tests/fixtures/metadata/style/valid/style_point.json`
+- Modify: `tests/fixtures/metadata/style/valid/style_categorical.json`
+- Modify: `tests/fixtures/metadata/style/valid/style_graduated.json`
+
+- [ ] **Step 1: Update polygon style fixture**
+
+Replace `tests/fixtures/metadata/style/valid/style_polygon.json` with a complete Mapbox GL style:
+
+```json
+{
+  "version": 8,
+  "name": "Default",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../parcels.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "parcels-fill",
+      "type": "fill",
+      "source": "data",
+      "source-layer": "parcels",
+      "paint": {
+        "fill-color": "#3388ff",
+        "fill-opacity": 0.6,
+        "fill-outline-color": "#2266cc"
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Update line style fixture**
+
+Replace `tests/fixtures/metadata/style/valid/style_line.json`:
+
+```json
+{
+  "version": 8,
+  "name": "Default",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../roads.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "roads-line",
+      "type": "line",
+      "source": "data",
+      "source-layer": "roads",
+      "paint": {
+        "line-color": "#3388ff",
+        "line-width": 2,
+        "line-opacity": 0.8
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Update point style fixture**
+
+Replace `tests/fixtures/metadata/style/valid/style_point.json`:
+
+```json
+{
+  "version": 8,
+  "name": "Default",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../cities.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "cities-circle",
+      "type": "circle",
+      "source": "data",
+      "source-layer": "cities",
+      "paint": {
+        "circle-color": "#3388ff",
+        "circle-radius": 4,
+        "circle-opacity": 0.8
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 4: Update categorical style fixture**
+
+Replace `tests/fixtures/metadata/style/valid/style_categorical.json`:
+
+```json
+{
+  "version": 8,
+  "name": "Land Use Categories",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../parcels.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "parcels-categorical",
+      "type": "fill",
+      "source": "data",
+      "source-layer": "parcels",
+      "paint": {
+        "fill-color": [
+          "match", ["get", "land_use"],
+          "residential", "#ff6b6b",
+          "commercial", "#4ecdc4",
+          "industrial", "#45b7d1",
+          "#95afc0"
+        ],
+        "fill-opacity": 0.7
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 5: Update graduated style fixture**
+
+Replace `tests/fixtures/metadata/style/valid/style_graduated.json`:
+
+```json
+{
+  "version": 8,
+  "name": "Population Density",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../parcels.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "parcels-graduated",
+      "type": "fill",
+      "source": "data",
+      "source-layer": "parcels",
+      "paint": {
+        "fill-color": [
+          "interpolate", ["linear"], ["get", "population"],
+          0, "#f7fbff",
+          100, "#6baed6",
+          1000, "#08306b"
+        ],
+        "fill-opacity": 0.7
+      }
+    }
+  ]
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/fixtures/metadata/style/valid/
+git commit -m "test(fixtures): update style fixtures to full Mapbox GL format
+
+Add sources block and name field to match the new standalone style
+file format from ADR-0044."
+```
+
+---
+
+### Task 3: Replace `build_pmtiles_style` with `build_full_style` and `write_style_file`
+
+**Files:**
+- Modify: `portolan_cli/style.py`
+- Test: `tests/unit/test_style.py`
+
+- [ ] **Step 1: Write failing tests for `build_full_style`**
+
+Replace the `TestBuildPmtilesStyle` class in `tests/unit/test_style.py` with:
+
+```python
+class TestBuildFullStyle:
+    """Tests for build_full_style function."""
+
+    @pytest.mark.unit
+    def test_polygon_full_style(self) -> None:
+        """Builds complete Mapbox GL style for polygon geometry."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Default",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        assert style["version"] == 8
+        assert style["name"] == "Default"
+        assert style["sources"]["data"]["type"] == "vector"
+        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert len(style["layers"]) == 1
+
+        layer = style["layers"][0]
+        assert layer["type"] == "fill"
+        assert layer["source"] == "data"
+        assert layer["source-layer"] == "parcels"
+        assert layer["paint"]["fill-color"] == "#3388ff"
+        assert layer["paint"]["fill-opacity"] == 0.6
+        assert layer["paint"]["fill-outline-color"] == "#2266cc"
+
+    @pytest.mark.unit
+    def test_linestring_full_style(self) -> None:
+        """Builds complete Mapbox GL style for line geometry."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Roads",
+            geometry_type="LineString",
+            source_layer="roads",
+            pmtiles_relative_path="../roads.pmtiles",
+            config=config,
+        )
+
+        assert style["name"] == "Roads"
+        assert style["sources"]["data"]["url"] == "../roads.pmtiles"
+        layer = style["layers"][0]
+        assert layer["type"] == "line"
+        assert layer["paint"]["line-color"] == "#3388ff"
+
+    @pytest.mark.unit
+    def test_point_full_style(self) -> None:
+        """Builds complete Mapbox GL style for point geometry."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Cities",
+            geometry_type="Point",
+            source_layer="cities",
+            pmtiles_relative_path="../cities.pmtiles",
+            config=config,
+        )
+
+        layer = style["layers"][0]
+        assert layer["type"] == "circle"
+        assert layer["paint"]["circle-radius"] == 4
+
+    @pytest.mark.unit
+    def test_custom_config_applied(self) -> None:
+        """Custom VectorStyleConfig values are applied to full style."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig(
+            polygon_fill_color="#ff0000",
+            polygon_fill_opacity=0.9,
+            polygon_outline_color="#000000",
+        )
+        style = build_full_style(
+            name="Custom",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        layer = style["layers"][0]
+        assert layer["paint"]["fill-color"] == "#ff0000"
+        assert layer["paint"]["fill-opacity"] == 0.9
+        assert layer["paint"]["fill-outline-color"] == "#000000"
+
+    @pytest.mark.unit
+    def test_full_style_is_json_serializable(self) -> None:
+        """Full style dict round-trips through JSON."""
+        import json
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Test",
+            geometry_type="Polygon",
+            source_layer="layer",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        serialized = json.dumps(style)
+        deserialized = json.loads(serialized)
+        assert deserialized == style
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_style.py::TestBuildFullStyle -v`
+Expected: FAIL — `build_full_style` does not exist yet.
+
+- [ ] **Step 3: Implement `build_full_style` in `style.py`**
+
+Replace the `build_pmtiles_style` function in `portolan_cli/style.py` with:
+
+```python
+def build_full_style(
+    name: str,
+    geometry_type: str,
+    source_layer: str,
+    pmtiles_relative_path: str,
+    config: VectorStyleConfig,
+) -> dict[str, Any]:
+    """Build a complete Mapbox GL v8 style spec for a PMTiles source.
+
+    Generates a self-contained style with sources, layers, and metadata.
+    The style can be loaded directly by MapLibre GL without assembly.
+
+    Args:
+        name: Human-readable style name (used in pickers).
+        geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
+        source_layer: Name of the source layer in PMTiles.
+        pmtiles_relative_path: Relative path from styles/ dir to the PMTiles file.
+        config: Style configuration for colors/sizes/opacities.
+
+    Returns:
+        Complete Mapbox GL v8 style dict.
+    """
+    geom_lower = geometry_type.lower()
+
+    if "point" in geom_lower:
+        layer_type = "circle"
+        paint: dict[str, Any] = {
+            "circle-color": config.point_color,
+            "circle-radius": config.point_radius,
+            "circle-opacity": config.point_opacity,
+        }
+        suffix = "circle"
+    elif "line" in geom_lower:
+        layer_type = "line"
+        paint = {
+            "line-color": config.line_color,
+            "line-width": config.line_width,
+            "line-opacity": config.line_opacity,
+        }
+        suffix = "line"
+    else:
+        layer_type = "fill"
+        paint = {
+            "fill-color": config.polygon_fill_color,
+            "fill-opacity": config.polygon_fill_opacity,
+            "fill-outline-color": config.polygon_outline_color,
+        }
+        suffix = "fill"
+
+    return {
+        "version": 8,
+        "name": name,
+        "sources": {
+            "data": {
+                "type": "vector",
+                "url": pmtiles_relative_path,
+            }
+        },
+        "layers": [
+            {
+                "id": f"{source_layer}-{suffix}",
+                "type": layer_type,
+                "source": "data",
+                "source-layer": source_layer,
+                "paint": paint,
+            }
+        ],
+    }
+```
+
+Also update the module docstring at the top of `style.py` to replace `build_pmtiles_style` with `build_full_style` in the public API list, and add `write_style_file`, `write_default_style`, `discover_styles`, `build_styles_manifest`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_style.py::TestBuildFullStyle -v`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 5: Write failing tests for `write_style_file`**
+
+Add to `tests/unit/test_style.py`:
+
+```python
+class TestWriteStyleFile:
+    """Tests for write_style_file function."""
+
+    @pytest.mark.unit
+    def test_writes_style_to_disk(self, tmp_path: Path) -> None:
+        """Writes style JSON to the specified directory."""
+        import json
+        from portolan_cli.style import write_style_file
+
+        style_dict = {"version": 8, "name": "Test", "sources": {}, "layers": []}
+        style_dir = tmp_path / "styles"
+
+        write_style_file(style_dir, "default", style_dict)
+
+        output = style_dir / "default.json"
+        assert output.exists()
+        loaded = json.loads(output.read_text())
+        assert loaded == style_dict
+
+    @pytest.mark.unit
+    def test_creates_styles_directory(self, tmp_path: Path) -> None:
+        """Creates the styles/ directory if it doesn't exist."""
+        from portolan_cli.style import write_style_file
+
+        style_dir = tmp_path / "styles"
+        assert not style_dir.exists()
+
+        write_style_file(style_dir, "default", {"version": 8, "name": "T", "sources": {}, "layers": []})
+
+        assert style_dir.exists()
+        assert (style_dir / "default.json").exists()
+
+    @pytest.mark.unit
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """Overwrites an existing style file."""
+        import json
+        from portolan_cli.style import write_style_file
+
+        style_dir = tmp_path / "styles"
+        style_dir.mkdir()
+        (style_dir / "default.json").write_text('{"old": true}')
+
+        new_style = {"version": 8, "name": "New", "sources": {}, "layers": []}
+        write_style_file(style_dir, "default", new_style)
+
+        loaded = json.loads((style_dir / "default.json").read_text())
+        assert loaded == new_style
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_style.py::TestWriteStyleFile -v`
+Expected: FAIL — `write_style_file` does not exist yet.
+
+- [ ] **Step 7: Implement `write_style_file`**
+
+Add to `portolan_cli/style.py`:
+
+```python
+def write_style_file(
+    style_dir: Path,
+    name: str,
+    style_dict: dict[str, Any],
+) -> Path:
+    """Write a style dict to a JSON file.
+
+    Args:
+        style_dir: Directory to write to (created if needed).
+        name: Filename stem (e.g., "default" -> "default.json").
+        style_dict: Complete Mapbox GL style dict.
+
+    Returns:
+        Path to the written file.
+    """
+    style_dir.mkdir(parents=True, exist_ok=True)
+    path = style_dir / f"{name}.json"
+    path.write_text(json.dumps(style_dict, indent=2))
+    return path
+```
+
+Add `import json` to the imports at the top of `style.py` (it's not there yet).
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_style.py::TestWriteStyleFile -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 9: Write failing tests for `write_default_style`**
+
+Add to `tests/unit/test_style.py`:
+
+```python
+class TestWriteDefaultStyle:
+    """Tests for write_default_style convenience function."""
+
+    @pytest.mark.unit
+    def test_writes_default_style_file(self, tmp_path: Path) -> None:
+        """Creates styles/default.json with correct content."""
+        import json
+        from portolan_cli.style import write_default_style
+
+        path = write_default_style(
+            collection_path=tmp_path,
+            geometry_type="Polygon",
+            source_layer="buildings",
+            pmtiles_filename="buildings.pmtiles",
+        )
+
+        assert path == tmp_path / "styles" / "default.json"
+        assert path.exists()
+
+        style = json.loads(path.read_text())
+        assert style["version"] == 8
+        assert style["name"] == "Default"
+        assert style["sources"]["data"]["url"] == "../buildings.pmtiles"
+        assert style["layers"][0]["source-layer"] == "buildings"
+        assert style["layers"][0]["type"] == "fill"
+
+    @pytest.mark.unit
+    def test_uses_custom_config(self, tmp_path: Path) -> None:
+        """Respects VectorStyleConfig when generating default style."""
+        import json
+        from portolan_cli.style import VectorStyleConfig, write_default_style
+
+        config = VectorStyleConfig(polygon_fill_color="#ff0000")
+        path = write_default_style(
+            collection_path=tmp_path,
+            geometry_type="Polygon",
+            source_layer="data",
+            pmtiles_filename="data.pmtiles",
+            config=config,
+        )
+
+        style = json.loads(path.read_text())
+        assert style["layers"][0]["paint"]["fill-color"] == "#ff0000"
+
+    @pytest.mark.unit
+    def test_does_not_overwrite_existing(self, tmp_path: Path) -> None:
+        """Does not overwrite an existing default.json (preserves user edits)."""
+        from portolan_cli.style import write_default_style
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        existing = styles_dir / "default.json"
+        existing.write_text('{"version": 8, "name": "Custom", "sources": {}, "layers": []}')
+
+        path = write_default_style(
+            collection_path=tmp_path,
+            geometry_type="Polygon",
+            source_layer="data",
+            pmtiles_filename="data.pmtiles",
+        )
+
+        assert path is None
+        assert '"Custom"' in existing.read_text()
+```
+
+- [ ] **Step 10: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_style.py::TestWriteDefaultStyle -v`
+Expected: FAIL — `write_default_style` does not exist yet.
+
+- [ ] **Step 11: Implement `write_default_style`**
+
+Add to `portolan_cli/style.py`:
+
+```python
+def write_default_style(
+    collection_path: Path,
+    geometry_type: str,
+    source_layer: str,
+    pmtiles_filename: str,
+    config: VectorStyleConfig | None = None,
+) -> Path | None:
+    """Write a default style file for a collection.
+
+    Creates `{collection_path}/styles/default.json` with a complete Mapbox GL
+    style. Does NOT overwrite if the file already exists (preserves user edits).
+
+    Args:
+        collection_path: Path to the collection directory.
+        geometry_type: OGC geometry type.
+        source_layer: Layer name in the PMTiles.
+        pmtiles_filename: PMTiles filename (e.g., "data.pmtiles").
+        config: Optional style config. Uses defaults if None.
+
+    Returns:
+        Path to the written file, or None if file already exists.
+    """
+    if config is None:
+        config = VectorStyleConfig()
+
+    style_dir = collection_path / "styles"
+    default_path = style_dir / "default.json"
+
+    if default_path.exists():
+        logger.debug("Default style already exists at %s, skipping", default_path)
+        return None
+
+    pmtiles_relative_path = f"../{pmtiles_filename}"
+    style_dict = build_full_style(
+        name="Default",
+        geometry_type=geometry_type,
+        source_layer=source_layer,
+        pmtiles_relative_path=pmtiles_relative_path,
+        config=config,
+    )
+
+    return write_style_file(style_dir, "default", style_dict)
+```
+
+- [ ] **Step 12: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_style.py::TestWriteDefaultStyle -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add portolan_cli/style.py tests/unit/test_style.py
+git commit -m "feat(style): add build_full_style, write_style_file, write_default_style
+
+Replace build_pmtiles_style (partial Mapbox GL snippet) with
+build_full_style (complete Mapbox GL v8 spec with sources).
+Add write_style_file and write_default_style for disk I/O."
+```
+
+---
+
+### Task 4: Add style discovery and manifest building
+
+**Files:**
+- Modify: `portolan_cli/style.py`
+- Test: `tests/unit/test_style.py`
+
+- [ ] **Step 1: Write failing tests for `discover_styles`**
+
+Add to `tests/unit/test_style.py`:
+
+```python
+class TestDiscoverStyles:
+    """Tests for discover_styles function."""
+
+    @pytest.mark.unit
+    def test_discovers_style_files(self, tmp_path: Path) -> None:
+        """Finds all JSON files in styles/ directory."""
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text('{"version":8,"name":"Default","sources":{},"layers":[]}')
+        (styles_dir / "by-age.json").write_text('{"version":8,"name":"By Age","sources":{},"layers":[]}')
+
+        styles = discover_styles(tmp_path)
+
+        assert len(styles) == 2
+        assert any(s["key"] == "styles/default" for s in styles)
+        assert any(s["key"] == "styles/by-age" for s in styles)
+
+    @pytest.mark.unit
+    def test_extracts_name_as_title(self, tmp_path: Path) -> None:
+        """Uses the style's name field as the asset title."""
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "by-age.json").write_text('{"version":8,"name":"Buildings by Age","sources":{},"layers":[]}')
+
+        styles = discover_styles(tmp_path)
+
+        assert styles[0]["title"] == "Buildings by Age"
+
+    @pytest.mark.unit
+    def test_returns_empty_when_no_styles_dir(self, tmp_path: Path) -> None:
+        """Returns empty list when no styles/ directory exists."""
+        from portolan_cli.style import discover_styles
+
+        styles = discover_styles(tmp_path)
+        assert styles == []
+
+    @pytest.mark.unit
+    def test_skips_non_json_files(self, tmp_path: Path) -> None:
+        """Ignores non-JSON files in styles/ directory."""
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text('{"version":8,"name":"Default","sources":{},"layers":[]}')
+        (styles_dir / "README.md").write_text("# Styles")
+
+        styles = discover_styles(tmp_path)
+        assert len(styles) == 1
+
+    @pytest.mark.unit
+    def test_skips_invalid_json(self, tmp_path: Path) -> None:
+        """Skips files that are not valid JSON."""
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text('{"version":8,"name":"Default","sources":{},"layers":[]}')
+        (styles_dir / "broken.json").write_text("{bad json")
+
+        styles = discover_styles(tmp_path)
+        assert len(styles) == 1
+
+    @pytest.mark.unit
+    def test_fallback_title_from_filename(self, tmp_path: Path) -> None:
+        """Uses filename stem as title when name field is missing."""
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "my-style.json").write_text('{"version":8,"sources":{},"layers":[]}')
+
+        styles = discover_styles(tmp_path)
+        assert styles[0]["title"] == "my-style"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_style.py::TestDiscoverStyles -v`
+Expected: FAIL — `discover_styles` does not exist yet.
+
+- [ ] **Step 3: Implement `discover_styles`**
+
+Add to `portolan_cli/style.py`:
+
+```python
+def discover_styles(collection_path: Path) -> list[dict[str, Any]]:
+    """Discover style files in a collection's styles/ directory.
+
+    Args:
+        collection_path: Path to the collection directory.
+
+    Returns:
+        List of dicts with keys: key, href, title, description, path.
+        Empty list if no styles/ directory or no valid style files.
+    """
+    styles_dir = collection_path / "styles"
+    if not styles_dir.is_dir():
+        return []
+
+    styles: list[dict[str, Any]] = []
+    for style_path in sorted(styles_dir.glob("*.json")):
+        try:
+            style_data = json.loads(style_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Skipping invalid style file: %s", style_path)
+            continue
+
+        if not isinstance(style_data, dict):
+            continue
+
+        name = style_path.stem
+        title = style_data.get("name", name)
+        description = style_data.get("description", "")
+
+        styles.append({
+            "key": f"styles/{name}",
+            "href": f"./styles/{style_path.name}",
+            "title": title,
+            "description": description,
+            "path": style_path,
+        })
+
+    return styles
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_style.py::TestDiscoverStyles -v`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 5: Write failing tests for `build_styles_manifest`**
+
+Add to `tests/unit/test_style.py`:
+
+```python
+class TestBuildStylesManifest:
+    """Tests for build_styles_manifest function."""
+
+    @pytest.mark.unit
+    def test_default_first(self) -> None:
+        """Default style is always first in the manifest."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [
+            {"key": "styles/by-age"},
+            {"key": "styles/default"},
+            {"key": "styles/by-use"},
+        ]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest[0] == "styles/default"
+        assert len(manifest) == 3
+
+    @pytest.mark.unit
+    def test_alphabetical_after_default(self) -> None:
+        """Non-default styles are sorted alphabetically."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [
+            {"key": "styles/zebra"},
+            {"key": "styles/default"},
+            {"key": "styles/alpha"},
+        ]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest == ["styles/default", "styles/alpha", "styles/zebra"]
+
+    @pytest.mark.unit
+    def test_no_default(self) -> None:
+        """Works when there's no style named default."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [
+            {"key": "styles/by-use"},
+            {"key": "styles/by-age"},
+        ]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest == ["styles/by-age", "styles/by-use"]
+
+    @pytest.mark.unit
+    def test_empty_list(self) -> None:
+        """Returns empty list for no styles."""
+        from portolan_cli.style import build_styles_manifest
+
+        assert build_styles_manifest([]) == []
+
+    @pytest.mark.unit
+    def test_single_style(self) -> None:
+        """Single style returns single-element list."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [{"key": "styles/custom"}]
+        manifest = build_styles_manifest(styles)
+        assert manifest == ["styles/custom"]
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_style.py::TestBuildStylesManifest -v`
+Expected: FAIL — `build_styles_manifest` does not exist yet.
+
+- [ ] **Step 7: Implement `build_styles_manifest`**
+
+Add to `portolan_cli/style.py`:
+
+```python
+def build_styles_manifest(styles: list[dict[str, Any]]) -> list[str]:
+    """Build the portolan:styles manifest array.
+
+    Orders style keys with "styles/default" first (if present),
+    then remaining styles in alphabetical order.
+
+    Args:
+        styles: List of style dicts (from discover_styles).
+
+    Returns:
+        Ordered list of asset keys for the portolan:styles property.
+    """
+    keys = [s["key"] for s in styles]
+    default_key = "styles/default"
+
+    if default_key in keys:
+        keys.remove(default_key)
+        return [default_key] + sorted(keys)
+
+    return sorted(keys)
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_style.py::TestBuildStylesManifest -v`
+Expected: All 5 tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add portolan_cli/style.py tests/unit/test_style.py
+git commit -m "feat(style): add discover_styles and build_styles_manifest
+
+Discover style JSON files in styles/ directories and build ordered
+portolan:styles manifest arrays for STAC collection properties."
+```
+
+---
+
+### Task 5: Remove `pmtiles:style` from PMTiles and metadata modules
+
+**Files:**
+- Modify: `portolan_cli/pmtiles.py`
+- Modify: `portolan_cli/metadata/pmtiles.py`
+- Modify: `tests/unit/test_style.py`
+
+- [ ] **Step 1: Remove `style` field from `PMTilesMetadata`**
+
+In `portolan_cli/metadata/pmtiles.py`:
+
+1. Remove the `style: dict[str, Any] | None = None` field from the `PMTilesMetadata` dataclass (line 39).
+2. Remove the `if self.style:` block from `to_dict()` (lines 53-54).
+3. Remove the `if self.style:` block from `to_stac_properties()` (lines 75-76).
+4. Remove `style: Optional Mapbox GL style spec (Issue #13).` from the docstring (line 30).
+5. Remove `from typing import Any` if it's no longer needed (check other uses first — `to_dict` and `to_stac_properties` still return `dict[str, Any]` so keep it).
+
+- [ ] **Step 2: Remove `pmtiles:style` from `add_pmtiles_asset_to_collection`**
+
+In `portolan_cli/pmtiles.py`:
+
+1. Remove the `style: dict[str, Any] | None = None` parameter from `add_pmtiles_asset_to_collection` (line 319).
+2. Remove the `style: Optional Mapbox GL style spec to add as pmtiles:style (Issue #13).` docstring line (line 331).
+3. Remove the style update block in the "already exists" branch (lines 357-359):
+   ```python
+   # Remove these lines:
+   if style and existing.get("pmtiles:style") != style:
+       existing["pmtiles:style"] = style
+       needs_update = True
+   ```
+4. Remove the style insertion in the new asset creation (lines 379-381):
+   ```python
+   # Remove these lines:
+   if style:
+       asset_dict["pmtiles:style"] = style
+   ```
+
+- [ ] **Step 3: Update `_build_style_for_geoparquet` to use `write_default_style`**
+
+Replace `_build_style_for_geoparquet` in `portolan_cli/pmtiles.py` with:
+
+```python
+def _write_default_style_for_geoparquet(
+    parquet_path: Path,
+    layer_name: str,
+    collection_path: Path,
+    pmtiles_filename: str,
+    catalog_path: Path | None = None,
+) -> Path | None:
+    """Write a default style file for a PMTiles asset.
+
+    Args:
+        parquet_path: Path to source GeoParquet (for geometry type detection).
+        layer_name: Layer name in the PMTiles.
+        collection_path: Path to the collection directory.
+        pmtiles_filename: Name of the PMTiles file.
+        catalog_path: Optional catalog path for loading style config.
+
+    Returns:
+        Path to the written style file, or None if skipped.
+    """
+    try:
+        from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
+        from portolan_cli.style import (
+            VectorStyleConfig,
+            get_vector_style_config,
+            write_default_style,
+        )
+    except ImportError:
+        logger.debug("Style dependencies not available")
+        return None
+
+    try:
+        metadata = extract_geoparquet_metadata(parquet_path)
+        geometry_type = metadata.geometry_type
+        if not geometry_type:
+            logger.debug("No geometry type found in %s", parquet_path)
+            return None
+
+        config = get_vector_style_config(catalog_path) if catalog_path else VectorStyleConfig()
+
+        return write_default_style(
+            collection_path=collection_path,
+            geometry_type=geometry_type,
+            source_layer=layer_name,
+            pmtiles_filename=pmtiles_filename,
+            config=config,
+        )
+    except Exception as e:
+        logger.debug("Failed to write default style for %s: %s", parquet_path, e)
+        return None
+```
+
+- [ ] **Step 4: Update `generate_pmtiles_for_collection` to call the new function**
+
+In the `generate_pmtiles_for_collection` function in `portolan_cli/pmtiles.py`:
+
+1. Remove the `style = _build_style_for_geoparquet(...)` line (line 573) and replace with a call after successful generation.
+2. Remove `style=style` from both `add_pmtiles_asset_to_collection` calls (lines 577, 605).
+3. After the successful generation block (after `result.generated.append(pmtiles_path)`, around line 611), add the default style file write:
+
+```python
+            # Generate default style file (ADR-0044)
+            _write_default_style_for_geoparquet(
+                parquet_path=parquet_path,
+                layer_name=layer_name,
+                collection_path=collection_path,
+                pmtiles_filename=pmtiles_path.name,
+                catalog_path=catalog_root,
+            )
+```
+
+Also add it to the "skipped" branch — when PMTiles already exists but we still want to ensure a default style exists:
+
+```python
+        if not _should_generate(parquet_path, pmtiles_path, force):
+            add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href)
+            # Ensure default style exists even when PMTiles generation is skipped
+            _write_default_style_for_geoparquet(
+                parquet_path=parquet_path,
+                layer_name=layer_name,
+                collection_path=collection_path,
+                pmtiles_filename=pmtiles_path.name,
+                catalog_path=catalog_root,
+            )
+            result.skipped.append(pmtiles_path)
+            continue
+```
+
+- [ ] **Step 5: Remove old build_pmtiles_style from style.py**
+
+Delete the `build_pmtiles_style` function from `portolan_cli/style.py` (lines 120-177). It's fully replaced by `build_full_style`.
+
+- [ ] **Step 6: Update old tests that reference `build_pmtiles_style`**
+
+In `tests/unit/test_style.py`:
+
+1. Delete the entire `TestBuildPmtilesStyle` class (it was replaced by `TestBuildFullStyle` in Task 3).
+2. Update `TestStyleInAssetProperties` to use `build_full_style` instead of `build_pmtiles_style`:
+
+```python
+class TestStyleInAssetProperties:
+    """Tests for style structure validation."""
+
+    @pytest.mark.unit
+    def test_full_style_structure(self) -> None:
+        """Full style has all required Mapbox GL fields."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Test",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        assert "version" in style
+        assert "name" in style
+        assert "sources" in style
+        assert "layers" in style
+        assert isinstance(style["layers"], list)
+        assert len(style["layers"]) > 0
+        assert style["layers"][0]["source"] == "data"
+
+    @pytest.mark.unit
+    def test_style_is_json_serializable(self) -> None:
+        """Style dict is JSON-serializable."""
+        import json
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Test",
+            geometry_type="Polygon",
+            source_layer="layer",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        serialized = json.dumps(style)
+        deserialized = json.loads(serialized)
+        assert deserialized == style
+```
+
+- [ ] **Step 7: Update style fixture tests**
+
+Update `TestStyleFixtures` in `tests/unit/test_style.py` to check for the new `sources` field:
+
+```python
+    @pytest.mark.unit
+    def test_valid_point_style_loads(self, valid_style_dir: Path) -> None:
+        """Valid point style fixture loads correctly."""
+        import json
+
+        style_path = valid_style_dir / "style_point.json"
+        style = json.loads(style_path.read_text())
+
+        assert style["version"] == 8
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert len(style["layers"]) == 1
+        assert style["layers"][0]["type"] == "circle"
+        assert style["layers"][0]["source"] == "data"
+```
+
+Apply the same pattern (add `sources` and `source` assertions) to `test_valid_polygon_style_loads`, `test_valid_line_style_loads`, `test_categorical_style_has_match_expression`, and `test_graduated_style_has_interpolate_expression`.
+
+- [ ] **Step 8: Run all style tests**
+
+Run: `uv run pytest tests/unit/test_style.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `uv run pytest -m unit`
+Expected: All unit tests PASS. No other modules should be affected since `pmtiles:style` was only set in `pmtiles.py` and `metadata/pmtiles.py`.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add portolan_cli/pmtiles.py portolan_cli/metadata/pmtiles.py portolan_cli/style.py tests/unit/test_style.py
+git commit -m "refactor(style): remove pmtiles:style inline approach
+
+Replace inline pmtiles:style on assets with standalone style files
+in styles/ directories. PMTiles generation now creates
+styles/default.json via write_default_style."
+```
+
+---
+
+### Task 6: Integrate style discovery into collection building
+
+**Files:**
+- Modify: `portolan_cli/dataset.py` (or wherever collections are built during scan/add)
+- Modify: `portolan_cli/pmtiles.py`
+- Test: `tests/unit/test_style.py`
+
+- [ ] **Step 1: Write failing test for style registration in collection.json**
+
+Add to `tests/unit/test_style.py`:
+
+```python
+class TestRegisterStyleAssets:
+    """Tests for registering discovered styles as STAC assets."""
+
+    @pytest.mark.unit
+    def test_registers_style_assets_in_collection(self, tmp_path: Path) -> None:
+        """Discovered styles are added as assets in collection.json."""
+        import json
+        from portolan_cli.style import discover_styles, register_style_assets
+
+        # Set up collection.json
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "assets": {"data": {"href": "./data.parquet", "type": "application/x-parquet"}},
+        }
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        # Set up styles
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text(
+            '{"version":8,"name":"Default","sources":{},"layers":[]}'
+        )
+        (styles_dir / "by-age.json").write_text(
+            '{"version":8,"name":"By Age","description":"Buildings colored by construction year","sources":{},"layers":[]}'
+        )
+
+        styles = discover_styles(tmp_path)
+        register_style_assets(tmp_path, styles)
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+
+        assert "styles/default" in updated["assets"]
+        assert "styles/by-age" in updated["assets"]
+
+        default_asset = updated["assets"]["styles/default"]
+        assert default_asset["type"] == "application/json"
+        assert default_asset["roles"] == ["style"]
+        assert default_asset["title"] == "Default"
+
+        by_age_asset = updated["assets"]["styles/by-age"]
+        assert by_age_asset["title"] == "By Age"
+        assert by_age_asset["description"] == "Buildings colored by construction year"
+
+        assert updated["portolan:styles"] == ["styles/default", "styles/by-age"]
+
+    @pytest.mark.unit
+    def test_no_styles_no_manifest(self, tmp_path: Path) -> None:
+        """No portolan:styles property when no styles exist."""
+        import json
+        from portolan_cli.style import register_style_assets
+
+        collection_data = {"type": "Collection", "id": "test", "assets": {}}
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        register_style_assets(tmp_path, [])
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "portolan:styles" not in updated
+
+    @pytest.mark.unit
+    def test_removes_stale_style_assets(self, tmp_path: Path) -> None:
+        """Removes style assets that no longer have files on disk."""
+        import json
+        from portolan_cli.style import register_style_assets
+
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "portolan:styles": ["styles/default", "styles/old"],
+            "assets": {
+                "styles/default": {"href": "./styles/default.json", "type": "application/json", "roles": ["style"]},
+                "styles/old": {"href": "./styles/old.json", "type": "application/json", "roles": ["style"]},
+            },
+        }
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        # Only default style exists on disk
+        current_styles = [{"key": "styles/default", "href": "./styles/default.json", "title": "Default", "description": ""}]
+        register_style_assets(tmp_path, current_styles)
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "styles/old" not in updated["assets"]
+        assert updated["portolan:styles"] == ["styles/default"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/test_style.py::TestRegisterStyleAssets -v`
+Expected: FAIL — `register_style_assets` does not exist yet.
+
+- [ ] **Step 3: Implement `register_style_assets`**
+
+Add to `portolan_cli/style.py`:
+
+```python
+def register_style_assets(
+    collection_path: Path,
+    styles: list[dict[str, Any]],
+) -> None:
+    """Register discovered styles as STAC assets and set portolan:styles manifest.
+
+    Updates collection.json to add/update style assets and remove stale ones.
+
+    Args:
+        collection_path: Path to the collection directory.
+        styles: List of style dicts from discover_styles().
+    """
+    collection_json_path = collection_path / "collection.json"
+    if not collection_json_path.exists():
+        return
+
+    data = json.loads(collection_json_path.read_text())
+    assets = data.get("assets", {})
+
+    # Remove stale style assets (assets with "style" role that no longer have files)
+    current_keys = {s["key"] for s in styles}
+    stale_keys = [
+        k for k, v in assets.items()
+        if k.startswith("styles/") and k not in current_keys
+    ]
+    for key in stale_keys:
+        del assets[key]
+
+    # Add/update style assets
+    for style_info in styles:
+        asset_dict: dict[str, Any] = {
+            "href": style_info["href"],
+            "type": "application/json",
+            "title": style_info["title"],
+            "roles": ["style"],
+        }
+        if style_info.get("description"):
+            asset_dict["description"] = style_info["description"]
+        assets[style_info["key"]] = asset_dict
+
+    data["assets"] = assets
+
+    # Set or remove portolan:styles manifest
+    if styles:
+        data["portolan:styles"] = build_styles_manifest(styles)
+    else:
+        data.pop("portolan:styles", None)
+
+    collection_json_path.write_text(json.dumps(data, indent=2))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/test_style.py::TestRegisterStyleAssets -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Wire style registration into PMTiles generation flow**
+
+In `portolan_cli/pmtiles.py`, at the end of `generate_pmtiles_for_collection` (after the `for` loop, before `return result`), add style discovery and registration:
+
+```python
+    # Discover and register style assets (ADR-0044)
+    from portolan_cli.style import discover_styles, register_style_assets
+
+    styles = discover_styles(collection_path)
+    if styles:
+        register_style_assets(collection_path, styles)
+
+    return result
+```
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest -m unit`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add portolan_cli/style.py portolan_cli/pmtiles.py tests/unit/test_style.py
+git commit -m "feat(style): register style assets in collection.json
+
+Add register_style_assets to write style entries to STAC assets and
+set portolan:styles manifest. Wired into PMTiles generation flow."
+```
+
+---
+
+### Task 7: Update scan classifier for styles/ directory
+
+**Files:**
+- Modify: `portolan_cli/scan_classify.py`
+
+- [ ] **Step 1: Update `STYLE_FILENAMES` and classification logic**
+
+In `portolan_cli/scan_classify.py`, the current `STYLE_FILENAMES` only matches `style.json`. We need to also classify files inside `styles/` directories as style files. Find the `classify_file` function and add a check for files in `styles/` directories.
+
+After the existing `STYLE_FILENAMES` check (around line 256), add:
+
+```python
+    # Check if file is inside a styles/ directory (ADR-0044)
+    if path.parent.name == "styles" and ext == ".json":
+        return (
+            FileCategory.STYLE,
+            SkipReasonType.METADATA_FILE,
+            f"{path.name} is a map style definition in styles/ directory",
+        )
+```
+
+- [ ] **Step 2: Run full tests**
+
+Run: `uv run pytest -m unit`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add portolan_cli/scan_classify.py
+git commit -m "fix(scan): classify files in styles/ directories as style metadata
+
+Files inside styles/ directories are map style definitions per ADR-0044
+and should be classified as STYLE, not scanned as geo assets."
+```
+
+---
+
+### Task 8: Update portolan skill
+
+**Files:**
+- Modify: `portolan_cli/skills/sourcecoop.md`
+
+- [ ] **Step 1: Check the current skill file name and content**
+
+Read `portolan_cli/skills/sourcecoop.md` to understand the current structure and find where to add the styles section.
+
+- [ ] **Step 2: Add styles section to the skill**
+
+Add a `## Styles` section to the skill file. Place it after the existing workflow/command sections:
+
+```markdown
+## Styles
+
+Portolan supports multiple named visualization styles per collection. Each style is a complete Mapbox GL v8 JSON file stored in `{collection}/styles/`.
+
+### Creating Styles
+
+Style files are complete Mapbox GL v8 specs with relative PMTiles source paths:
+
+```json
+{
+  "version": 8,
+  "name": "Buildings by Construction Year",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../data.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "buildings-by-age",
+      "type": "fill",
+      "source": "data",
+      "source-layer": "layer_name",
+      "paint": {
+        "fill-color": ["interpolate", ["linear"], ["get", "bouwjaar"],
+          1400, "#1a0a00", 1900, "#8B4513", 1960, "#DAA520", 2020, "#FFFF00"
+        ],
+        "fill-opacity": 0.7
+      }
+    }
+  ]
+}
+```
+
+A default style is auto-generated during PMTiles creation. Drop additional style files into `styles/` and they'll be discovered automatically.
+
+### Style Best Practices
+
+1. **Create multiple styles for rich datasets.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each. Example: buildings by construction year, by usage type, by height. Don't stop at a single default.
+
+2. **Vary default styles across a catalog.** Each collection should have a visually distinct default color/palette. Use subject matter to inform color choices — water features in blues, vegetation in greens, built environment in warm tones, infrastructure in grays.
+
+3. **Use data-driven styling.** Leverage Mapbox GL expressions (`interpolate`, `match`, `case`, `step`) to reveal patterns in data. For categorical data use `match`; for continuous data use `interpolate` or `step`.
+
+4. **Include a description field on the STAC asset** explaining what the colors/sizes represent. This appears in style pickers and tooltips.
+
+5. **Consider label layers.** For datasets with names (monuments, administrative areas, roads), add a label style layer or a dedicated "with labels" style variant.
+
+6. **Look at the collection's table:columns** to understand what attributes are available for data-driven styling. Interesting fields for visualization include: categories/enums, dates/years, numeric measurements, status fields.
+
+### STAC Registration
+
+Styles are registered as collection-level assets with the `portolan:styles` manifest:
+
+```json
+{
+  "portolan:styles": ["styles/default", "styles/by-age", "styles/by-use"],
+  "assets": {
+    "styles/default": {
+      "href": "./styles/default.json",
+      "type": "application/json",
+      "title": "Default",
+      "description": "Blue building footprints.",
+      "roles": ["style"]
+    }
+  }
+}
+```
+
+First entry in `portolan:styles` is the default. `portolan scan` discovers styles and registers them automatically.
+```
+
+- [ ] **Step 3: Sync to portolan-skills repo**
+
+Copy the updated skill to the portolan-skills repo:
+
+```bash
+cp portolan_cli/skills/sourcecoop.md /Users/cholmes/repos/portolan-skills/skills/portolan-cli/SKILL.md
+```
+
+Note: The portolan-skills repo is a separate git repository. Commit there separately:
+
+```bash
+cd /Users/cholmes/repos/portolan-skills && git add skills/portolan-cli/SKILL.md && git commit -m "docs: sync portolan-cli skill with styles section"
+```
+
+- [ ] **Step 4: Commit in portolan-cli**
+
+```bash
+git add portolan_cli/skills/sourcecoop.md
+git commit -m "docs(skill): add styles best practices to portolan skill
+
+Guide AI agents on creating rich, varied style sets per collection
+with data-driven styling and catalog-wide color diversity."
+```
+
+---
+
+### Task 9: Clean up old `build_pmtiles_style` references and run full quality checks
+
+**Files:**
+- Various (grep-based cleanup)
+
+- [ ] **Step 1: Search for any remaining `build_pmtiles_style` references**
+
+```bash
+grep -rn "build_pmtiles_style" portolan_cli/ tests/ --include="*.py"
+```
+
+Fix any remaining references to use `build_full_style`.
+
+- [ ] **Step 2: Search for any remaining `pmtiles:style` references**
+
+```bash
+grep -rn "pmtiles:style\|pmtiles_style" portolan_cli/ tests/ --include="*.py"
+```
+
+Remove or update any remaining references.
+
+- [ ] **Step 3: Run full test suite**
+
+```bash
+uv run pytest -m unit
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Run linting and type checks**
+
+```bash
+uv run ruff check .
+uv run ruff format .
+uv run mypy portolan_cli
+```
+
+Expected: All pass clean.
+
+- [ ] **Step 5: Run dead code check**
+
+```bash
+uv run vulture portolan_cli tests
+```
+
+Expected: No new dead code introduced.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "chore: clean up remaining pmtiles:style references"
+```
+
+(Only if there were changes to commit.)
+
+---
+
+## Summary
+
+| Task | What | Files |
+|------|------|-------|
+| 1 | ADR-0044 + CLAUDE.md index | `context/shared/adr/0044-*`, `0043-*`, `CLAUDE.md` |
+| 2 | Update style fixtures | `tests/fixtures/metadata/style/valid/*.json` |
+| 3 | `build_full_style` + `write_style_file` + `write_default_style` | `portolan_cli/style.py`, `tests/unit/test_style.py` |
+| 4 | `discover_styles` + `build_styles_manifest` | `portolan_cli/style.py`, `tests/unit/test_style.py` |
+| 5 | Remove `pmtiles:style` inline approach | `portolan_cli/pmtiles.py`, `metadata/pmtiles.py`, `style.py`, tests |
+| 6 | `register_style_assets` + wire into PMTiles flow | `portolan_cli/style.py`, `pmtiles.py`, tests |
+| 7 | Scan classifier for `styles/` directory | `portolan_cli/scan_classify.py` |
+| 8 | Portolan skill update | `portolan_cli/skills/sourcecoop.md`, portolan-skills repo |
+| 9 | Final cleanup + quality checks | Various |

--- a/portolan_cli/metadata/pmtiles.py
+++ b/portolan_cli/metadata/pmtiles.py
@@ -27,7 +27,6 @@ class PMTilesMetadata:
         tile_type: Tile type ("mvt", "png", "jpeg", "webp", "avif").
         center: Optional center point as (lon, lat, zoom).
         layer_name: Name of the primary layer in the PMTiles (for styling).
-        style: Optional Mapbox GL style spec (Issue #13).
     """
 
     bbox: tuple[float, float, float, float] | None
@@ -36,7 +35,6 @@ class PMTilesMetadata:
     tile_type: str
     center: tuple[float, float, int] | None
     layer_name: str | None = None
-    style: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dict."""
@@ -49,8 +47,6 @@ class PMTilesMetadata:
         }
         if self.layer_name:
             result["layer_name"] = self.layer_name
-        if self.style:
-            result["style"] = self.style
         return result
 
     def to_stac_properties(self) -> dict[str, Any]:
@@ -71,9 +67,6 @@ class PMTilesMetadata:
 
         if self.layer_name:
             props["pmtiles:layers"] = [self.layer_name]
-
-        if self.style:
-            props["pmtiles:style"] = self.style
 
         return props
 

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -266,27 +266,31 @@ def generate_pmtiles(
         raise PMTilesGenerationError(str(parquet_path), e) from e
 
 
-def _build_style_for_geoparquet(
+def _write_default_style_for_geoparquet(
     parquet_path: Path,
     layer_name: str,
+    collection_path: Path,
+    pmtiles_filename: str,
     catalog_path: Path | None = None,
-) -> dict[str, Any] | None:
-    """Build Mapbox GL style for PMTiles based on source GeoParquet geometry.
+) -> Path | None:
+    """Write a default style file for a PMTiles asset.
 
     Args:
-        parquet_path: Path to source GeoParquet file.
-        layer_name: Layer name for the style (typically filename stem).
+        parquet_path: Path to source GeoParquet (for geometry type detection).
+        layer_name: Layer name in the PMTiles.
+        collection_path: Path to the collection directory.
+        pmtiles_filename: Name of the PMTiles file.
         catalog_path: Optional catalog path for loading style config.
 
     Returns:
-        Mapbox GL style dict, or None if geometry type cannot be determined.
+        Path to the written style file, or None if skipped.
     """
     try:
         from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
         from portolan_cli.style import (
             VectorStyleConfig,
-            build_pmtiles_style,
             get_vector_style_config,
+            write_default_style,
         )
     except ImportError:
         logger.debug("Style dependencies not available")
@@ -299,15 +303,17 @@ def _build_style_for_geoparquet(
             logger.debug("No geometry type found in %s", parquet_path)
             return None
 
-        # Load style config from catalog if available
-        if catalog_path:
-            config = get_vector_style_config(catalog_path)
-        else:
-            config = VectorStyleConfig()
+        config = get_vector_style_config(catalog_path) if catalog_path else VectorStyleConfig()
 
-        return build_pmtiles_style(geometry_type, layer_name, config)
+        return write_default_style(
+            collection_path=collection_path,
+            geometry_type=geometry_type,
+            source_layer=layer_name,
+            pmtiles_filename=pmtiles_filename,
+            config=config,
+        )
     except Exception as e:
-        logger.debug("Failed to build style for %s: %s", parquet_path, e)
+        logger.debug("Failed to write default style for %s: %s", parquet_path, e)
         return None
 
 
@@ -316,7 +322,6 @@ def add_pmtiles_asset_to_collection(
     parquet_key: str,
     pmtiles_href: str,
     *,
-    style: dict[str, Any] | None = None,
     extra_properties: dict[str, Any] | None = None,
 ) -> None:
     """Add PMTiles asset to collection.json.
@@ -328,7 +333,6 @@ def add_pmtiles_asset_to_collection(
         collection_path: Path to collection directory.
         parquet_key: Asset key of the source GeoParquet.
         pmtiles_href: Relative href to PMTiles file (e.g., "./data.pmtiles").
-        style: Optional Mapbox GL style spec to add as pmtiles:style (Issue #13).
         extra_properties: Additional properties to add to the asset.
 
     Raises:
@@ -348,15 +352,10 @@ def add_pmtiles_asset_to_collection(
     source_asset = assets.get(parquet_key, {})
     source_title = source_asset.get("title", parquet_key)
 
-    # Check if already exists - update style if changed, otherwise skip
+    # Check if already exists - update extra properties if changed, otherwise skip
     if pmtiles_key in assets:
         existing = assets[pmtiles_key]
         needs_update = False
-
-        # Update style if provided and different
-        if style and existing.get("pmtiles:style") != style:
-            existing["pmtiles:style"] = style
-            needs_update = True
 
         # Update extra properties if provided
         if extra_properties:
@@ -375,10 +374,6 @@ def add_pmtiles_asset_to_collection(
         "title": f"{source_title} (vector tiles)",
         "roles": ["visual"],
     }
-
-    # Add style if provided (Issue #13)
-    if style:
-        asset_dict["pmtiles:style"] = style
 
     # Add any extra properties
     if extra_properties:
@@ -568,13 +563,20 @@ def generate_pmtiles_for_collection(
         except ValueError:
             pmtiles_href = f"./{pmtiles_path.name}"
 
-        # Determine layer name and build style once (Issue #13)
+        # Determine layer name (Issue #13)
         layer_name = layer if layer else parquet_path.stem
-        style = _build_style_for_geoparquet(parquet_path, layer_name, catalog_root)
 
         if not _should_generate(parquet_path, pmtiles_path, force):
             # Ensure asset is registered/updated in collection.json even when skipping
-            add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href, style=style)
+            add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href)
+            # Ensure default style exists even when PMTiles generation is skipped
+            _write_default_style_for_geoparquet(
+                parquet_path=parquet_path,
+                layer_name=layer_name,
+                collection_path=collection_path,
+                pmtiles_filename=pmtiles_path.name,
+                catalog_path=catalog_root,
+            )
             result.skipped.append(pmtiles_path)
             continue
 
@@ -601,14 +603,23 @@ def generate_pmtiles_for_collection(
                 src_crs=src_crs,
             )
 
-            # Register asset in collection.json with style (Issue #13)
-            add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href, style=style)
+            # Register asset in collection.json (Issue #13)
+            add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href)
 
             # Track in versions.json
             track_pmtiles_in_versions(collection_path, pmtiles_path, catalog_root)
 
             result.generated.append(pmtiles_path)
             generation_succeeded = True
+
+            # Generate default style file (ADR-0044)
+            _write_default_style_for_geoparquet(
+                parquet_path=parquet_path,
+                layer_name=layer_name,
+                collection_path=collection_path,
+                pmtiles_filename=pmtiles_path.name,
+                catalog_path=catalog_root,
+            )
 
         except PMTilesGenerationError as e:
             result.failed.append((parquet_path, str(e)))

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -270,7 +270,7 @@ def _write_default_style_for_geoparquet(
     parquet_path: Path,
     layer_name: str,
     collection_path: Path,
-    pmtiles_filename: str,
+    pmtiles_relative_path: str,
     catalog_path: Path | None = None,
 ) -> Path | None:
     """Write a default style file for a PMTiles asset.
@@ -279,12 +279,17 @@ def _write_default_style_for_geoparquet(
         parquet_path: Path to source GeoParquet (for geometry type detection).
         layer_name: Layer name in the PMTiles.
         collection_path: Path to the collection directory.
-        pmtiles_filename: Name of the PMTiles file.
+        pmtiles_relative_path: PMTiles path relative to collection (e.g., "data.pmtiles").
         catalog_path: Optional catalog path for loading style config.
 
     Returns:
         Path to the written style file, or None if skipped.
     """
+    # Check existence before expensive metadata extraction
+    default_path = collection_path / "styles" / "default.json"
+    if default_path.exists():
+        return None
+
     try:
         from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
         from portolan_cli.style import (
@@ -309,7 +314,7 @@ def _write_default_style_for_geoparquet(
             collection_path=collection_path,
             geometry_type=geometry_type,
             source_layer=layer_name,
-            pmtiles_filename=pmtiles_filename,
+            pmtiles_relative_path=pmtiles_relative_path,
             config=config,
         )
     except Exception as e:
@@ -566,6 +571,12 @@ def generate_pmtiles_for_collection(
         # Determine layer name (Issue #13)
         layer_name = layer if layer else parquet_path.stem
 
+        # Compute collection-relative PMTiles path for style source URLs
+        try:
+            pmtiles_col_rel = pmtiles_path.relative_to(collection_path).as_posix()
+        except ValueError:
+            pmtiles_col_rel = pmtiles_path.name
+
         if not _should_generate(parquet_path, pmtiles_path, force):
             # Ensure asset is registered/updated in collection.json even when skipping
             add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href)
@@ -574,7 +585,7 @@ def generate_pmtiles_for_collection(
                 parquet_path=parquet_path,
                 layer_name=layer_name,
                 collection_path=collection_path,
-                pmtiles_filename=pmtiles_path.name,
+                pmtiles_relative_path=pmtiles_col_rel,
                 catalog_path=catalog_root,
             )
             result.skipped.append(pmtiles_path)
@@ -617,7 +628,7 @@ def generate_pmtiles_for_collection(
                 parquet_path=parquet_path,
                 layer_name=layer_name,
                 collection_path=collection_path,
-                pmtiles_filename=pmtiles_path.name,
+                pmtiles_relative_path=pmtiles_col_rel,
                 catalog_path=catalog_root,
             )
 
@@ -655,7 +666,6 @@ def generate_pmtiles_for_collection(
     from portolan_cli.style import discover_styles, register_style_assets
 
     styles = discover_styles(collection_path)
-    if styles:
-        register_style_assets(collection_path, styles)
+    register_style_assets(collection_path, styles)
 
     return result

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -651,4 +651,11 @@ def generate_pmtiles_for_collection(
             except Exception as e:
                 logger.warning("Thumbnail generation failed for %s: %s", pmtiles_path.name, e)
 
+    # Discover and register style assets (ADR-0044)
+    from portolan_cli.style import discover_styles, register_style_assets
+
+    styles = discover_styles(collection_path)
+    if styles:
+        register_style_assets(collection_path, styles)
+
     return result

--- a/portolan_cli/scan_classify.py
+++ b/portolan_cli/scan_classify.py
@@ -260,6 +260,14 @@ def classify_file(
             f"{name} is a map style definition",
         )
 
+    # Check if file is inside a styles/ directory (ADR-0044)
+    if path.parent.name == "styles" and ext == ".json":
+        return (
+            FileCategory.STYLE,
+            SkipReasonType.METADATA_FILE,
+            f"{path.name} is a map style definition in styles/ directory",
+        )
+
     # Check by extension
     if ext in GEO_ASSET_EXTENSIONS:
         return (FileCategory.GEO_ASSET, None, None)

--- a/portolan_cli/skills/sourcecoop.md
+++ b/portolan_cli/skills/sourcecoop.md
@@ -375,6 +375,80 @@ portolan push --workers 8 --verbose
 
 ---
 
+## Styles
+
+Portolan supports multiple named visualization styles per collection. Each style is a complete Mapbox GL v8 JSON file stored in `{collection}/styles/`.
+
+### Creating Styles
+
+Style files are complete Mapbox GL v8 specs with relative PMTiles source paths:
+
+```json
+{
+  "version": 8,
+  "name": "Buildings by Construction Year",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../data.pmtiles"
+    }
+  },
+  "layers": [
+    {
+      "id": "buildings-by-age",
+      "type": "fill",
+      "source": "data",
+      "source-layer": "layer_name",
+      "paint": {
+        "fill-color": ["interpolate", ["linear"], ["get", "bouwjaar"],
+          1400, "#1a0a00", 1900, "#8B4513", 1960, "#DAA520", 2020, "#FFFF00"
+        ],
+        "fill-opacity": 0.7
+      }
+    }
+  ]
+}
+```
+
+A default style is auto-generated during PMTiles creation. Drop additional style files into `styles/` and they'll be discovered automatically.
+
+### Style Best Practices
+
+1. **Create multiple styles for rich datasets.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each. Example: buildings by construction year, by usage type, by height. Don't stop at a single default.
+
+2. **Vary default styles across a catalog.** Each collection should have a visually distinct default color/palette. Use subject matter to inform color choices — water features in blues, vegetation in greens, built environment in warm tones, infrastructure in grays.
+
+3. **Use data-driven styling.** Leverage Mapbox GL expressions (`interpolate`, `match`, `case`, `step`) to reveal patterns in data. For categorical data use `match`; for continuous data use `interpolate` or `step`.
+
+4. **Include a description field on the STAC asset** explaining what the colors/sizes represent. This appears in style pickers and tooltips.
+
+5. **Consider label layers.** For datasets with names (monuments, administrative areas, roads), add a label style layer or a dedicated "with labels" style variant.
+
+6. **Look at the collection's table:columns** to understand what attributes are available for data-driven styling. Interesting fields for visualization include: categories/enums, dates/years, numeric measurements, status fields.
+
+### STAC Registration
+
+Styles are registered as collection-level assets with the `portolan:styles` manifest:
+
+```json
+{
+  "portolan:styles": ["styles/default", "styles/by-age", "styles/by-use"],
+  "assets": {
+    "styles/default": {
+      "href": "./styles/default.json",
+      "type": "application/json",
+      "title": "Default",
+      "description": "Blue building footprints.",
+      "roles": ["style"]
+    }
+  }
+}
+```
+
+First entry in `portolan:styles` is the default. `portolan scan` discovers styles and registers them automatically.
+
+---
+
 ## Source Cooperative Best Practices
 
 1. **Use descriptive titles** — "Philadelphia 2023 Aerial Orthoimagery" not "imagery"

--- a/portolan_cli/skills/sourcecoop.md
+++ b/portolan_cli/skills/sourcecoop.md
@@ -163,7 +163,7 @@ portolan metadata init --recursive
 
 **Recommended fields** (prompt user for these):
 - `keywords` — List of tags for discoverability
-- `citation` — How to cite this dataset
+- `citation` — How to cite this collection
 - `temporal_extent` — Time range the data covers
 - `providers` — Organizations that created/host the data
 
@@ -414,7 +414,7 @@ A default style is auto-generated during PMTiles creation. Drop additional style
 
 ### Style Best Practices
 
-1. **Create multiple styles for rich datasets.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each. Example: buildings by construction year, by usage type, by height. Don't stop at a single default.
+1. **Create multiple styles for rich collections.** If a collection has interesting categorical or numeric attributes, create data-driven styles for each. Example: buildings by construction year, by usage type, by height. Don't stop at a single default.
 
 2. **Vary default styles across a catalog.** Each collection should have a visually distinct default color/palette. Use subject matter to inform color choices — water features in blues, vegetation in greens, built environment in warm tones, infrastructure in grays.
 
@@ -422,7 +422,7 @@ A default style is auto-generated during PMTiles creation. Drop additional style
 
 4. **Include a description field on the STAC asset** explaining what the colors/sizes represent. This appears in style pickers and tooltips.
 
-5. **Consider label layers.** For datasets with names (monuments, administrative areas, roads), add a label style layer or a dedicated "with labels" style variant.
+5. **Consider label layers.** For collections with names (monuments, administrative areas, roads), add a label style layer or a dedicated "with labels" style variant.
 
 6. **Look at the collection's table:columns** to understand what attributes are available for data-driven styling. Interesting fields for visualization include: categories/enums, dates/years, numeric measurements, status fields.
 

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -123,23 +123,28 @@ class RasterStyleConfig:
 # =============================================================================
 
 
-def build_pmtiles_style(
+def build_full_style(
+    name: str,
     geometry_type: str,
     source_layer: str,
+    pmtiles_relative_path: str,
     config: VectorStyleConfig,
 ) -> dict[str, Any]:
-    """Build Mapbox GL style spec for PMTiles based on geometry type.
+    """Build complete Mapbox GL v8 style with sources and layers.
 
-    Generates a minimal Mapbox GL style spec (version 8) with a single layer
-    appropriate for the geometry type.
+    Generates a full Mapbox GL style spec (version 8) including sources
+    section with PMTiles URL and a single layer appropriate for the
+    geometry type.
 
     Args:
+        name: Style name (e.g., "Default").
         geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
         source_layer: Name of the source layer in PMTiles.
+        pmtiles_relative_path: Relative path to PMTiles file (e.g., "../data.pmtiles").
         config: Style configuration.
 
     Returns:
-        Mapbox GL style spec dict with version and layers.
+        Complete Mapbox GL style spec dict with version, name, sources, and layers.
     """
     # Normalize geometry type to layer type
     geom_lower = geometry_type.lower()
@@ -173,45 +178,10 @@ def build_pmtiles_style(
     layer = {
         "id": f"{source_layer}-{suffix}",
         "type": layer_type,
+        "source": "data",
         "source-layer": source_layer,
         "paint": paint,
     }
-
-    return {
-        "version": 8,
-        "layers": [layer],
-    }
-
-
-def build_full_style(
-    name: str,
-    geometry_type: str,
-    source_layer: str,
-    pmtiles_relative_path: str,
-    config: VectorStyleConfig,
-) -> dict[str, Any]:
-    """Build complete Mapbox GL v8 style with sources and layers.
-
-    Generates a full Mapbox GL style spec (version 8) including sources
-    section with PMTiles URL and a single layer appropriate for the
-    geometry type.
-
-    Args:
-        name: Style name (e.g., "Default").
-        geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
-        source_layer: Name of the source layer in PMTiles.
-        pmtiles_relative_path: Relative path to PMTiles file (e.g., "../data.pmtiles").
-        config: Style configuration.
-
-    Returns:
-        Complete Mapbox GL style spec dict with version, name, sources, and layers.
-    """
-    # Reuse build_pmtiles_style logic for layer generation
-    partial_style = build_pmtiles_style(geometry_type, source_layer, config)
-
-    # Extract layer and add source reference
-    layer = partial_style["layers"][0]
-    layer["source"] = "data"
 
     return {
         "version": 8,

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -6,6 +6,9 @@ Public API:
 - VectorStyleConfig: Configuration for vector styling
 - RasterStyleConfig: Configuration for raster styling
 - build_pmtiles_style: Generate Mapbox GL style for PMTiles
+- build_full_style: Generate complete Mapbox GL style with sources
+- write_style_file: Write style dict to JSON file
+- write_default_style: Convenience function to write default.json
 - build_raster_style: Generate render extension properties for COG
 - get_vector_style_config: Load vector style config from catalog
 - get_raster_style_config: Load raster style config from catalog
@@ -13,6 +16,7 @@ Public API:
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -175,6 +179,116 @@ def build_pmtiles_style(
         "version": 8,
         "layers": [layer],
     }
+
+
+def build_full_style(
+    name: str,
+    geometry_type: str,
+    source_layer: str,
+    pmtiles_relative_path: str,
+    config: VectorStyleConfig,
+) -> dict[str, Any]:
+    """Build complete Mapbox GL v8 style with sources and layers.
+
+    Generates a full Mapbox GL style spec (version 8) including sources
+    section with PMTiles URL and a single layer appropriate for the
+    geometry type.
+
+    Args:
+        name: Style name (e.g., "Default").
+        geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
+        source_layer: Name of the source layer in PMTiles.
+        pmtiles_relative_path: Relative path to PMTiles file (e.g., "../data.pmtiles").
+        config: Style configuration.
+
+    Returns:
+        Complete Mapbox GL style spec dict with version, name, sources, and layers.
+    """
+    # Reuse build_pmtiles_style logic for layer generation
+    partial_style = build_pmtiles_style(geometry_type, source_layer, config)
+
+    # Extract layer and add source reference
+    layer = partial_style["layers"][0]
+    layer["source"] = "data"
+
+    return {
+        "version": 8,
+        "name": name,
+        "sources": {
+            "data": {
+                "type": "vector",
+                "url": pmtiles_relative_path,
+            }
+        },
+        "layers": [layer],
+    }
+
+
+def write_style_file(
+    style_dir: Path,
+    name: str,
+    style_dict: dict[str, Any],
+) -> Path:
+    """Write a style dict to a JSON file.
+
+    Creates the directory if needed, writes {style_dir}/{name}.json with
+    indented JSON formatting.
+
+    Args:
+        style_dir: Directory to write the style file into.
+        name: Style filename (without .json extension).
+        style_dict: Style dict to serialize.
+
+    Returns:
+        Path to the written file.
+    """
+    style_dir.mkdir(parents=True, exist_ok=True)
+    style_path = style_dir / f"{name}.json"
+    style_path.write_text(json.dumps(style_dict, indent=2))
+    return style_path
+
+
+def write_default_style(
+    collection_path: Path,
+    geometry_type: str,
+    source_layer: str,
+    pmtiles_filename: str,
+    config: VectorStyleConfig | None = None,
+) -> Path | None:
+    """Write default style to {collection_path}/styles/default.json.
+
+    Convenience function that creates a default.json style file. Does NOT
+    overwrite if file already exists (returns None).
+
+    Args:
+        collection_path: Path to the collection directory.
+        geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
+        source_layer: Name of the source layer in PMTiles.
+        pmtiles_filename: PMTiles filename (e.g., "data.pmtiles").
+        config: Optional style configuration (uses defaults if None).
+
+    Returns:
+        Path to written file, or None if default.json already exists.
+    """
+    styles_dir = collection_path / "styles"
+    default_path = styles_dir / "default.json"
+
+    # Don't overwrite existing file
+    if default_path.exists():
+        return None
+
+    if config is None:
+        config = VectorStyleConfig()
+
+    style_dict = build_full_style(
+        name="Default",
+        geometry_type=geometry_type,
+        source_layer=source_layer,
+        pmtiles_relative_path=f"../{pmtiles_filename}",
+        config=config,
+    )
+
+    return write_style_file(styles_dir, "default", style_dict)
 
 
 def build_raster_style(config: RasterStyleConfig) -> dict[str, Any]:

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -5,7 +5,6 @@ Generates Mapbox GL style specs for PMTiles and render extension properties for 
 Public API:
 - VectorStyleConfig: Configuration for vector styling
 - RasterStyleConfig: Configuration for raster styling
-- build_pmtiles_style: Generate Mapbox GL style for PMTiles
 - build_full_style: Generate complete Mapbox GL style with sources
 - write_style_file: Write style dict to JSON file
 - write_default_style: Convenience function to write default.json
@@ -429,10 +428,7 @@ def register_style_assets(
 
     # Remove stale style assets (assets with "styles/" prefix that no longer have files)
     current_keys = {s["key"] for s in styles}
-    stale_keys = [
-        k for k in assets
-        if k.startswith("styles/") and k not in current_keys
-    ]
+    stale_keys = [k for k in assets if k.startswith("styles/") and k not in current_keys]
     for key in stale_keys:
         del assets[key]
 

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -12,6 +12,8 @@ Public API:
 - build_raster_style: Generate render extension properties for COG
 - get_vector_style_config: Load vector style config from catalog
 - get_raster_style_config: Load raster style config from catalog
+- discover_styles: Discover style JSON files in styles/ directory
+- build_styles_manifest: Build portolan:styles manifest array
 """
 
 from __future__ import annotations
@@ -359,6 +361,80 @@ def enrich_cog_assets(
     for asset in assets.values():
         if getattr(asset, "media_type", None) in _COG_MEDIA_TYPES:
             enrich_cog_asset_with_style(asset, catalog_path)
+
+
+# =============================================================================
+# Style Discovery
+# =============================================================================
+
+
+def discover_styles(collection_path: Path) -> list[dict[str, Any]]:
+    """Discover style JSON files in {collection_path}/styles/ directory.
+
+    Returns a list of dicts with keys: key, href, title, description, path.
+
+    Args:
+        collection_path: Path to the collection directory.
+
+    Returns:
+        List of style dicts. Empty list if no styles/ directory exists.
+    """
+    styles_dir = collection_path / "styles"
+
+    if not styles_dir.exists():
+        return []
+
+    styles: list[dict[str, Any]] = []
+
+    for path in sorted(styles_dir.glob("*.json")):
+        try:
+            style_data = json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Skipping style file %s: %s", path, e)
+            continue
+
+        # Skip if parsed result is not a dict
+        if not isinstance(style_data, dict):
+            continue
+
+        name = path.stem
+        title = style_data.get("name", name)
+        description = style_data.get("description", "")
+
+        styles.append(
+            {
+                "key": f"styles/{name}",
+                "href": f"./styles/{path.name}",
+                "title": title,
+                "description": description,
+                "path": path,
+            }
+        )
+
+    return styles
+
+
+def build_styles_manifest(styles: list[dict[str, Any]]) -> list[str]:
+    """Build the portolan:styles manifest array.
+
+    Returns ordered list of asset keys with styles/default first if present,
+    then remaining styles sorted alphabetically.
+
+    Args:
+        styles: List of style dicts (from discover_styles).
+
+    Returns:
+        List of style asset keys.
+    """
+    keys = [s["key"] for s in styles]
+
+    if "styles/default" in keys:
+        # Put default first, sort the rest
+        remaining = [k for k in keys if k != "styles/default"]
+        return ["styles/default"] + sorted(remaining)
+
+    # No default, just sort all
+    return sorted(keys)
 
 
 # =============================================================================

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -5,6 +5,7 @@ Generates Mapbox GL style specs for PMTiles and render extension properties for 
 Public API:
 - VectorStyleConfig: Configuration for vector styling
 - RasterStyleConfig: Configuration for raster styling
+- StyleInfo: Discovered style file metadata
 - build_full_style: Generate complete Mapbox GL style with sources
 - write_style_file: Write style dict to JSON file
 - write_default_style: Convenience function to write default.json
@@ -68,6 +69,25 @@ def _parse_config_float(value: Any, key: str, default: float) -> float:
 # =============================================================================
 # Configuration Dataclasses
 # =============================================================================
+
+
+@dataclass(frozen=True)
+class StyleInfo:
+    """Metadata for a discovered style file.
+
+    Attributes:
+        key: STAC asset key (e.g., "styles/default").
+        href: Relative href for STAC asset (e.g., "./styles/default.json").
+        title: Human-readable title from style's "name" field or filename.
+        description: Description from style file (empty string if absent).
+        path: Absolute path to the style file on disk.
+    """
+
+    key: str
+    href: str
+    title: str
+    description: str
+    path: Path
 
 
 @dataclass(frozen=True)
@@ -208,12 +228,19 @@ def write_style_file(
 
     Args:
         style_dir: Directory to write the style file into.
-        name: Style filename (without .json extension).
+        name: Style filename (without .json extension). Must not contain
+            path separators or parent directory references.
         style_dict: Style dict to serialize.
 
     Returns:
         Path to the written file.
+
+    Raises:
+        ValueError: If name contains path traversal characters.
     """
+    if "/" in name or "\\" in name or ".." in name:
+        msg = f"Style name must not contain path separators or '..': {name!r}"
+        raise ValueError(msg)
     style_dir.mkdir(parents=True, exist_ok=True)
     style_path = style_dir / f"{name}.json"
     style_path.write_text(json.dumps(style_dict, indent=2))
@@ -224,7 +251,7 @@ def write_default_style(
     collection_path: Path,
     geometry_type: str,
     source_layer: str,
-    pmtiles_filename: str,
+    pmtiles_relative_path: str,
     config: VectorStyleConfig | None = None,
 ) -> Path | None:
     """Write default style to {collection_path}/styles/default.json.
@@ -236,7 +263,8 @@ def write_default_style(
         collection_path: Path to the collection directory.
         geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
         source_layer: Name of the source layer in PMTiles.
-        pmtiles_filename: PMTiles filename (e.g., "data.pmtiles").
+        pmtiles_relative_path: PMTiles path relative to collection (e.g., "data.pmtiles"
+            or "sub/data.pmtiles"). Will be prefixed with "../" for styles/ directory.
         config: Optional style configuration (uses defaults if None).
 
     Returns:
@@ -256,7 +284,7 @@ def write_default_style(
         name="Default",
         geometry_type=geometry_type,
         source_layer=source_layer,
-        pmtiles_relative_path=f"../{pmtiles_filename}",
+        pmtiles_relative_path=f"../{pmtiles_relative_path}",
         config=config,
     )
 
@@ -338,23 +366,21 @@ def enrich_cog_assets(
 # =============================================================================
 
 
-def discover_styles(collection_path: Path) -> list[dict[str, Any]]:
+def discover_styles(collection_path: Path) -> list[StyleInfo]:
     """Discover style JSON files in {collection_path}/styles/ directory.
-
-    Returns a list of dicts with keys: key, href, title, description, path.
 
     Args:
         collection_path: Path to the collection directory.
 
     Returns:
-        List of style dicts. Empty list if no styles/ directory exists.
+        List of StyleInfo objects. Empty list if no styles/ directory exists.
     """
     styles_dir = collection_path / "styles"
 
     if not styles_dir.exists():
         return []
 
-    styles: list[dict[str, Any]] = []
+    styles: list[StyleInfo] = []
 
     for path in sorted(styles_dir.glob("*.json")):
         try:
@@ -372,31 +398,31 @@ def discover_styles(collection_path: Path) -> list[dict[str, Any]]:
         description = style_data.get("description", "")
 
         styles.append(
-            {
-                "key": f"styles/{name}",
-                "href": f"./styles/{path.name}",
-                "title": title,
-                "description": description,
-                "path": path,
-            }
+            StyleInfo(
+                key=f"styles/{name}",
+                href=f"./styles/{path.name}",
+                title=title,
+                description=description,
+                path=path,
+            )
         )
 
     return styles
 
 
-def build_styles_manifest(styles: list[dict[str, Any]]) -> list[str]:
+def build_styles_manifest(styles: list[StyleInfo]) -> list[str]:
     """Build the portolan:styles manifest array.
 
     Returns ordered list of asset keys with styles/default first if present,
     then remaining styles sorted alphabetically.
 
     Args:
-        styles: List of style dicts (from discover_styles).
+        styles: List of StyleInfo objects (from discover_styles).
 
     Returns:
         List of style asset keys.
     """
-    keys = [s["key"] for s in styles]
+    keys = [s.key for s in styles]
 
     if "styles/default" in keys:
         # Put default first, sort the rest
@@ -409,7 +435,7 @@ def build_styles_manifest(styles: list[dict[str, Any]]) -> list[str]:
 
 def register_style_assets(
     collection_path: Path,
-    styles: list[dict[str, Any]],
+    styles: list[StyleInfo],
 ) -> None:
     """Register discovered styles as STAC assets and set portolan:styles manifest.
 
@@ -417,7 +443,7 @@ def register_style_assets(
 
     Args:
         collection_path: Path to the collection directory.
-        styles: List of style dicts from discover_styles().
+        styles: List of StyleInfo objects from discover_styles().
     """
     collection_json_path = collection_path / "collection.json"
     if not collection_json_path.exists():
@@ -427,7 +453,7 @@ def register_style_assets(
     assets = data.get("assets", {})
 
     # Remove stale style assets (assets with "styles/" prefix that no longer have files)
-    current_keys = {s["key"] for s in styles}
+    current_keys = {s.key for s in styles}
     stale_keys = [k for k in assets if k.startswith("styles/") and k not in current_keys]
     for key in stale_keys:
         del assets[key]
@@ -435,14 +461,14 @@ def register_style_assets(
     # Add/update style assets
     for style_info in styles:
         asset_dict: dict[str, Any] = {
-            "href": style_info["href"],
+            "href": style_info.href,
             "type": "application/json",
-            "title": style_info["title"],
+            "title": style_info.title,
             "roles": ["style"],
         }
-        if style_info.get("description"):
-            asset_dict["description"] = style_info["description"]
-        assets[style_info["key"]] = asset_dict
+        if style_info.description:
+            asset_dict["description"] = style_info.description
+        assets[style_info.key] = asset_dict
 
     data["assets"] = assets
 

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -14,6 +14,7 @@ Public API:
 - get_raster_style_config: Load raster style config from catalog
 - discover_styles: Discover style JSON files in styles/ directory
 - build_styles_manifest: Build portolan:styles manifest array
+- register_style_assets: Register styles as STAC assets in collection.json
 """
 
 from __future__ import annotations
@@ -405,6 +406,57 @@ def build_styles_manifest(styles: list[dict[str, Any]]) -> list[str]:
 
     # No default, just sort all
     return sorted(keys)
+
+
+def register_style_assets(
+    collection_path: Path,
+    styles: list[dict[str, Any]],
+) -> None:
+    """Register discovered styles as STAC assets and set portolan:styles manifest.
+
+    Updates collection.json to add/update style assets and remove stale ones.
+
+    Args:
+        collection_path: Path to the collection directory.
+        styles: List of style dicts from discover_styles().
+    """
+    collection_json_path = collection_path / "collection.json"
+    if not collection_json_path.exists():
+        return
+
+    data = json.loads(collection_json_path.read_text())
+    assets = data.get("assets", {})
+
+    # Remove stale style assets (assets with "styles/" prefix that no longer have files)
+    current_keys = {s["key"] for s in styles}
+    stale_keys = [
+        k for k in assets
+        if k.startswith("styles/") and k not in current_keys
+    ]
+    for key in stale_keys:
+        del assets[key]
+
+    # Add/update style assets
+    for style_info in styles:
+        asset_dict: dict[str, Any] = {
+            "href": style_info["href"],
+            "type": "application/json",
+            "title": style_info["title"],
+            "roles": ["style"],
+        }
+        if style_info.get("description"):
+            asset_dict["description"] = style_info["description"]
+        assets[style_info["key"]] = asset_dict
+
+    data["assets"] = assets
+
+    # Set or remove portolan:styles manifest
+    if styles:
+        data["portolan:styles"] = build_styles_manifest(styles)
+    else:
+        data.pop("portolan:styles", None)
+
+    collection_json_path.write_text(json.dumps(data, indent=2))
 
 
 # =============================================================================

--- a/tests/fixtures/metadata/style/valid/style_categorical.json
+++ b/tests/fixtures/metadata/style/valid/style_categorical.json
@@ -1,19 +1,25 @@
 {
   "version": 8,
+  "name": "Land Use Categories",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../parcels.pmtiles"
+    }
+  },
   "layers": [
     {
-      "id": "landuse-fill",
+      "id": "parcels-categorical",
       "type": "fill",
-      "source-layer": "landuse",
+      "source": "data",
+      "source-layer": "parcels",
       "paint": {
         "fill-color": [
-          "match",
-          ["get", "type"],
-          "residential", "#f0e68c",
-          "commercial", "#ff6347",
-          "industrial", "#808080",
-          "park", "#90ee90",
-          "#3388ff"
+          "match", ["get", "land_use"],
+          "residential", "#ff6b6b",
+          "commercial", "#4ecdc4",
+          "industrial", "#45b7d1",
+          "#95afc0"
         ],
         "fill-opacity": 0.7
       }

--- a/tests/fixtures/metadata/style/valid/style_graduated.json
+++ b/tests/fixtures/metadata/style/valid/style_graduated.json
@@ -1,22 +1,26 @@
 {
   "version": 8,
+  "name": "Population Density",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../parcels.pmtiles"
+    }
+  },
   "layers": [
     {
-      "id": "population-fill",
+      "id": "parcels-graduated",
       "type": "fill",
-      "source-layer": "census",
+      "source": "data",
+      "source-layer": "parcels",
       "paint": {
         "fill-color": [
-          "interpolate",
-          ["linear"],
-          ["get", "population"],
-          0, "#ffffcc",
-          10000, "#a1dab4",
-          50000, "#41b6c4",
-          100000, "#2c7fb8",
-          500000, "#253494"
+          "interpolate", ["linear"], ["get", "population"],
+          0, "#f7fbff",
+          100, "#6baed6",
+          1000, "#08306b"
         ],
-        "fill-opacity": 0.8
+        "fill-opacity": 0.7
       }
     }
   ]

--- a/tests/fixtures/metadata/style/valid/style_line.json
+++ b/tests/fixtures/metadata/style/valid/style_line.json
@@ -1,9 +1,17 @@
 {
   "version": 8,
+  "name": "Default",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../roads.pmtiles"
+    }
+  },
   "layers": [
     {
       "id": "roads-line",
       "type": "line",
+      "source": "data",
       "source-layer": "roads",
       "paint": {
         "line-color": "#3388ff",

--- a/tests/fixtures/metadata/style/valid/style_point.json
+++ b/tests/fixtures/metadata/style/valid/style_point.json
@@ -1,9 +1,17 @@
 {
   "version": 8,
+  "name": "Default",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../cities.pmtiles"
+    }
+  },
   "layers": [
     {
       "id": "cities-circle",
       "type": "circle",
+      "source": "data",
       "source-layer": "cities",
       "paint": {
         "circle-color": "#3388ff",

--- a/tests/fixtures/metadata/style/valid/style_polygon.json
+++ b/tests/fixtures/metadata/style/valid/style_polygon.json
@@ -1,9 +1,17 @@
 {
   "version": 8,
+  "name": "Default",
+  "sources": {
+    "data": {
+      "type": "vector",
+      "url": "../parcels.pmtiles"
+    }
+  },
   "layers": [
     {
       "id": "parcels-fill",
       "type": "fill",
+      "source": "data",
       "source-layer": "parcels",
       "paint": {
         "fill-color": "#3388ff",

--- a/tests/integration/test_thumbnail_workflow.py
+++ b/tests/integration/test_thumbnail_workflow.py
@@ -202,7 +202,7 @@ styles:
             collection_path=collection_path,
             geometry_type="Polygon",
             source_layer="data",
-            pmtiles_filename="data.pmtiles",
+            pmtiles_relative_path="data.pmtiles",
             config=config,
         )
 

--- a/tests/integration/test_thumbnail_workflow.py
+++ b/tests/integration/test_thumbnail_workflow.py
@@ -105,31 +105,24 @@ class TestStyleInStacAssets:
     """Integration tests for style storage in STAC assets."""
 
     @pytest.mark.integration
-    def test_pmtiles_metadata_includes_style(self) -> None:
-        """PMTilesMetadata.to_stac_properties includes style when set."""
-        from portolan_cli.metadata.pmtiles import PMTilesMetadata
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
+    def test_build_full_style_creates_valid_mapbox_gl_spec(self) -> None:
+        """build_full_style produces a complete Mapbox GL v8 style spec."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
 
-        # Build a style
         config = VectorStyleConfig()
-        style = build_pmtiles_style("Polygon", "parcels", config)
-
-        # Create metadata with style
-        metadata = PMTilesMetadata(
-            bbox=(-122.5, 37.5, -122.0, 38.0),
-            min_zoom=0,
-            max_zoom=14,
-            tile_type="mvt",
-            center=None,
-            layer_name="parcels",
-            style=style,
+        style = build_full_style(
+            name="Default",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
         )
 
-        props = metadata.to_stac_properties()
-
-        assert "pmtiles:style" in props
-        assert props["pmtiles:style"]["version"] == 8
-        assert len(props["pmtiles:style"]["layers"]) == 1
+        assert style["version"] == 8
+        assert style["name"] == "Default"
+        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert len(style["layers"]) == 1
+        assert style["layers"][0]["type"] == "fill"
 
     @pytest.mark.integration
     def test_pmtiles_metadata_includes_layer_name(self) -> None:
@@ -143,7 +136,6 @@ class TestStyleInStacAssets:
             tile_type="mvt",
             center=None,
             layer_name="boundaries",
-            style=None,
         )
 
         props = metadata.to_stac_properties()
@@ -172,10 +164,14 @@ styles:
         assert config.polygon_fill_opacity == 0.75
 
     @pytest.mark.integration
-    def test_style_applied_to_generated_pmtiles_asset(self, tmp_path: Path) -> None:
-        """Style is written to PMTiles asset in collection.json."""
-        from portolan_cli.pmtiles import add_pmtiles_asset_to_collection
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
+    def test_style_registered_as_stac_asset(self, tmp_path: Path) -> None:
+        """Style files are registered as STAC assets with portolan:styles manifest."""
+        from portolan_cli.style import (
+            VectorStyleConfig,
+            discover_styles,
+            register_style_assets,
+            write_default_style,
+        )
 
         # Create minimal collection.json
         collection_path = tmp_path / "test-collection"
@@ -200,23 +196,25 @@ styles:
             )
         )
 
-        # Build style and add asset
+        # Write a default style and register it
         config = VectorStyleConfig(polygon_fill_color="#00ff00")
-        style = build_pmtiles_style("Polygon", "data", config)
-
-        add_pmtiles_asset_to_collection(
-            collection_path,
-            "data",
-            "./data.pmtiles",
-            style=style,
+        write_default_style(
+            collection_path=collection_path,
+            geometry_type="Polygon",
+            source_layer="data",
+            pmtiles_filename="data.pmtiles",
+            config=config,
         )
 
-        # Verify style in collection.json
-        collection = json.loads((collection_path / "collection.json").read_text())
-        pmtiles_asset = collection["assets"]["data-tiles"]
+        styles = discover_styles(collection_path)
+        register_style_assets(collection_path, styles)
 
-        assert "pmtiles:style" in pmtiles_asset
-        assert pmtiles_asset["pmtiles:style"]["layers"][0]["paint"]["fill-color"] == "#00ff00"
+        # Verify style asset in collection.json
+        collection = json.loads((collection_path / "collection.json").read_text())
+
+        assert "styles/default" in collection["assets"]
+        assert collection["assets"]["styles/default"]["roles"] == ["style"]
+        assert collection["portolan:styles"] == ["styles/default"]
 
 
 # =============================================================================

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -62,161 +62,6 @@ class TestVectorStyleConfig:
 # =============================================================================
 
 
-class TestBuildPmtilesStyle:
-    """Tests for build_pmtiles_style function."""
-
-    @pytest.mark.unit
-    def test_polygon_style(self) -> None:
-        """Builds fill layer for polygon geometry."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("Polygon", "layer_name", config)
-
-        assert style["version"] == 8
-        assert len(style["layers"]) == 1
-
-        layer = style["layers"][0]
-        assert layer["type"] == "fill"
-        assert layer["source-layer"] == "layer_name"
-        assert layer["paint"]["fill-color"] == "#3388ff"
-        assert layer["paint"]["fill-opacity"] == 0.6
-        assert layer["paint"]["fill-outline-color"] == "#2266cc"
-
-    @pytest.mark.unit
-    def test_multipolygon_style(self) -> None:
-        """MultiPolygon uses same style as Polygon."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("MultiPolygon", "data", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "fill"
-
-    @pytest.mark.unit
-    def test_linestring_style(self) -> None:
-        """Builds line layer for line geometry."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("LineString", "roads", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "line"
-        assert layer["paint"]["line-color"] == "#3388ff"
-        assert layer["paint"]["line-width"] == 2
-        assert layer["paint"]["line-opacity"] == 0.8
-
-    @pytest.mark.unit
-    def test_multilinestring_style(self) -> None:
-        """MultiLineString uses same style as LineString."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("MultiLineString", "rivers", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "line"
-
-    @pytest.mark.unit
-    def test_point_style(self) -> None:
-        """Builds circle layer for point geometry."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("Point", "cities", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "circle"
-        assert layer["paint"]["circle-color"] == "#3388ff"
-        assert layer["paint"]["circle-radius"] == 4
-        assert layer["paint"]["circle-opacity"] == 0.8
-
-    @pytest.mark.unit
-    def test_multipoint_style(self) -> None:
-        """MultiPoint uses same style as Point."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("MultiPoint", "events", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "circle"
-
-    @pytest.mark.unit
-    def test_geometry_collection_fallback(self) -> None:
-        """GeometryCollection falls back to polygon style."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("GeometryCollection", "mixed", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "fill"
-
-    @pytest.mark.unit
-    def test_unknown_geometry_fallback(self) -> None:
-        """Unknown geometry type falls back to polygon style."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("Unknown", "data", config)
-
-        layer = style["layers"][0]
-        assert layer["type"] == "fill"
-
-    @pytest.mark.unit
-    def test_custom_config_applied(self) -> None:
-        """Custom config values are applied to style."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig(
-            polygon_fill_color="#ff0000",
-            polygon_fill_opacity=0.9,
-            polygon_outline_color="#000000",
-        )
-        style = build_pmtiles_style("Polygon", "parcels", config)
-
-        layer = style["layers"][0]
-        assert layer["paint"]["fill-color"] == "#ff0000"
-        assert layer["paint"]["fill-opacity"] == 0.9
-        assert layer["paint"]["fill-outline-color"] == "#000000"
-
-    @pytest.mark.unit
-    def test_layer_id_generated(self) -> None:
-        """Layer ID is auto-generated from source-layer."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("Polygon", "parcels", config)
-
-        layer = style["layers"][0]
-        assert layer["id"] == "parcels-fill"
-
-    @pytest.mark.unit
-    def test_line_layer_id(self) -> None:
-        """Line layer ID uses -line suffix."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("LineString", "roads", config)
-
-        layer = style["layers"][0]
-        assert layer["id"] == "roads-line"
-
-    @pytest.mark.unit
-    def test_circle_layer_id(self) -> None:
-        """Circle layer ID uses -circle suffix."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
-
-        config = VectorStyleConfig()
-        style = build_pmtiles_style("Point", "points", config)
-
-        layer = style["layers"][0]
-        assert layer["id"] == "points-circle"
-
-
 # =============================================================================
 # Phase 3: Raster Style Tests
 # =============================================================================
@@ -339,37 +184,47 @@ styles:
 
 
 class TestStyleInAssetProperties:
-    """Tests for adding style to STAC asset properties."""
+    """Tests for style structure validation."""
 
     @pytest.mark.unit
-    def test_pmtiles_style_in_properties(self) -> None:
-        """PMTiles style is serialized to pmtiles:style property."""
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
+    def test_full_style_structure(self) -> None:
+        """Full style has all required Mapbox GL fields."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
 
         config = VectorStyleConfig()
-        style = build_pmtiles_style("Polygon", "parcels", config)
+        style = build_full_style(
+            name="Test",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
 
-        # Style should be a complete Mapbox GL style spec subset
         assert "version" in style
+        assert "name" in style
+        assert "sources" in style
         assert "layers" in style
         assert isinstance(style["layers"], list)
         assert len(style["layers"]) > 0
+        assert style["layers"][0]["source"] == "data"
 
     @pytest.mark.unit
     def test_style_is_json_serializable(self) -> None:
-        """Style dict is JSON-serializable for STAC asset storage."""
+        """Style dict is JSON-serializable."""
         import json
 
-        from portolan_cli.style import VectorStyleConfig, build_pmtiles_style
+        from portolan_cli.style import VectorStyleConfig, build_full_style
 
         config = VectorStyleConfig()
-        style = build_pmtiles_style("Polygon", "layer", config)
+        style = build_full_style(
+            name="Test",
+            geometry_type="Polygon",
+            source_layer="layer",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
 
-        # Should not raise
         serialized = json.dumps(style)
-        assert isinstance(serialized, str)
-
-        # Should round-trip
         deserialized = json.loads(serialized)
         assert deserialized == style
 
@@ -590,6 +445,9 @@ class TestStyleFixtures:
         assert style["version"] == 8
         assert len(style["layers"]) == 1
         assert style["layers"][0]["type"] == "circle"
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert style["layers"][0]["source"] == "data"
 
     @pytest.mark.unit
     def test_valid_polygon_style_loads(self, valid_style_dir: Path) -> None:
@@ -603,6 +461,9 @@ class TestStyleFixtures:
         assert style["version"] == 8
         assert len(style["layers"]) == 1
         assert style["layers"][0]["type"] == "fill"
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert style["layers"][0]["source"] == "data"
 
     @pytest.mark.unit
     def test_valid_line_style_loads(self, valid_style_dir: Path) -> None:
@@ -616,6 +477,9 @@ class TestStyleFixtures:
         assert style["version"] == 8
         assert len(style["layers"]) == 1
         assert style["layers"][0]["type"] == "line"
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert style["layers"][0]["source"] == "data"
 
     @pytest.mark.unit
     def test_categorical_style_has_match_expression(self, valid_style_dir: Path) -> None:
@@ -631,6 +495,9 @@ class TestStyleFixtures:
         fill_color = paint["fill-color"]
         assert isinstance(fill_color, list)
         assert fill_color[0] == "match"
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert style["layers"][0]["source"] == "data"
 
     @pytest.mark.unit
     def test_graduated_style_has_interpolate_expression(self, valid_style_dir: Path) -> None:
@@ -646,6 +513,9 @@ class TestStyleFixtures:
         fill_color = paint["fill-color"]
         assert isinstance(fill_color, list)
         assert fill_color[0] == "interpolate"
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert style["layers"][0]["source"] == "data"
 
     @pytest.mark.unit
     def test_bad_syntax_fixture_fails_parse(self, invalid_style_dir: Path) -> None:

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -6,8 +6,12 @@ Tests style generation for PMTiles assets and render extension for rasters.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from portolan_cli.style import StyleInfo
 
 # =============================================================================
 # Phase 1: VectorStyleConfig Tests
@@ -183,54 +187,8 @@ styles:
 # =============================================================================
 
 
-class TestStyleInAssetProperties:
-    """Tests for style structure validation."""
-
-    @pytest.mark.unit
-    def test_full_style_structure(self) -> None:
-        """Full style has all required Mapbox GL fields."""
-        from portolan_cli.style import VectorStyleConfig, build_full_style
-
-        config = VectorStyleConfig()
-        style = build_full_style(
-            name="Test",
-            geometry_type="Polygon",
-            source_layer="parcels",
-            pmtiles_relative_path="../data.pmtiles",
-            config=config,
-        )
-
-        assert "version" in style
-        assert "name" in style
-        assert "sources" in style
-        assert "layers" in style
-        assert isinstance(style["layers"], list)
-        assert len(style["layers"]) > 0
-        assert style["layers"][0]["source"] == "data"
-
-    @pytest.mark.unit
-    def test_style_is_json_serializable(self) -> None:
-        """Style dict is JSON-serializable."""
-        import json
-
-        from portolan_cli.style import VectorStyleConfig, build_full_style
-
-        config = VectorStyleConfig()
-        style = build_full_style(
-            name="Test",
-            geometry_type="Polygon",
-            source_layer="layer",
-            pmtiles_relative_path="../data.pmtiles",
-            config=config,
-        )
-
-        serialized = json.dumps(style)
-        deserialized = json.loads(serialized)
-        assert deserialized == style
-
-
 # =============================================================================
-# Phase 5b: Style Discovery Tests
+# Phase 5: Style Discovery Tests
 # =============================================================================
 
 
@@ -254,7 +212,7 @@ class TestDiscoverStyles:
         styles = discover_styles(tmp_path)
 
         assert len(styles) == 2
-        keys = {s["key"] for s in styles}
+        keys = {s.key for s in styles}
         assert keys == {"styles/default", "styles/custom"}
 
     @pytest.mark.unit
@@ -274,7 +232,7 @@ class TestDiscoverStyles:
         styles = discover_styles(tmp_path)
 
         assert len(styles) == 1
-        assert styles[0]["title"] == "Buildings by Age"
+        assert styles[0].title == "Buildings by Age"
 
     @pytest.mark.unit
     def test_returns_empty_when_no_styles_dir(self, tmp_path: Path) -> None:
@@ -302,7 +260,7 @@ class TestDiscoverStyles:
         styles = discover_styles(tmp_path)
 
         assert len(styles) == 1
-        assert styles[0]["key"] == "styles/default"
+        assert styles[0].key == "styles/default"
 
     @pytest.mark.unit
     def test_skips_invalid_json(self, tmp_path: Path) -> None:
@@ -323,7 +281,7 @@ class TestDiscoverStyles:
 
         # Should only find the two valid files
         assert len(styles) == 2
-        keys = {s["key"] for s in styles}
+        keys = {s.key for s in styles}
         assert keys == {"styles/default", "styles/custom"}
 
     @pytest.mark.unit
@@ -342,11 +300,17 @@ class TestDiscoverStyles:
         styles = discover_styles(tmp_path)
 
         assert len(styles) == 1
-        assert styles[0]["title"] == "custom-theme"
+        assert styles[0].title == "custom-theme"
 
 
 class TestBuildStylesManifest:
     """Tests for build_styles_manifest function."""
+
+    @staticmethod
+    def _style_info(key: str) -> StyleInfo:
+        from portolan_cli.style import StyleInfo
+
+        return StyleInfo(key=key, href="", title="", description="", path=Path())
 
     @pytest.mark.unit
     def test_default_first(self) -> None:
@@ -354,9 +318,9 @@ class TestBuildStylesManifest:
         from portolan_cli.style import build_styles_manifest
 
         styles = [
-            {"key": "styles/zebra"},
-            {"key": "styles/default"},
-            {"key": "styles/alpha"},
+            self._style_info("styles/zebra"),
+            self._style_info("styles/default"),
+            self._style_info("styles/alpha"),
         ]
 
         manifest = build_styles_manifest(styles)
@@ -370,10 +334,10 @@ class TestBuildStylesManifest:
         from portolan_cli.style import build_styles_manifest
 
         styles = [
-            {"key": "styles/zebra"},
-            {"key": "styles/default"},
-            {"key": "styles/alpha"},
-            {"key": "styles/beta"},
+            self._style_info("styles/zebra"),
+            self._style_info("styles/default"),
+            self._style_info("styles/alpha"),
+            self._style_info("styles/beta"),
         ]
 
         manifest = build_styles_manifest(styles)
@@ -386,8 +350,8 @@ class TestBuildStylesManifest:
         from portolan_cli.style import build_styles_manifest
 
         styles = [
-            {"key": "styles/zebra"},
-            {"key": "styles/alpha"},
+            self._style_info("styles/zebra"),
+            self._style_info("styles/alpha"),
         ]
 
         manifest = build_styles_manifest(styles)
@@ -408,7 +372,7 @@ class TestBuildStylesManifest:
         """Single style returns single-element list."""
         from portolan_cli.style import build_styles_manifest
 
-        styles = [{"key": "styles/custom"}]
+        styles = [self._style_info("styles/custom")]
 
         manifest = build_styles_manifest(styles)
 
@@ -751,7 +715,7 @@ class TestWriteDefaultStyle:
             collection_path=tmp_path,
             geometry_type="Polygon",
             source_layer="parcels",
-            pmtiles_filename="data.pmtiles",
+            pmtiles_relative_path="data.pmtiles",
             config=config,
         )
 
@@ -783,7 +747,7 @@ class TestWriteDefaultStyle:
             collection_path=tmp_path,
             geometry_type="Polygon",
             source_layer="parcels",
-            pmtiles_filename="data.pmtiles",
+            pmtiles_relative_path="data.pmtiles",
             config=config,
         )
 
@@ -814,7 +778,7 @@ class TestWriteDefaultStyle:
             collection_path=tmp_path,
             geometry_type="Polygon",
             source_layer="parcels",
-            pmtiles_filename="data.pmtiles",
+            pmtiles_relative_path="data.pmtiles",
         )
 
         # Should return None
@@ -916,13 +880,16 @@ class TestRegisterStyleAssets:
         }
         (tmp_path / "collection.json").write_text(json.dumps(collection_data))
 
+        from portolan_cli.style import StyleInfo
+
         current_styles = [
-            {
-                "key": "styles/default",
-                "href": "./styles/default.json",
-                "title": "Default",
-                "description": "",
-            }
+            StyleInfo(
+                key="styles/default",
+                href="./styles/default.json",
+                title="Default",
+                description="",
+                path=tmp_path / "styles" / "default.json",
+            )
         ]
         register_style_assets(tmp_path, current_styles)
 

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -823,3 +823,91 @@ class TestWriteDefaultStyle:
         # Original content should be unchanged
         written = json.loads(default_path.read_text())
         assert written == original_content
+
+
+# =============================================================================
+# Phase 10: Style Registration Tests
+# =============================================================================
+
+
+class TestRegisterStyleAssets:
+    """Tests for registering discovered styles as STAC assets."""
+
+    @pytest.mark.unit
+    def test_registers_style_assets_in_collection(self, tmp_path: Path) -> None:
+        """Discovered styles are added as assets in collection.json."""
+        import json
+        from portolan_cli.style import discover_styles, register_style_assets
+
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "assets": {"data": {"href": "./data.parquet", "type": "application/x-parquet"}},
+        }
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text(
+            '{"version":8,"name":"Default","sources":{},"layers":[]}'
+        )
+        (styles_dir / "by-age.json").write_text(
+            '{"version":8,"name":"By Age","description":"Buildings colored by construction year","sources":{},"layers":[]}'
+        )
+
+        styles = discover_styles(tmp_path)
+        register_style_assets(tmp_path, styles)
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+
+        assert "styles/default" in updated["assets"]
+        assert "styles/by-age" in updated["assets"]
+
+        default_asset = updated["assets"]["styles/default"]
+        assert default_asset["type"] == "application/json"
+        assert default_asset["roles"] == ["style"]
+        assert default_asset["title"] == "Default"
+
+        by_age_asset = updated["assets"]["styles/by-age"]
+        assert by_age_asset["title"] == "By Age"
+        assert by_age_asset["description"] == "Buildings colored by construction year"
+
+        assert updated["portolan:styles"] == ["styles/default", "styles/by-age"]
+
+    @pytest.mark.unit
+    def test_no_styles_no_manifest(self, tmp_path: Path) -> None:
+        """No portolan:styles property when no styles exist."""
+        import json
+        from portolan_cli.style import register_style_assets
+
+        collection_data = {"type": "Collection", "id": "test", "assets": {}}
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        register_style_assets(tmp_path, [])
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "portolan:styles" not in updated
+
+    @pytest.mark.unit
+    def test_removes_stale_style_assets(self, tmp_path: Path) -> None:
+        """Removes style assets that no longer have files on disk."""
+        import json
+        from portolan_cli.style import register_style_assets
+
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "portolan:styles": ["styles/default", "styles/old"],
+            "assets": {
+                "styles/default": {"href": "./styles/default.json", "type": "application/json", "roles": ["style"]},
+                "styles/old": {"href": "./styles/old.json", "type": "application/json", "roles": ["style"]},
+            },
+        }
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        current_styles = [{"key": "styles/default", "href": "./styles/default.json", "title": "Default", "description": ""}]
+        register_style_assets(tmp_path, current_styles)
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "styles/old" not in updated["assets"]
+        assert updated["portolan:styles"] == ["styles/default"]

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -375,6 +375,192 @@ class TestStyleInAssetProperties:
 
 
 # =============================================================================
+# Phase 5b: Style Discovery Tests
+# =============================================================================
+
+
+class TestDiscoverStyles:
+    """Tests for discover_styles function."""
+
+    @pytest.mark.unit
+    def test_discovers_style_files(self, tmp_path: Path) -> None:
+        """Creates 2 style files and verifies both found with correct keys."""
+        import json
+
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+
+        # Create two style files
+        (styles_dir / "default.json").write_text(json.dumps({"version": 8, "layers": []}))
+        (styles_dir / "custom.json").write_text(json.dumps({"version": 8, "layers": []}))
+
+        styles = discover_styles(tmp_path)
+
+        assert len(styles) == 2
+        keys = {s["key"] for s in styles}
+        assert keys == {"styles/default", "styles/custom"}
+
+    @pytest.mark.unit
+    def test_extracts_name_as_title(self, tmp_path: Path) -> None:
+        """Style with 'name' field returns that as title."""
+        import json
+
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+
+        (styles_dir / "buildings.json").write_text(
+            json.dumps({"version": 8, "name": "Buildings by Age", "layers": []})
+        )
+
+        styles = discover_styles(tmp_path)
+
+        assert len(styles) == 1
+        assert styles[0]["title"] == "Buildings by Age"
+
+    @pytest.mark.unit
+    def test_returns_empty_when_no_styles_dir(self, tmp_path: Path) -> None:
+        """No styles/ directory returns empty list."""
+        from portolan_cli.style import discover_styles
+
+        styles = discover_styles(tmp_path)
+
+        assert styles == []
+
+    @pytest.mark.unit
+    def test_skips_non_json_files(self, tmp_path: Path) -> None:
+        """Non-JSON files in styles/ directory are ignored."""
+        import json
+
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+
+        # Create a valid JSON file and a .md file
+        (styles_dir / "default.json").write_text(json.dumps({"version": 8, "layers": []}))
+        (styles_dir / "README.md").write_text("# Styles\n")
+
+        styles = discover_styles(tmp_path)
+
+        assert len(styles) == 1
+        assert styles[0]["key"] == "styles/default"
+
+    @pytest.mark.unit
+    def test_skips_invalid_json(self, tmp_path: Path) -> None:
+        """Malformed JSON is skipped, valid files still returned."""
+        import json
+
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+
+        # Create valid and invalid JSON files
+        (styles_dir / "default.json").write_text(json.dumps({"version": 8, "layers": []}))
+        (styles_dir / "broken.json").write_text("{invalid json")
+        (styles_dir / "custom.json").write_text(json.dumps({"version": 8, "layers": []}))
+
+        styles = discover_styles(tmp_path)
+
+        # Should only find the two valid files
+        assert len(styles) == 2
+        keys = {s["key"] for s in styles}
+        assert keys == {"styles/default", "styles/custom"}
+
+    @pytest.mark.unit
+    def test_fallback_title_from_filename(self, tmp_path: Path) -> None:
+        """Style without 'name' field uses filename stem as title."""
+        import json
+
+        from portolan_cli.style import discover_styles
+
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+
+        # Create style without name field
+        (styles_dir / "custom-theme.json").write_text(json.dumps({"version": 8, "layers": []}))
+
+        styles = discover_styles(tmp_path)
+
+        assert len(styles) == 1
+        assert styles[0]["title"] == "custom-theme"
+
+
+class TestBuildStylesManifest:
+    """Tests for build_styles_manifest function."""
+
+    @pytest.mark.unit
+    def test_default_first(self) -> None:
+        """Default style always first regardless of input order."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [
+            {"key": "styles/zebra"},
+            {"key": "styles/default"},
+            {"key": "styles/alpha"},
+        ]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest[0] == "styles/default"
+        assert len(manifest) == 3
+
+    @pytest.mark.unit
+    def test_alphabetical_after_default(self) -> None:
+        """Non-default styles sorted alphabetically."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [
+            {"key": "styles/zebra"},
+            {"key": "styles/default"},
+            {"key": "styles/alpha"},
+            {"key": "styles/beta"},
+        ]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest == ["styles/default", "styles/alpha", "styles/beta", "styles/zebra"]
+
+    @pytest.mark.unit
+    def test_no_default(self) -> None:
+        """Works without a style named 'default'."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [
+            {"key": "styles/zebra"},
+            {"key": "styles/alpha"},
+        ]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest == ["styles/alpha", "styles/zebra"]
+
+    @pytest.mark.unit
+    def test_empty_list(self) -> None:
+        """Empty input returns empty output."""
+        from portolan_cli.style import build_styles_manifest
+
+        manifest = build_styles_manifest([])
+
+        assert manifest == []
+
+    @pytest.mark.unit
+    def test_single_style(self) -> None:
+        """Single style returns single-element list."""
+        from portolan_cli.style import build_styles_manifest
+
+        styles = [{"key": "styles/custom"}]
+
+        manifest = build_styles_manifest(styles)
+
+        assert manifest == ["styles/custom"]
+
+
+# =============================================================================
 # Phase 6: Style Fixture Tests
 # =============================================================================
 

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -837,6 +837,7 @@ class TestRegisterStyleAssets:
     def test_registers_style_assets_in_collection(self, tmp_path: Path) -> None:
         """Discovered styles are added as assets in collection.json."""
         import json
+
         from portolan_cli.style import discover_styles, register_style_assets
 
         collection_data = {
@@ -878,6 +879,7 @@ class TestRegisterStyleAssets:
     def test_no_styles_no_manifest(self, tmp_path: Path) -> None:
         """No portolan:styles property when no styles exist."""
         import json
+
         from portolan_cli.style import register_style_assets
 
         collection_data = {"type": "Collection", "id": "test", "assets": {}}
@@ -892,6 +894,7 @@ class TestRegisterStyleAssets:
     def test_removes_stale_style_assets(self, tmp_path: Path) -> None:
         """Removes style assets that no longer have files on disk."""
         import json
+
         from portolan_cli.style import register_style_assets
 
         collection_data = {
@@ -899,13 +902,28 @@ class TestRegisterStyleAssets:
             "id": "test",
             "portolan:styles": ["styles/default", "styles/old"],
             "assets": {
-                "styles/default": {"href": "./styles/default.json", "type": "application/json", "roles": ["style"]},
-                "styles/old": {"href": "./styles/old.json", "type": "application/json", "roles": ["style"]},
+                "styles/default": {
+                    "href": "./styles/default.json",
+                    "type": "application/json",
+                    "roles": ["style"],
+                },
+                "styles/old": {
+                    "href": "./styles/old.json",
+                    "type": "application/json",
+                    "roles": ["style"],
+                },
             },
         }
         (tmp_path / "collection.json").write_text(json.dumps(collection_data))
 
-        current_styles = [{"key": "styles/default", "href": "./styles/default.json", "title": "Default", "description": ""}]
+        current_styles = [
+            {
+                "key": "styles/default",
+                "href": "./styles/default.json",
+                "title": "Default",
+                "description": "",
+            }
+        ]
         register_style_assets(tmp_path, current_styles)
 
         updated = json.loads((tmp_path / "collection.json").read_text())

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -480,3 +480,290 @@ class TestStyleFixtures:
 
         style = json.loads(style_path.read_text())
         assert "layers" not in style
+
+
+# =============================================================================
+# Phase 7: Full Style Building Tests
+# =============================================================================
+
+
+class TestBuildFullStyle:
+    """Tests for build_full_style function."""
+
+    @pytest.mark.unit
+    def test_polygon_full_style(self) -> None:
+        """Builds complete Mapbox GL style for Polygon geometry."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Default",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        # Check version and name
+        assert style["version"] == 8
+        assert style["name"] == "Default"
+
+        # Check sources
+        assert "sources" in style
+        assert "data" in style["sources"]
+        assert style["sources"]["data"]["type"] == "vector"
+        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+
+        # Check layers
+        assert "layers" in style
+        assert len(style["layers"]) == 1
+        layer = style["layers"][0]
+        assert layer["type"] == "fill"
+        assert layer["source"] == "data"
+        assert layer["source-layer"] == "parcels"
+        assert layer["paint"]["fill-color"] == "#3388ff"
+        assert layer["paint"]["fill-opacity"] == 0.6
+        assert layer["paint"]["fill-outline-color"] == "#2266cc"
+
+    @pytest.mark.unit
+    def test_linestring_full_style(self) -> None:
+        """Builds complete Mapbox GL style for LineString geometry."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Roads",
+            geometry_type="LineString",
+            source_layer="roads",
+            pmtiles_relative_path="../roads.pmtiles",
+            config=config,
+        )
+
+        # Check layer type is line
+        assert style["layers"][0]["type"] == "line"
+        assert style["layers"][0]["source"] == "data"
+        assert style["layers"][0]["paint"]["line-color"] == "#3388ff"
+
+    @pytest.mark.unit
+    def test_point_full_style(self) -> None:
+        """Builds complete Mapbox GL style for Point geometry."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Cities",
+            geometry_type="Point",
+            source_layer="cities",
+            pmtiles_relative_path="../cities.pmtiles",
+            config=config,
+        )
+
+        # Check layer type is circle
+        assert style["layers"][0]["type"] == "circle"
+        assert style["layers"][0]["source"] == "data"
+        assert style["layers"][0]["paint"]["circle-color"] == "#3388ff"
+
+    @pytest.mark.unit
+    def test_custom_config_applied(self) -> None:
+        """Custom VectorStyleConfig values appear in paint properties."""
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig(
+            polygon_fill_color="#ff0000",
+            polygon_fill_opacity=0.9,
+            polygon_outline_color="#000000",
+        )
+        style = build_full_style(
+            name="Custom",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        paint = style["layers"][0]["paint"]
+        assert paint["fill-color"] == "#ff0000"
+        assert paint["fill-opacity"] == 0.9
+        assert paint["fill-outline-color"] == "#000000"
+
+    @pytest.mark.unit
+    def test_full_style_is_json_serializable(self) -> None:
+        """Full style dict is JSON-serializable."""
+        import json
+
+        from portolan_cli.style import VectorStyleConfig, build_full_style
+
+        config = VectorStyleConfig()
+        style = build_full_style(
+            name="Test",
+            geometry_type="Polygon",
+            source_layer="layer",
+            pmtiles_relative_path="../data.pmtiles",
+            config=config,
+        )
+
+        # Should round-trip through JSON
+        serialized = json.dumps(style)
+        deserialized = json.loads(serialized)
+        assert deserialized == style
+
+
+# =============================================================================
+# Phase 8: Style File Writing Tests
+# =============================================================================
+
+
+class TestWriteStyleFile:
+    """Tests for write_style_file function."""
+
+    @pytest.mark.unit
+    def test_writes_style_to_disk(self, tmp_path: Path) -> None:
+        """Writes style dict to disk as JSON."""
+        from portolan_cli.style import write_style_file
+
+        style_dir = tmp_path / "styles"
+        style_dict = {
+            "version": 8,
+            "name": "Test",
+            "sources": {"data": {"type": "vector", "url": "../data.pmtiles"}},
+            "layers": [],
+        }
+
+        result_path = write_style_file(style_dir, "default", style_dict)
+
+        assert result_path == style_dir / "default.json"
+        assert result_path.exists()
+
+        # Verify content
+        import json
+
+        written = json.loads(result_path.read_text())
+        assert written == style_dict
+
+    @pytest.mark.unit
+    def test_creates_styles_directory(self, tmp_path: Path) -> None:
+        """Creates styles directory if it doesn't exist."""
+        from portolan_cli.style import write_style_file
+
+        style_dir = tmp_path / "styles"
+        assert not style_dir.exists()
+
+        style_dict = {"version": 8}
+        write_style_file(style_dir, "test", style_dict)
+
+        assert style_dir.exists()
+        assert style_dir.is_dir()
+
+    @pytest.mark.unit
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """Overwrites existing style file."""
+        from portolan_cli.style import write_style_file
+
+        style_dir = tmp_path / "styles"
+        style_dir.mkdir()
+
+        # Write original
+        original = {"version": 7}
+        write_style_file(style_dir, "default", original)
+
+        # Overwrite with new
+        new = {"version": 8}
+        write_style_file(style_dir, "default", new)
+
+        # Verify new content
+        import json
+
+        written = json.loads((style_dir / "default.json").read_text())
+        assert written == new
+
+
+# =============================================================================
+# Phase 9: Default Style Writing Tests
+# =============================================================================
+
+
+class TestWriteDefaultStyle:
+    """Tests for write_default_style function."""
+
+    @pytest.mark.unit
+    def test_writes_default_style_file(self, tmp_path: Path) -> None:
+        """Creates styles/default.json with correct content."""
+        from portolan_cli.style import VectorStyleConfig, write_default_style
+
+        config = VectorStyleConfig()
+        result_path = write_default_style(
+            collection_path=tmp_path,
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_filename="data.pmtiles",
+            config=config,
+        )
+
+        assert result_path is not None
+        assert result_path == tmp_path / "styles" / "default.json"
+        assert result_path.exists()
+
+        # Verify content
+        import json
+
+        style = json.loads(result_path.read_text())
+        assert style["version"] == 8
+        assert style["name"] == "Default"
+        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert style["layers"][0]["type"] == "fill"
+        assert style["layers"][0]["source"] == "data"
+        assert style["layers"][0]["source-layer"] == "parcels"
+
+    @pytest.mark.unit
+    def test_uses_custom_config(self, tmp_path: Path) -> None:
+        """Custom VectorStyleConfig affects output."""
+        from portolan_cli.style import VectorStyleConfig, write_default_style
+
+        config = VectorStyleConfig(
+            polygon_fill_color="#ff0000",
+            polygon_fill_opacity=0.9,
+        )
+        result_path = write_default_style(
+            collection_path=tmp_path,
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_filename="data.pmtiles",
+            config=config,
+        )
+
+        import json
+
+        style = json.loads(result_path.read_text())  # type: ignore[union-attr]
+        paint = style["layers"][0]["paint"]
+        assert paint["fill-color"] == "#ff0000"
+        assert paint["fill-opacity"] == 0.9
+
+    @pytest.mark.unit
+    def test_does_not_overwrite_existing(self, tmp_path: Path) -> None:
+        """Returns None if default.json already exists, doesn't overwrite."""
+        from portolan_cli.style import write_default_style
+
+        # Create existing default.json
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        default_path = styles_dir / "default.json"
+        original_content = {"version": 7, "name": "Original"}
+
+        import json
+
+        default_path.write_text(json.dumps(original_content))
+
+        # Try to write default style
+        result = write_default_style(
+            collection_path=tmp_path,
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_filename="data.pmtiles",
+        )
+
+        # Should return None
+        assert result is None
+
+        # Original content should be unchanged
+        written = json.loads(default_path.read_text())
+        assert written == original_content


### PR DESCRIPTION
## Summary

- Replace inline `pmtiles:style` on PMTiles assets with standalone Mapbox GL v8 style files stored in `{collection}/styles/` directories
- Add `portolan:styles` manifest on collections (first entry = default style)
- Auto-generate `styles/default.json` during PMTiles creation; additional styles discovered and registered automatically
- Styles registered as STAC assets with `application/json` type and `["style"]` role
- ADR-0044 documents the architecture decision (supersedes ADR-0043's style storage section)

### Key changes
- **`portolan_cli/style.py`**: Added `build_full_style`, `write_style_file`, `write_default_style`, `discover_styles`, `build_styles_manifest`, `register_style_assets`; removed `build_pmtiles_style`
- **`portolan_cli/pmtiles.py`**: Removed `pmtiles:style` inline approach; PMTiles generation now writes `styles/default.json` and registers style assets
- **`portolan_cli/metadata/pmtiles.py`**: Removed `style` field from `PMTilesMetadata`
- **`portolan_cli/scan_classify.py`**: Classify files in `styles/` directories as STYLE metadata
- **`portolan_cli/skills/sourcecoop.md`**: Added styles best practices section

## Test plan

- [x] 44 unit tests for style functions (build, write, discover, manifest, register)
- [x] 3 integration tests updated (style structure, layer name, style-as-asset registration)
- [x] 4021 unit tests pass (6 pre-existing failures unrelated to changes)
- [x] ruff, mypy, and formatting all clean
- [x] No remaining `build_pmtiles_style` or `pmtiles:style` references in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collections support multiple named Mapbox GL v8 styles in per-collection style directories; default style is auto-generated and registered as a collection asset. Manifest ordering of styles is deterministic (default first).

* **Documentation**
  * Guidance updated for organizing, authoring, and registering style files and recommended manifest usage.

* **Tests**
  * Expanded fixtures and tests covering style generation, discovery, manifest ordering, registration, and I/O behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/portolan-sdi/portolan-cli/pull/420)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->