### PR TITLE
perf(iceberg): compute table:row_count from snapshot metadata instead of materializing the table

### DIFF
--- a/portolan_cli/backends/iceberg/stac_generator.py
+++ b/portolan_cli/backends/iceberg/stac_generator.py
@@ -75,6 +75,28 @@ def _detect_primary_geometry(field_names: list[str]) -> str | None:
     return None
 
 
+def _get_row_count(table: Table) -> int:
+    """Return the total row count via O(1) snapshot metadata.
+
+    Iceberg records ``total-records`` (net of deletes) in each snapshot's
+    summary, so we read that instead of materializing the whole table — the
+    datasets the Iceberg backend targets can be 100K+ rows, and this runs on
+    every ``on_post_add``. Returns 0 for an empty table (no current snapshot),
+    and falls back to a metadata-only file count for the rare catalog/writer
+    that doesn't populate ``total-records``.
+    """
+    snapshot = table.current_snapshot()
+    if snapshot is None:
+        return 0
+    if snapshot.summary is not None:
+        total_records = snapshot.summary.additional_properties.get("total-records")
+        if total_records is not None:
+            return int(total_records)
+    # Falls back to file record_count metadata; only materializes data files
+    # that carry unmerged positional deletes (see DataScan.count).
+    return table.scan().count()
+
+
 def generate_table_metadata(table: Table) -> dict[str, Any]:
     # portolan-cli also generates table:* from GeoParquet source metadata.
     # This version reflects the Iceberg table state and takes precedence
@@ -101,7 +123,7 @@ def generate_table_metadata(table: Table) -> dict[str, Any]:
             }
         )
 
-    row_count = len(table.scan().to_arrow())
+    row_count = _get_row_count(table)
     primary_geometry = _detect_primary_geometry(field_names)
 
     return {

--- a/tests/iceberg/unit/test_stac_generator.py
+++ b/tests/iceberg/unit/test_stac_generator.py
@@ -5,6 +5,7 @@ Phase 4: iceberg:* fields (STAC Iceberg Extension) from catalog/table state.
 """
 
 import struct
+from unittest.mock import MagicMock
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -16,7 +17,74 @@ def _make_wkb_point(x: float, y: float) -> bytes:
     return struct.pack("<BIdd", 1, 1, x, y)
 
 
+# --- Row count from snapshot metadata (issue #436) ---
+
+
+@pytest.mark.unit
+def test_row_count_reads_from_snapshot_summary_without_materializing():
+    """row_count should come from the snapshot's total-records, not a table scan.
+
+    Materializing the table (table.scan().to_arrow()) is wasteful for the large
+    datasets Iceberg targets; the count must be read from O(1) snapshot metadata.
+    """
+    from portolan_cli.backends.iceberg.stac_generator import _get_row_count
+
+    table = MagicMock()
+    table.current_snapshot.return_value.summary.additional_properties = {"total-records": "123456"}
+
+    assert _get_row_count(table) == 123456
+    # The whole point of the fix: no full materialization.
+    table.scan.assert_not_called()
+
+
+@pytest.mark.unit
+def test_row_count_zero_for_empty_table():
+    """row_count should be 0 when the table has no current snapshot (empty table)."""
+    from portolan_cli.backends.iceberg.stac_generator import _get_row_count
+
+    table = MagicMock()
+    table.current_snapshot.return_value = None
+
+    assert _get_row_count(table) == 0
+    table.scan.assert_not_called()
+
+
+@pytest.mark.unit
+def test_row_count_falls_back_when_total_records_absent():
+    """row_count should fall back to a metadata count when total-records is missing.
+
+    Not every catalog/writer populates total-records; we must still produce a
+    count rather than crash, while avoiding a full materialization.
+    """
+    from portolan_cli.backends.iceberg.stac_generator import _get_row_count
+
+    table = MagicMock()
+    table.current_snapshot.return_value.summary.additional_properties = {}
+    table.scan.return_value.count.return_value = 42
+
+    assert _get_row_count(table) == 42
+    table.scan.return_value.count.assert_called_once_with()
+
+
 # --- Phase 3: STAC Table Extension fields ---
+
+
+@pytest.mark.integration
+def test_table_row_count_empty_table_returns_zero(iceberg_catalog):
+    """table:row_count should be 0 for a table created without any data (no snapshot)."""
+    from pyiceberg.schema import Schema
+    from pyiceberg.types import LongType, NestedField
+
+    from portolan_cli.backends.iceberg.backend import NAMESPACE
+    from portolan_cli.backends.iceberg.stac_generator import generate_table_metadata
+
+    iceberg_catalog.create_namespace_if_not_exists(NAMESPACE)
+    schema = Schema(NestedField(field_id=1, name="id", field_type=LongType(), required=False))
+    table = iceberg_catalog.create_table(f"{NAMESPACE}.empty", schema=schema)
+
+    metadata = generate_table_metadata(table)
+
+    assert metadata["table:row_count"] == 0
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

`generate_table_metadata()` computed `table:row_count` by loading the **entire** Iceberg table into Arrow just to take its length:

```python
row_count = len(table.scan().to_arrow())
```

This runs on every `on_post_add`, so for the 100K+ row datasets that make Iceberg the right backend it materializes the full table in memory each time — wasteful and slow.

This PR reads the count from the current snapshot's `total-records` summary instead (O(1) metadata access), with safe handling of the edge cases the issue calls out.

## Changes

- Add `_get_row_count(table)` helper in `stac_generator.py`:
  - Reads `total-records` from the current snapshot summary (O(1), net of deletes).
  - Returns `0` for an empty table (no current snapshot).
  - Falls back to a **metadata-only** file count (`DataScan.count`) when a catalog/writer doesn't populate `total-records` — this only materializes data files carrying unmerged positional deletes, never the whole table.
- `generate_table_metadata()` now calls the helper instead of `len(table.scan().to_arrow())`.

## Tests

Added (TDD — written first, verified red, then green):

- `test_row_count_reads_from_snapshot_summary_without_materializing` — reads from summary and asserts `table.scan()` is **not** called (locks in the O(1) behavior, guards against regressing to materialization).
- `test_row_count_zero_for_empty_table` — no snapshot → `0`.
- `test_row_count_falls_back_when_total_records_absent` — missing `total-records` → metadata file count.
- `test_table_row_count_empty_table_returns_zero` — integration test over a real empty Iceberg table.

Existing happy-path integration tests (`test_table_row_count`, `test_table_row_count_updates_after_publish`) continue to pass unchanged, confirming correctness against real tables.

> Note: 3 unrelated tests (`test_config.py`, `test_entry_point.py`) fail locally due to a missing optional `google-auth` dependency in PyIceberg's REST catalog auth — pre-existing on `main`, untouched by this PR.

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)