### PR TITLE
feat(cli): make metadata and readme commands recursive by default

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -147,10 +147,10 @@ portolan push --dry-run  # Uses configured remote
 Generate README.md from STAC metadata and metadata.yaml.
 
 ```bash
-portolan readme                    # Generate at catalog root
-portolan readme demographics       # Generate for collection
-portolan readme --stdout           # Print without writing
-portolan readme --check            # CI mode: exit 1 if stale
+portolan readme                        # Generate for catalog and all collections
+portolan readme climate                # Generate under climate/
+portolan readme --check                # CI mode: exit 1 if any stale
+portolan readme --no-recursive         # Only at catalog root
 ```
 
 ### `portolan rm`

--- a/docs/guides/extract-wfs.md
+++ b/docs/guides/extract-wfs.md
@@ -131,7 +131,7 @@ portolan add inspire_bu_.../*.pmtiles
 Create human-readable documentation from STAC metadata:
 
 ```bash
-portolan readme --recursive
+portolan readme
 ```
 
 This generates README.md files at catalog and collection levels.
@@ -160,7 +160,7 @@ portolan push --verbose
 | Metadata | Edit `.portolan/metadata.yaml` files |
 | PMTiles | `ogr2ogr \| tippecanoe` pipeline |
 | Add tiles | `portolan add *.pmtiles --stac-geoparquet` |
-| READMEs | `portolan readme --recursive` |
+| READMEs | `portolan readme` |
 | Push | `portolan push --verbose` |
 
 ## See Also

--- a/docs/guides/nested-catalogs.md
+++ b/docs/guides/nested-catalogs.md
@@ -18,7 +18,7 @@ portolan add . --workers 4
 # Add metadata and generate documentation
 portolan metadata init
 # Edit .portolan/metadata.yaml with your info
-portolan readme --recursive
+portolan readme
 ```
 
 ## How Directory Structure Maps to STAC
@@ -87,7 +87,7 @@ known_issues: "Temporal extent not specified for most datasets."
 ### Generating READMEs
 
 ```bash
-portolan readme --recursive
+portolan readme
 ```
 
 This generates README.md files at every level — root catalog, subcatalogs, and collections. Metadata from the root cascades down, so you only need to edit one `metadata.yaml` for consistent attribution across all READMEs.
@@ -135,7 +135,7 @@ portolan init --auto --title "The Hague Open Data" \
 portolan add . --workers 4
 portolan metadata init
 # Edit .portolan/metadata.yaml
-portolan readme --recursive
+portolan readme
 portolan check
 ```
 

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -77,13 +77,13 @@ portolan config set profile source-coop
 
 # Add files and create metadata
 portolan add .
-portolan metadata init --recursive
+portolan metadata init
 
 # Edit .portolan/metadata.yaml with:
 #   title, description, license, contact.email
 
 # Generate READMEs and push
-portolan readme --recursive
+portolan readme
 portolan push --workers 8
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -897,7 +897,7 @@ portolan readme --stdout
 portolan readme --check
 
 # Generate for catalog and all collections
-portolan readme --recursive
+portolan readme
 ```
 
 **Catalog-level README:** When run at catalog root, generates an index README with:

--- a/portolan_cli/backends/iceberg/backend.py
+++ b/portolan_cli/backends/iceberg/backend.py
@@ -104,7 +104,8 @@ class IcebergBackend:
         snap = table.current_snapshot()
         if snap is None or snap.summary is None:
             return None
-        return snap.summary.additional_properties.get("portolake.version")
+        version = snap.summary.additional_properties.get("portolake.version")
+        return str(version) if version is not None else None
 
     def get_current_version(self, collection: str) -> Version:
         """Get the current (latest) version of a collection."""

--- a/portolan_cli/backends/iceberg/stac_generator.py
+++ b/portolan_cli/backends/iceberg/stac_generator.py
@@ -94,7 +94,7 @@ def _get_row_count(table: Table) -> int:
             return int(total_records)
     # Falls back to file record_count metadata; only materializes data files
     # that carry unmerged positional deletes (see DataScan.count).
-    return table.scan().count()
+    return int(table.scan().count())
 
 
 def generate_table_metadata(table: Table) -> dict[str, Any]:

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -4966,12 +4966,10 @@ def metadata() -> None:
     help="Overwrite existing metadata.yaml file.",
 )
 @click.option(
-    "-r",
-    "--recursive",
+    "--no-recursive",
     is_flag=True,
     default=False,
-    help="Create templates at all STAC levels (catalogs, subcatalogs, collections). "
-    "Skips items (item.json directories) and preserves existing files unless --force is used.",
+    help="Only create template at the specified path (skip subdirectories).",
 )
 @click.pass_context
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
@@ -4980,23 +4978,24 @@ def metadata_init(
     json_output: bool,
     path: str | None,
     force: bool,
-    recursive: bool,
+    no_recursive: bool,
 ) -> None:
     """Generate a metadata.yaml template.
 
-    Creates a .portolan/metadata.yaml file with all required and optional
-    fields, including helpful comments explaining each field.
+    Creates .portolan/metadata.yaml files at all STAC levels (catalogs,
+    subcatalogs, collections) by default. Skips items (item.json directories)
+    and preserves existing files unless --force is used.
 
-    If PATH is provided, creates the template at that directory. Otherwise,
-    creates it at the catalog root.
+    If PATH is provided, starts from that directory. Otherwise, starts at the
+    catalog root.
 
     \b
     Examples:
-        portolan metadata init                # Template at catalog root
-        portolan metadata init demographics   # Template for collection
-        portolan metadata init --force        # Overwrite existing
-        portolan metadata init --recursive    # All levels in catalog
-        portolan metadata init climate -r     # All levels under climate/
+        portolan metadata init                    # All levels in catalog
+        portolan metadata init climate            # All levels under climate/
+        portolan metadata init --force            # Overwrite existing
+        portolan metadata init --no-recursive     # Only at catalog root
+        portolan metadata init demographics --no-recursive  # Only for collection
     """
     from portolan_cli.metadata_yaml import generate_metadata_template
 
@@ -5021,8 +5020,8 @@ def metadata_init(
             info_output("Run 'portolan init' to create one")
         raise SystemExit(1)
 
-    # Handle recursive mode
-    if recursive:
+    # Handle recursive mode (default) vs single-path mode
+    if not no_recursive:
         _metadata_init_recursive(catalog_path, path, use_json, force)
         return
 
@@ -5074,17 +5073,25 @@ def metadata_init(
 
 @metadata.command("validate")
 @click.argument("path", required=False, type=click.Path())
+@click.option(
+    "--no-recursive",
+    is_flag=True,
+    default=False,
+    help="Only validate at the specified path (skip subdirectories).",
+)
 @click.pass_context
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
 def metadata_validate(
     ctx: click.Context,
     json_output: bool,
     path: str | None,
+    no_recursive: bool,
 ) -> None:
     """Validate metadata.yaml against schema.
 
+    Validates all .portolan/metadata.yaml files in the catalog tree by default.
     Checks for:
-    - Required fields: title, description, contact (name + email), license
+    - Required fields: contact (name + email), license
     - Format validation: email, SPDX license identifier, DOI
 
     Uses hierarchical resolution: child metadata.yaml files inherit from
@@ -5092,8 +5099,10 @@ def metadata_validate(
 
     \b
     Examples:
-        portolan metadata validate              # Validate at catalog root
-        portolan metadata validate demographics # Validate for collection
+        portolan metadata validate                    # Validate all levels
+        portolan metadata validate climate            # Validate under climate/
+        portolan metadata validate --no-recursive     # Only at catalog root
+        portolan metadata validate demographics --no-recursive  # Only for collection
     """
     from portolan_cli.errors import ConfigInvalidStructureError
     from portolan_cli.metadata_yaml import load_and_validate_metadata
@@ -5119,11 +5128,13 @@ def metadata_validate(
             info_output("Run 'portolan init' to create one")
         raise SystemExit(1)
 
-    # Determine target directory
-    if path:
-        target_dir = catalog_path / path
-    else:
-        target_dir = catalog_path
+    # Handle recursive mode (default) vs single-path mode
+    if not no_recursive:
+        _metadata_validate_recursive(catalog_path, path, use_json)
+        return
+
+    # Single-path validation (--no-recursive)
+    target_dir = catalog_path / path if path else catalog_path
 
     # Load and validate
     try:
@@ -5414,6 +5425,114 @@ def _metadata_init_recursive(
             warn("No catalogs or collections found")
 
 
+def _validate_metadata_at_path(dirpath: Path, rel_path: str, catalog_path: Path) -> dict[str, Any]:
+    """Validate metadata at a single directory."""
+    from portolan_cli.errors import ConfigInvalidStructureError
+    from portolan_cli.metadata_yaml import load_and_validate_metadata
+
+    metadata_file = dirpath / ".portolan" / "metadata.yaml"
+    if not metadata_file.exists():
+        return {"path": rel_path, "valid": True, "errors": [], "skipped": True}
+
+    try:
+        _metadata, errors = load_and_validate_metadata(dirpath, catalog_path)
+        return {"path": rel_path, "valid": len(errors) == 0, "errors": errors}
+    except ConfigInvalidStructureError as err:
+        return {"path": rel_path, "valid": False, "errors": [f"Invalid YAML: {err}"]}
+
+
+def _output_validate_results_json(
+    results: list[dict[str, Any]], valid_count: int, invalid_count: int
+) -> None:
+    """Output validation results as JSON."""
+    all_valid = invalid_count == 0
+    data = {
+        "mode": "recursive",
+        "results": [
+            {"path": r["path"], "valid": r["valid"], "errors": r["errors"]} for r in results
+        ],
+        "summary": {"total": len(results), "valid": valid_count, "invalid": invalid_count},
+    }
+    if all_valid:
+        envelope = success_envelope("metadata validate", data)
+    else:
+        envelope = error_envelope(
+            "metadata validate",
+            [
+                ErrorDetail(type="ValidationError", message=f"{r['path']}: {e}")
+                for r in results
+                if not r["valid"]
+                for e in r["errors"]
+            ],
+            data=data,
+        )
+    output_json_envelope(envelope)
+    if not all_valid:
+        raise SystemExit(1)
+
+
+def _output_validate_results_text(
+    results: list[dict[str, Any]], valid_count: int, invalid_count: int
+) -> None:
+    """Output validation results as text."""
+    if invalid_count == 0:
+        if len(results) == 0:
+            warn("No metadata.yaml files found to validate")
+        else:
+            success(f"Validated {valid_count} metadata.yaml file(s) - all valid")
+        return
+
+    error(f"Validation failed: {invalid_count}/{len(results)} file(s) invalid")
+    for r in results:
+        if not r["valid"]:
+            detail(f"  {r['path']}:")
+            for e in r["errors"]:
+                detail(f"    - {e}")
+    raise SystemExit(1)
+
+
+def _metadata_validate_recursive(
+    catalog_path: Path,
+    start_path: str | None,
+    use_json: bool,
+) -> None:
+    """Validate metadata.yaml files at all STAC levels recursively."""
+    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json)
+    results: list[dict[str, Any]] = []
+
+    # Process base directory first (if it's a STAC entity or is catalog root)
+    is_catalog_root = base_dir == catalog_path
+    is_stac = (base_dir / "catalog.json").exists() or (base_dir / "collection.json").exists()
+    if is_catalog_root or is_stac:
+        rel_path = "." if is_catalog_root else str(base_dir.relative_to(catalog_path))
+        result = _validate_metadata_at_path(base_dir, rel_path, catalog_path)
+        if not result.get("skipped"):
+            results.append(result)
+
+    # Walk tree for subdirectories
+    try:
+        dir_iterator = sorted(base_dir.rglob("*"))
+    except PermissionError as e:
+        _recursive_init_error(use_json, "PermissionError", f"Permission denied during scan: {e}")
+
+    for dirpath in dir_iterator:
+        if not _should_process_directory(dirpath, catalog_path):
+            continue
+        rel_path = str(dirpath.relative_to(catalog_path))
+        result = _validate_metadata_at_path(dirpath, rel_path, catalog_path)
+        if not result.get("skipped"):
+            results.append(result)
+
+    # Calculate summary and output
+    valid_count = sum(1 for r in results if r["valid"])
+    invalid_count = len(results) - valid_count
+
+    if use_json:
+        _output_validate_results_json(results, valid_count, invalid_count)
+    else:
+        _output_validate_results_text(results, valid_count, invalid_count)
+
+
 def _process_readme_entry(
     readme_path: Path,
     content: str,
@@ -5538,7 +5657,7 @@ def _readme_recursive(
                 error(f"{len(stale_paths)} README(s) are stale:")
                 for p in stale_paths:
                     detail(f"  {p}")
-                info_output("Run 'portolan readme --recursive' to regenerate")
+                info_output("Run 'portolan readme' to regenerate")
                 raise SystemExit(1)
             else:
                 success(f"All {len(generated_paths)} README(s) are up-to-date")
@@ -5563,11 +5682,10 @@ def _readme_recursive(
     help="Check if README is up-to-date (for CI). Exits 1 if stale.",
 )
 @click.option(
-    "--recursive",
-    "-r",
+    "--no-recursive",
     is_flag=True,
     default=False,
-    help="Generate READMEs for catalog and all collections.",
+    help="Only generate README at the specified path (skip subdirectories).",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output.")
 @click.pass_context
@@ -5578,24 +5696,26 @@ def readme(
     path: str | None,
     stdout: bool,
     check: bool,
-    recursive: bool,
+    no_recursive: bool,
     verbose: bool,
 ) -> None:
     """Generate README.md from STAC metadata and metadata.yaml.
 
-    The README is a pure output - always generated from STAC (machine-extracted
-    metadata) plus .portolan/metadata.yaml (human enrichment). Never hand-edit
-    the README; edit metadata.yaml instead and regenerate.
+    Generates READMEs for the catalog and all collections by default. The README
+    is a pure output - always generated from STAC (machine-extracted metadata)
+    plus .portolan/metadata.yaml (human enrichment). Never hand-edit the README;
+    edit metadata.yaml instead and regenerate.
 
-    Use --check in CI to verify the README is up-to-date:
+    Use --check in CI to verify READMEs are up-to-date:
 
     \b
     Examples:
-        portolan readme                    # Generate at catalog root
-        portolan readme demographics       # Generate for collection
-        portolan readme --stdout           # Print without writing
-        portolan readme --check            # CI mode: exit 1 if stale
-        portolan readme --recursive        # Generate for catalog and all collections
+        portolan readme                        # Generate for catalog and all collections
+        portolan readme climate                # Generate under climate/
+        portolan readme --check                # CI mode: exit 1 if any stale
+        portolan readme --no-recursive         # Only at catalog root
+        portolan readme demographics --no-recursive  # Only for collection
+        portolan readme --stdout --no-recursive      # Print single README
     """
 
     use_json = should_output_json(ctx, json_output)
@@ -5619,8 +5739,8 @@ def readme(
             info_output("Run 'portolan init' to create one")
         raise SystemExit(1)
 
-    # Handle recursive mode
-    if recursive:
+    # Handle recursive mode (default) vs single-path mode
+    if not no_recursive:
         _readme_recursive(catalog_path, use_json, check, stdout, verbose)
         return
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -68,7 +68,9 @@ from portolan_cli.scan_progress import ScanProgressReporter, count_directories
 from portolan_cli.status import CollectionStatus, get_collection_status
 from portolan_cli.temporal import FLEXIBLE_DATETIME
 from portolan_cli.validation import (
+    InputValidationError,
     Severity,
+    validate_safe_path,
 )
 from portolan_cli.validation import check as validate_catalog
 
@@ -5025,11 +5027,8 @@ def metadata_init(
         _metadata_init_recursive(catalog_path, path, use_json, force)
         return
 
-    # Determine target directory
-    if path:
-        target_dir = catalog_path / path
-    else:
-        target_dir = catalog_path
+    # Determine target directory (rejecting paths that escape the catalog)
+    target_dir = _validate_path_within_catalog(catalog_path, path, use_json, "metadata init")
 
     # Create .portolan directory if needed
     portolan_dir = target_dir / ".portolan"
@@ -5134,7 +5133,7 @@ def metadata_validate(
         return
 
     # Single-path validation (--no-recursive)
-    target_dir = catalog_path / path if path else catalog_path
+    target_dir = _validate_path_within_catalog(catalog_path, path, use_json, "metadata validate")
 
     # Load and validate
     try:
@@ -5292,12 +5291,45 @@ def _recursive_init_error(use_json: bool, error_type: str, message: str) -> None
     raise SystemExit(1)
 
 
+def _validate_path_within_catalog(
+    catalog_path: Path, path: str | None, use_json: bool, command: str
+) -> Path:
+    """Resolve a user-supplied PATH within the catalog, rejecting traversal.
+
+    Returns the target directory (``catalog_path / path``) when safe, or the
+    catalog root when no path is given. Exits with an error envelope if the
+    path escapes the catalog root (ADR-0030 input hardening).
+    """
+    if not path:
+        return catalog_path
+    try:
+        validate_safe_path(Path(path), catalog_path)
+    except InputValidationError as err:
+        if use_json:
+            output_json_envelope(
+                error_envelope(
+                    command,
+                    [ErrorDetail(type="InputValidationError", message=str(err))],
+                )
+            )
+        else:
+            error(str(err))
+        raise SystemExit(1) from err
+    return catalog_path / path
+
+
 def _validate_recursive_start_path(
     catalog_path: Path, start_path: str | None, use_json: bool
 ) -> Path:
     """Validate and return the starting directory for recursive init."""
     if not start_path:
         return catalog_path
+
+    # Reject paths that escape the catalog root (ADR-0030 input hardening).
+    try:
+        validate_safe_path(Path(start_path), catalog_path)
+    except InputValidationError as err:
+        _recursive_init_error(use_json, "InputValidationError", str(err))
 
     base_dir = catalog_path / start_path
     if not base_dir.exists():
@@ -5561,6 +5593,7 @@ def _process_readme_entry(
 
 def _readme_recursive(
     catalog_path: Path,
+    start_path: str | None,
     use_json: bool,
     check: bool,
     stdout: bool,
@@ -5568,12 +5601,15 @@ def _readme_recursive(
 ) -> None:
     """Generate READMEs for catalog and all collections recursively.
 
-    Helper for --recursive flag. Walks the entire catalog tree and generates:
+    Walks the catalog tree (or the subtree under ``start_path`` when given)
+    and generates:
     1. Catalog/subcatalog READMEs (directories with catalog.json)
     2. Collection READMEs (directories with collection.json)
 
     Args:
         catalog_path: Path to catalog root.
+        start_path: Optional subdirectory to scope generation to (relative to
+            the catalog root). When None, the whole catalog is processed.
         use_json: Output JSON format.
         check: CI mode - check freshness only.
         stdout: Print to stdout (not supported in recursive mode).
@@ -5585,22 +5621,20 @@ def _readme_recursive(
     )
 
     if stdout:
-        error("--stdout is not supported with --recursive")
+        error("--stdout is not supported in recursive mode")
         raise SystemExit(1)
+
+    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json)
 
     generated_paths: list[str] = []
     stale_paths: list[str] = []
 
-    # Walk entire tree to find all catalogs and collections
-    for dirpath in sorted(catalog_path.rglob("*")):
-        if not dirpath.is_dir():
-            continue
-        if any(part.startswith(".") for part in dirpath.relative_to(catalog_path).parts):
-            continue
-
+    def _process_stac_dir(dirpath: Path) -> None:
+        """Generate a README for a single catalog/subcatalog/collection dir."""
+        is_root = dirpath == catalog_path
         rel_dir = dirpath.relative_to(catalog_path)
         readme_path = dirpath / "README.md"
-        rel_path = str(rel_dir / "README.md")
+        rel_path = "README.md" if is_root else str(rel_dir / "README.md")
 
         if (dirpath / "collection.json").exists():
             _verbose_readme(f"Processing collection: {rel_dir}/", verbose, use_json)
@@ -5610,20 +5644,31 @@ def _readme_recursive(
                 readme_path, content, rel_path, check, generated_paths, stale_paths
             )
         elif (dirpath / "catalog.json").exists():
-            _verbose_readme(f"Processing subcatalog: {rel_dir}/", verbose, use_json)
-            _verbose_readme_files(dirpath, str(rel_dir), "catalog.json", verbose, use_json)
+            label = "catalog root" if is_root else f"subcatalog: {rel_dir}/"
+            file_label = "catalog root" if is_root else str(rel_dir)
+            _verbose_readme(f"Processing {label}", verbose, use_json)
+            _verbose_readme_files(dirpath, file_label, "catalog.json", verbose, use_json)
             content = generate_catalog_readme(dirpath)
             _process_readme_entry(
                 readme_path, content, rel_path, check, generated_paths, stale_paths
             )
 
-    # Generate root catalog README
-    _verbose_readme("Processing catalog root", verbose, use_json)
-    _verbose_readme_files(catalog_path, "catalog root", "catalog.json", verbose, use_json)
-    root_content = generate_catalog_readme(catalog_path)
-    _process_readme_entry(
-        catalog_path / "README.md", root_content, "README.md", check, generated_paths, stale_paths
-    )
+    # Process the base directory itself (catalog root or a scoped STAC entity)
+    if (
+        base_dir == catalog_path
+        or (base_dir / "collection.json").exists()
+        or (base_dir / "catalog.json").exists()
+    ):
+        _process_stac_dir(base_dir)
+
+    # Walk the subtree to find nested catalogs and collections
+    for dirpath in sorted(base_dir.rglob("*")):
+        if not dirpath.is_dir():
+            continue
+        if any(part.startswith(".") for part in dirpath.relative_to(catalog_path).parts):
+            continue
+        _process_stac_dir(dirpath)
+
     # Move root to front of list
     if "README.md" in generated_paths:
         generated_paths.remove("README.md")
@@ -5741,14 +5786,11 @@ def readme(
 
     # Handle recursive mode (default) vs single-path mode
     if not no_recursive:
-        _readme_recursive(catalog_path, use_json, check, stdout, verbose)
+        _readme_recursive(catalog_path, path, use_json, check, stdout, verbose)
         return
 
-    # Determine target directory
-    if path:
-        target_dir = catalog_path / path
-    else:
-        target_dir = catalog_path
+    # Determine target directory (rejecting paths that escape the catalog)
+    target_dir = _validate_path_within_catalog(catalog_path, path, use_json, "readme")
 
     # Generate README content
     readme_content, is_catalog_root = _generate_readme_content(

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -5278,11 +5278,15 @@ def _generate_readme_content(
     return generate_readme(stac=stac, metadata=metadata_dict), False
 
 
-def _recursive_init_error(use_json: bool, error_type: str, message: str) -> None:
-    """Output error for recursive init and exit."""
+def _recursive_init_error(use_json: bool, command: str, error_type: str, message: str) -> None:
+    """Output error for a recursive command and exit.
+
+    ``command`` is the CLI command label (e.g. "metadata init", "readme") so
+    JSON error envelopes report the command that actually failed.
+    """
     if use_json:
         envelope = error_envelope(
-            "metadata init",
+            command,
             [ErrorDetail(type=error_type, message=message)],
         )
         output_json_envelope(envelope)
@@ -5319,9 +5323,9 @@ def _validate_path_within_catalog(
 
 
 def _validate_recursive_start_path(
-    catalog_path: Path, start_path: str | None, use_json: bool
+    catalog_path: Path, start_path: str | None, use_json: bool, command: str
 ) -> Path:
-    """Validate and return the starting directory for recursive init."""
+    """Validate and return the starting directory for a recursive command."""
     if not start_path:
         return catalog_path
 
@@ -5329,16 +5333,19 @@ def _validate_recursive_start_path(
     try:
         validate_safe_path(Path(start_path), catalog_path)
     except InputValidationError as err:
-        _recursive_init_error(use_json, "InputValidationError", str(err))
+        _recursive_init_error(use_json, command, "InputValidationError", str(err))
 
     base_dir = catalog_path / start_path
     if not base_dir.exists():
         _recursive_init_error(
-            use_json, "PathNotFoundError", f"Path '{start_path}' does not exist in catalog."
+            use_json,
+            command,
+            "PathNotFoundError",
+            f"Path '{start_path}' does not exist in catalog.",
         )
     if not base_dir.is_dir():
         _recursive_init_error(
-            use_json, "NotADirectoryError", f"Path '{start_path}' is not a directory."
+            use_json, command, "NotADirectoryError", f"Path '{start_path}' is not a directory."
         )
     return base_dir
 
@@ -5380,7 +5387,7 @@ def _metadata_init_recursive(
     """
     from portolan_cli.metadata_yaml import generate_metadata_template
 
-    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json)
+    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json, "metadata init")
 
     created_paths: list[str] = []
     skipped_paths: list[str] = []
@@ -5421,7 +5428,9 @@ def _metadata_init_recursive(
     try:
         dir_iterator = sorted(base_dir.rglob("*"))
     except PermissionError as e:
-        _recursive_init_error(use_json, "PermissionError", f"Permission denied during scan: {e}")
+        _recursive_init_error(
+            use_json, "metadata init", "PermissionError", f"Permission denied during scan: {e}"
+        )
 
     for dirpath in dir_iterator:
         if not _should_process_directory(dirpath, catalog_path):
@@ -5529,7 +5538,9 @@ def _metadata_validate_recursive(
     use_json: bool,
 ) -> None:
     """Validate metadata.yaml files at all STAC levels recursively."""
-    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json)
+    base_dir = _validate_recursive_start_path(
+        catalog_path, start_path, use_json, "metadata validate"
+    )
     results: list[dict[str, Any]] = []
 
     # Process base directory first (if it's a STAC entity or is catalog root)
@@ -5545,7 +5556,9 @@ def _metadata_validate_recursive(
     try:
         dir_iterator = sorted(base_dir.rglob("*"))
     except PermissionError as e:
-        _recursive_init_error(use_json, "PermissionError", f"Permission denied during scan: {e}")
+        _recursive_init_error(
+            use_json, "metadata validate", "PermissionError", f"Permission denied during scan: {e}"
+        )
 
     for dirpath in dir_iterator:
         if not _should_process_directory(dirpath, catalog_path):
@@ -5621,10 +5634,16 @@ def _readme_recursive(
     )
 
     if stdout:
-        error("--stdout is not supported in recursive mode")
+        msg = "--stdout is not supported in recursive mode"
+        if use_json:
+            output_json_envelope(
+                error_envelope("readme", [ErrorDetail(type="UnsupportedOptionError", message=msg)])
+            )
+        else:
+            error(msg)
         raise SystemExit(1)
 
-    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json)
+    base_dir = _validate_recursive_start_path(catalog_path, start_path, use_json, "readme")
 
     generated_paths: list[str] = []
     stale_paths: list[str] = []

--- a/tests/integration/test_readme_recursive.py
+++ b/tests/integration/test_readme_recursive.py
@@ -1,7 +1,7 @@
-"""Integration tests for portolan readme --recursive flag.
+"""Integration tests for portolan readme recursive behavior.
 
-Tests that --recursive regenerates all collection READMEs along with
-the catalog README.
+Tests that readme (recursive by default) regenerates all collection READMEs
+along with the catalog README. Use --no-recursive to limit scope.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ from portolan_cli.cli import cli
 
 
 class TestReadmeRecursive:
-    """Tests for portolan readme --recursive."""
+    """Tests for portolan readme recursive behavior (recursive by default)."""
 
     @pytest.fixture
     def catalog_with_collections(self, tmp_path: Path) -> Path:
@@ -68,11 +68,11 @@ class TestReadmeRecursive:
 
     @pytest.mark.integration
     def test_recursive_generates_all_readmes(self, catalog_with_collections: Path) -> None:
-        """--recursive should generate README for catalog and all collections."""
+        """readme (recursive by default) should generate README for catalog and all collections."""
         runner = CliRunner()
 
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            result = runner.invoke(cli, ["readme", "--recursive"])
+            result = runner.invoke(cli, ["readme"])
 
         assert result.exit_code == 0, result.output
 
@@ -85,40 +85,40 @@ class TestReadmeRecursive:
 
     @pytest.mark.integration
     def test_recursive_reports_count(self, catalog_with_collections: Path) -> None:
-        """--recursive should report how many READMEs were generated."""
-        runner = CliRunner()
-
-        with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            result = runner.invoke(cli, ["readme", "--recursive"])
-
-        assert result.exit_code == 0
-        # Should mention generating multiple READMEs
-        assert "3" in result.output or "README" in result.output
-
-    @pytest.mark.integration
-    def test_without_recursive_only_generates_target(self, catalog_with_collections: Path) -> None:
-        """Without --recursive, only the target README is generated."""
+        """readme (recursive by default) should report how many READMEs were generated."""
         runner = CliRunner()
 
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
             result = runner.invoke(cli, ["readme"])
 
         assert result.exit_code == 0
+        # Should mention generating multiple READMEs
+        assert "3" in result.output or "README" in result.output
+
+    @pytest.mark.integration
+    def test_no_recursive_only_generates_target(self, catalog_with_collections: Path) -> None:
+        """With --no-recursive, only the target README is generated."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_collections):
+            result = runner.invoke(cli, ["readme", "--no-recursive"])
+
+        assert result.exit_code == 0
 
         # Only catalog README should exist
         assert (catalog_with_collections / "README.md").exists()
 
-        # Collection READMEs should NOT exist (not generated without --recursive)
+        # Collection READMEs should NOT exist (not generated with --no-recursive)
         assert not (catalog_with_collections / "alpha" / "README.md").exists()
         assert not (catalog_with_collections / "beta" / "README.md").exists()
 
     @pytest.mark.integration
     def test_recursive_json_output(self, catalog_with_collections: Path) -> None:
-        """--recursive with --json should output structured results."""
+        """readme --json (recursive by default) should output structured results."""
         runner = CliRunner()
 
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            result = runner.invoke(cli, ["--format", "json", "readme", "--recursive"])
+            result = runner.invoke(cli, ["--format", "json", "readme"])
 
         assert result.exit_code == 0
 
@@ -129,27 +129,27 @@ class TestReadmeRecursive:
 
     @pytest.mark.integration
     def test_recursive_check_mode(self, catalog_with_collections: Path) -> None:
-        """--recursive --check should check all READMEs."""
+        """readme --check (recursive by default) should check all READMEs."""
         runner = CliRunner()
 
         # First generate all READMEs
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            runner.invoke(cli, ["readme", "--recursive"])
+            runner.invoke(cli, ["readme"])
 
         # Then check - should pass
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            result = runner.invoke(cli, ["readme", "--recursive", "--check"])
+            result = runner.invoke(cli, ["readme", "--check"])
 
         assert result.exit_code == 0
 
     @pytest.mark.integration
     def test_recursive_check_fails_when_stale(self, catalog_with_collections: Path) -> None:
-        """--recursive --check should fail if any README is stale."""
+        """readme --check (recursive by default) should fail if any README is stale."""
         runner = CliRunner()
 
         # Generate all READMEs
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            runner.invoke(cli, ["readme", "--recursive"])
+            runner.invoke(cli, ["readme"])
 
         # Modify a collection to make its README stale
         coll_json = catalog_with_collections / "alpha" / "collection.json"
@@ -159,7 +159,7 @@ class TestReadmeRecursive:
 
         # Check should now fail
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
-            result = runner.invoke(cli, ["readme", "--recursive", "--check"])
+            result = runner.invoke(cli, ["readme", "--check"])
 
         assert result.exit_code == 1
         assert "stale" in result.output.lower() or "alpha" in result.output
@@ -244,11 +244,11 @@ class TestReadmeVerbose:
 
     @pytest.mark.integration
     def test_verbose_recursive_shows_all_file_reads(self, catalog_with_metadata: Path) -> None:
-        """--recursive --verbose should show file reads for every entity."""
+        """readme --verbose (recursive by default) should show file reads for every entity."""
         runner = CliRunner()
 
         with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
-            result = runner.invoke(cli, ["readme", "--recursive", "--verbose"])
+            result = runner.invoke(cli, ["readme", "--verbose"])
 
         assert result.exit_code == 0
         # Should show processing messages
@@ -277,11 +277,11 @@ class TestReadmeVerbose:
 
     @pytest.mark.integration
     def test_verbose_recursive_json_produces_valid_json(self, catalog_with_metadata: Path) -> None:
-        """--recursive --verbose --json should produce valid JSON."""
+        """readme --verbose --json (recursive by default) should produce valid JSON."""
         runner = CliRunner()
 
         with runner.isolated_filesystem(temp_dir=catalog_with_metadata):
-            result = runner.invoke(cli, ["--format", "json", "readme", "--recursive", "--verbose"])
+            result = runner.invoke(cli, ["--format", "json", "readme", "--verbose"])
 
         assert result.exit_code == 0
         output = json.loads(result.output)

--- a/tests/integration/test_readme_recursive.py
+++ b/tests/integration/test_readme_recursive.py
@@ -130,6 +130,20 @@ class TestReadmeRecursive:
         assert not (catalog_with_collections / "README.md").exists()
 
     @pytest.mark.integration
+    def test_recursive_stdout_rejection_json_is_valid(self, catalog_with_collections: Path) -> None:
+        """readme --stdout in JSON mode should emit a JSON error, not plain text."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_collections):
+            result = runner.invoke(cli, ["--format", "json", "readme", "--stdout"])
+
+        assert result.exit_code != 0
+        # Output must be parseable JSON (not a plain-text error line)
+        output = json.loads(result.output)
+        assert output["success"] is False
+        assert "stdout" in result.output.lower()
+
+    @pytest.mark.integration
     def test_recursive_json_output(self, catalog_with_collections: Path) -> None:
         """readme --json (recursive by default) should output structured results."""
         runner = CliRunner()

--- a/tests/integration/test_readme_recursive.py
+++ b/tests/integration/test_readme_recursive.py
@@ -113,6 +113,23 @@ class TestReadmeRecursive:
         assert not (catalog_with_collections / "beta" / "README.md").exists()
 
     @pytest.mark.integration
+    def test_recursive_scopes_to_path_argument(self, catalog_with_collections: Path) -> None:
+        """readme PATH should scope generation to that subtree, not the whole catalog."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem(temp_dir=catalog_with_collections):
+            result = runner.invoke(cli, ["readme", "alpha"])
+
+        assert result.exit_code == 0, result.output
+
+        # Only the targeted collection README should be generated
+        assert (catalog_with_collections / "alpha" / "README.md").exists()
+
+        # Out-of-scope READMEs should NOT be generated
+        assert not (catalog_with_collections / "beta" / "README.md").exists()
+        assert not (catalog_with_collections / "README.md").exists()
+
+    @pytest.mark.integration
     def test_recursive_json_output(self, catalog_with_collections: Path) -> None:
         """readme --json (recursive by default) should output structured results."""
         runner = CliRunner()

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -28,35 +28,35 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_creates_metadata_yaml_at_catalog_root(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init should create .portolan/metadata.yaml at catalog root."""
+        """metadata init --no-recursive should create .portolan/metadata.yaml at catalog root."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
 
-            result = runner.invoke(cli, ["metadata", "init"])
+            result = runner.invoke(cli, ["metadata", "init", "--no-recursive"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             assert Path(".portolan/metadata.yaml").exists()
 
     @pytest.mark.unit
     def test_creates_metadata_yaml_at_collection(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init PATH should create .portolan/metadata.yaml at collection level."""
+        """metadata init PATH --no-recursive should create .portolan/metadata.yaml at collection level."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("demographics").mkdir()
 
-            result = runner.invoke(cli, ["metadata", "init", "demographics"])
+            result = runner.invoke(cli, ["metadata", "init", "demographics", "--no-recursive"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             assert Path("demographics/.portolan/metadata.yaml").exists()
 
     @pytest.mark.unit
     def test_does_not_overwrite_existing(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init should not overwrite existing metadata.yaml."""
+        """metadata init --no-recursive should not overwrite existing metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path(".portolan/metadata.yaml").write_text("license: CC-BY-4.0\n")
 
-            runner.invoke(cli, ["metadata", "init"])
+            runner.invoke(cli, ["metadata", "init", "--no-recursive"])
 
             # Should either error or warn, not overwrite
             content = Path(".portolan/metadata.yaml").read_text()
@@ -64,12 +64,12 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_force_overwrites_existing(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --force should overwrite existing metadata.yaml."""
+        """metadata init --force --no-recursive should overwrite existing metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path(".portolan/metadata.yaml").write_text("license: Old\n")
 
-            result = runner.invoke(cli, ["metadata", "init", "--force"])
+            result = runner.invoke(cli, ["metadata", "init", "--force", "--no-recursive"])
 
             assert result.exit_code == 0
             content = Path(".portolan/metadata.yaml").read_text()
@@ -78,11 +78,11 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --format json should output JSON envelope."""
+        """metadata init --format json --no-recursive should output JSON envelope."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "init"])
+            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "--no-recursive"])
 
             assert result.exit_code == 0
             output = json.loads(result.output)
@@ -97,13 +97,13 @@ class TestMetadataInit:
 
             assert result.exit_code != 0
 
-    # --recursive flag tests
+    # Recursive behavior tests (recursive is now default)
 
     @pytest.mark.unit
     def test_recursive_creates_metadata_at_all_levels(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """metadata init --recursive should create templates at all STAC levels."""
+        """metadata init (recursive by default) should create templates at all STAC levels."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Set up catalog with subcatalog and collection
             runner.invoke(cli, ["init", "--auto"])
@@ -117,7 +117,7 @@ class TestMetadataInit:
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
 
-            result = runner.invoke(cli, ["metadata", "init", "--recursive"])
+            result = runner.invoke(cli, ["metadata", "init"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             # Root
@@ -131,7 +131,7 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_skips_existing_metadata(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive should skip directories with existing metadata.yaml."""
+        """metadata init (recursive by default) should skip directories with existing metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             # Create collection with existing metadata
@@ -140,7 +140,7 @@ class TestMetadataInit:
             Path("demographics/.portolan").mkdir()
             Path("demographics/.portolan/metadata.yaml").write_text("license: CC-BY-4.0\n")
 
-            result = runner.invoke(cli, ["metadata", "init", "--recursive"])
+            result = runner.invoke(cli, ["metadata", "init"])
 
             assert result.exit_code == 0
             # Existing metadata should be preserved
@@ -151,7 +151,7 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_skips_items(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive should NOT create metadata for items."""
+        """metadata init (recursive by default) should NOT create metadata for items."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             # Collection with an item
@@ -160,7 +160,7 @@ class TestMetadataInit:
             Path("demographics/census-2020").mkdir()
             Path("demographics/census-2020/item.json").write_text('{"type": "Feature"}')
 
-            result = runner.invoke(cli, ["metadata", "init", "--recursive"])
+            result = runner.invoke(cli, ["metadata", "init"])
 
             assert result.exit_code == 0
             # Collection should have metadata
@@ -170,13 +170,13 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive --json should report created and skipped paths."""
+        """metadata init --json (recursive by default) should report created and skipped paths."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "--recursive"])
+            result = runner.invoke(cli, ["--format", "json", "metadata", "init"])
 
             assert result.exit_code == 0
             output = json.loads(result.output)
@@ -186,7 +186,7 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_with_explicit_path(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init PATH --recursive should start from specified path."""
+        """metadata init PATH (recursive by default) should start from specified path."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             # Subcatalog with nested collection
@@ -198,7 +198,7 @@ class TestMetadataInit:
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
 
-            result = runner.invoke(cli, ["metadata", "init", "climate", "--recursive"])
+            result = runner.invoke(cli, ["metadata", "init", "climate"])
 
             assert result.exit_code == 0
             # climate subtree should have metadata
@@ -211,11 +211,11 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_nonexistent_path_fails(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive with non-existent path should fail with clear error."""
+        """metadata init with non-existent path should fail with clear error."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
 
-            result = runner.invoke(cli, ["metadata", "init", "nonexistent", "--recursive"])
+            result = runner.invoke(cli, ["metadata", "init", "nonexistent"])
 
             assert result.exit_code != 0
             assert "does not exist" in result.output.lower()
@@ -224,13 +224,11 @@ class TestMetadataInit:
     def test_recursive_nonexistent_path_json_output(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """metadata init --recursive with non-existent path should output JSON error."""
+        """metadata init with non-existent path should output JSON error."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
 
-            result = runner.invoke(
-                cli, ["--format", "json", "metadata", "init", "nonexistent", "--recursive"]
-            )
+            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "nonexistent"])
 
             assert result.exit_code != 0
             output = json.loads(result.output)
@@ -239,7 +237,7 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_force_overwrites_content(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive --force should actually overwrite existing content."""
+        """metadata init --force (recursive by default) should actually overwrite existing content."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("demographics").mkdir()
@@ -248,7 +246,7 @@ class TestMetadataInit:
             original_content = "# Custom content\nlicense: CC-BY-4.0\n"
             Path("demographics/.portolan/metadata.yaml").write_text(original_content)
 
-            result = runner.invoke(cli, ["metadata", "init", "--recursive", "--force"])
+            result = runner.invoke(cli, ["metadata", "init", "--force"])
 
             assert result.exit_code == 0
             # Content should be overwritten with template
@@ -258,7 +256,7 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_json_output_complete_schema(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive --json should have complete schema fields."""
+        """metadata init --json (recursive by default) should have complete schema fields."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             # Create collection with existing metadata (to get skipped paths)
@@ -270,7 +268,7 @@ class TestMetadataInit:
             Path("climate").mkdir()
             Path("climate/collection.json").write_text('{"type": "Collection"}')
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "--recursive"])
+            result = runner.invoke(cli, ["--format", "json", "metadata", "init"])
 
             assert result.exit_code == 0
             output = json.loads(result.output)
@@ -292,7 +290,7 @@ class TestMetadataInit:
 
     @pytest.mark.unit
     def test_recursive_skips_symlinks(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --recursive should skip symlinks to prevent infinite loops."""
+        """metadata init (recursive by default) should skip symlinks to prevent infinite loops."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("climate").mkdir()
@@ -303,7 +301,7 @@ class TestMetadataInit:
             except OSError:
                 pytest.skip("Symlinks not supported on this platform")
 
-            result = runner.invoke(cli, ["metadata", "init", "--recursive"])
+            result = runner.invoke(cli, ["metadata", "init"])
 
             # Should complete without hanging/crashing
             assert result.exit_code == 0
@@ -320,7 +318,7 @@ class TestMetadataValidate:
 
     @pytest.mark.unit
     def test_passes_for_valid_metadata(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata validate should pass for valid metadata.yaml with contact + license."""
+        """metadata validate --no-recursive should pass for valid metadata.yaml with contact + license."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             # Only contact and license are required now
@@ -328,20 +326,20 @@ class TestMetadataValidate:
                 "contact:\n  name: Test User\n  email: test@example.org\nlicense: CC-BY-4.0\n"
             )
 
-            result = runner.invoke(cli, ["metadata", "validate"])
+            result = runner.invoke(cli, ["metadata", "validate", "--no-recursive"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
 
     @pytest.mark.unit
     def test_fails_for_missing_required_fields(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata validate should fail when required fields (contact, license) are missing."""
+        """metadata validate --no-recursive should fail when required fields (contact, license) are missing."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path(".portolan/metadata.yaml").write_text(
                 "citation: Some citation\n"  # Missing contact and license
             )
 
-            result = runner.invoke(cli, ["metadata", "validate"])
+            result = runner.invoke(cli, ["metadata", "validate", "--no-recursive"])
 
             assert result.exit_code != 0
             # Should mention missing fields
@@ -349,21 +347,21 @@ class TestMetadataValidate:
 
     @pytest.mark.unit
     def test_fails_for_invalid_email(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata validate should fail for invalid email format."""
+        """metadata validate --no-recursive should fail for invalid email format."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path(".portolan/metadata.yaml").write_text(
                 "contact:\n  name: Test\n  email: not-an-email\nlicense: MIT\n"
             )
 
-            result = runner.invoke(cli, ["metadata", "validate"])
+            result = runner.invoke(cli, ["metadata", "validate", "--no-recursive"])
 
             assert result.exit_code != 0
             assert "email" in result.output.lower()
 
     @pytest.mark.unit
     def test_validates_collection_level(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata validate PATH should validate at collection level."""
+        """metadata validate PATH --no-recursive should validate at collection level."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("demographics/.portolan").mkdir(parents=True)
@@ -371,20 +369,22 @@ class TestMetadataValidate:
                 "contact:\n  name: Team\n  email: team@org.com\nlicense: CC0-1.0\n"
             )
 
-            result = runner.invoke(cli, ["metadata", "validate", "demographics"])
+            result = runner.invoke(cli, ["metadata", "validate", "demographics", "--no-recursive"])
 
             assert result.exit_code == 0
 
     @pytest.mark.unit
     def test_json_output_success(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata validate --format json should output JSON on success."""
+        """metadata validate --format json --no-recursive should output JSON on success."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path(".portolan/metadata.yaml").write_text(
                 "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
             )
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "validate"])
+            result = runner.invoke(
+                cli, ["--format", "json", "metadata", "validate", "--no-recursive"]
+            )
 
             assert result.exit_code == 0
             output = json.loads(result.output)
@@ -394,16 +394,186 @@ class TestMetadataValidate:
 
     @pytest.mark.unit
     def test_json_output_failure(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata validate --format json should output errors in JSON."""
+        """metadata validate --format json --no-recursive should output errors in JSON."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path(".portolan/metadata.yaml").write_text("citation: Test\n")  # Incomplete
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "validate"])
+            result = runner.invoke(
+                cli, ["--format", "json", "metadata", "validate", "--no-recursive"]
+            )
 
             output = json.loads(result.output)
             assert output["data"]["valid"] is False
             assert len(output["data"]["errors"]) > 0
+
+    # --no-recursive flag tests (recursive is now default)
+
+    @pytest.mark.unit
+    def test_recursive_validates_all_levels(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate (recursive by default) should validate all STAC levels."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
+            # Root metadata
+            Path(".portolan/metadata.yaml").write_text(valid_metadata)
+            # Subcatalog
+            Path("climate").mkdir()
+            Path("climate/catalog.json").write_text('{"type": "Catalog"}')
+            Path("climate/.portolan").mkdir()
+            Path("climate/.portolan/metadata.yaml").write_text(valid_metadata)
+            # Collection
+            Path("demographics").mkdir()
+            Path("demographics/collection.json").write_text('{"type": "Collection"}')
+            Path("demographics/.portolan").mkdir()
+            Path("demographics/.portolan/metadata.yaml").write_text(valid_metadata)
+
+            result = runner.invoke(cli, ["metadata", "validate"])
+
+            assert result.exit_code == 0, f"Failed: {result.output}"
+
+    @pytest.mark.unit
+    def test_recursive_aggregates_errors(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate should aggregate errors from multiple invalid files.
+
+        Note: metadata uses hierarchical resolution, so children inherit from parents.
+        To test aggregated errors, children must explicitly override with INVALID values
+        (not just missing fields, which would inherit from parent).
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
+            # Invalid metadata: override with invalid email (can't be fixed by inheritance)
+            invalid_email_metadata = "contact:\n  name: Test\n  email: not-an-email\nlicense: MIT\n"
+            # Root: valid
+            Path(".portolan/metadata.yaml").write_text(valid_metadata)
+            # Collection 1: invalid email
+            Path("climate").mkdir()
+            Path("climate/collection.json").write_text('{"type": "Collection"}')
+            Path("climate/.portolan").mkdir()
+            Path("climate/.portolan/metadata.yaml").write_text(invalid_email_metadata)
+            # Collection 2: invalid email
+            Path("demographics").mkdir()
+            Path("demographics/collection.json").write_text('{"type": "Collection"}')
+            Path("demographics/.portolan").mkdir()
+            Path("demographics/.portolan/metadata.yaml").write_text(invalid_email_metadata)
+
+            result = runner.invoke(cli, ["metadata", "validate"])
+
+            assert result.exit_code != 0
+            # Should mention multiple failures (2 invalid collections)
+            assert "2" in result.output or "invalid" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_recursive_json_output_schema(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate --json should have complete recursive schema."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
+            invalid_metadata = "citation: Test\n"
+            # Root: valid
+            Path(".portolan/metadata.yaml").write_text(valid_metadata)
+            # Collection: invalid
+            Path("climate").mkdir()
+            Path("climate/collection.json").write_text('{"type": "Collection"}')
+            Path("climate/.portolan").mkdir()
+            Path("climate/.portolan/metadata.yaml").write_text(invalid_metadata)
+
+            result = runner.invoke(cli, ["--format", "json", "metadata", "validate"])
+
+            output = json.loads(result.output)
+            assert output["command"] == "metadata validate"
+            data = output["data"]
+            # Verify recursive schema
+            assert data["mode"] == "recursive"
+            assert "results" in data
+            assert isinstance(data["results"], list)
+            assert "summary" in data
+            assert "total" in data["summary"]
+            assert "valid" in data["summary"]
+            assert "invalid" in data["summary"]
+
+    @pytest.mark.unit
+    def test_recursive_exit_code_on_any_failure(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate should exit 1 if ANY file is invalid.
+
+        Note: metadata uses hierarchical resolution, so children inherit from parents.
+        To test actual errors, children must explicitly override with INVALID values.
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
+            # Invalid: override with invalid email (can't be fixed by inheritance)
+            invalid_email = "contact:\n  name: Test\n  email: not-valid\nlicense: MIT\n"
+            # Root: valid
+            Path(".portolan/metadata.yaml").write_text(valid_metadata)
+            # Collection: invalid (only one)
+            Path("climate").mkdir()
+            Path("climate/collection.json").write_text('{"type": "Collection"}')
+            Path("climate/.portolan").mkdir()
+            Path("climate/.portolan/metadata.yaml").write_text(invalid_email)
+
+            result = runner.invoke(cli, ["metadata", "validate"])
+
+            assert result.exit_code != 0  # Fails if ANY invalid
+
+    @pytest.mark.unit
+    def test_no_recursive_limits_to_single_path(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate --no-recursive should only validate target path."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
+            invalid_metadata = "citation: Test\n"
+            # Root: valid
+            Path(".portolan/metadata.yaml").write_text(valid_metadata)
+            # Collection: invalid (should NOT be checked with --no-recursive)
+            Path("climate").mkdir()
+            Path("climate/collection.json").write_text('{"type": "Collection"}')
+            Path("climate/.portolan").mkdir()
+            Path("climate/.portolan/metadata.yaml").write_text(invalid_metadata)
+
+            result = runner.invoke(cli, ["metadata", "validate", "--no-recursive"])
+
+            # Should pass because we only check root (which is valid)
+            assert result.exit_code == 0, f"Failed: {result.output}"
+
+    @pytest.mark.unit
+    def test_recursive_skips_directories_without_metadata(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """metadata validate should skip STAC levels without metadata.yaml."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
+            # Root: valid
+            Path(".portolan/metadata.yaml").write_text(valid_metadata)
+            # Collection: no metadata.yaml (should be skipped, not fail)
+            Path("climate").mkdir()
+            Path("climate/collection.json").write_text('{"type": "Collection"}')
+            # No .portolan/metadata.yaml created
+
+            result = runner.invoke(cli, ["metadata", "validate"])
+
+            assert result.exit_code == 0, f"Failed: {result.output}"
+
+    @pytest.mark.unit
+    def test_no_recursive_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate --no-recursive --json should output single-path schema."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+            Path(".portolan/metadata.yaml").write_text(
+                "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
+            )
+
+            result = runner.invoke(
+                cli, ["--format", "json", "metadata", "validate", "--no-recursive"]
+            )
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["success"] is True
+            # Non-recursive mode uses original schema (no "mode" or "results")
+            assert output["data"]["valid"] is True
 
 
 class TestReadmeGenerate:
@@ -468,7 +638,10 @@ class TestReadmeGenerate:
 
     @pytest.mark.unit
     def test_stdout_option(self, runner: CliRunner, tmp_path: Path) -> None:
-        """readme --stdout should print README to stdout without writing file."""
+        """readme --stdout --no-recursive should print README to stdout without writing file.
+
+        Note: --stdout requires --no-recursive since you can't print multiple READMEs to stdout.
+        """
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("catalog.json").write_text(
@@ -478,7 +651,7 @@ class TestReadmeGenerate:
                 "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
             )
 
-            result = runner.invoke(cli, ["readme", "--stdout"])
+            result = runner.invoke(cli, ["readme", "--stdout", "--no-recursive"])
 
             assert result.exit_code == 0
             assert "# My Catalog" in result.output
@@ -627,7 +800,7 @@ class TestReadmeGenerate:
     def test_verbose_recursive_shows_per_collection_progress(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """readme --recursive --verbose should show progress for each collection."""
+        """readme --verbose (recursive by default) should show progress for each collection."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto"])
             Path("catalog.json").write_text(
@@ -647,7 +820,7 @@ class TestReadmeGenerate:
                     "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
                 )
 
-            result = runner.invoke(cli, ["readme", "--recursive", "--verbose"])
+            result = runner.invoke(cli, ["readme", "--verbose"])
 
             assert result.exit_code == 0
             # Should mention both collections in verbose output

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -936,6 +936,19 @@ class TestPathTraversalHardening:
             assert "traversal" in result.output.lower()
 
     @pytest.mark.unit
+    def test_metadata_validate_no_recursive_rejects_traversal(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """metadata validate --no-recursive rejects a PATH escaping the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["metadata", "validate", "../escape", "--no-recursive"])
+
+            assert result.exit_code != 0
+            assert "traversal" in result.output.lower()
+
+    @pytest.mark.unit
     def test_readme_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -945,3 +958,42 @@ class TestPathTraversalHardening:
 
             assert result.exit_code != 0
             assert "traversal" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_readme_no_recursive_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
+        """readme --no-recursive rejects a PATH escaping the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["readme", "../escape", "--no-recursive"])
+
+            assert result.exit_code != 0
+            assert "traversal" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_recursive_readme_traversal_json_uses_correct_command(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """JSON error for a recursive readme traversal must be labeled 'readme'."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["--format", "json", "readme", "../escape"])
+
+            assert result.exit_code != 0
+            payload = json.loads(result.output)
+            assert payload["command"] == "readme"
+
+    @pytest.mark.unit
+    def test_recursive_validate_traversal_json_uses_correct_command(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """JSON error for a recursive validate traversal must be labeled 'metadata validate'."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["--format", "json", "metadata", "validate", "../escape"])
+
+            assert result.exit_code != 0
+            payload = json.loads(result.output)
+            assert payload["command"] == "metadata validate"

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -888,3 +888,60 @@ class TestReadmeGenerate:
             assert "Reading" not in result.output
             # Should show success message
             assert "README.md" in result.output or "Generated" in result.output
+
+
+class TestPathTraversalHardening:
+    """ADR-0030: user-supplied PATH args must not escape the catalog root."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.unit
+    def test_metadata_init_recursive_rejects_traversal(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """metadata init (recursive default) rejects a PATH escaping the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["metadata", "init", "../escape"])
+
+            assert result.exit_code != 0
+            assert "traversal" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_metadata_init_no_recursive_rejects_traversal(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """metadata init --no-recursive rejects a PATH escaping the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["metadata", "init", "../escape", "--no-recursive"])
+
+            assert result.exit_code != 0
+            assert "traversal" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_metadata_validate_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
+        """metadata validate rejects a PATH escaping the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["metadata", "validate", "../escape"])
+
+            assert result.exit_code != 0
+            assert "traversal" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_readme_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
+        """readme rejects a PATH escaping the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            result = runner.invoke(cli, ["readme", "../escape"])
+
+            assert result.exit_code != 0
+            assert "traversal" in result.output.lower()


### PR DESCRIPTION
## Summary

- `metadata init`, `metadata validate`, and `readme` commands are now recursive by default
- Use `--no-recursive` to limit scope to a single path
- Brings consistency with `scan` command behavior

## Breaking Changes

Users relying on non-recursive default behavior should add `--no-recursive`:

```bash
# Before: generates only root README
portolan readme

# After: generates all READMEs (catalog + all collections)
portolan readme

# After: to get old behavior
portolan readme --no-recursive
```

## Changes

| Command | Before | After |
|---------|--------|-------|
| `metadata init` | `--recursive` opt-in | recursive by default, `--no-recursive` opt-out |
| `metadata validate` | no recursive support | recursive by default, `--no-recursive` opt-out |
| `readme` | `--recursive` opt-in | recursive by default, `--no-recursive` opt-out |

## Test plan

- [x] Unit tests updated (~25 tests modified)
- [x] Integration tests updated
- [x] All 56 metadata/readme tests pass
- [x] Full unit test suite passes

Closes #435

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--no-recursive` option to metadata init, metadata validate, and readme to restrict operations to a single directory.

* **Behavior Changes**
  * Commands now operate recursively by default (catalog + collections).
  * `readme` no longer supports `--stdout`.
  * Single-path modes validate that the supplied path stays within the catalog.

* **Bug Fixes**
  * Normalized version and row-count values to ensure consistent integer/string types.

* **Tests**
  * Updated/added tests to reflect recursive-by-default behavior and path traversal hardening.

* **Documentation**
  * Updated CLI examples and guides to match the new default recursion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/portolan-sdi/portolan-cli/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->