### PR TITLE
feat(skills): add consume skill for querying Portolan catalogs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0041](context/shared/adr/0041-stac-manifest-as-canonical-scan-source.md) | STAC manifest as canonical scan source for metadata_fresh; unifies check/--fix; adds ORPHANED status |
 | [0042](context/shared/adr/0042-partition-stac-extension.md) | Standalone `partition:` STAC extension for Hive-style partitioned datasets |
 | [0043](context/shared/adr/0043-style-and-thumbnail-architecture.md) | Style/thumbnail: inline in STAC, Mapbox GL spec, basemaps for vectors only |
+| [0044](context/shared/adr/0044-consumption-guides-architecture.md) | Consumption guides: DuckDB + Python in README, skill for advanced cases |
 
 ## Common Commands
 

--- a/context/shared/adr/0044-consumption-guides-architecture.md
+++ b/context/shared/adr/0044-consumption-guides-architecture.md
@@ -1,0 +1,135 @@
+# ADR-0044: Consumption Guides Architecture
+
+## Status
+Proposed
+
+## Context
+
+Portolan's value proposition is "publish once, consume anywhere." Currently, users can publish data to cloud storage with rich STAC metadata, but there's no guidance on how to actually *consume* that data from analytics engines like DuckDB, Python/GeoPandas, or other tools.
+
+Issue #121 tracks this gap. The question: what's the right mechanism for consumption guides?
+
+### Forces at Play
+
+1. **Two audiences**: Human users (need readable docs) and AI agents (need structured, parseable guidance)
+2. **Self-describing catalogs**: Consumers often have just a URL—no Portolan installed
+3. **Portolan's optimizations**: GeoParquet files are spatially ordered (Hilbert), row-grouped, ZSTD compressed, with bbox structs
+4. **Protocol complexity**: S3 URLs need credential config; some endpoints (Source Coop) serve HTTPS directly
+5. **User environment varies**: Some users have DuckDB installed, others don't; some are new to geospatial
+
+### Options Evaluated
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Static docs only** | Simple, no code | Generic, not adaptive |
+| **README snippets** | Self-describing | Can't adapt to user's environment |
+| **STAC extension** | Machine-readable | Snippets drift, overengineered |
+| **metadata.yaml field** | Human-curated | Another schema to maintain |
+| **Skill only** | Adaptive, environment-aware, contextual | Requires AI assistant |
+
+## Decision
+
+**Use a Claude Code skill as the primary consumption interface.** No mandatory README changes or metadata schema additions.
+
+The skill:
+1. **Detects user's environment** — checks for DuckDB, rioxarray, geopandas, etc.
+2. **Understands Portolan's structure** — STAC catalogs, collection-level vector assets, item-level raster assets
+3. **Knows Portolan's optimizations** — leverages Hilbert ordering, row groups, bbox structs for efficient queries
+4. **Guides exploration** — dry runs, size checks, schema inspection before full queries
+5. **Adapts to skill level** — explains options to naive users, suggests cloud-native approaches
+
+### Why Skill-Only
+
+1. **Adaptive**: Can check what's installed and guide accordingly
+2. **Contextual**: Reads actual STAC metadata, understands schema, suggests appropriate queries
+3. **No code changes**: README generation stays simple; no new metadata fields
+4. **Iteratively improvable**: Skill instructions can evolve without code releases
+
+### Portolan GeoParquet Optimizations
+
+The skill must know that Portolan produces optimized GeoParquet:
+
+| Optimization | What it enables |
+|--------------|-----------------|
+| **Hilbert spatial ordering** | Sequential reads for spatial queries |
+| **Row groups** | Efficient range scans, predicate pushdown |
+| **ZSTD compression** | Smaller files, fast decompression |
+| **bbox struct column** | Fast spatial filtering without geometry parsing |
+
+DuckDB and PyArrow can leverage these automatically, but the skill should explain why queries are fast.
+
+### Recommended Tools
+
+| Data Type | Primary Tool | Alternative |
+|-----------|--------------|-------------|
+| **Vectors (GeoParquet)** | DuckDB + spatial extension | GeoPandas, PyArrow |
+| **Rasters (COG)** | rioxarray | rasterio |
+| **STAC metadata** | Read JSON directly | pystac |
+
+The skill checks what's installed and recommends accordingly. For users without tools installed, it explains options and suggests the most cloud-native approach.
+
+## Consequences
+
+### Easier
+
+- **Minimal code changes** — just an optional metadata.yaml field
+- **Environment-aware** guidance (checks what's installed)
+- **Adaptive to complexity** — simple catalogs get simple queries, complex ones get contextual help
+- **Leverages Portolan optimizations** — skill knows about Hilbert ordering, bbox structs
+
+### Harder
+
+- **Requires AI assistant** — users without Claude Code don't get this guidance
+- **Non-deterministic** — skill output varies by context
+- **Documentation gap** — need a simple docs page for non-AI users
+
+### Mitigation
+
+Add a basic consumption guide to `docs/` for users without AI assistants. This is static but covers the fundamentals.
+
+## Optional: metadata.yaml Examples
+
+For datasets with unusual structure (required joins, non-obvious columns, multiple related files), publishers can add custom examples to metadata.yaml:
+
+```yaml
+examples:
+  - engine: duckdb
+    description: "Join census data with geographic boundaries"
+    code: |
+      SELECT r.*, c.population
+      FROM read_parquet('https://.../radios.parquet') r
+      JOIN read_parquet('https://.../census-data.parquet') c
+        ON r.cod_2022 = c.id_geo
+  - engine: python
+    description: "Load and merge with GeoPandas"
+    code: |
+      radios = gpd.read_parquet('https://.../radios.parquet')
+      census = pd.read_parquet('https://.../census-data.parquet')
+      merged = radios.merge(census, left_on='cod_2022', right_on='id_geo')
+```
+
+This is **optional** — the skill generates default examples if omitted. Use it when:
+- Dataset requires joins across multiple files
+- Column names are non-obvious
+- Spatial structure is unusual (partitioned, multi-resolution)
+- Domain-specific query patterns would help users
+
+## Alternatives Considered
+
+### README Snippets with Auto-Generated URLs
+
+Enhancing `portolan readme` to include DuckDB/Python examples with full URLs.
+
+Rejected because:
+- Can't adapt to user's environment
+- Asset selection is ambiguous for complex catalogs
+- Joins and relationships need contextual understanding
+
+### Mandatory metadata.yaml Examples
+
+Requiring consumption examples in metadata.yaml for all catalogs.
+
+Rejected because:
+- Overhead for simple single-file catalogs
+- Skill generates good defaults automatically
+- Optional field serves complex cases without burdening simple ones

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -7,6 +7,7 @@ Portolan includes **skills** — markdown guides that help AI assistants guide y
 | Skill | Description |
 |-------|-------------|
 | `sourcecoop` | Upload data to [Source Cooperative](https://source.coop) |
+| `consume` | Query and explore Portolan catalogs with DuckDB/Python |
 
 ## Using Skills
 
@@ -91,3 +92,86 @@ Source Co-op emphasizes good documentation. The skill ensures you provide:
 **Slow uploads** — Use `--workers 8` for parallel uploads. More than 8 workers doesn't usually help.
 
 **Missing metadata** — Run `portolan metadata validate` to see which required fields are missing.
+
+---
+
+## Consume Skill
+
+The `consume` skill helps you query and explore data from Portolan catalogs. It detects your environment, reads STAC metadata, and generates optimized queries.
+
+### What It Does
+
+1. **Detects your environment** — Checks for DuckDB, GeoPandas, rioxarray
+2. **Reads STAC metadata** — Understands schema, assets, spatial extent
+3. **Generates queries** — DuckDB SQL or Python code with full URLs
+4. **Explains optimizations** — How to leverage Portolan's Hilbert ordering and bbox structs
+5. **Guides exploration** — Dry runs, size checks, spatial filters
+
+### Portolan GeoParquet Optimizations
+
+Portolan produces optimized GeoParquet files that enable fast cloud-native queries:
+
+| Optimization | Benefit |
+|--------------|---------|
+| **Hilbert spatial ordering** | Spatial queries read data sequentially |
+| **Row groups (~100K rows)** | Predicate pushdown skips irrelevant data |
+| **ZSTD compression** | Smaller files, fast decompression |
+| **bbox struct column** | Fast spatial filter without geometry parsing |
+
+### Quick Example (DuckDB)
+
+```sql
+-- Install spatial extension (once)
+INSTALL spatial; LOAD spatial;
+
+-- Query directly from Source Cooperative
+SELECT * FROM read_parquet(
+  'https://data.source.coop/nlebovits/censo-argentino/2022/radios.parquet'
+) LIMIT 10;
+
+-- Fast spatial filter using bbox struct
+SELECT * FROM read_parquet(
+  'https://data.source.coop/nlebovits/censo-argentino/2022/radios.parquet'
+) WHERE bbox.xmin > -58.6 AND bbox.xmax < -58.2
+    AND bbox.ymin > -34.8 AND bbox.ymax < -34.4;
+```
+
+### Quick Example (Python)
+
+```python
+import geopandas as gpd
+
+gdf = gpd.read_parquet(
+    "https://data.source.coop/nlebovits/censo-argentino/2022/radios.parquet"
+)
+print(gdf.head())
+```
+
+### Custom Examples in metadata.yaml
+
+For datasets with unusual structure (required joins, multiple files), add custom examples to `.portolan/metadata.yaml`:
+
+```yaml
+examples:
+  - engine: duckdb
+    description: "Join census data with geographic boundaries"
+    code: |
+      SELECT r.*, c.population
+      FROM read_parquet('https://.../radios.parquet') r
+      JOIN read_parquet('https://.../census-data.parquet') c
+        ON r.cod_2022 = c.id_geo
+  - engine: python
+    description: "Load and merge with GeoPandas"
+    code: |
+      radios = gpd.read_parquet('https://.../radios.parquet')
+      census = pd.read_parquet('https://.../census-data.parquet')
+      merged = radios.merge(census, left_on='cod_2022', right_on='id_geo')
+```
+
+### Troubleshooting
+
+**403 Forbidden** — Source Cooperative uses HTTPS URLs, not S3. Use `https://data.source.coop/...` not `s3://...`.
+
+**Slow queries** — Always `LIMIT` during exploration. Use `bbox` struct for spatial pre-filtering.
+
+**Memory issues** — Use DuckDB (streams data) instead of loading everything into GeoPandas.

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -624,6 +624,30 @@ known_issues: ""                    # optional - Known limitations or caveats
 #     nodata: 0                     # Uniform nodata for all bands
 #     # Or per-band:
 #     # nodata: [0, 0, 255]         # Per-band nodata values
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Consumption examples
+# -----------------------------------------------------------------------------
+# Add dataset-specific query examples, especially when structure is unusual
+# (multiple related files, required joins, non-obvious column meanings).
+# Default examples (DuckDB SQL + GeoPandas) are auto-generated if omitted.
+#
+# examples:
+#   - engine: duckdb                # duckdb | python | r | other
+#     description: "Join census data with geographic boundaries"
+#     code: |
+#       SELECT r.*, c.population
+#       FROM read_parquet('https://.../radios.parquet') r
+#       JOIN read_parquet('https://.../census-data.parquet') c
+#         ON r.cod_2022 = c.id_geo
+#   - engine: python
+#     description: "Load and merge with GeoPandas"
+#     code: |
+#       import geopandas as gpd
+#       import pandas as pd
+#       radios = gpd.read_parquet('https://.../radios.parquet')
+#       census = pd.read_parquet('https://.../census-data.parquet')
+#       merged = radios.merge(census, left_on='cod_2022', right_on='id_geo')
 """
 
 

--- a/portolan_cli/skills/consume.md
+++ b/portolan_cli/skills/consume.md
@@ -1,0 +1,259 @@
+---
+name: portolan-consume
+description: Guide users through querying and exploring Portolan/STAC catalogs with optimized GeoParquet and COGs
+triggers:
+  - "how do I query this catalog"
+  - "consume this data"
+  - "duckdb query"
+  - "read the parquet"
+  - "access this dataset"
+  - "query the geoparquet"
+---
+
+<!-- freshness: last-verified: 2026-05-08, maps-to: ADR-0044 -->
+
+# Portolan Catalog Consumption Skill
+
+You are helping a user query and explore data from a Portolan catalog. Portolan produces optimized cloud-native geospatial data (GeoParquet for vectors, COG for rasters) with rich STAC metadata.
+
+## Portolan Catalog Consumption Guide
+
+Help users query and explore Portolan catalogs. Portolan produces optimized cloud-native geospatial data (GeoParquet for vectors, COG for rasters) with rich STAC metadata.
+
+### Step 1: Detect User's Environment
+
+Before suggesting tools, check what's installed:
+
+```bash
+# Check for DuckDB
+which duckdb 2>/dev/null && echo "DuckDB CLI available"
+python -c "import duckdb; print(f'DuckDB Python: {duckdb.__version__}')" 2>/dev/null
+
+# Check for Python geospatial stack
+python -c "import geopandas; print(f'GeoPandas: {geopandas.__version__}')" 2>/dev/null
+python -c "import rioxarray; print('rioxarray available')" 2>/dev/null
+python -c "import rasterio; print(f'rasterio: {rasterio.__version__}')" 2>/dev/null
+```
+
+**Recommendations based on environment:**
+
+| Installed | For Vectors | For Rasters |
+|-----------|-------------|-------------|
+| DuckDB | DuckDB + spatial extension (best) | N/A |
+| GeoPandas only | `gpd.read_parquet()` | N/A |
+| rioxarray | N/A | `rioxarray.open_rasterio()` (best) |
+| rasterio only | N/A | `rasterio.open()` |
+| Nothing | Suggest DuckDB installation | Suggest rioxarray |
+
+If user has nothing installed, explain options and suggest cloud-native approach (DuckDB for vectors, rioxarray for rasters). Offer to guide through installation but respect if they don't want to install.
+
+### Step 2: Understand the Catalog Structure
+
+Read STAC metadata before querying data:
+
+```bash
+# For remote catalogs
+curl -s "https://data.source.coop/user/catalog/collection/collection.json" | jq '.id, .title, .description'
+
+# Check assets
+curl -s "https://data.source.coop/user/catalog/collection/collection.json" | jq '.assets | keys'
+
+# Check schema (table:columns)
+curl -s "https://data.source.coop/user/catalog/collection/collection.json" | jq '."table:columns"'
+```
+
+For local catalogs, read the JSON files directly.
+
+**Key STAC locations:**
+- `catalog.json` — root, lists collections
+- `collection.json` — collection metadata, schema, **vector assets live here**
+- `item.json` — item metadata, **raster assets live here**
+
+### Step 3: URL Protocol Handling
+
+Convert remote storage URLs to consumption URLs:
+
+| Storage URL | Consumption URL | Notes |
+|-------------|-----------------|-------|
+| `s3://data.source.coop/...` | `https://data.source.coop/...` | Source Coop serves HTTPS |
+| `s3://private-bucket/...` | `s3://private-bucket/...` | Needs credential config |
+| `gs://bucket/...` | `https://storage.googleapis.com/bucket/...` | For public GCS |
+| Local path | `file:///path/to/...` | Works with DuckDB |
+
+For private S3, configure credentials:
+
+```sql
+-- DuckDB
+SET s3_region = 'us-east-1';
+SET s3_access_key_id = getenv('AWS_ACCESS_KEY_ID');
+SET s3_secret_access_key = getenv('AWS_SECRET_ACCESS_KEY');
+```
+
+### Step 4: Portolan GeoParquet Optimizations
+
+**Portolan produces optimized GeoParquet files.** Understand these to write efficient queries:
+
+| Optimization | Description | How to Leverage |
+|--------------|-------------|-----------------|
+| **Hilbert spatial ordering** | Features sorted by Hilbert curve | Spatial queries read sequentially |
+| **Row groups (~100K rows)** | Data chunked for parallel access | Predicate pushdown skips irrelevant groups |
+| **ZSTD compression** | Fast decompression, small files | Automatic, no action needed |
+| **bbox struct column** | `bbox.xmin/xmax/ymin/ymax` | Use for fast spatial pre-filter |
+
+**Fast spatial filtering with bbox struct:**
+
+```sql
+-- Step 1: Fast filter using bbox (doesn't parse geometry)
+SELECT * FROM read_parquet('https://...')
+WHERE bbox.xmin > -58.5 AND bbox.xmax < -58.3
+  AND bbox.ymin > -34.7 AND bbox.ymax < -34.5
+LIMIT 100;
+
+-- Step 2: Refine with actual geometry if needed
+SELECT * FROM (
+  SELECT * FROM read_parquet('https://...')
+  WHERE bbox.xmin > -58.5 AND bbox.xmax < -58.3
+        AND bbox.ymin > -34.7 AND bbox.ymax < -34.5
+)
+WHERE ST_Intersects(geometry, ST_GeomFromText('POLYGON(...)'));
+```
+
+### Step 5: Exploration Workflow (Vectors)
+
+Always explore before full queries:
+
+```sql
+-- 1. Install spatial extension (once)
+INSTALL spatial; LOAD spatial;
+
+-- 2. Check schema
+DESCRIBE SELECT * FROM read_parquet('https://...') LIMIT 0;
+
+-- 3. Row count (uses metadata, fast)
+SELECT COUNT(*) FROM read_parquet('https://...');
+
+-- 4. Dry run (always LIMIT first!)
+SELECT * FROM read_parquet('https://...') LIMIT 10;
+
+-- 5. Spatial extent
+SELECT
+  MIN(bbox.xmin) as west,
+  MIN(bbox.ymin) as south,
+  MAX(bbox.xmax) as east,
+  MAX(bbox.ymax) as north
+FROM read_parquet('https://...');
+
+-- 6. Sample values for key columns
+SELECT DISTINCT column_name FROM read_parquet('https://...') LIMIT 20;
+```
+
+### Step 6: Exploration Workflow (Rasters)
+
+For COGs, STAC metadata has most info. Then use rioxarray:
+
+```python
+import rioxarray
+
+# Open COG (lazy - doesn't load data yet)
+da = rioxarray.open_rasterio(
+    "https://data.source.coop/user/catalog/collection/item/image.tif"
+)
+
+# Check metadata
+print(f"Shape: {da.shape}")
+print(f"CRS: {da.rio.crs}")
+print(f"Bounds: {da.rio.bounds()}")
+print(f"Resolution: {da.rio.resolution()}")
+
+# Read a small window (efficient - only fetches needed tiles)
+window = da.isel(x=slice(0, 512), y=slice(0, 512))
+data = window.compute()  # Actually loads data
+```
+
+### Step 7: Common Query Patterns
+
+**Spatial filter:**
+```sql
+SELECT * FROM read_parquet('https://...')
+WHERE ST_Intersects(
+  geometry,
+  ST_GeomFromText('POLYGON((-58.5 -34.7, -58.3 -34.7, -58.3 -34.5, -58.5 -34.5, -58.5 -34.7))')
+);
+```
+
+**Attribute filter:**
+```sql
+SELECT * FROM read_parquet('https://...')
+WHERE population > 10000;
+```
+
+**Aggregation:**
+```sql
+SELECT
+  province,
+  SUM(population) as total_pop,
+  COUNT(*) as num_areas
+FROM read_parquet('https://...')
+GROUP BY province;
+```
+
+**Join multiple assets:**
+```sql
+-- When collection has related tables (check STAC metadata for relationships)
+SELECT r.*, c.population, c.households
+FROM read_parquet('https://.../radios.parquet') r
+JOIN read_parquet('https://.../census-data.parquet') c
+  ON r.cod_2022 = c.id_geo;
+```
+
+### Step 8: Partitioned Datasets
+
+For datasets with `partition:glob` in STAC:
+
+```sql
+-- Query all partitions (use glob pattern from STAC)
+SELECT * FROM read_parquet(
+  'https://data.source.coop/user/catalog/collection/kdtree_cell=*/*.parquet'
+) LIMIT 10;
+
+-- Query single partition first (faster for exploration)
+SELECT * FROM read_parquet(
+  'https://data.source.coop/user/catalog/collection/kdtree_cell=0/*.parquet'
+);
+
+-- DuckDB automatically prunes partitions for Hive-style paths
+SELECT * FROM read_parquet(
+  'https://.../kdtree_cell=*/*.parquet'
+) WHERE kdtree_cell = '42';
+```
+
+### Troubleshooting
+
+**403 Forbidden:**
+- Check if bucket is public
+- For private buckets, configure S3 credentials
+- Source Coop uses HTTPS, not S3 protocol
+
+**Slow queries:**
+- Always LIMIT during exploration
+- Use bbox struct for spatial pre-filtering
+- Check file size in STAC (`file:size`) before querying large files
+- For partitioned data, query one partition first
+
+**Schema mismatch:**
+- Read `table:columns` from STAC first
+- Column names are case-sensitive
+- Geometry column is usually `geometry` (check STAC)
+
+**Memory issues:**
+- Use DuckDB (streams data, low memory)
+- For GeoPandas, read with `columns=` parameter to limit columns
+- For rasters, use window reads
+
+### Tips
+
+- **Always read STAC metadata first** — it has schema, extent, file sizes
+- **Always LIMIT during exploration** — don't load full dataset until you know what you need
+- **Use bbox struct** — faster than full geometry intersection
+- **Portolan's Hilbert ordering** means spatial queries are I/O efficient
+- **Check for partitioning** — `partition:glob` in STAC indicates partitioned dataset


### PR DESCRIPTION
## Summary

- Add `consume` skill to guide users through querying Portolan catalogs with DuckDB/Python
- Skill detects user environment, reads STAC metadata, generates optimized queries
- Leverages Portolan's GeoParquet optimizations (Hilbert ordering, bbox struct, ZSTD)
- Add optional `examples:` section to metadata.yaml for datasets with unusual structure
- Document skill in `docs/guides/skills.md`
- Add ADR-0044 documenting the consumption guides architecture

Closes #121

## Test plan

- [x] Tested consume skill against censo-argentino catalog on Source Coop
- [x] Verified DuckDB queries work with bbox struct spatial filtering
- [x] Verified environment detection logic

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new "consume" skill for querying and exploring Portolan STAC/GeoParquet datasets
  * Support for DuckDB and Python workflows with optimized spatial filtering guidance

* **Documentation**
  * Added comprehensive consumption guides for DuckDB and Python environments
  * STAC exploration workflows, query patterns, and performance optimization tips
  * Support for custom consumption examples via metadata configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->