### PR TITLE
chore(claude): drop dangling hook references in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,40 +1,6 @@
 {
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/prompt-inject.sh\"",
-            "timeout": 2
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Read",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-read-check.sh\"",
-            "timeout": 2
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/post-bash-remind.sh\"",
-            "timeout": 5
-          }
-        ]
-      },
       {
         "matcher": "Read",
         "hooks": [


### PR DESCRIPTION
## Summary

Removes three dead hook entries from `.claude/settings.json` that point to scripts which no longer exist. These dangling references cause `command not found` warnings on every prompt during local development.

## Root cause

[PR #334](https://github.com/portolan-sdi/portolan-cli/pull/334) (*"refactor: remove global AI tool config from project"*, merged 2026-04-08) deleted the hook scripts but left their entries behind in `.claude/settings.json`. The scripts removed by #334:

| Hook event | Dangling script (deleted in #334) |
|------------|-----------------------------------|
| `UserPromptSubmit` | `.claude/hooks/prompt-inject.sh` |
| `PreToolUse(Read)` | `.claude/hooks/pre-read-check.sh` |
| `PostToolUse(Bash)` | `.claude/hooks/post-bash-remind.sh` |

## What changed

Drops the three entries above. **Keeps** the one hook still wired to an existing script:

- `PostToolUse(Read)` → `.claude/hooks/post-read-inject-docs.sh` (the only script remaining in `.claude/hooks/` on `main`)

Resulting `.claude/settings.json`:

```json
{
  "hooks": {
    "PostToolUse": [
      {
        "matcher": "Read",
        "hooks": [
          {
            "type": "command",
            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/post-read-inject-docs.sh\"",
            "timeout": 30
          }
        ]
      }
    ]
  }
}
```

## Why a separate PR

This was originally bundled into [PR #342](https://github.com/portolan-sdi/portolan-cli/pull/342) (the `[iceberg]` extra merge). In review, @nlebovits flagged it as unrelated to the iceberg work (action item 1) and asked for it to be split out. It has now been reverted from #342, so the fix is no longer carried anywhere — hence this standalone PR.

## Verification

- `.claude/settings.json` is valid JSON
- Only `post-read-inject-docs.sh` exists under `.claude/hooks/` on `main`, so no live hook is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/portolan-sdi/portolan-cli/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->