### PR TITLE
feat(readme): make collections list collapsible for large catalogs

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -855,7 +855,7 @@ portolan readme --recursive
 **Catalog-level README:** When run at catalog root, generates an index README with:
 - Aggregated spatial extent (envelope of all collections)
 - Aggregated temporal extent (earliest to latest)
-- List of collections with links
+- List of collections with links (collapsible when ≥10 collections)
 
 ### Data Defaults
 

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -708,18 +708,36 @@ def aggregate_catalog_extent(catalog_path: Path) -> dict[str, Any]:
     }
 
 
+# Default threshold for making collections list collapsible (#424)
+# Catalogs with >= this many collections will use <details> tags
+COLLAPSIBLE_COLLECTIONS_THRESHOLD = 10
+
+
 def _add_collections_section(
     sections: list[str],
     catalog_path: Path,
     aggregation: dict[str, Any],
 ) -> None:
-    """Add collections listing section for catalog README."""
+    """Add collections listing section for catalog README.
+
+    For large catalogs (>= COLLAPSIBLE_COLLECTIONS_THRESHOLD), wraps the
+    collections list in an HTML <details> tag to make it collapsible.
+    This improves README navigability for catalogs with many collections (#424).
+    """
     collections = aggregation.get("collections", [])
     if not collections:
         return
 
+    collection_count = len(collections)
+    use_collapsible = collection_count >= COLLAPSIBLE_COLLECTIONS_THRESHOLD
+
     sections.append("## Collections")
     sections.append("")
+
+    if use_collapsible:
+        sections.append("<details>")
+        sections.append(f"<summary>📁 {collection_count} collections (click to expand)</summary>")
+        sections.append("")
 
     for coll_id in sorted(collections):
         coll_json = catalog_path / coll_id / "collection.json"
@@ -743,6 +761,10 @@ def _add_collections_section(
                 description = description[:197] + "..."
             sections.append(description)
             sections.append("")
+
+    if use_collapsible:
+        sections.append("</details>")
+        sections.append("")
 
 
 def _add_aggregated_extent_section(

--- a/tests/unit/test_readme_catalog_aggregation.py
+++ b/tests/unit/test_readme_catalog_aggregation.py
@@ -282,3 +282,123 @@ class TestGenerateCatalogReadme:
         # The readme should reflect the full US extent
         assert "-125" in readme  # West bound
         assert "-65" in readme or "-66" in readme  # East bound
+
+
+class TestCollapsibleCollections:
+    """Tests for collapsible collections list (#424).
+
+    Large catalogs (many collections) should use <details> tags to make
+    the collections list collapsible, improving README navigability.
+    """
+
+    def _create_collections(self, tmp_path: Path, count: int) -> None:
+        """Helper to create N collections."""
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "test-catalog",
+                    "title": "Test Catalog",
+                    "description": "Catalog for testing collapsible collections",
+                }
+            )
+        )
+        for i in range(count):
+            coll_dir = tmp_path / f"collection-{i:03d}"
+            coll_dir.mkdir()
+            (coll_dir / "collection.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Collection",
+                        "id": f"collection-{i:03d}",
+                        "title": f"Collection {i}",
+                        "description": f"Test collection number {i}",
+                        "extent": {
+                            "spatial": {"bbox": [[0, 0, 1, 1]]},
+                            "temporal": {"interval": [[None, None]]},
+                        },
+                    }
+                )
+            )
+
+    @pytest.mark.unit
+    def test_small_catalog_not_collapsible(self, tmp_path: Path) -> None:
+        """Catalogs with few collections should NOT use <details> tags."""
+        self._create_collections(tmp_path, 5)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # Should NOT contain <details> tags for small catalogs
+        assert "<details>" not in readme
+        assert "</details>" not in readme
+        # Should still list collections normally
+        assert "## Collections" in readme
+        assert "Collection 0" in readme
+
+    @pytest.mark.unit
+    def test_large_catalog_is_collapsible(self, tmp_path: Path) -> None:
+        """Catalogs with many collections SHOULD use <details> tags."""
+        self._create_collections(tmp_path, 15)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # Should contain <details> tags
+        assert "<details>" in readme
+        assert "</details>" in readme
+        # Should have summary with count
+        assert "<summary>" in readme
+        assert "15 collections" in readme
+
+    @pytest.mark.unit
+    def test_collapsible_at_threshold(self, tmp_path: Path) -> None:
+        """Collections should be collapsible at exactly the threshold."""
+        # Default threshold is 10
+        self._create_collections(tmp_path, 10)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # At threshold, should be collapsible
+        assert "<details>" in readme
+        assert "10 collections" in readme
+
+    @pytest.mark.unit
+    def test_just_below_threshold_not_collapsible(self, tmp_path: Path) -> None:
+        """Collections just below threshold should NOT be collapsible."""
+        self._create_collections(tmp_path, 9)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # Just below threshold, should NOT be collapsible
+        assert "<details>" not in readme
+
+    @pytest.mark.unit
+    def test_collapsible_contains_all_collections(self, tmp_path: Path) -> None:
+        """Collapsible section should contain all collection links."""
+        self._create_collections(tmp_path, 12)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # All collections should be present
+        for i in range(12):
+            assert f"collection-{i:03d}" in readme
+            assert f"Collection {i}" in readme
+
+    @pytest.mark.unit
+    def test_collapsible_summary_emoji(self, tmp_path: Path) -> None:
+        """Summary should include folder emoji for visual clarity."""
+        self._create_collections(tmp_path, 20)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # Summary should have emoji
+        assert "📁" in readme
+
+    @pytest.mark.unit
+    def test_very_large_catalog_collapsible(self, tmp_path: Path) -> None:
+        """Very large catalogs (100+ collections) should be collapsible."""
+        self._create_collections(tmp_path, 100)
+
+        readme = generate_catalog_readme(tmp_path)
+
+        assert "<details>" in readme
+        assert "100 collections" in readme


### PR DESCRIPTION
## Summary

Closes #424

For catalogs with ≥10 collections, wraps the collections list in HTML `<details>` tags to improve README navigability:

```markdown
## Collections

<details>
<summary>📁 187 collections (click to expand)</summary>

### [Collection 1](./collection1/)
Description...

</details>
```

**Key changes:**
- Added `COLLAPSIBLE_COLLECTIONS_THRESHOLD = 10` constant
- Modified `_add_collections_section()` to wrap content in `<details>` when threshold is met
- Summary includes folder emoji and count for visual clarity

## Test plan

- [x] Test small catalog (5 collections) - NOT collapsible
- [x] Test at threshold (10 collections) - IS collapsible
- [x] Test just below threshold (9 collections) - NOT collapsible  
- [x] Test large catalog (100 collections) - IS collapsible
- [x] Verify all collections still appear in output
- [x] Verify summary has emoji and count

All 4156 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)