### PR TITLE
feat(add): merge strategy for preserving human-authored metadata

### DIFF
--- a/docs/guides/merge-strategies.md
+++ b/docs/guides/merge-strategies.md
@@ -1,0 +1,78 @@
+# Merge Strategies
+
+When running `portolan add`, Portolan auto-detects metadata from your data files (row counts, column types, MIME types). But what happens when your collection already has hand-authored metadata?
+
+The `--merge-strategy` flag controls how auto-detected values are merged with existing metadata.
+
+## Strategies
+
+### `smart` (default)
+
+The smart strategy preserves human-authored fields while updating machine-derivable fields:
+
+**Preserved (human-enrichable):**
+- Asset `title`
+- Asset `description`
+- Column `description` in `table:columns`
+
+**Updated (machine-derivable):**
+- Asset `href`, `media_type`, `roles`
+- `table:row_count`, `table:primary_geometry`
+- Column `name` and `type` in `table:columns`
+- Extension fields (`file:size`, `proj:epsg`, `pmtiles:*`, etc.)
+
+```bash
+# Default behavior - preserves your titles and descriptions
+portolan add data.parquet
+```
+
+### `keep`
+
+Preserve all existing metadata. Only add fields that are missing.
+
+Use this when importing a legacy catalog where you trust the existing metadata completely.
+
+```bash
+# Don't overwrite anything
+portolan add data.parquet --merge-strategy=keep
+```
+
+### `overwrite`
+
+Replace everything with auto-detected values. Use when you want to regenerate metadata from scratch.
+
+```bash
+# Start fresh
+portolan add data.parquet --merge-strategy=overwrite
+```
+
+## Use Cases
+
+### AI-Generated Metadata
+
+When Claude Code or another AI agent generates your `collection.json` with rich descriptions, use the default `smart` strategy. Portolan preserves the agent's prose while ensuring machine-derived values (row counts, types) are accurate.
+
+### Legacy Catalog Migration
+
+When importing an existing STAC catalog into Portolan, use `keep` to preserve all existing metadata:
+
+```bash
+portolan add . --merge-strategy=keep
+```
+
+### Regenerating Metadata
+
+If metadata has become stale or corrupted, use `overwrite` to regenerate everything from the data files:
+
+```bash
+portolan add . --merge-strategy=overwrite --force
+```
+
+## Field Classification
+
+| Category | Fields | Default Behavior |
+|----------|--------|------------------|
+| Human-enrichable | `title`, `description`, column descriptions | Preserved |
+| Machine-derivable | `href`, `media_type`, `roles`, row counts, types, extension fields | Updated |
+
+The full classification is defined in `portolan_cli/stac.py` as `HUMAN_ENRICHABLE_ASSET_FIELDS` and `MACHINE_DERIVABLE_EXTRA_FIELD_PREFIXES`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,12 +78,14 @@ nav:
   - Home: index.md
   - Guides:
     - Version Management: guides/version-management.md
+    - Merge Strategies: guides/merge-strategies.md
     - AI Skills: guides/skills.md
     - Extracting from ArcGIS: guides/extract-arcgis.md
     - Extracting from WFS: guides/extract-wfs.md
     - Iceberg Backend: guides/iceberg.md
     - Metadata Defaults: guides/metadata-defaults.md
     - Nested Catalogs: guides/nested-catalogs.md
+    - Partitioning: guides/partitioning.md
   - Reference:
     - CLI: reference/cli.md
     - Configuration: reference/configuration.md

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -65,6 +65,7 @@ from portolan_cli.scan_output import (
     render_tree_view,
 )
 from portolan_cli.scan_progress import ScanProgressReporter, count_directories
+from portolan_cli.stac import MergeStrategy
 from portolan_cli.status import CollectionStatus, get_collection_status
 from portolan_cli.temporal import FLEXIBLE_DATETIME
 from portolan_cli.validation import (
@@ -3125,6 +3126,19 @@ def _coerce_int(value: Any, *, default: int) -> int:
     is_flag=True,
     help="Re-convert from source files (requires --force).",
 )
+@click.option(
+    "--merge-strategy",
+    "merge_strategy",
+    type=click.Choice(["smart", "keep", "overwrite"], case_sensitive=False),
+    default="smart",
+    help=(
+        "How to merge auto-detected metadata with existing values. "
+        "'smart' (default): preserve human-authored fields (title, description), "
+        "update machine-derivable fields (href, type, row_count). "
+        "'keep': preserve all existing fields. "
+        "'overwrite': replace everything with auto-detected values."
+    ),
+)
 @click.pass_context
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
 def add_cmd(
@@ -3141,6 +3155,7 @@ def add_cmd(
     force_pmtiles: bool,
     force: bool,
     reconvert: bool,
+    merge_strategy: str,
 ) -> None:
     """Track files in the catalog.
 
@@ -3284,6 +3299,7 @@ def add_cmd(
                 force=force,
                 reconvert=reconvert,
                 skip_partitioning=skip_partitioning,
+                merge_strategy=MergeStrategy(merge_strategy),
             )
     except (ValueError, FileNotFoundError) as err:
         err_type = type(err).__name__

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -67,6 +67,7 @@ from portolan_cli.metadata_yaml import (
 )
 from portolan_cli.scan_detect import is_filegdb
 from portolan_cli.stac import (
+    MergeStrategy,
     add_asset_to_collection,
     add_collection_extensions_from_summaries,
     add_collection_properties_from_metadata,
@@ -142,7 +143,7 @@ IGNORED_FILES: frozenset[str] = frozenset(
 
 # Extension-to-MIME-type mapping for asset files.
 _MEDIA_TYPE_MAP: dict[str, str] = {
-    ".parquet": "application/x-parquet",
+    ".parquet": "application/vnd.apache.parquet",
     ".tif": "image/tiff; application=geotiff; profile=cloud-optimized",
     ".tiff": "image/tiff; application=geotiff; profile=cloud-optimized",
     ".geojson": "application/geo+json",
@@ -1428,6 +1429,7 @@ def prepare_dataset(
 def _add_prepared_items_to_collection(
     collection: pystac.Collection,
     items: list[PreparedDataset],
+    merge_strategy: MergeStrategy = MergeStrategy.SMART,
 ) -> None:
     """Add prepared items or collection-level assets to a collection.
 
@@ -1437,13 +1439,18 @@ def _add_prepared_items_to_collection(
     Args:
         collection: The pystac Collection to add to.
         items: List of PreparedDataset objects.
+        merge_strategy: How to merge auto-detected metadata with existing values.
     """
     for p in items:
         if p.is_collection_level_asset and p.stac_assets is not None:
             # Collection-level asset: add directly to collection.assets
             for asset_key, asset in p.stac_assets.items():
                 add_asset_to_collection(
-                    collection, asset_key, asset, update_extent_from_bbox=p.bbox
+                    collection,
+                    asset_key,
+                    asset,
+                    update_extent_from_bbox=p.bbox,
+                    merge_strategy=merge_strategy,
                 )
             # Add format-specific properties (proj:epsg, pmtiles:*, flatgeobuf:*)
             if p.metadata is not None:
@@ -1456,6 +1463,7 @@ def _add_prepared_items_to_collection(
 def finalize_datasets(
     catalog_root: Path,
     prepared: list[PreparedDataset],
+    merge_strategy: MergeStrategy = MergeStrategy.SMART,
 ) -> list[DatasetInfo]:
     """Finalize prepared datasets by writing versions.json and collection.json.
 
@@ -1465,6 +1473,7 @@ def finalize_datasets(
     Args:
         catalog_root: Root directory of the catalog.
         prepared: List of PreparedDataset objects from prepare_dataset().
+        merge_strategy: How to merge auto-detected metadata with existing values.
 
     Returns:
         List of DatasetInfo for each finalized dataset.
@@ -1493,7 +1502,7 @@ def finalize_datasets(
         )
 
         # Add items or collection-level assets to collection (in memory)
-        _add_prepared_items_to_collection(collection, items)
+        _add_prepared_items_to_collection(collection, items, merge_strategy)
 
         # Add table extension if any items are GeoParquet format (Issue #304)
         # Aggregate metadata from all GeoParquet items and apply to collection
@@ -1514,7 +1523,7 @@ def finalize_datasets(
             if existing_meta is not None:
                 vector_metadata.insert(0, existing_meta)
             aggregated = aggregate_table_metadata(vector_metadata)
-            add_table_extension(collection, aggregated)
+            add_table_extension(collection, aggregated, merge_strategy=merge_strategy)
 
         # Add partition extension if any items have partition metadata (Issue #232)
         for p in items:
@@ -3066,6 +3075,7 @@ def add_files(
     force: bool = False,
     reconvert: bool = False,
     skip_partitioning: bool = False,
+    merge_strategy: MergeStrategy = MergeStrategy.SMART,
 ) -> tuple[list[DatasetInfo], list[Path], list[AddFailure]]:
     """Add files to a Portolan catalog.
 
@@ -3331,7 +3341,7 @@ def add_files(
     # ========================================================================
     # This is the key optimization: ONE write per collection instead of O(n)
     if prepared_datasets:
-        added.extend(finalize_datasets(catalog_root, prepared_datasets))
+        added.extend(finalize_datasets(catalog_root, prepared_datasets, merge_strategy))
 
     # ========================================================================
     # PHASE 3: Process deferred non-geo files (sequential)

--- a/portolan_cli/item.py
+++ b/portolan_cli/item.py
@@ -152,8 +152,8 @@ def _get_media_type(path: Path) -> str:
     suffix = path.suffix.lower()
 
     media_types = {
-        ".parquet": "application/x-parquet",
-        ".geoparquet": "application/x-parquet",
+        ".parquet": "application/vnd.apache.parquet",
+        ".geoparquet": "application/vnd.apache.parquet",
         ".tif": "image/tiff; application=geotiff",
         ".tiff": "image/tiff; application=geotiff",
         ".json": "application/json",

--- a/portolan_cli/models/item.py
+++ b/portolan_cli/models/item.py
@@ -19,7 +19,7 @@ class AssetModel:
 
     Attributes:
         href: Asset URL or relative path.
-        type: Media type (e.g., "application/x-parquet").
+        type: Media type (e.g., "application/vnd.apache.parquet").
         roles: Asset roles (e.g., ["data"], ["thumbnail"]).
         title: Human-readable title.
     """

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -13,10 +13,58 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 
 import pystac
 from pystac.summaries import Summarizer, SummaryStrategy
+
+
+class MergeStrategy(Enum):
+    """Strategy for merging existing metadata with auto-detected values.
+
+    Issue #446: Controls how `portolan add` handles conflicts between
+    human-authored metadata and auto-detected values.
+
+    Strategies:
+        SMART: Preserve human-enrichable fields (title, description),
+               update machine-derivable fields (href, type, row_count).
+               This is the default and recommended for most use cases.
+        KEEP: Preserve all existing fields, only add missing ones.
+              Use for legacy catalog imports where existing metadata is trusted.
+        OVERWRITE: Replace everything with auto-detected values.
+                   Use for regenerating metadata from scratch.
+        INTERACTIVE: Prompt per-conflict (not yet implemented).
+    """
+
+    SMART = "smart"
+    KEEP = "keep"
+    OVERWRITE = "overwrite"
+    INTERACTIVE = "interactive"
+
+
+# Fields that are human-enrichable (preserve existing by default in SMART mode)
+HUMAN_ENRICHABLE_ASSET_FIELDS = frozenset({"title", "description"})
+
+# Extra fields that are machine-derivable (update in SMART mode)
+# All extension prefixes that are auto-detected from file metadata
+MACHINE_DERIVABLE_EXTRA_FIELD_PREFIXES = frozenset(
+    {
+        "file:",  # file:size, file:checksum
+        "proj:",  # proj:epsg, proj:wkt2
+        "pmtiles:",  # pmtiles:min_zoom, pmtiles:max_zoom, etc.
+        "flatgeobuf:",  # flatgeobuf:feature_count, etc.
+        "raster:",  # raster:spatial_resolution, etc.
+        "portolan:",  # portolan:glob (auto-generated on push)
+    }
+)
+
+# Specific extra fields that are machine-derivable (not prefix-based)
+MACHINE_DERIVABLE_EXTRA_FIELDS = frozenset(
+    {
+        "bands",  # Unified bands array (STAC v1.1.0)
+    }
+)
 
 # STAC version we generate (v1.1.0 has unified bands array, superseding eo:bands/raster:bands)
 STAC_VERSION = "1.1.0"
@@ -234,17 +282,89 @@ def add_item_to_collection(
         _update_collection_extent(collection, item)
 
 
+def _is_machine_derivable_extra_field(field_name: str) -> bool:
+    """Check if an extra_field key is machine-derivable.
+
+    Machine-derivable fields are updated in SMART merge mode.
+    Human-authored custom fields are preserved.
+    """
+    if field_name in MACHINE_DERIVABLE_EXTRA_FIELDS:
+        return True
+    return any(field_name.startswith(prefix) for prefix in MACHINE_DERIVABLE_EXTRA_FIELD_PREFIXES)
+
+
+def _merge_asset(
+    existing: pystac.Asset,
+    new: pystac.Asset,
+    strategy: MergeStrategy,
+) -> pystac.Asset:
+    """Merge an existing asset with a new asset based on strategy.
+
+    Args:
+        existing: The existing asset in the collection.
+        new: The new asset from auto-detection.
+        strategy: The merge strategy to apply.
+
+    Returns:
+        The merged asset.
+    """
+    if strategy == MergeStrategy.OVERWRITE:
+        return new
+
+    if strategy == MergeStrategy.KEEP:
+        return existing
+
+    # SMART strategy: preserve human-enrichable, update machine-derivable
+    merged = pystac.Asset(
+        href=new.href,  # Machine-derivable: always update
+        media_type=new.media_type,  # Machine-derivable: always update
+        roles=new.roles,  # Machine-derivable: always update
+        title=existing.title if existing.title else new.title,
+        description=existing.description if existing.description else new.description,
+    )
+
+    # Merge extra_fields
+    merged_extra: dict[str, object] = {}
+
+    # Start with existing extra_fields (preserve custom fields)
+    if existing.extra_fields:
+        merged_extra.update(existing.extra_fields)
+
+    # Update machine-derivable extra_fields from new asset
+    if new.extra_fields:
+        for key, value in new.extra_fields.items():
+            if _is_machine_derivable_extra_field(key):
+                merged_extra[key] = value
+            elif key not in merged_extra:
+                # Add new fields that don't exist
+                merged_extra[key] = value
+
+    if merged_extra:
+        merged.extra_fields = merged_extra
+
+    return merged
+
+
 def add_asset_to_collection(
     collection: pystac.Collection,
     asset_key: str,
     asset: pystac.Asset,
     *,
     update_extent_from_bbox: list[float] | None = None,
+    merge_strategy: MergeStrategy = MergeStrategy.SMART,
 ) -> None:
     """Add an asset directly to a collection (collection-level asset).
 
     Per ADR-0031: Single vector files (GeoParquet, Shapefile, GeoPackage) are
     collection-level assets—no item.json, asset directly in collection.json.
+
+    When an asset with the same key already exists, the merge_strategy controls
+    how fields are combined (Issue #446):
+    - SMART (default): Preserve human-enrichable fields (title, description),
+                       update machine-derivable fields (href, media_type, roles).
+    - KEEP: Preserve all existing fields, only add the asset if missing.
+    - OVERWRITE: Replace the existing asset entirely.
+    - INTERACTIVE: Not yet implemented.
 
     Args:
         collection: The collection to add the asset to.
@@ -252,7 +372,13 @@ def add_asset_to_collection(
         asset: The pystac.Asset to add.
         update_extent_from_bbox: If provided, update collection's spatial extent
             to encompass this bbox [min_x, min_y, max_x, max_y].
+        merge_strategy: How to handle conflicts with existing assets.
     """
+    existing_asset = collection.assets.get(asset_key)
+
+    if existing_asset is not None:
+        asset = _merge_asset(existing_asset, asset, merge_strategy)
+
     collection.add_asset(asset_key, asset)
 
     if update_extent_from_bbox:
@@ -462,31 +588,95 @@ def build_stac_extensions(properties: dict[str, object]) -> list[str]:
     return extensions
 
 
+def _merge_table_columns(
+    existing_columns: list[dict[str, object]],
+    new_schema: dict[str, str],
+    strategy: MergeStrategy,
+) -> list[dict[str, object]]:
+    """Merge existing table:columns with new schema based on strategy.
+
+    Args:
+        existing_columns: Existing table:columns array from collection.
+        new_schema: New schema dict mapping column name to type.
+        strategy: The merge strategy to apply.
+
+    Returns:
+        Merged columns array.
+    """
+    if strategy == MergeStrategy.OVERWRITE:
+        return [{"name": name, "type": dtype} for name, dtype in new_schema.items()]
+
+    if strategy == MergeStrategy.KEEP:
+        return existing_columns
+
+    # SMART strategy: preserve descriptions, update types, handle adds/removes
+    # Build lookup of existing columns by name
+    existing_by_name = {col["name"]: col for col in existing_columns}
+
+    merged_columns = []
+    for name, dtype in new_schema.items():
+        if name in existing_by_name:
+            # Column exists: preserve description, update type
+            existing = existing_by_name[name]
+            merged_col: dict[str, object] = {"name": name, "type": dtype}
+            if "description" in existing:
+                merged_col["description"] = existing["description"]
+            # Preserve any other human-authored fields
+            for key, value in existing.items():
+                if key not in ("name", "type", "statistics"):
+                    merged_col.setdefault(key, value)
+            merged_columns.append(merged_col)
+        else:
+            # New column: just name and type
+            merged_columns.append({"name": name, "type": dtype})
+
+    return merged_columns
+
+
 def add_table_extension(
     collection: pystac.Collection,
     metadata: object,
+    *,
+    merge_strategy: MergeStrategy = MergeStrategy.SMART,
 ) -> None:
     """Add Table extension fields to a collection from GeoParquet metadata.
 
     Sets table:row_count, table:primary_geometry, and table:columns based on
     the provided GeoParquet metadata object.
 
+    When the collection already has table:columns, the merge_strategy controls
+    how column metadata is combined (Issue #446):
+    - SMART (default): Preserve column descriptions, update types.
+    - KEEP: Preserve all existing table extension fields.
+    - OVERWRITE: Replace everything with auto-detected values.
+
     Args:
         collection: The collection to add extension fields to.
         metadata: A GeoParquetMetadata-like object with feature_count,
                  geometry_column, and schema attributes.
+        merge_strategy: How to handle conflicts with existing metadata.
     """
-    # Set row count
+    # KEEP strategy: don't modify existing table extension fields
+    if merge_strategy == MergeStrategy.KEEP:
+        if "table:row_count" in collection.extra_fields:
+            # Already has table extension, don't overwrite
+            return
+
+    # Set row count (machine-derivable: always update in SMART/OVERWRITE)
     if hasattr(metadata, "feature_count") and metadata.feature_count is not None:
         collection.extra_fields["table:row_count"] = metadata.feature_count
 
-    # Set primary geometry column
+    # Set primary geometry column (machine-derivable: always update)
     if hasattr(metadata, "geometry_column") and metadata.geometry_column is not None:
         collection.extra_fields["table:primary_geometry"] = metadata.geometry_column
 
-    # Set columns from schema
+    # Set columns from schema with merge logic
     if hasattr(metadata, "schema") and metadata.schema:
-        columns = [{"name": name, "type": dtype} for name, dtype in metadata.schema.items()]
+        existing_columns = collection.extra_fields.get("table:columns", [])
+        if existing_columns and merge_strategy != MergeStrategy.OVERWRITE:
+            columns = _merge_table_columns(existing_columns, metadata.schema, merge_strategy)
+        else:
+            columns = [{"name": name, "type": dtype} for name, dtype in metadata.schema.items()]
         collection.extra_fields["table:columns"] = columns
 
     # Update stac_extensions if not already present

--- a/portolan_cli/stac_parquet.py
+++ b/portolan_cli/stac_parquet.py
@@ -6,7 +6,7 @@ many items, enabling efficient spatial/temporal queries without N HTTP requests.
 Per issue #319:
 - Optional but recommended for collections exceeding threshold (default: 100 items)
 - Uses stac-geoparquet library for STAC → GeoParquet conversion
-- Adds items.parquet link to collection.json with rel=items, type=application/x-parquet
+- Adds items.parquet link to collection.json with rel=items, type=application/vnd.apache.parquet
 - Tracks items.parquet in versions.json so push detects changes
 
 Usage:
@@ -32,7 +32,7 @@ from typing import Any
 
 # Constants
 PARQUET_FILENAME = "items.parquet"
-PARQUET_MEDIA_TYPE = "application/x-parquet"
+PARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
 
 
 def count_items(collection_path: Path) -> int:
@@ -205,7 +205,7 @@ def add_parquet_link_to_collection(collection_path: Path) -> None:
     """Add items.parquet link and asset to collection.json.
 
     Per ADR-0031 (collection-level assets), adds:
-    1. A link with rel="items" and type="application/x-parquet"
+    1. A link with rel="items" and type="application/vnd.apache.parquet"
     2. A collection-level asset for the GeoParquet file
 
     Idempotent - won't duplicate if already present.

--- a/tests/fixtures/metadata/stac/valid/item_geoparquet.json
+++ b/tests/fixtures/metadata/stac/valid/item_geoparquet.json
@@ -22,7 +22,7 @@
   "assets": {
     "data": {
       "href": "./parcels-2026q1.parquet",
-      "type": "application/x-parquet",
+      "type": "application/vnd.apache.parquet",
       "title": "Parcel Data",
       "roles": ["data"]
     }

--- a/tests/integration/test_add_merge_strategy.py
+++ b/tests/integration/test_add_merge_strategy.py
@@ -1,0 +1,268 @@
+"""Integration tests for --merge-strategy flag in portolan add.
+
+Issue #446: portolan add strips human-authored asset and column metadata.
+
+These tests verify the CLI flag works end-to-end:
+1. smart (default): Preserves human-enrichable fields, updates machine-derivable
+2. keep: Preserves all existing fields
+3. overwrite: Replaces everything with auto-detected values
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def initialized_catalog(tmp_path: Path) -> Path:
+    """Create an initialized Portolan catalog using CLI."""
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+    return tmp_path
+
+
+@pytest.fixture
+def collection_with_metadata(initialized_catalog: Path, valid_points_parquet: Path) -> Path:
+    """Create a collection with hand-authored metadata that should be preserved."""
+    collection_dir = initialized_catalog / "census"
+    collection_dir.mkdir()
+
+    # Copy parquet file
+    data_file = collection_dir / "data.parquet"
+    shutil.copy(valid_points_parquet, data_file)
+
+    # Create collection.json with human-authored metadata
+    collection_json = {
+        "type": "Collection",
+        "stac_version": "1.1.0",
+        "id": "census",
+        "description": "Test collection",
+        "license": "proprietary",
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+        },
+        "links": [],
+        "assets": {
+            "data": {
+                "href": "./data.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+                "title": "Census Demographics 2020",
+                "description": "Detailed census data with population demographics by tract.",
+            }
+        },
+        "table:columns": [
+            {
+                "name": "id",
+                "type": "int64",
+                "description": "Unique identifier for each census tract.",
+            },
+            {
+                "name": "geometry",
+                "type": "binary",
+                "description": "Tract boundary polygon in WGS84.",
+            },
+        ],
+    }
+    (collection_dir / "collection.json").write_text(json.dumps(collection_json, indent=2))
+
+    return collection_dir
+
+
+class TestMergeStrategySmartIntegration:
+    """Integration tests for --merge-strategy=smart (default)."""
+
+    @pytest.mark.integration
+    def test_smart_preserves_asset_title(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+        collection_with_metadata: Path,
+    ) -> None:
+        """Smart strategy preserves existing asset title through CLI."""
+        data_file = collection_with_metadata / "data.parquet"
+
+        # Re-add the file (simulating update)
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(data_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Verify title preserved
+        collection_json = json.loads((collection_with_metadata / "collection.json").read_text())
+        assert collection_json["assets"]["data"]["title"] == "Census Demographics 2020"
+
+    @pytest.mark.integration
+    def test_smart_preserves_asset_description(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+        collection_with_metadata: Path,
+    ) -> None:
+        """Smart strategy preserves existing asset description through CLI."""
+        data_file = collection_with_metadata / "data.parquet"
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(data_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        collection_json = json.loads((collection_with_metadata / "collection.json").read_text())
+        assert "census data with population" in collection_json["assets"]["data"]["description"]
+
+    @pytest.mark.integration
+    def test_smart_preserves_column_descriptions(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+        collection_with_metadata: Path,
+    ) -> None:
+        """Smart strategy preserves table:columns descriptions through CLI."""
+        data_file = collection_with_metadata / "data.parquet"
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(data_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        collection_json = json.loads((collection_with_metadata / "collection.json").read_text())
+
+        # Find the id column and check description preserved
+        columns = collection_json.get("table:columns", [])
+        id_col = next((c for c in columns if c["name"] == "id"), None)
+        if id_col:
+            # Description should be preserved if column still exists
+            assert id_col.get("description") == "Unique identifier for each census tract."
+
+
+class TestMergeStrategyKeepIntegration:
+    """Integration tests for --merge-strategy=keep."""
+
+    @pytest.mark.integration
+    def test_keep_preserves_all_metadata(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+        collection_with_metadata: Path,
+    ) -> None:
+        """Keep strategy preserves all existing metadata through CLI."""
+        data_file = collection_with_metadata / "data.parquet"
+
+        # Get original metadata
+        original = json.loads((collection_with_metadata / "collection.json").read_text())
+        original_title = original["assets"]["data"]["title"]
+        original_description = original["assets"]["data"]["description"]
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                "--merge-strategy=keep",
+                str(data_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Verify all metadata preserved
+        collection_json = json.loads((collection_with_metadata / "collection.json").read_text())
+        assert collection_json["assets"]["data"]["title"] == original_title
+        assert collection_json["assets"]["data"]["description"] == original_description
+
+
+class TestMergeStrategyOverwriteIntegration:
+    """Integration tests for --merge-strategy=overwrite."""
+
+    @pytest.mark.integration
+    def test_overwrite_clears_human_metadata(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+        collection_with_metadata: Path,
+    ) -> None:
+        """Overwrite strategy replaces metadata through CLI."""
+        data_file = collection_with_metadata / "data.parquet"
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                "--merge-strategy=overwrite",
+                str(data_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Verify metadata overwritten (title/description should be None or missing)
+        collection_json = json.loads((collection_with_metadata / "collection.json").read_text())
+        asset = collection_json["assets"]["data"]
+        # After overwrite, human-authored fields should be cleared
+        assert asset.get("title") is None or "title" not in asset
+        assert asset.get("description") is None or "description" not in asset
+
+
+class TestMergeStrategyCLIValidation:
+    """Tests for CLI flag validation."""
+
+    @pytest.mark.integration
+    def test_invalid_merge_strategy_rejected(
+        self, runner: CliRunner, initialized_catalog: Path
+    ) -> None:
+        """Invalid merge strategy values are rejected by CLI."""
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--merge-strategy=invalid",
+                "somefile.parquet",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "invalid" in result.output.lower() or "choice" in result.output.lower()

--- a/tests/integration/test_add_merge_strategy.py
+++ b/tests/integration/test_add_merge_strategy.py
@@ -67,14 +67,14 @@ def collection_with_metadata(initialized_catalog: Path, valid_points_parquet: Pa
         },
         "table:columns": [
             {
-                "name": "id",
+                "name": "boundary_id",
                 "type": "int64",
-                "description": "Unique identifier for each census tract.",
+                "description": "Unique building boundary identifier.",
             },
             {
                 "name": "geometry",
                 "type": "binary",
-                "description": "Tract boundary polygon in WGS84.",
+                "description": "Building footprint polygon in WGS84.",
             },
         ],
     }
@@ -165,12 +165,11 @@ class TestMergeStrategySmartIntegration:
 
         collection_json = json.loads((collection_with_metadata / "collection.json").read_text())
 
-        # Find the id column and check description preserved
+        # Find the boundary_id column and check description preserved
         columns = collection_json.get("table:columns", [])
-        id_col = next((c for c in columns if c["name"] == "id"), None)
-        if id_col:
-            # Description should be preserved if column still exists
-            assert id_col.get("description") == "Unique identifier for each census tract."
+        boundary_col = next((c for c in columns if c["name"] == "boundary_id"), None)
+        assert boundary_col is not None, "boundary_id column should exist in table:columns"
+        assert boundary_col.get("description") == "Unique building boundary identifier."
 
 
 class TestMergeStrategyKeepIntegration:

--- a/tests/unit/models/test_item.py
+++ b/tests/unit/models/test_item.py
@@ -35,12 +35,12 @@ class TestAssetModel:
         """AssetModel can be created with all fields."""
         asset = AssetModel(
             href="./data.parquet",
-            type="application/x-parquet",
+            type="application/vnd.apache.parquet",
             roles=["data"],
             title="GeoParquet data file",
         )
 
-        assert asset.type == "application/x-parquet"
+        assert asset.type == "application/vnd.apache.parquet"
         assert asset.roles == ["data"]
         assert asset.title == "GeoParquet data file"
 
@@ -59,13 +59,13 @@ class TestAssetModel:
         """AssetModel.to_dict() returns correct dict."""
         asset = AssetModel(
             href="./data.parquet",
-            type="application/x-parquet",
+            type="application/vnd.apache.parquet",
             roles=["data"],
         )
         data = asset.to_dict()
 
         assert data["href"] == "./data.parquet"
-        assert data["type"] == "application/x-parquet"
+        assert data["type"] == "application/vnd.apache.parquet"
         assert data["roles"] == ["data"]
 
     @pytest.mark.unit
@@ -138,7 +138,7 @@ class TestItemModel:
             assets={
                 "data": AssetModel(
                     href="./data.parquet",
-                    type="application/x-parquet",
+                    type="application/vnd.apache.parquet",
                     roles=["data"],
                 ),
             },
@@ -263,7 +263,7 @@ class TestItemSerialization:
             assets={
                 "data": AssetModel(
                     href="./data.parquet",
-                    type="application/x-parquet",
+                    type="application/vnd.apache.parquet",
                     roles=["data"],
                 ),
             },
@@ -295,7 +295,7 @@ class TestItemSerialization:
 
         assert "data" in data["assets"]
         assert data["assets"]["data"]["href"] == "./data.parquet"
-        assert data["assets"]["data"]["type"] == "application/x-parquet"
+        assert data["assets"]["data"]["type"] == "application/vnd.apache.parquet"
 
     @pytest.mark.unit
     def test_from_dict_creates_item(self) -> None:

--- a/tests/unit/test_cli_info.py
+++ b/tests/unit/test_cli_info.py
@@ -98,7 +98,7 @@ def catalog_with_tracked_file(tmp_path: Path, valid_points_parquet: Path) -> Pat
         "assets": {
             "data": {
                 "href": "./census.parquet",
-                "type": "application/x-parquet",
+                "type": "application/vnd.apache.parquet",
                 "roles": ["data"],
             }
         },

--- a/tests/unit/test_cli_stac_geoparquet.py
+++ b/tests/unit/test_cli_stac_geoparquet.py
@@ -163,7 +163,9 @@ class TestStacGeoparquetCommand:
             (catalog_with_collection / "imagery" / "collection.json").read_text()
         )
         parquet_links = [
-            link for link in collection_json["links"] if link.get("type") == "application/x-parquet"
+            link
+            for link in collection_json["links"]
+            if link.get("type") == "application/vnd.apache.parquet"
         ]
         assert len(parquet_links) == 1
         assert parquet_links[0]["rel"] == "items"

--- a/tests/unit/test_csv_skip.py
+++ b/tests/unit/test_csv_skip.py
@@ -983,7 +983,7 @@ class TestUpdateItemWithAsset:
             "assets": {
                 "data": {
                     "href": "./data.parquet",
-                    "type": "application/x-parquet",
+                    "type": "application/vnd.apache.parquet",
                     "roles": ["data"],
                 }
             },

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -586,7 +586,7 @@ class TestGetDatasetInfo:
             "bbox": [-122.5, 37.5, -122.0, 38.0],
             "properties": {"datetime": "2024-01-01T00:00:00Z", "title": "My Item"},
             "links": [],
-            "assets": {"data": {"href": "data.parquet", "type": "application/x-parquet"}},
+            "assets": {"data": {"href": "data.parquet", "type": "application/vnd.apache.parquet"}},
         }
         (item_dir / "my-item.json").write_text(json.dumps(item_data))
 
@@ -1086,7 +1086,7 @@ class TestGetMediaType:
         """_get_media_type returns correct type for .parquet files."""
         p = tmp_path / "data.parquet"
         p.write_bytes(b"fake")
-        assert _get_media_type(p) == "application/x-parquet"
+        assert _get_media_type(p) == "application/vnd.apache.parquet"
 
     @pytest.mark.unit
     def test_tif_media_type(self, tmp_path: Path) -> None:
@@ -1170,7 +1170,7 @@ class TestGetMediaType:
         """_get_media_type handles uppercase extensions."""
         p = tmp_path / "data.PARQUET"
         p.write_bytes(b"fake")
-        assert _get_media_type(p) == "application/x-parquet"
+        assert _get_media_type(p) == "application/vnd.apache.parquet"
 
 
 class TestGetAssetRole:
@@ -1575,7 +1575,7 @@ class TestMultiAssetListAndInfo:
             "properties": {"datetime": "2024-01-01T00:00:00Z"},
             "links": [],
             "assets": {
-                "data": {"href": "data.parquet", "type": "application/x-parquet"},
+                "data": {"href": "data.parquet", "type": "application/vnd.apache.parquet"},
                 "thumbnail": {"href": "thumb.png", "type": "image/png"},
                 "metadata": {"href": "extra.xml", "type": "application/xml"},
             },

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -85,7 +85,7 @@ def catalog_with_tracked_file(tmp_path: Path, valid_points_parquet: Path) -> Pat
         "assets": {
             "data": {
                 "href": "./census.parquet",
-                "type": "application/x-parquet",
+                "type": "application/vnd.apache.parquet",
                 "roles": ["data"],
             }
         },

--- a/tests/unit/test_issue_252_catalog_json_roundtrip.py
+++ b/tests/unit/test_issue_252_catalog_json_roundtrip.py
@@ -160,7 +160,7 @@ def full_catalog(tmp_path: Path) -> Path:
         "assets": {
             "data": {
                 "href": "./data.parquet",
-                "type": "application/x-parquet",
+                "type": "application/vnd.apache.parquet",
             }
         },
     }

--- a/tests/unit/test_item_creation.py
+++ b/tests/unit/test_item_creation.py
@@ -142,7 +142,7 @@ class TestAssetModel:
         """AssetModel should serialize correctly."""
         asset = AssetModel(
             href="data/file.parquet",
-            type="application/x-parquet",
+            type="application/vnd.apache.parquet",
             roles=["data"],
             title="Data file",
         )
@@ -150,7 +150,7 @@ class TestAssetModel:
         data = asset.to_dict()
 
         assert data["href"] == "data/file.parquet"
-        assert data["type"] == "application/x-parquet"
+        assert data["type"] == "application/vnd.apache.parquet"
         assert data["roles"] == ["data"]
         assert data["title"] == "Data file"
 
@@ -159,14 +159,14 @@ class TestAssetModel:
         """AssetModel should deserialize correctly."""
         data = {
             "href": "data/file.parquet",
-            "type": "application/x-parquet",
+            "type": "application/vnd.apache.parquet",
             "roles": ["data"],
         }
 
         asset = AssetModel.from_dict(data)
 
         assert asset.href == "data/file.parquet"
-        assert asset.type == "application/x-parquet"
+        assert asset.type == "application/vnd.apache.parquet"
         assert asset.roles == ["data"]
 
 
@@ -186,7 +186,7 @@ class TestItemSerialization:
             },
             bbox=[-122.5, 37.5, -122.0, 38.0],
             properties={"datetime": "2024-01-01T00:00:00Z"},
-            assets={"data": AssetModel(href="data.parquet", type="application/x-parquet")},
+            assets={"data": AssetModel(href="data.parquet", type="application/vnd.apache.parquet")},
             collection="test-collection",
         )
 

--- a/tests/unit/test_merge_strategy.py
+++ b/tests/unit/test_merge_strategy.py
@@ -1,0 +1,451 @@
+"""Tests for merge strategy functionality in metadata preservation.
+
+Issue #446: portolan add strips human-authored asset and column metadata.
+
+These tests verify that the merge strategy correctly preserves human-enrichable
+fields while updating machine-derivable fields.
+"""
+
+from __future__ import annotations
+
+import pystac
+import pytest
+
+from portolan_cli.metadata.geoparquet import GeoParquetMetadata
+from portolan_cli.stac import (
+    MergeStrategy,
+    add_asset_to_collection,
+    add_table_extension,
+    create_collection,
+)
+
+
+class TestMergeStrategyEnum:
+    """Tests for MergeStrategy enum definition."""
+
+    @pytest.mark.unit
+    def test_merge_strategy_has_smart_default(self) -> None:
+        """MergeStrategy.SMART should be the default strategy."""
+        assert MergeStrategy.SMART is not None
+
+    @pytest.mark.unit
+    def test_merge_strategy_has_all_options(self) -> None:
+        """MergeStrategy should have smart, keep, overwrite, interactive options."""
+        assert hasattr(MergeStrategy, "SMART")
+        assert hasattr(MergeStrategy, "KEEP")
+        assert hasattr(MergeStrategy, "OVERWRITE")
+        assert hasattr(MergeStrategy, "INTERACTIVE")
+
+
+class TestAddAssetToCollectionMerge:
+    """Tests for asset merge behavior in add_asset_to_collection."""
+
+    def _create_collection_with_asset(self) -> pystac.Collection:
+        """Create a collection with a pre-existing asset with human-authored fields."""
+        collection = create_collection(
+            collection_id="test-merge",
+            description="Test merge behavior",
+        )
+        existing_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            title="Census Demographics 2020",
+            description="Detailed census data with population demographics by tract.",
+        )
+        collection.add_asset("data", existing_asset)
+        return collection
+
+    @pytest.mark.unit
+    def test_smart_strategy_preserves_title(self) -> None:
+        """SMART strategy preserves existing asset title."""
+        collection = self._create_collection_with_asset()
+
+        new_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            title=None,  # Auto-detected has no title
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.SMART)
+
+        assert collection.assets["data"].title == "Census Demographics 2020"
+
+    @pytest.mark.unit
+    def test_smart_strategy_preserves_description(self) -> None:
+        """SMART strategy preserves existing asset description."""
+        collection = self._create_collection_with_asset()
+
+        new_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            description=None,
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.SMART)
+
+        assert "census data with population" in collection.assets["data"].description
+
+    @pytest.mark.unit
+    def test_smart_strategy_updates_href(self) -> None:
+        """SMART strategy updates href (machine-derivable field)."""
+        collection = self._create_collection_with_asset()
+
+        new_asset = pystac.Asset(
+            href="updated/path/data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.SMART)
+
+        assert collection.assets["data"].href == "updated/path/data.parquet"
+
+    @pytest.mark.unit
+    def test_smart_strategy_updates_media_type(self) -> None:
+        """SMART strategy updates media_type (machine-derivable field)."""
+        collection = self._create_collection_with_asset()
+
+        new_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",  # Correct MIME
+            roles=["data"],
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.SMART)
+
+        assert collection.assets["data"].media_type == "application/vnd.apache.parquet"
+
+    @pytest.mark.unit
+    def test_keep_strategy_preserves_all_existing(self) -> None:
+        """KEEP strategy preserves all existing fields, only adds missing."""
+        collection = self._create_collection_with_asset()
+        original_href = collection.assets["data"].href
+
+        new_asset = pystac.Asset(
+            href="different/path.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data", "overview"],
+            title="New Title",
+            description="New description",
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.KEEP)
+
+        asset = collection.assets["data"]
+        assert asset.href == original_href
+        assert asset.title == "Census Demographics 2020"
+        assert "census data with population" in asset.description
+
+    @pytest.mark.unit
+    def test_overwrite_strategy_replaces_everything(self) -> None:
+        """OVERWRITE strategy replaces all fields with new values."""
+        collection = self._create_collection_with_asset()
+
+        new_asset = pystac.Asset(
+            href="new/data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            title=None,
+            description=None,
+        )
+
+        add_asset_to_collection(
+            collection, "data", new_asset, merge_strategy=MergeStrategy.OVERWRITE
+        )
+
+        asset = collection.assets["data"]
+        assert asset.href == "new/data.parquet"
+        assert asset.title is None
+        assert asset.description is None
+
+    @pytest.mark.unit
+    def test_new_asset_added_without_merge(self) -> None:
+        """Adding a new asset key doesn't require merge logic."""
+        collection = create_collection(
+            collection_id="test-new",
+            description="Test new asset",
+        )
+
+        new_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            title="New Asset",
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.SMART)
+
+        assert collection.assets["data"].title == "New Asset"
+
+    @pytest.mark.unit
+    def test_smart_strategy_preserves_extra_fields(self) -> None:
+        """SMART strategy preserves human-authored extra_fields."""
+        collection = create_collection(
+            collection_id="test-extra",
+            description="Test extra fields",
+        )
+        existing_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"custom:note": "Hand-authored annotation"},
+        )
+        collection.add_asset("data", existing_asset)
+
+        new_asset = pystac.Asset(
+            href="data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"file:size": 12345},
+        )
+
+        add_asset_to_collection(collection, "data", new_asset, merge_strategy=MergeStrategy.SMART)
+
+        asset = collection.assets["data"]
+        # Machine-derivable extra_fields updated
+        assert asset.extra_fields.get("file:size") == 12345
+        # Custom fields preserved (not in machine-derivable list)
+        assert asset.extra_fields.get("custom:note") == "Hand-authored annotation"
+
+
+class TestAddTableExtensionMerge:
+    """Tests for table:columns merge behavior in add_table_extension."""
+
+    def _create_collection_with_columns(self) -> pystac.Collection:
+        """Create a collection with pre-existing table:columns with descriptions."""
+        collection = create_collection(
+            collection_id="test-table-merge",
+            description="Test table merge",
+        )
+        collection.extra_fields["table:columns"] = [
+            {
+                "name": "id",
+                "type": "int64",
+                "description": "Unique identifier for each census tract.",
+            },
+            {
+                "name": "population",
+                "type": "int64",
+                "description": "Total population count from 2020 census.",
+            },
+            {
+                "name": "geometry",
+                "type": "binary",
+                "description": "Tract boundary polygon in WGS84.",
+            },
+        ]
+        collection.extra_fields["table:row_count"] = 1000
+        return collection
+
+    @pytest.mark.unit
+    def test_smart_strategy_preserves_column_descriptions(self) -> None:
+        """SMART strategy preserves existing column descriptions."""
+        collection = self._create_collection_with_columns()
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=1500,  # Updated row count
+            schema={"id": "int64", "population": "int64", "geometry": "binary"},
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.SMART)
+
+        columns = collection.extra_fields["table:columns"]
+        id_col = next(c for c in columns if c["name"] == "id")
+        pop_col = next(c for c in columns if c["name"] == "population")
+
+        assert id_col["description"] == "Unique identifier for each census tract."
+        assert pop_col["description"] == "Total population count from 2020 census."
+
+    @pytest.mark.unit
+    def test_smart_strategy_updates_row_count(self) -> None:
+        """SMART strategy updates table:row_count (machine-derivable)."""
+        collection = self._create_collection_with_columns()
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=2000,
+            schema={"id": "int64", "population": "int64", "geometry": "binary"},
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.SMART)
+
+        assert collection.extra_fields["table:row_count"] == 2000
+
+    @pytest.mark.unit
+    def test_smart_strategy_updates_column_types(self) -> None:
+        """SMART strategy updates column types (machine-derivable)."""
+        collection = self._create_collection_with_columns()
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=1000,
+            schema={
+                "id": "int32",  # Type changed
+                "population": "float64",  # Type changed
+                "geometry": "binary",
+            },
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.SMART)
+
+        columns = collection.extra_fields["table:columns"]
+        id_col = next(c for c in columns if c["name"] == "id")
+        pop_col = next(c for c in columns if c["name"] == "population")
+
+        assert id_col["type"] == "int32"
+        assert pop_col["type"] == "float64"
+        # Descriptions still preserved
+        assert id_col["description"] == "Unique identifier for each census tract."
+
+    @pytest.mark.unit
+    def test_smart_strategy_handles_new_columns(self) -> None:
+        """SMART strategy adds new columns from schema."""
+        collection = self._create_collection_with_columns()
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=1000,
+            schema={
+                "id": "int64",
+                "population": "int64",
+                "geometry": "binary",
+                "median_income": "float64",  # New column
+            },
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.SMART)
+
+        columns = collection.extra_fields["table:columns"]
+        column_names = {c["name"] for c in columns}
+
+        assert "median_income" in column_names
+        income_col = next(c for c in columns if c["name"] == "median_income")
+        assert income_col["type"] == "float64"
+
+    @pytest.mark.unit
+    def test_smart_strategy_removes_deleted_columns(self) -> None:
+        """SMART strategy removes columns no longer in schema."""
+        collection = self._create_collection_with_columns()
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=1000,
+            schema={
+                "id": "int64",
+                "geometry": "binary",
+                # population column removed
+            },
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.SMART)
+
+        columns = collection.extra_fields["table:columns"]
+        column_names = {c["name"] for c in columns}
+
+        assert "population" not in column_names
+        assert len(columns) == 2
+
+    @pytest.mark.unit
+    def test_keep_strategy_preserves_all_columns(self) -> None:
+        """KEEP strategy preserves all existing column metadata."""
+        collection = self._create_collection_with_columns()
+        original_row_count = collection.extra_fields["table:row_count"]
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=9999,
+            schema={"id": "int32", "population": "float64", "geometry": "binary"},
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.KEEP)
+
+        # Row count preserved
+        assert collection.extra_fields["table:row_count"] == original_row_count
+
+        # Column types preserved
+        columns = collection.extra_fields["table:columns"]
+        id_col = next(c for c in columns if c["name"] == "id")
+        assert id_col["type"] == "int64"  # Original type, not int32
+
+    @pytest.mark.unit
+    def test_overwrite_strategy_replaces_all_columns(self) -> None:
+        """OVERWRITE strategy replaces all column metadata."""
+        collection = self._create_collection_with_columns()
+
+        metadata = GeoParquetMetadata(
+            bbox=(-180, -90, 180, 90),
+            crs="EPSG:4326",
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=500,
+            schema={"id": "int64", "geometry": "binary"},
+        )
+
+        add_table_extension(collection, metadata, merge_strategy=MergeStrategy.OVERWRITE)
+
+        columns = collection.extra_fields["table:columns"]
+
+        # Only 2 columns now
+        assert len(columns) == 2
+
+        # No descriptions (auto-detected only has name/type)
+        id_col = next(c for c in columns if c["name"] == "id")
+        assert "description" not in id_col
+
+
+class TestMimeTypeStandardization:
+    """Tests for MIME type standardization (application/vnd.apache.parquet)."""
+
+    @pytest.mark.unit
+    def test_parquet_mime_type_constant(self) -> None:
+        """PARQUET_MEDIA_TYPE should be the spec-compliant value."""
+        from portolan_cli.stac_parquet import PARQUET_MEDIA_TYPE
+
+        assert PARQUET_MEDIA_TYPE == "application/vnd.apache.parquet"
+
+    @pytest.mark.unit
+    def test_dataset_media_type_parquet(self) -> None:
+        """Dataset module should detect spec-compliant MIME for .parquet."""
+        from portolan_cli.dataset import _MEDIA_TYPE_MAP
+
+        assert _MEDIA_TYPE_MAP[".parquet"] == "application/vnd.apache.parquet"
+
+    @pytest.mark.unit
+    def test_item_media_type_parquet(self) -> None:
+        """Item module should detect spec-compliant MIME for .parquet."""
+        from pathlib import Path
+
+        from portolan_cli.item import _get_media_type
+
+        assert _get_media_type(Path("data.parquet")) == "application/vnd.apache.parquet"
+
+    @pytest.mark.unit
+    def test_item_media_type_geoparquet(self) -> None:
+        """Item module should detect spec-compliant MIME for .geoparquet."""
+        from pathlib import Path
+
+        from portolan_cli.item import _get_media_type
+
+        assert _get_media_type(Path("data.geoparquet")) == "application/vnd.apache.parquet"

--- a/tests/unit/test_metadata_detection.py
+++ b/tests/unit/test_metadata_detection.py
@@ -48,7 +48,7 @@ def sample_item_json() -> dict[str, Any]:
         "assets": {
             "data": {
                 "href": "parcels.parquet",
-                "type": "application/x-parquet",
+                "type": "application/vnd.apache.parquet",
                 "roles": ["data"],
             }
         },

--- a/tests/unit/test_metadata_validation.py
+++ b/tests/unit/test_metadata_validation.py
@@ -383,7 +383,7 @@ class TestCheckDirectoryMetadata:
             assets={
                 "data": AssetModel(
                     href="./parcel1.parquet",
-                    type="application/x-parquet",
+                    type="application/vnd.apache.parquet",
                     roles=["data"],
                 )
             },

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -170,7 +170,7 @@ class TestFindGeoparquetAssets:
             "assets": {
                 "geoparquet-items": {
                     "href": "./items.parquet",
-                    "type": "application/x-parquet",
+                    "type": "application/vnd.apache.parquet",
                     "roles": ["stac-items"],
                 }
             },

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -117,7 +117,7 @@ def local_catalog(tmp_path: Path) -> Path:
         "bbox": None,
         "properties": {"datetime": "2024-01-01T00:00:00Z"},
         "links": [],
-        "assets": {"data": {"href": "./data.parquet", "type": "application/x-parquet"}},
+        "assets": {"data": {"href": "./data.parquet", "type": "application/vnd.apache.parquet"}},
     }
     (item_dir / "data.json").write_text(json.dumps(item_data, indent=2))
 

--- a/tests/unit/test_push_async.py
+++ b/tests/unit/test_push_async.py
@@ -126,7 +126,7 @@ def async_catalog(tmp_path: Path) -> Path:
         "properties": {"datetime": "2024-01-01T00:00:00Z"},
         "links": [],
         "assets": {
-            f"file{i}": {"href": f"./file{i}.parquet", "type": "application/x-parquet"}
+            f"file{i}": {"href": f"./file{i}.parquet", "type": "application/vnd.apache.parquet"}
             for i in range(10)
         },
     }
@@ -216,7 +216,7 @@ def many_files_catalog(tmp_path: Path) -> Path:
         "properties": {"datetime": "2024-01-01T00:00:00Z"},
         "links": [],
         "assets": {
-            f"file{i}": {"href": f"./file{i}.parquet", "type": "application/x-parquet"}
+            f"file{i}": {"href": f"./file{i}.parquet", "type": "application/vnd.apache.parquet"}
             for i in range(num_files)
         },
     }

--- a/tests/unit/test_stac.py
+++ b/tests/unit/test_stac.py
@@ -175,7 +175,7 @@ class TestCreateItem:
             assets={
                 "data": pystac.Asset(
                     href="data.parquet",
-                    media_type="application/x-parquet",
+                    media_type="application/vnd.apache.parquet",
                     roles=["data"],
                 )
             },
@@ -183,7 +183,7 @@ class TestCreateItem:
 
         assert "data" in item.assets
         assert item.assets["data"].href == "data.parquet"
-        assert item.assets["data"].media_type == "application/x-parquet"
+        assert item.assets["data"].media_type == "application/vnd.apache.parquet"
 
 
 class TestCatalogOperations:

--- a/tests/unit/test_stac_parquet.py
+++ b/tests/unit/test_stac_parquet.py
@@ -350,7 +350,9 @@ class TestCollectionLinkManagement:
         # Verify link was added
         collection_json = json.loads((collection_with_items / "collection.json").read_text())
         parquet_links = [
-            link for link in collection_json["links"] if link.get("type") == "application/x-parquet"
+            link
+            for link in collection_json["links"]
+            if link.get("type") == "application/vnd.apache.parquet"
         ]
 
         assert len(parquet_links) == 1
@@ -374,7 +376,9 @@ class TestCollectionLinkManagement:
         # Verify only one link
         collection_json = json.loads((collection_with_items / "collection.json").read_text())
         parquet_links = [
-            link for link in collection_json["links"] if link.get("type") == "application/x-parquet"
+            link
+            for link in collection_json["links"]
+            if link.get("type") == "application/vnd.apache.parquet"
         ]
 
         assert len(parquet_links) == 1
@@ -544,7 +548,7 @@ class TestCollectionLevelAsset:
 
         asset = collection_json["assets"]["geoparquet-items"]
         assert asset["href"] == "./items.parquet"
-        assert asset["type"] == "application/x-parquet"
+        assert asset["type"] == "application/vnd.apache.parquet"
         assert "stac-items" in asset["roles"]
 
     @pytest.mark.unit

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -850,7 +850,9 @@ class TestRegisterStyleAssets:
         collection_data = {
             "type": "Collection",
             "id": "test",
-            "assets": {"data": {"href": "./data.parquet", "type": "application/x-parquet"}},
+            "assets": {
+                "data": {"href": "./data.parquet", "type": "application/vnd.apache.parquet"}
+            },
         }
         (tmp_path / "collection.json").write_text(json.dumps(collection_data))
 

--- a/tests/unit/test_validation_rules.py
+++ b/tests/unit/test_validation_rules.py
@@ -645,7 +645,7 @@ class TestPMTilesRecommendedRule:
             "assets": {
                 "geoparquet-items": {
                     "href": "./items.parquet",
-                    "type": "application/x-parquet",
+                    "type": "application/vnd.apache.parquet",
                     "roles": ["stac-items"],
                 }
             },
@@ -949,7 +949,7 @@ class TestMetadataFreshRule:
             "assets": {
                 "data": {
                     "href": "./test.parquet",
-                    "type": "application/x-parquet",
+                    "type": "application/vnd.apache.parquet",
                 }
             },
             "links": [],
@@ -1035,7 +1035,7 @@ class TestMetadataFreshRule:
             "assets": {
                 "data": {
                     "href": "./test.parquet",
-                    "type": "application/x-parquet",
+                    "type": "application/vnd.apache.parquet",
                 }
             },
             "links": [],


### PR DESCRIPTION
## Summary

- Add `--merge-strategy` flag to `portolan add` with three options:
  - `smart` (default): Preserve human-enrichable fields (title, description, column descriptions), update machine-derivable fields
  - `keep`: Preserve all existing fields, only add missing
  - `overwrite`: Replace everything with auto-detected values
- Fix GeoParquet MIME type to use spec-compliant `application/vnd.apache.parquet`
- Add documentation guide for merge strategies

## Field Classification

| Category | Fields | Default Behavior |
|----------|--------|------------------|
| Human-enrichable | `title`, `description`, column descriptions | Preserved in `smart` mode |
| Machine-derivable | `href`, `media_type`, `roles`, row counts, types, extension fields | Updated in `smart` mode |

## Test plan

- [x] Unit tests for `MergeStrategy` enum
- [x] Unit tests for `add_asset_to_collection` with all strategies
- [x] Unit tests for `add_table_extension` with column description preservation
- [x] Unit tests for MIME type standardization
- [x] All 4311 existing tests pass
- [x] Docs build successfully

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--merge-strategy` option to `add` with choices: `smart` (default), `keep`, `overwrite` — controls how existing item/asset/table metadata is handled when adding files.

* **Documentation**
  * New Merge Strategies guide with examples, field classification, and usage scenarios.

* **Changes**
  * Standardized Parquet MIME type to the industry-recommended value.

* **Tests**
  * New and updated unit and integration tests covering merge strategies and Parquet MIME type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->