### PR TITLE
fix(push): sync all catalog files to remote (closes #426)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -590,6 +590,54 @@ portolan add imagery/ --stac-geoparquet
 !!! warning "Known Limitation"
     For existing catalogs with thousands of items, `push` after generating items.parquet may be slow ([#329](https://github.com/portolan-sdi/portolan-cli/issues/329)). This affects incremental updates to large catalogs. New catalogs and small catalogs work normally.
 
+## Push Settings
+
+Control which files are synced to remote storage during `portolan push`.
+
+### Metadata File Sync
+
+By default, `push` syncs **all catalog files** to remote storage, not just versioned assets. This includes:
+
+- `style.json` (map styling)
+- Thumbnails (`*.thumb.png`)
+- Updated `collection.json` and `catalog.json`
+- Any other catalog metadata files
+
+### Exclusion Patterns
+
+Files matching these patterns are **never** synced:
+
+| Pattern | Excluded Files |
+|---------|----------------|
+| `.portolan/` | Internal Portolan state |
+| `.git/` | Git repository data |
+| `.env`, `.env.*` | Environment files with secrets |
+| `*.py`, `*.pyc` | Python source and bytecode |
+| `__pycache__/` | Python cache directories |
+| `.DS_Store`, `Thumbs.db` | OS metadata files |
+| `*.log`, `*.tmp`, `*.bak`, `*~` | Temporary and backup files |
+
+### Custom Exclusions
+
+Add custom patterns to exclude additional files:
+
+```yaml
+# .portolan/config.yaml
+push.exclude:
+  - "*.backup"
+  - "temp/"
+  - "draft-*"
+```
+
+!!! warning "Security Patterns Always Enforced"
+    Patterns for `.env`, `.git/`, and `.portolan/` are **always** enforced regardless of custom configuration. This prevents accidental upload of secrets or internal state.
+
+### Settings Reference
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `push.exclude` | See above | Glob patterns for files to exclude from sync |
+
 ## Collection-Level Configuration
 
 Override settings for specific collections using the `collections:` section:

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -99,18 +99,18 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "pmtiles.attribution": None,  # None = gpio-pmtiles default
     "pmtiles.src_crs": None,  # None = use metadata CRS
     # Push exclusion patterns for metadata sync (Issue #426)
-    # These files/directories are never synced to remote storage
+    # These files/directories are never synced to remote storage.
+    # Note: Security-critical patterns (.env, .git/, .portolan/) are also
+    # enforced in push.py's _SECURITY_EXCLUDE_PATTERNS and cannot be overridden.
+    # Directory patterns (ending with /) match if ANY path component equals the name.
     "push.exclude": [
         ".portolan/",  # Internal Portolan state
-        ".portolan/*",  # Internal Portolan state (alternate pattern)
         ".git/",  # Git repository data
-        ".git/*",  # Git repository data (alternate pattern)
         ".env",  # Environment files with secrets
-        ".env.*",  # Environment file variants
+        ".env.*",  # Environment file variants (.env.local, etc.)
         "*.py",  # Python source files
         "*.pyc",  # Python bytecode
         "__pycache__/",  # Python cache directories
-        "__pycache__/*",  # Python cache (alternate pattern)
         ".DS_Store",  # macOS metadata
         "Thumbs.db",  # Windows thumbnails
         "*.log",  # Log files

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -67,6 +67,7 @@ KNOWN_SETTINGS: frozenset[str] = frozenset(
         "pmtiles.precision",  # Coordinate decimal precision (default: 6)
         "pmtiles.attribution",  # Attribution HTML for tiles
         "pmtiles.src_crs",  # Override source CRS if metadata is incorrect
+        "push.exclude",  # Glob patterns to exclude from metadata sync (Issue #426)
     }
 )
 
@@ -97,6 +98,26 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "pmtiles.precision": 6,  # Coordinate decimal precision
     "pmtiles.attribution": None,  # None = gpio-pmtiles default
     "pmtiles.src_crs": None,  # None = use metadata CRS
+    # Push exclusion patterns for metadata sync (Issue #426)
+    # These files/directories are never synced to remote storage
+    "push.exclude": [
+        ".portolan/",  # Internal Portolan state
+        ".portolan/*",  # Internal Portolan state (alternate pattern)
+        ".git/",  # Git repository data
+        ".git/*",  # Git repository data (alternate pattern)
+        ".env",  # Environment files with secrets
+        ".env.*",  # Environment file variants
+        "*.py",  # Python source files
+        "*.pyc",  # Python bytecode
+        "__pycache__/",  # Python cache directories
+        "__pycache__/*",  # Python cache (alternate pattern)
+        ".DS_Store",  # macOS metadata
+        "Thumbs.db",  # Windows thumbnails
+        "*.log",  # Log files
+        "*.tmp",  # Temporary files
+        "*.bak",  # Backup files
+        "*~",  # Editor backup files
+    ],
 }
 
 # Default glob patterns for files to exclude from asset tracking (per ADR-0028).

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -20,6 +20,7 @@ See ADR-0007 for CLI wraps Python API (all logic in library layer).
 from __future__ import annotations
 
 import asyncio
+import fnmatch  # Module-level import for performance (used in hot path)
 import json
 import threading
 import time
@@ -95,7 +96,9 @@ class PushResult:
         files_uploaded: Number of asset files uploaded.
         versions_pushed: Number of new versions pushed (from versions.json).
         conflicts: List of conflict descriptions.
-        errors: List of error messages.
+        errors: List of error messages (fatal errors that caused push to fail).
+        metadata_errors: List of metadata upload errors (non-fatal, push continues).
+            These indicate partial sync - metadata files failed but assets succeeded.
         dry_run: True if this was a dry-run operation (no network calls made).
         would_push_versions: In dry-run mode, max versions that would be pushed
             (upper bound; actual count depends on remote state).
@@ -107,9 +110,15 @@ class PushResult:
     versions_pushed: int
     conflicts: list[str] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    metadata_errors: list[str] = field(default_factory=list)
     dry_run: bool = False
     would_push_versions: int = 0
     metrics: UploadMetrics | None = None
+
+    @property
+    def has_metadata_errors(self) -> bool:
+        """True if any metadata files failed to upload."""
+        return len(self.metadata_errors) > 0
 
 
 @dataclass
@@ -672,8 +681,12 @@ def _matches_exclude_pattern(path: Path, pattern: str, base_dir: Path) -> bool:
 
     Supports:
     - Directory patterns ending with / (e.g., ".portolan/", "__pycache__/")
+      These match if ANY path component equals the directory name.
     - Glob patterns with * (e.g., "*.py", ".env.*")
     - Exact filename matches (e.g., ".env", ".DS_Store")
+
+    Note: fnmatch is imported at module level for performance since this
+    function is called O(files × patterns) times during discovery.
 
     Args:
         path: Absolute path to check.
@@ -683,8 +696,6 @@ def _matches_exclude_pattern(path: Path, pattern: str, base_dir: Path) -> bool:
     Returns:
         True if the path matches the pattern and should be excluded.
     """
-    import fnmatch
-
     # Get relative path for pattern matching
     try:
         rel_path = path.relative_to(base_dir)
@@ -694,19 +705,13 @@ def _matches_exclude_pattern(path: Path, pattern: str, base_dir: Path) -> bool:
     rel_str = str(rel_path)
     name = path.name
 
-    # Directory pattern (ends with /)
-    if pattern.endswith("/"):
-        dir_name = pattern.rstrip("/")
-        # Check if any path component matches
+    # Directory pattern (ends with / or /*)
+    # Unified handling: ".portolan/" and ".portolan/*" both mean
+    # "exclude anything under a directory named .portolan"
+    if pattern.endswith("/") or pattern.endswith("/*"):
+        dir_name = pattern.rstrip("/").rstrip("*").rstrip("/")
+        # Check if any path component matches the directory name
         for part in rel_path.parts:
-            if part == dir_name:
-                return True
-        return False
-
-    # Directory pattern with /* (matches contents)
-    if pattern.endswith("/*"):
-        dir_name = pattern[:-2]
-        for part in rel_path.parts[:-1]:  # Check parent directories
             if part == dir_name:
                 return True
         return False
@@ -745,32 +750,86 @@ def _get_exclude_patterns(catalog_root: Path | None = None) -> list[str]:
     return list(patterns)
 
 
+# Security-critical patterns that MUST always be excluded.
+# These are never overridden by user config - they are merged with user patterns.
+# Prevents accidental upload of secrets, git history, or internal state.
+_SECURITY_EXCLUDE_PATTERNS: frozenset[str] = frozenset(
+    [
+        ".env",  # Environment files with secrets
+        ".env.*",  # Environment file variants (.env.local, .env.production)
+        ".git/",  # Git repository data
+        ".portolan/",  # Internal Portolan state
+    ]
+)
+
+
+def _get_effective_exclude_patterns(
+    catalog_root: Path | None = None,
+    additional_patterns: list[str] | None = None,
+) -> list[str]:
+    """Get effective exclusion patterns, always including security-critical ones.
+
+    This function ensures security patterns (.env, .git/, .portolan/) are ALWAYS
+    included, even when custom patterns are provided. This prevents accidental
+    upload of secrets or internal state.
+
+    Args:
+        catalog_root: Catalog root for loading config. If None, uses defaults.
+        additional_patterns: Extra patterns to add (merged with defaults, not replacing).
+
+    Returns:
+        List of exclusion patterns including security-critical ones.
+    """
+    # Start with security-critical patterns (always included)
+    patterns: set[str] = set(_SECURITY_EXCLUDE_PATTERNS)
+
+    # Add config/default patterns
+    config_patterns = _get_exclude_patterns(catalog_root)
+    patterns.update(config_patterns)
+
+    # Add any additional patterns
+    if additional_patterns:
+        patterns.update(additional_patterns)
+
+    return list(patterns)
+
+
 def _discover_catalog_files(
     catalog_root: Path,
-    collection: str,
+    collection: str | None = None,
     *,
     include_catalog_root: bool = False,
-    exclude_patterns: list[str] | None = None,
+    additional_exclude_patterns: list[str] | None = None,
+    stac_item_paths: set[Path] | None = None,
 ) -> list[Path]:
     """Discover all catalog files that should be synced to remote (Issue #426).
 
     This discovers ALL files in the catalog/collection except:
-    - Files matching exclusion patterns (from config or defaults)
+    - Files matching exclusion patterns (ALWAYS includes security patterns)
     - Versioned assets (handled separately by existing asset upload)
     - versions.json (uploaded last for atomicity)
     - Files already discovered by _discover_stac_files (collection.json, item/*.json)
+    - Symlinks (security: could point outside catalog)
+
+    Security: The security-critical patterns (.env, .git/, .portolan/) are ALWAYS
+    applied, even when additional_exclude_patterns is provided. This prevents
+    accidental upload of secrets.
 
     Args:
         catalog_root: Path to catalog root.
-        collection: Collection identifier.
+        collection: Collection identifier. If None and include_catalog_root=True,
+            only discovers root-level files.
         include_catalog_root: If True, include root-level files (not in collection).
-        exclude_patterns: Custom exclusion patterns. If None, loads from config.
+        additional_exclude_patterns: Extra patterns to add (merged with defaults,
+            never replaces security patterns).
+        stac_item_paths: Optional set of known STAC item JSON paths to exclude.
+            If provided, used instead of heuristic detection.
 
     Returns:
         List of absolute paths to files that should be synced.
     """
-    if exclude_patterns is None:
-        exclude_patterns = _get_exclude_patterns(catalog_root)
+    # Always use effective patterns which include security-critical ones
+    exclude_patterns = _get_effective_exclude_patterns(catalog_root, additional_exclude_patterns)
 
     # Files to exclude because they're handled by other upload phases
     # These are uploaded in specific order for atomicity
@@ -782,7 +841,6 @@ def _discover_catalog_files(
     }
 
     discovered: list[Path] = []
-    collection_dir = catalog_root / collection
 
     def should_exclude(path: Path, base_dir: Path) -> bool:
         """Check if a file should be excluded."""
@@ -791,9 +849,16 @@ def _discover_catalog_files(
             return True
 
         # Item STAC files (handled by _discover_stac_files)
-        # Pattern: collection/item_dir/item_dir.json
-        if path.suffix == ".json" and path.parent.name == path.stem:
-            return True
+        if stac_item_paths is not None:
+            # Use explicit list if provided (more precise)
+            if path in stac_item_paths:
+                return True
+        else:
+            # Heuristic fallback: collection/item_dir/item_dir.json
+            # This pattern matches STAC item files where the JSON filename
+            # matches its parent directory name
+            if path.suffix == ".json" and path.parent.name == path.stem:
+                return True
 
         # Check exclusion patterns
         for pattern in exclude_patterns:
@@ -802,17 +867,25 @@ def _discover_catalog_files(
 
         return False
 
-    # Walk collection directory
-    if collection_dir.exists():
-        for item in collection_dir.rglob("*"):
-            if item.is_file() and not should_exclude(item, catalog_root):
-                discovered.append(item)
+    # Walk collection directory if specified
+    if collection is not None:
+        collection_dir = catalog_root / collection
+        if collection_dir.exists():
+            for item in collection_dir.rglob("*"):
+                # Skip symlinks (security: could point outside catalog)
+                if item.is_symlink():
+                    continue
+                if item.is_file() and not should_exclude(item, catalog_root):
+                    discovered.append(item)
 
     # Optionally include catalog root files
     if include_catalog_root:
         for item in catalog_root.iterdir():
             # Skip directories (collections are handled separately)
             if item.is_dir():
+                continue
+            # Skip symlinks (security)
+            if item.is_symlink():
                 continue
             if item.is_file() and not should_exclude(item, catalog_root):
                 discovered.append(item)
@@ -1624,6 +1697,9 @@ async def _upload_metadata_files_async(
     This uploads ALL catalog files that aren't versioned assets or STAC metadata.
     Happens after assets and STAC files, before versions.json (manifest-last).
 
+    Security: Uses _get_effective_exclude_patterns which always includes
+    security-critical patterns (.env, .git/, .portolan/).
+
     Args:
         store: Object store instance.
         catalog_root: Path to catalog root.
@@ -1634,7 +1710,8 @@ async def _upload_metadata_files_async(
         verbose: If True, print per-file upload details.
 
     Returns:
-        Tuple of (files_uploaded, errors).
+        Tuple of (files_uploaded, errors). Errors are returned, not swallowed,
+        so callers can decide how to handle partial failures.
     """
     metadata_files = _discover_catalog_files(
         catalog_root,
@@ -1653,14 +1730,15 @@ async def _upload_metadata_files_async(
         async with semaphore:
             try:
                 rel_path = file_path.relative_to(catalog_root)
-                target_key = f"{prefix}/{rel_path}".lstrip("/")
+                # Use as_posix() for consistent path separators in object keys
+                target_key = f"{prefix}/{rel_path.as_posix()}".lstrip("/")
                 content = file_path.read_bytes()
                 await obs.put_async(store, target_key, content)
                 if verbose:
                     detail(f"  Uploaded {rel_path} ({len(content)} bytes)")
                 return True
             except Exception as e:
-                error_msg = f"Failed to upload {file_path}: {e}"
+                error_msg = f"Failed to upload metadata file {file_path.name}: {e}"
                 errors.append(error_msg)
                 error(error_msg)
                 return False
@@ -1799,10 +1877,9 @@ async def _execute_push_uploads_async(
     )
     files_uploaded += metadata_uploaded
 
-    if metadata_errors:
-        # Metadata errors are warnings, not fatal (don't abort push)
-        for err in metadata_errors:
-            warn(err)
+    # Metadata errors are warnings, not fatal (push continues)
+    # But we surface them in PushResult so callers can act on partial sync
+    all_metadata_errors: list[str] = list(metadata_errors)
 
     # Upload versions.json (async, manifest-last)
     info("Uploading versions.json...")
@@ -1826,6 +1903,7 @@ async def _execute_push_uploads_async(
             versions_pushed=0,
             conflicts=[],
             errors=[f"Failed to upload versions.json: {e}"],
+            metadata_errors=all_metadata_errors,
             metrics=metrics,
         )
 
@@ -1834,8 +1912,14 @@ async def _execute_push_uploads_async(
         store, catalog_root, prefix, stac_files, concurrency=concurrency
     )
     files_uploaded += readme_uploaded
-    for err in readme_errors:
-        warn(err)
+    # README errors are also non-fatal metadata issues
+    all_metadata_errors.extend(readme_errors)
+
+    # Log metadata warnings (after push succeeds, so user sees them)
+    if all_metadata_errors:
+        warn(f"{len(all_metadata_errors)} metadata file(s) failed to upload:")
+        for err in all_metadata_errors:
+            warn(f"  {err}")
 
     return PushResult(
         success=True,
@@ -1843,6 +1927,7 @@ async def _execute_push_uploads_async(
         versions_pushed=len(diff.local_only),
         conflicts=[],
         errors=[],
+        metadata_errors=all_metadata_errors,
         metrics=metrics,
     )
 
@@ -2102,12 +2187,8 @@ def _push_all_process_result(
 def _discover_root_metadata_files(catalog_root: Path) -> list[Path]:
     """Discover root-level metadata files that should be synced (Issue #426).
 
-    These are files at the catalog root that aren't:
-    - catalog.json (uploaded by _push_all_upload_root_files)
-    - README.md (uploaded by _push_all_upload_root_files)
-    - versions.json (uploaded last for atomicity)
-    - Directories (collections are handled separately)
-    - Excluded by push.exclude patterns
+    This is a convenience wrapper around _discover_catalog_files for root-only
+    discovery. Delegates to the unified discovery function for consistency.
 
     Args:
         catalog_root: Path to catalog root.
@@ -2115,33 +2196,11 @@ def _discover_root_metadata_files(catalog_root: Path) -> list[Path]:
     Returns:
         List of absolute paths to root metadata files.
     """
-    exclude_patterns = _get_exclude_patterns(catalog_root)
-
-    # Files handled by other upload phases
-    handled_separately = {"catalog.json", "README.md", "versions.json"}
-
-    discovered: list[Path] = []
-
-    for item in catalog_root.iterdir():
-        # Skip directories
-        if item.is_dir():
-            continue
-
-        # Skip files handled separately
-        if item.name in handled_separately:
-            continue
-
-        # Check exclusion patterns
-        should_exclude = False
-        for pattern in exclude_patterns:
-            if _matches_exclude_pattern(item, pattern, catalog_root):
-                should_exclude = True
-                break
-
-        if not should_exclude:
-            discovered.append(item)
-
-    return discovered
+    return _discover_catalog_files(
+        catalog_root,
+        collection=None,  # No collection, root only
+        include_catalog_root=True,
+    )
 
 
 def _push_all_upload_root_files(

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -662,6 +662,164 @@ def _discover_stac_files(
     return stac_files
 
 
+# =============================================================================
+# Metadata File Discovery (Issue #426)
+# =============================================================================
+
+
+def _matches_exclude_pattern(path: Path, pattern: str, base_dir: Path) -> bool:
+    """Check if a path matches an exclusion pattern.
+
+    Supports:
+    - Directory patterns ending with / (e.g., ".portolan/", "__pycache__/")
+    - Glob patterns with * (e.g., "*.py", ".env.*")
+    - Exact filename matches (e.g., ".env", ".DS_Store")
+
+    Args:
+        path: Absolute path to check.
+        pattern: Exclusion pattern.
+        base_dir: Base directory for relative path matching.
+
+    Returns:
+        True if the path matches the pattern and should be excluded.
+    """
+    import fnmatch
+
+    # Get relative path for pattern matching
+    try:
+        rel_path = path.relative_to(base_dir)
+    except ValueError:
+        return False
+
+    rel_str = str(rel_path)
+    name = path.name
+
+    # Directory pattern (ends with /)
+    if pattern.endswith("/"):
+        dir_name = pattern.rstrip("/")
+        # Check if any path component matches
+        for part in rel_path.parts:
+            if part == dir_name:
+                return True
+        return False
+
+    # Directory pattern with /* (matches contents)
+    if pattern.endswith("/*"):
+        dir_name = pattern[:-2]
+        for part in rel_path.parts[:-1]:  # Check parent directories
+            if part == dir_name:
+                return True
+        return False
+
+    # Glob pattern (contains *)
+    if "*" in pattern:
+        # Match against filename
+        if fnmatch.fnmatch(name, pattern):
+            return True
+        # Also match against relative path for patterns like "**/*.py"
+        if fnmatch.fnmatch(rel_str, pattern):
+            return True
+        return False
+
+    # Exact match against filename
+    return name == pattern
+
+
+def _get_exclude_patterns(catalog_root: Path | None = None) -> list[str]:
+    """Get exclusion patterns from config or defaults.
+
+    Args:
+        catalog_root: Catalog root for loading config. If None, uses defaults.
+
+    Returns:
+        List of exclusion patterns.
+    """
+    from portolan_cli.config import DEFAULT_SETTINGS, get_setting
+
+    if catalog_root is None:
+        return list(DEFAULT_SETTINGS.get("push.exclude", []))
+
+    patterns = get_setting("push.exclude", catalog_path=catalog_root)
+    if patterns is None:
+        return list(DEFAULT_SETTINGS.get("push.exclude", []))
+    return list(patterns)
+
+
+def _discover_catalog_files(
+    catalog_root: Path,
+    collection: str,
+    *,
+    include_catalog_root: bool = False,
+    exclude_patterns: list[str] | None = None,
+) -> list[Path]:
+    """Discover all catalog files that should be synced to remote (Issue #426).
+
+    This discovers ALL files in the catalog/collection except:
+    - Files matching exclusion patterns (from config or defaults)
+    - Versioned assets (handled separately by existing asset upload)
+    - versions.json (uploaded last for atomicity)
+    - Files already discovered by _discover_stac_files (collection.json, item/*.json)
+
+    Args:
+        catalog_root: Path to catalog root.
+        collection: Collection identifier.
+        include_catalog_root: If True, include root-level files (not in collection).
+        exclude_patterns: Custom exclusion patterns. If None, loads from config.
+
+    Returns:
+        List of absolute paths to files that should be synced.
+    """
+    if exclude_patterns is None:
+        exclude_patterns = _get_exclude_patterns(catalog_root)
+
+    # Files to exclude because they're handled by other upload phases
+    # These are uploaded in specific order for atomicity
+    handled_separately = {
+        "versions.json",  # Uploaded last (manifest-last)
+        "collection.json",  # Uploaded by _upload_stac_files
+        "catalog.json",  # Uploaded by _push_all_upload_root_files
+        "README.md",  # Uploaded by _upload_readmes_async
+    }
+
+    discovered: list[Path] = []
+    collection_dir = catalog_root / collection
+
+    def should_exclude(path: Path, base_dir: Path) -> bool:
+        """Check if a file should be excluded."""
+        # Files handled by other upload phases
+        if path.name in handled_separately:
+            return True
+
+        # Item STAC files (handled by _discover_stac_files)
+        # Pattern: collection/item_dir/item_dir.json
+        if path.suffix == ".json" and path.parent.name == path.stem:
+            return True
+
+        # Check exclusion patterns
+        for pattern in exclude_patterns:
+            if _matches_exclude_pattern(path, pattern, base_dir):
+                return True
+
+        return False
+
+    # Walk collection directory
+    if collection_dir.exists():
+        for item in collection_dir.rglob("*"):
+            if item.is_file() and not should_exclude(item, catalog_root):
+                discovered.append(item)
+
+    # Optionally include catalog root files
+    if include_catalog_root:
+        for item in catalog_root.iterdir():
+            # Skip directories (collections are handled separately)
+            if item.is_dir():
+                continue
+            if item.is_file() and not should_exclude(item, catalog_root):
+                discovered.append(item)
+
+    return discovered
+
+
 def _stat_files_safely(files: list[Path], errors: list[str]) -> tuple[dict[Path, int], list[Path]]:
     """Stat files safely, recording errors for files that can't be stat'd.
 
@@ -890,6 +1048,7 @@ def _upload_versions_json(
 
 def _handle_push_dry_run(
     catalog_root: Path,
+    collection: str,
     local_data: dict[str, Any],
     local_versions: list[str],
 ) -> PushResult:
@@ -899,6 +1058,7 @@ def _handle_push_dry_run(
 
     Args:
         catalog_root: Resolved catalog root path.
+        collection: Collection identifier.
         local_data: Parsed versions.json data.
         local_versions: List of version strings from local data.
 
@@ -922,6 +1082,19 @@ def _handle_push_dry_run(
     info(f"[DRY RUN] Would upload up to {asset_count} asset file(s)")
     for rel_path in asset_paths:
         detail(f"  {rel_path}")
+
+    # Show metadata files that would be synced (Issue #426)
+    metadata_files = _discover_catalog_files(
+        catalog_root,
+        collection,
+        include_catalog_root=True,  # Dry-run shows complete picture
+    )
+    if metadata_files:
+        info(f"[DRY RUN] Would sync {len(metadata_files)} metadata file(s)")
+        for f in metadata_files:
+            rel_path = f.relative_to(catalog_root)
+            detail(f"  {rel_path}")
+
     warn("[DRY RUN] Remote conflict detection skipped (requires network)")
     warn("[DRY RUN] Actual versions pushed may be fewer if remote already has some")
 
@@ -1436,6 +1609,73 @@ async def _upload_readmes_async(
     return uploaded_count, errors
 
 
+async def _upload_metadata_files_async(
+    store: ObjectStore,
+    catalog_root: Path,
+    prefix: str,
+    collection: str,
+    *,
+    include_catalog_root: bool = False,
+    concurrency: int = 50,
+    verbose: bool = False,
+) -> tuple[int, list[str]]:
+    """Upload metadata files (style.json, thumbnails, etc.) to remote (Issue #426).
+
+    This uploads ALL catalog files that aren't versioned assets or STAC metadata.
+    Happens after assets and STAC files, before versions.json (manifest-last).
+
+    Args:
+        store: Object store instance.
+        catalog_root: Path to catalog root.
+        prefix: Prefix in object storage.
+        collection: Collection identifier.
+        include_catalog_root: If True, include root-level metadata files.
+        concurrency: Maximum concurrent uploads.
+        verbose: If True, print per-file upload details.
+
+    Returns:
+        Tuple of (files_uploaded, errors).
+    """
+    metadata_files = _discover_catalog_files(
+        catalog_root,
+        collection,
+        include_catalog_root=include_catalog_root,
+    )
+
+    if not metadata_files:
+        return 0, []
+
+    errors: list[str] = []
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def upload_one(file_path: Path) -> bool:
+        """Upload a single metadata file with semaphore control."""
+        async with semaphore:
+            try:
+                rel_path = file_path.relative_to(catalog_root)
+                target_key = f"{prefix}/{rel_path}".lstrip("/")
+                content = file_path.read_bytes()
+                await obs.put_async(store, target_key, content)
+                if verbose:
+                    detail(f"  Uploaded {rel_path} ({len(content)} bytes)")
+                return True
+            except Exception as e:
+                error_msg = f"Failed to upload {file_path}: {e}"
+                errors.append(error_msg)
+                error(error_msg)
+                return False
+
+    # Upload all metadata files in parallel
+    tasks = [upload_one(f) for f in metadata_files]
+    results = await asyncio.gather(*tasks)
+    uploaded_count = sum(1 for r in results if r)
+
+    if uploaded_count > 0 and not verbose:
+        info(f"Synced {uploaded_count} metadata file(s)")
+
+    return uploaded_count, errors
+
+
 async def _execute_push_uploads_async(
     store: ObjectStore,
     catalog_root: Path,
@@ -1545,6 +1785,24 @@ async def _execute_push_uploads_async(
             errors=stac_errors,
             metrics=metrics,
         )
+
+    # Upload metadata files (style.json, thumbnails, etc.) - Issue #426
+    # This happens after STAC files, before versions.json (manifest-last)
+    metadata_uploaded, metadata_errors = await _upload_metadata_files_async(
+        store,
+        catalog_root,
+        prefix,
+        collection,
+        include_catalog_root=include_catalog,
+        concurrency=concurrency,
+        verbose=verbose,
+    )
+    files_uploaded += metadata_uploaded
+
+    if metadata_errors:
+        # Metadata errors are warnings, not fatal (don't abort push)
+        for err in metadata_errors:
+            warn(err)
 
     # Upload versions.json (async, manifest-last)
     info("Uploading versions.json...")
@@ -1656,7 +1914,7 @@ async def push_async(
 
     # Dry-run: return early without network I/O
     if dry_run:
-        return _handle_push_dry_run(catalog_root, local_data, local_versions)
+        return _handle_push_dry_run(catalog_root, collection, local_data, local_versions)
 
     # Setup store and fetch remote versions
     store, prefix = setup_store(destination, profile=profile, region=region)
@@ -1841,6 +2099,51 @@ def _push_all_process_result(
             stats["errors"][coll] = ["Unknown error"]
 
 
+def _discover_root_metadata_files(catalog_root: Path) -> list[Path]:
+    """Discover root-level metadata files that should be synced (Issue #426).
+
+    These are files at the catalog root that aren't:
+    - catalog.json (uploaded by _push_all_upload_root_files)
+    - README.md (uploaded by _push_all_upload_root_files)
+    - versions.json (uploaded last for atomicity)
+    - Directories (collections are handled separately)
+    - Excluded by push.exclude patterns
+
+    Args:
+        catalog_root: Path to catalog root.
+
+    Returns:
+        List of absolute paths to root metadata files.
+    """
+    exclude_patterns = _get_exclude_patterns(catalog_root)
+
+    # Files handled by other upload phases
+    handled_separately = {"catalog.json", "README.md", "versions.json"}
+
+    discovered: list[Path] = []
+
+    for item in catalog_root.iterdir():
+        # Skip directories
+        if item.is_dir():
+            continue
+
+        # Skip files handled separately
+        if item.name in handled_separately:
+            continue
+
+        # Check exclusion patterns
+        should_exclude = False
+        for pattern in exclude_patterns:
+            if _matches_exclude_pattern(item, pattern, catalog_root):
+                should_exclude = True
+                break
+
+        if not should_exclude:
+            discovered.append(item)
+
+    return discovered
+
+
 def _push_all_upload_root_files(
     catalog_root: Path,
     destination: str,
@@ -1849,12 +2152,13 @@ def _push_all_upload_root_files(
     dry_run: bool,
     stats: dict[str, Any],
 ) -> bool:
-    """Upload root-level files after all collections (Issue #357).
+    """Upload root-level files after all collections (Issue #357, #426).
 
     Uploads from catalog root (in order):
     1. README.md (documentation, optional)
-    2. catalog.json (STAC catalog metadata, required)
-    3. versions.json (manifest, required - uploaded LAST per manifest-last atomicity)
+    2. Root metadata files (style.json, thumbnails, etc.) - Issue #426
+    3. catalog.json (STAC catalog metadata, required)
+    4. versions.json (manifest, required - uploaded LAST per manifest-last atomicity)
 
     These are uploaded AFTER all collections succeed.
 
@@ -1878,9 +2182,16 @@ def _push_all_upload_root_files(
         warn(f"catalog.json not found at {catalog_root} - remote catalog may be incomplete")
         return True
 
+    # Discover root metadata files (Issue #426)
+    root_metadata = _discover_root_metadata_files(catalog_root)
+
     if dry_run:
         if root_readme.exists():
             info("[DRY RUN] Would upload README.md")
+        if root_metadata:
+            info(f"[DRY RUN] Would sync {len(root_metadata)} root metadata file(s)")
+            for f in root_metadata:
+                detail(f"  {f.name}")
         info("[DRY RUN] Would upload catalog.json")
         if root_versions.exists():
             info("[DRY RUN] Would upload versions.json")
@@ -1895,6 +2206,16 @@ def _push_all_upload_root_files(
             obs.put(store, readme_key, root_readme.read_bytes())
             success("Uploaded README.md")
             stats["total_files"] += 1
+
+        # Upload root metadata files (Issue #426)
+        for meta_file in root_metadata:
+            meta_key = f"{prefix}/{meta_file.name}".lstrip("/")
+            obs.put(store, meta_key, meta_file.read_bytes())
+            detail(f"  Synced {meta_file.name}")
+            stats["total_files"] += 1
+
+        if root_metadata:
+            info(f"Synced {len(root_metadata)} root metadata file(s)")
 
         # Upload catalog.json (STAC metadata)
         catalog_key = f"{prefix}/catalog.json".lstrip("/")

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -794,6 +794,43 @@ def _get_effective_exclude_patterns(
     return list(patterns)
 
 
+def _load_versioned_asset_paths(catalog_root: Path, collection: str) -> set[str]:
+    """Load versioned asset relative paths from versions.json.
+
+    Args:
+        catalog_root: Path to catalog root.
+        collection: Collection identifier.
+
+    Returns:
+        Set of relative paths (as POSIX strings) for all versioned assets.
+        Returns empty set if versions.json doesn't exist or is invalid.
+    """
+    versions_file = catalog_root / collection / "versions.json"
+    if not versions_file.exists():
+        return set()
+
+    try:
+        data = json.loads(versions_file.read_text())
+        versioned_paths: set[str] = set()
+
+        # Extract asset paths from all versions
+        for version_entry in data.get("versions", []):
+            assets = version_entry.get("assets", {})
+            for asset_key, asset_info in assets.items():
+                # asset_key is typically the relative path like "data.parquet"
+                # or can be nested like "v1/data.parquet"
+                if isinstance(asset_info, dict):
+                    # Check for explicit href if available
+                    href = asset_info.get("href", asset_key)
+                    versioned_paths.add(href)
+                versioned_paths.add(asset_key)
+
+        return versioned_paths
+    except (json.JSONDecodeError, KeyError, TypeError):
+        # Invalid versions.json - return empty set, don't fail discovery
+        return set()
+
+
 def _discover_catalog_files(
     catalog_root: Path,
     collection: str | None = None,
@@ -806,7 +843,7 @@ def _discover_catalog_files(
 
     This discovers ALL files in the catalog/collection except:
     - Files matching exclusion patterns (ALWAYS includes security patterns)
-    - Versioned assets (handled separately by existing asset upload)
+    - Versioned assets (loaded from versions.json, handled by asset upload)
     - versions.json (uploaded last for atomicity)
     - Files already discovered by _discover_stac_files (collection.json, item/*.json)
     - Symlinks (security: could point outside catalog)
@@ -840,6 +877,12 @@ def _discover_catalog_files(
         "README.md",  # Uploaded by _upload_readmes_async
     }
 
+    # Load versioned asset paths from versions.json (if collection specified)
+    # These are already handled by _upload_assets_async
+    versioned_asset_paths: set[str] = set()
+    if collection is not None:
+        versioned_asset_paths = _load_versioned_asset_paths(catalog_root, collection)
+
     discovered: list[Path] = []
 
     def should_exclude(path: Path, base_dir: Path) -> bool:
@@ -847,6 +890,24 @@ def _discover_catalog_files(
         # Files handled by other upload phases
         if path.name in handled_separately:
             return True
+
+        # Versioned assets (handled by _upload_assets_async)
+        # Check if the relative path matches any versioned asset
+        if versioned_asset_paths:
+            try:
+                rel_path = path.relative_to(base_dir)
+                rel_posix = rel_path.as_posix()
+                # Check both full relative path and just the filename
+                # (versions.json may use either format)
+                if rel_posix in versioned_asset_paths or path.name in versioned_asset_paths:
+                    return True
+                # Also check collection-relative path
+                if collection is not None:
+                    coll_rel = rel_posix.removeprefix(f"{collection}/")
+                    if coll_rel in versioned_asset_paths:
+                        return True
+            except ValueError:
+                pass
 
         # Item STAC files (handled by _discover_stac_files)
         if stac_item_paths is not None:

--- a/tests/unit/test_push_metadata_sync.py
+++ b/tests/unit/test_push_metadata_sync.py
@@ -182,11 +182,8 @@ class TestDiscoverCatalogFiles:
         assert len(pycache_files) == 0
 
     @pytest.mark.unit
-    def test_excludes_versioned_assets(self, catalog_with_metadata: Path) -> None:
-        """Versioned assets (in versions.json) should NOT be in metadata files.
-
-        These are handled separately by the existing asset upload logic.
-        """
+    def test_excludes_versions_json_file(self, catalog_with_metadata: Path) -> None:
+        """versions.json should NOT be in metadata files (uploaded separately)."""
         from portolan_cli.push import _discover_catalog_files
 
         files = _discover_catalog_files(
@@ -197,6 +194,66 @@ class TestDiscoverCatalogFiles:
         # versions.json itself should not be in the list (uploaded separately)
         versions_files = [f for f in files if f.name == "versions.json"]
         assert len(versions_files) == 0
+
+    @pytest.mark.unit
+    def test_excludes_versioned_assets_from_versions_json(self, tmp_path: Path) -> None:
+        """Versioned assets listed in versions.json should be excluded.
+
+        These are handled separately by the existing asset upload logic.
+        """
+        from portolan_cli.push import _discover_catalog_files
+
+        # Create catalog with versioned asset
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        collection_dir = catalog_root / "collection1"
+        collection_dir.mkdir()
+
+        # Create versioned asset file
+        (collection_dir / "data.parquet").write_bytes(b"parquet data")
+
+        # Create metadata file (should be discovered)
+        (collection_dir / "style.json").write_text('{"version": 8}')
+
+        # Create versions.json listing the parquet as versioned asset
+        (collection_dir / "versions.json").write_text(
+            json.dumps(
+                {
+                    "spec_version": "1.0.0",
+                    "current_version": "v1",
+                    "versions": [
+                        {
+                            "version": "v1",
+                            "created": "2024-01-01T00:00:00Z",
+                            "assets": {
+                                "data.parquet": {
+                                    "href": "data.parquet",
+                                    "sha256": "abc123",
+                                }
+                            },
+                        }
+                    ],
+                }
+            )
+        )
+
+        # Create .portolan to make it a valid catalog
+        portolan_dir = catalog_root / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("backend: filesystem")
+
+        files = _discover_catalog_files(
+            catalog_root,
+            collection="collection1",
+        )
+
+        names = [f.name for f in files]
+
+        # data.parquet should be excluded (it's a versioned asset)
+        assert "data.parquet" not in names, "Versioned assets should be excluded"
+
+        # style.json should be included (it's metadata)
+        assert "style.json" in names, "Metadata files should be included"
 
     @pytest.mark.unit
     def test_additional_exclude_patterns(self, catalog_with_metadata: Path) -> None:

--- a/tests/unit/test_push_metadata_sync.py
+++ b/tests/unit/test_push_metadata_sync.py
@@ -1,0 +1,426 @@
+"""Tests for metadata file syncing in push (Issue #426).
+
+Portolan push should sync ALL catalog files to remote, not just versioned assets.
+This includes style.json, thumbnails, collection.json updates, etc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def catalog_with_metadata(tmp_path: Path) -> Path:
+    """Create a catalog with various metadata files for testing.
+
+    Structure:
+        catalog_root/
+        ├── catalog.json
+        ├── README.md
+        ├── .portolan/
+        │   └── config.yaml
+        ├── .env
+        ├── collection1/
+        │   ├── collection.json
+        │   ├── README.md
+        │   ├── style.json
+        │   ├── collection1.thumb.png
+        │   ├── versions.json
+        │   └── .portolan/
+        │       └── metadata.yaml
+        └── __pycache__/
+            └── cache.pyc
+    """
+    catalog_root = tmp_path / "catalog"
+    catalog_root.mkdir()
+
+    # Root level files
+    (catalog_root / "catalog.json").write_text(
+        json.dumps({"type": "Catalog", "id": "test-catalog"})
+    )
+    (catalog_root / "README.md").write_text("# Test Catalog")
+    # Root-level metadata file (should be synced)
+    (catalog_root / "root-style.json").write_text(json.dumps({"version": 8, "name": "root-style"}))
+
+    # .portolan directory (should be excluded)
+    portolan_dir = catalog_root / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("backend: filesystem")
+
+    # .env file (should be excluded)
+    (catalog_root / ".env").write_text("SECRET_KEY=supersecret")
+
+    # __pycache__ (should be excluded)
+    pycache = catalog_root / "__pycache__"
+    pycache.mkdir()
+    (pycache / "cache.pyc").write_bytes(b"\x00\x00\x00\x00")
+
+    # Collection with metadata files
+    collection_dir = catalog_root / "collection1"
+    collection_dir.mkdir()
+    (collection_dir / "collection.json").write_text(
+        json.dumps({"type": "Collection", "id": "collection1"})
+    )
+    (collection_dir / "README.md").write_text("# Collection 1")
+    (collection_dir / "style.json").write_text(json.dumps({"version": 8, "name": "test-style"}))
+    (collection_dir / "collection1.thumb.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    (collection_dir / "versions.json").write_text(
+        json.dumps(
+            {
+                "spec_version": "1.0.0",
+                "current_version": "v1",
+                "versions": [
+                    {
+                        "version": "v1",
+                        "created": "2024-01-01T00:00:00Z",
+                        "breaking": False,
+                        "message": "Initial version",
+                        "assets": {},
+                        "changes": [],
+                    }
+                ],
+            }
+        )
+    )
+
+    # Collection-level .portolan (should be excluded)
+    coll_portolan = collection_dir / ".portolan"
+    coll_portolan.mkdir()
+    (coll_portolan / "metadata.yaml").write_text("title: Test Collection")
+
+    return catalog_root
+
+
+# =============================================================================
+# Tests for _discover_catalog_files
+# =============================================================================
+
+
+class TestDiscoverCatalogFiles:
+    """Tests for discovering all catalog files for sync."""
+
+    @pytest.mark.unit
+    def test_discovers_style_json(self, catalog_with_metadata: Path) -> None:
+        """style.json files should be discovered for sync."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        style_files = [f for f in files if f.name == "style.json"]
+        assert len(style_files) == 1
+        assert style_files[0] == catalog_with_metadata / "collection1" / "style.json"
+
+    @pytest.mark.unit
+    def test_discovers_thumbnail_files(self, catalog_with_metadata: Path) -> None:
+        """Thumbnail files (*.thumb.*) should be discovered for sync."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        thumb_files = [f for f in files if ".thumb." in f.name]
+        assert len(thumb_files) == 1
+        assert thumb_files[0].name == "collection1.thumb.png"
+
+    @pytest.mark.unit
+    def test_excludes_portolan_directory(self, catalog_with_metadata: Path) -> None:
+        """.portolan/ directories should be excluded by default."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        portolan_files = [f for f in files if ".portolan" in str(f)]
+        assert len(portolan_files) == 0
+
+    @pytest.mark.unit
+    def test_excludes_env_file(self, catalog_with_metadata: Path) -> None:
+        """.env files should be excluded by default."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+            include_catalog_root=True,
+        )
+
+        env_files = [f for f in files if f.name == ".env"]
+        assert len(env_files) == 0
+
+    @pytest.mark.unit
+    def test_excludes_pycache(self, catalog_with_metadata: Path) -> None:
+        """__pycache__/ directories should be excluded by default."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+            include_catalog_root=True,
+        )
+
+        pycache_files = [f for f in files if "__pycache__" in str(f)]
+        assert len(pycache_files) == 0
+
+    @pytest.mark.unit
+    def test_excludes_versioned_assets(self, catalog_with_metadata: Path) -> None:
+        """Versioned assets (in versions.json) should NOT be in metadata files.
+
+        These are handled separately by the existing asset upload logic.
+        """
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        # versions.json itself should not be in the list (uploaded separately)
+        versions_files = [f for f in files if f.name == "versions.json"]
+        assert len(versions_files) == 0
+
+    @pytest.mark.unit
+    def test_custom_exclude_patterns(self, catalog_with_metadata: Path) -> None:
+        """Custom exclude patterns should be respected."""
+        from portolan_cli.push import _discover_catalog_files
+
+        # Add a file that matches a custom pattern
+        (catalog_with_metadata / "collection1" / "debug.log").write_text("debug info")
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+            exclude_patterns=["*.log"],
+        )
+
+        log_files = [f for f in files if f.suffix == ".log"]
+        assert len(log_files) == 0
+
+    @pytest.mark.unit
+    def test_returns_relative_paths_structure(self, catalog_with_metadata: Path) -> None:
+        """Discovered files should be absolute paths for upload."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        # All paths should be absolute
+        for f in files:
+            assert f.is_absolute()
+
+    @pytest.mark.unit
+    def test_include_catalog_root_files(self, catalog_with_metadata: Path) -> None:
+        """When include_catalog_root=True, include root-level metadata.
+
+        Note: catalog.json and README.md are NOT included because they're
+        handled separately by _push_all_upload_root_files for atomicity.
+        """
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+            include_catalog_root=True,
+        )
+
+        # Should include root-level metadata files (not catalog.json/README.md)
+        root_style = [f for f in files if f.name == "root-style.json"]
+        assert len(root_style) == 1
+        assert root_style[0] == catalog_with_metadata / "root-style.json"
+
+        # catalog.json and README.md should NOT be included (handled separately)
+        catalog_json = [f for f in files if f.name == "catalog.json"]
+        assert len(catalog_json) == 0
+        readme = [f for f in files if f.name == "README.md"]
+        assert len(readme) == 0
+
+
+# =============================================================================
+# Tests for config integration
+# =============================================================================
+
+
+class TestPushExcludeConfig:
+    """Tests for push.exclude configuration."""
+
+    @pytest.mark.unit
+    def test_default_exclude_patterns(self) -> None:
+        """Default exclusion patterns should include common non-syncable files."""
+        from portolan_cli.config import DEFAULT_SETTINGS
+
+        defaults = DEFAULT_SETTINGS.get("push.exclude", [])
+
+        # These should be in defaults
+        assert ".portolan/" in defaults or ".portolan/*" in defaults
+        assert ".env" in defaults
+        assert "__pycache__/" in defaults or "__pycache__/*" in defaults
+        assert "*.py" in defaults
+        assert ".git/" in defaults or ".git/*" in defaults
+
+    @pytest.mark.unit
+    def test_exclude_patterns_from_config(self, tmp_path: Path) -> None:
+        """Exclusion patterns should be loadable from config.yaml."""
+        from portolan_cli.config import get_setting
+
+        # Create config with custom exclusions
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text(
+            """
+push:
+  exclude:
+    - "*.backup"
+    - "temp/"
+"""
+        )
+
+        patterns = get_setting("push.exclude", catalog_path=tmp_path)
+        assert "*.backup" in patterns
+        assert "temp/" in patterns
+
+
+# =============================================================================
+# Tests for metadata sync in push flow
+# =============================================================================
+
+
+class TestPushMetadataSync:
+    """Tests for metadata sync phase in push."""
+
+    @pytest.mark.unit
+    def test_upload_metadata_files_async_uploads_style_json(
+        self, catalog_with_metadata: Path
+    ) -> None:
+        """_upload_metadata_files_async should upload style.json files."""
+        import asyncio
+
+        from portolan_cli.push import _upload_metadata_files_async
+
+        uploaded_keys: list[str] = []
+
+        async def mock_put_async(store, key, content):
+            uploaded_keys.append(key)
+
+        with patch("portolan_cli.push.obs.put_async", side_effect=mock_put_async):
+            mock_store = MagicMock()
+
+            count, errors = asyncio.run(
+                _upload_metadata_files_async(
+                    mock_store,
+                    catalog_with_metadata,
+                    "prefix",
+                    "collection1",
+                    include_catalog_root=False,
+                    concurrency=10,
+                )
+            )
+
+        # Should have uploaded style.json and thumbnail
+        assert count >= 2
+        assert any("style.json" in k for k in uploaded_keys)
+        assert any(".thumb." in k for k in uploaded_keys)
+        assert len(errors) == 0
+
+    @pytest.mark.unit
+    def test_push_dry_run_shows_metadata_files(self, catalog_with_metadata: Path, capsys) -> None:
+        """Dry run should list metadata files that would be synced."""
+        from portolan_cli.push import push
+
+        push(
+            catalog_root=catalog_with_metadata,
+            collection="collection1",
+            destination="s3://test-bucket/catalog",
+            dry_run=True,
+        )
+
+        captured = capsys.readouterr()
+        # Should mention style.json or metadata files
+        assert "style.json" in captured.out or "metadata" in captured.out.lower()
+
+    @pytest.mark.unit
+    def test_discover_catalog_files_finds_metadata(self, catalog_with_metadata: Path) -> None:
+        """_discover_catalog_files should find style.json and thumbnails."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        names = [f.name for f in files]
+        assert "style.json" in names
+        assert "collection1.thumb.png" in names
+
+
+# =============================================================================
+# Tests for push_all_collections metadata sync
+# =============================================================================
+
+
+class TestPushAllMetadataSync:
+    """Tests for metadata sync in push_all_collections."""
+
+    @pytest.mark.unit
+    def test_discover_root_metadata_files(self, catalog_with_metadata: Path) -> None:
+        """_discover_root_metadata_files should find root-level metadata."""
+        from portolan_cli.push import _discover_root_metadata_files
+
+        files = _discover_root_metadata_files(catalog_with_metadata)
+
+        # Should include root-style.json (added in fixture)
+        names = [f.name for f in files]
+        assert "root-style.json" in names
+
+        # Should NOT include handled-separately files
+        assert "catalog.json" not in names
+        assert "README.md" not in names
+
+    @pytest.mark.unit
+    def test_push_all_root_files_dry_run_shows_metadata(
+        self, catalog_with_metadata: Path, capsys
+    ) -> None:
+        """_push_all_upload_root_files dry run should show metadata files."""
+        from portolan_cli.push import _push_all_upload_root_files
+
+        stats: dict[str, Any] = {
+            "failed": 0,
+            "successful": 1,  # At least one collection succeeded
+            "total_files": 0,
+            "total_versions": 0,
+            "errors": {},
+        }
+
+        result = _push_all_upload_root_files(
+            catalog_root=catalog_with_metadata,
+            destination="s3://test-bucket/catalog",
+            profile=None,
+            region=None,
+            dry_run=True,
+            stats=stats,
+        )
+
+        assert result is True
+        captured = capsys.readouterr()
+        # Should mention root metadata files
+        assert "root-style.json" in captured.out or "metadata" in captured.out.lower()

--- a/tests/unit/test_push_metadata_sync.py
+++ b/tests/unit/test_push_metadata_sync.py
@@ -199,8 +199,8 @@ class TestDiscoverCatalogFiles:
         assert len(versions_files) == 0
 
     @pytest.mark.unit
-    def test_custom_exclude_patterns(self, catalog_with_metadata: Path) -> None:
-        """Custom exclude patterns should be respected."""
+    def test_additional_exclude_patterns(self, catalog_with_metadata: Path) -> None:
+        """Additional exclude patterns should be merged with defaults."""
         from portolan_cli.push import _discover_catalog_files
 
         # Add a file that matches a custom pattern
@@ -209,11 +209,66 @@ class TestDiscoverCatalogFiles:
         files = _discover_catalog_files(
             catalog_with_metadata,
             collection="collection1",
-            exclude_patterns=["*.log"],
+            additional_exclude_patterns=["*.log"],
         )
 
         log_files = [f for f in files if f.suffix == ".log"]
         assert len(log_files) == 0
+
+    @pytest.mark.unit
+    def test_security_patterns_always_enforced(self, catalog_with_metadata: Path) -> None:
+        """Security patterns (.env, .git/, .portolan/) are ALWAYS enforced.
+
+        Even when additional_exclude_patterns is provided, security-critical
+        patterns must still be applied to prevent accidental secret upload.
+        """
+        from portolan_cli.push import _discover_catalog_files
+
+        # Add a .git directory with a config file
+        git_dir = catalog_with_metadata / "collection1" / ".git"
+        git_dir.mkdir()
+        (git_dir / "config").write_text("[core]\n\tbare = false")
+
+        # Add .env.local in collection
+        (catalog_with_metadata / "collection1" / ".env.local").write_text("SECRET=value")
+
+        # Use custom patterns that don't include security patterns
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+            additional_exclude_patterns=["*.backup"],  # Custom pattern only
+        )
+
+        # Security patterns must STILL be enforced
+        git_files = [f for f in files if ".git" in str(f)]
+        assert len(git_files) == 0, "Security: .git/ must always be excluded"
+
+        env_files = [f for f in files if ".env" in f.name]
+        assert len(env_files) == 0, "Security: .env* must always be excluded"
+
+        portolan_files = [f for f in files if ".portolan" in str(f)]
+        assert len(portolan_files) == 0, "Security: .portolan/ must always be excluded"
+
+    @pytest.mark.unit
+    def test_symlinks_excluded(self, catalog_with_metadata: Path) -> None:
+        """Symlinks should be excluded for security (could point outside catalog)."""
+        from portolan_cli.push import _discover_catalog_files
+
+        # Create a symlink in the collection
+        symlink_path = catalog_with_metadata / "collection1" / "link-to-passwd"
+        try:
+            symlink_path.symlink_to("/etc/passwd")
+        except OSError:
+            pytest.skip("Cannot create symlinks on this system")
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection="collection1",
+        )
+
+        # Symlinks should NOT be in the discovered files
+        symlink_files = [f for f in files if f.name == "link-to-passwd"]
+        assert len(symlink_files) == 0, "Symlinks must be excluded for security"
 
     @pytest.mark.unit
     def test_returns_relative_paths_structure(self, catalog_with_metadata: Path) -> None:
@@ -424,3 +479,169 @@ class TestPushAllMetadataSync:
         captured = capsys.readouterr()
         # Should mention root metadata files
         assert "root-style.json" in captured.out or "metadata" in captured.out.lower()
+
+
+# =============================================================================
+# Tests for security patterns
+# =============================================================================
+
+
+class TestSecurityExcludePatterns:
+    """Tests for security-critical exclusion patterns."""
+
+    @pytest.mark.unit
+    def test_security_patterns_exist(self) -> None:
+        """Security patterns constant should exist and include critical files."""
+        from portolan_cli.push import _SECURITY_EXCLUDE_PATTERNS
+
+        # These patterns MUST be in the security set
+        assert ".env" in _SECURITY_EXCLUDE_PATTERNS
+        assert ".env.*" in _SECURITY_EXCLUDE_PATTERNS
+        assert ".git/" in _SECURITY_EXCLUDE_PATTERNS
+        assert ".portolan/" in _SECURITY_EXCLUDE_PATTERNS
+
+    @pytest.mark.unit
+    def test_effective_patterns_include_security(self, tmp_path: Path) -> None:
+        """_get_effective_exclude_patterns must always include security patterns."""
+        from portolan_cli.push import (
+            _SECURITY_EXCLUDE_PATTERNS,
+            _get_effective_exclude_patterns,
+        )
+
+        # Even with custom additional patterns, security patterns are included
+        patterns = _get_effective_exclude_patterns(
+            catalog_root=tmp_path,
+            additional_patterns=["*.custom"],
+        )
+
+        for security_pattern in _SECURITY_EXCLUDE_PATTERNS:
+            assert security_pattern in patterns, f"Missing security pattern: {security_pattern}"
+
+        # Custom pattern should also be included
+        assert "*.custom" in patterns
+
+
+# =============================================================================
+# Tests for PushResult metadata_errors field
+# =============================================================================
+
+
+class TestPushResultMetadataErrors:
+    """Tests for PushResult.metadata_errors field."""
+
+    @pytest.mark.unit
+    def test_push_result_has_metadata_errors_field(self) -> None:
+        """PushResult should have metadata_errors field."""
+        from portolan_cli.push import PushResult
+
+        result = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+            metadata_errors=["Failed to upload style.json: permission denied"],
+        )
+
+        assert result.metadata_errors == ["Failed to upload style.json: permission denied"]
+        assert result.has_metadata_errors is True
+
+    @pytest.mark.unit
+    def test_push_result_no_metadata_errors(self) -> None:
+        """PushResult with no metadata errors should return empty list."""
+        from portolan_cli.push import PushResult
+
+        result = PushResult(
+            success=True,
+            files_uploaded=5,
+            versions_pushed=1,
+        )
+
+        assert result.metadata_errors == []
+        assert result.has_metadata_errors is False
+
+
+# =============================================================================
+# Tests for upload ordering (integration)
+# =============================================================================
+
+
+class TestUploadOrdering:
+    """Tests for upload ordering verification.
+
+    Manifest-last atomicity requires:
+    1. Assets first
+    2. STAC files
+    3. Metadata files
+    4. versions.json LAST
+    """
+
+    @pytest.mark.unit
+    def test_upload_metadata_files_uses_posix_paths(self, catalog_with_metadata: Path) -> None:
+        """_upload_metadata_files_async should use POSIX paths for object keys."""
+        import asyncio
+
+        from portolan_cli.push import _upload_metadata_files_async
+
+        uploaded_keys: list[str] = []
+
+        async def mock_put_async(store, key, content):
+            uploaded_keys.append(key)
+
+        with patch("portolan_cli.push.obs.put_async", side_effect=mock_put_async):
+            mock_store = MagicMock()
+
+            asyncio.run(
+                _upload_metadata_files_async(
+                    mock_store,
+                    catalog_with_metadata,
+                    "prefix",
+                    "collection1",
+                    include_catalog_root=False,
+                    concurrency=10,
+                )
+            )
+
+        # All keys should use forward slashes (POSIX)
+        for key in uploaded_keys:
+            assert "\\" not in key, f"Key should use POSIX paths: {key}"
+            assert key.startswith("prefix/collection1/"), f"Key should have correct prefix: {key}"
+
+
+# =============================================================================
+# Tests for _discover_catalog_files with collection=None
+# =============================================================================
+
+
+class TestDiscoverRootOnlyFiles:
+    """Tests for discovering root-level files only (collection=None)."""
+
+    @pytest.mark.unit
+    def test_discover_root_only_no_collection(self, catalog_with_metadata: Path) -> None:
+        """With collection=None and include_catalog_root=True, only root files."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection=None,  # No collection
+            include_catalog_root=True,
+        )
+
+        # Should only have root-level files, not collection files
+        names = [f.name for f in files]
+        assert "root-style.json" in names
+
+        # Should NOT include collection files
+        assert "style.json" not in names  # This is in collection1/
+        assert "collection1.thumb.png" not in names
+
+    @pytest.mark.unit
+    def test_discover_nothing_when_no_collection_no_root(self, catalog_with_metadata: Path) -> None:
+        """With collection=None and include_catalog_root=False, should find nothing."""
+        from portolan_cli.push import _discover_catalog_files
+
+        files = _discover_catalog_files(
+            catalog_with_metadata,
+            collection=None,
+            include_catalog_root=False,
+        )
+
+        assert len(files) == 0


### PR DESCRIPTION
## Summary

- `portolan push` now syncs **all catalog files** to remote, not just versioned assets
- Adds `push.exclude` config option for customizing exclusion patterns
- Metadata files (style.json, thumbnails, etc.) are synced after STAC files, before versions.json

## Problem

Previously, `portolan push` only synced versioned data assets tracked in `versions.json`. Metadata files like:
- `style.json`
- `*.thumb.png` (thumbnails)
- Updated `collection.json`
- Any other catalog files

...were NOT synced, requiring a manual `aws s3 sync` workaround.

## Solution

Added a metadata sync phase that discovers and uploads all catalog files except:
- Files in `.portolan/`, `.git/`, `__pycache__/`
- `.env` files and Python source files
- Files already handled by other upload phases (versions.json, collection.json, README.md)

Users can customize exclusions via `push.exclude` in `.portolan/config.yaml`.

## Test plan

- [x] New tests for `_discover_catalog_files()` function
- [x] Tests for exclusion pattern matching
- [x] Tests for `_upload_metadata_files_async()` 
- [x] Tests for dry-run output showing metadata files
- [x] All existing push tests pass (84 tests)
- [x] Full unit test suite passes (4165 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `push.exclude` configuration option to define glob patterns for excluding files from metadata sync operations.
  * Metadata files are now synced during push operations alongside STAC assets and catalogs.
  * Dry-run output now displays the count and list of metadata files that would be synced.
  * Includes sensible default exclusions for common non-syncable patterns (VCS, environment files, temporary files, etc.).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->