### PR TITLE
fix(scan): strip Hive partition dirs from collection ID inference

### DIFF
--- a/portolan_cli/scan.py
+++ b/portolan_cli/scan.py
@@ -467,6 +467,13 @@ def _infer_collection_id_from_relative_path(relative_path: str) -> str:
     Hive-style partition directories (key=value) are stripped from the
     collection ID since they represent Items, not Collections (ADR-0031).
 
+    Warning:
+        ANY directory matching the pattern `key=value` (where key is a valid
+        identifier starting with letter/underscore) is treated as a Hive
+        partition and stripped. This includes directories that may not be
+        intended as partitions, e.g., "version=2.0/" or "config=prod/".
+        Users should avoid = in directory names unless intending partitioning.
+
     Examples:
         "data.parquet" -> ""
         "collection/data.parquet" -> "collection"
@@ -474,6 +481,7 @@ def _infer_collection_id_from_relative_path(relative_path: str) -> str:
         "env/air/quality/pm25.parquet" -> "env/air/quality"
         "sites/contours/gms_feature_id=abc/data.parquet" -> "sites/contours"
         "data/year=2024/month=01/file.parquet" -> "data"
+        "project/version=2.0/data.parquet" -> "project"  (version=2.0 stripped!)
 
     Args:
         relative_path: Path relative to scan root, using forward slashes.
@@ -492,9 +500,10 @@ def _infer_collection_id_from_relative_path(relative_path: str) -> str:
     dir_path = relative_path[:last_slash_idx]
     segments = dir_path.split("/")
 
-    # Filter out Hive partition directories (key=value pattern)
+    # Filter out Hive partition directories (key=value pattern) and empty segments
     # Per issue #448: any directory matching key=value is a partition, not collection
-    non_partition_segments = [seg for seg in segments if is_hive_partition_dir(seg) is None]
+    # Empty segments (from double slashes like "foo//bar") are also filtered
+    non_partition_segments = [seg for seg in segments if seg and is_hive_partition_dir(seg) is None]
 
     return "/".join(non_partition_segments)
 

--- a/portolan_cli/scan.py
+++ b/portolan_cli/scan.py
@@ -67,6 +67,7 @@ from portolan_cli.scan_detect import (
     DualFormatPair,
     SpecialFormat,
     is_filegdb,
+    is_hive_partition_dir,
 )
 from portolan_cli.scan_fix import ProposedFix
 from portolan_cli.scan_infer import CollectionSuggestion
@@ -463,25 +464,39 @@ def _infer_collection_id_from_relative_path(relative_path: str) -> str:
 
     The collection ID is the directory portion of the relative path,
     representing the leaf collection in a nested catalog structure.
+    Hive-style partition directories (key=value) are stripped from the
+    collection ID since they represent Items, not Collections (ADR-0031).
 
     Examples:
         "data.parquet" -> ""
         "collection/data.parquet" -> "collection"
         "climate/hittekaart/data.parquet" -> "climate/hittekaart"
         "env/air/quality/pm25.parquet" -> "env/air/quality"
+        "sites/contours/gms_feature_id=abc/data.parquet" -> "sites/contours"
+        "data/year=2024/month=01/file.parquet" -> "data"
 
     Args:
         relative_path: Path relative to scan root, using forward slashes.
 
     Returns:
-        Collection ID (parent directory path). Empty string for root-level files.
+        Collection ID (parent directory path, excluding Hive partitions).
+        Empty string for root-level files or files only under partition dirs.
     """
-    # Find the last slash - everything before it is the collection ID
+    # Find the last slash - everything before it is the directory path
     last_slash_idx = relative_path.rfind("/")
     if last_slash_idx == -1:
         # File is at root level (no directory component)
         return ""
-    return relative_path[:last_slash_idx]
+
+    # Get directory portion and split into segments
+    dir_path = relative_path[:last_slash_idx]
+    segments = dir_path.split("/")
+
+    # Filter out Hive partition directories (key=value pattern)
+    # Per issue #448: any directory matching key=value is a partition, not collection
+    non_partition_segments = [seg for seg in segments if is_hive_partition_dir(seg) is None]
+
+    return "/".join(non_partition_segments)
 
 
 def _get_format_info(path: Path, ext: str) -> FormatInfo:

--- a/tests/unit/test_hive_partition_collection_id.py
+++ b/tests/unit/test_hive_partition_collection_id.py
@@ -1,0 +1,167 @@
+"""Tests for generic Hive partition detection in collection ID inference.
+
+Issue #448: Hive partition detection uses hard-coded column allowlist,
+causing directories like `gms_feature_id=<uuid>` to be misrouted as
+collection IDs instead of being recognized as partition directories.
+
+The fix: strip any `key=value/` path segments when inferring collection ID.
+"""
+
+from __future__ import annotations
+
+from portolan_cli.scan import _infer_collection_id_from_relative_path
+from portolan_cli.scan_detect import is_hive_partition_dir
+
+
+class TestIsHivePartitionDir:
+    """Tests for Hive partition directory detection."""
+
+    def test_standard_partition_key(self) -> None:
+        """Standard partition keys like year, month are detected."""
+        assert is_hive_partition_dir("year=2024") == ("year", "2024")
+        assert is_hive_partition_dir("month=01") == ("month", "01")
+
+    def test_custom_partition_key(self) -> None:
+        """Custom partition keys like gms_feature_id are detected."""
+        # This is the core fix for issue #448
+        result = is_hive_partition_dir("gms_feature_id=abc123")
+        assert result == ("gms_feature_id", "abc123")
+
+    def test_uuid_values(self) -> None:
+        """UUID values in partitions are handled correctly."""
+        result = is_hive_partition_dir("gms_feature_id=550e8400-e29b-41d4-a716-446655440000")
+        assert result == ("gms_feature_id", "550e8400-e29b-41d4-a716-446655440000")
+
+    def test_spatial_partition_keys(self) -> None:
+        """Spatial partition keys (kdtree, h3, etc.) are detected."""
+        assert is_hive_partition_dir("kdtree_cell=42") == ("kdtree_cell", "42")
+        assert is_hive_partition_dir("h3_cell=8928308280fffff") == (
+            "h3_cell",
+            "8928308280fffff",
+        )
+        assert is_hive_partition_dir("s2_cell=89c25a31") == ("s2_cell", "89c25a31")
+
+    def test_non_partition_directories(self) -> None:
+        """Regular directories are not detected as partitions."""
+        assert is_hive_partition_dir("sites") is None
+        assert is_hive_partition_dir("contours") is None
+        assert is_hive_partition_dir("data-2024") is None
+
+    def test_invalid_key_format(self) -> None:
+        """Keys must start with letter or underscore."""
+        # Keys starting with numbers are invalid identifiers
+        assert is_hive_partition_dir("2024=data") is None
+        # Empty key or value
+        assert is_hive_partition_dir("=value") is None
+        assert is_hive_partition_dir("key=") is None
+
+
+class TestInferCollectionIdFromRelativePath:
+    """Tests for collection ID inference with Hive partition stripping."""
+
+    def test_simple_collection(self) -> None:
+        """Simple collection without partitions."""
+        assert _infer_collection_id_from_relative_path("collection/data.parquet") == "collection"
+
+    def test_nested_collection(self) -> None:
+        """Nested collection path without partitions."""
+        assert (
+            _infer_collection_id_from_relative_path("climate/hittekaart/data.parquet")
+            == "climate/hittekaart"
+        )
+
+    def test_root_level_file(self) -> None:
+        """File at root level has empty collection ID."""
+        assert _infer_collection_id_from_relative_path("data.parquet") == ""
+
+    def test_strips_single_hive_partition(self) -> None:
+        """Single Hive partition directory is stripped from collection ID.
+
+        This is the core test for issue #448:
+        sites/contours/gms_feature_id=abc123/contours.parquet
+        → collection ID should be "sites/contours", not "sites/contours/gms_feature_id=abc123"
+        """
+        result = _infer_collection_id_from_relative_path(
+            "sites/contours/gms_feature_id=abc123/contours.parquet"
+        )
+        assert result == "sites/contours"
+
+    def test_strips_uuid_partition(self) -> None:
+        """UUID-valued partitions are stripped."""
+        result = _infer_collection_id_from_relative_path(
+            "sites/contours/gms_feature_id=550e8400-e29b-41d4-a716-446655440000/data.parquet"
+        )
+        assert result == "sites/contours"
+
+    def test_strips_spatial_partition(self) -> None:
+        """Spatial partitions (kdtree, h3) are stripped."""
+        assert (
+            _infer_collection_id_from_relative_path(
+                "demographics/census/kdtree_cell=42/data.parquet"
+            )
+            == "demographics/census"
+        )
+        assert (
+            _infer_collection_id_from_relative_path(
+                "climate/temperature/h3_cell=8928308280fffff/data.parquet"
+            )
+            == "climate/temperature"
+        )
+
+    def test_strips_multiple_partition_levels(self) -> None:
+        """Multiple nested partitions are all stripped.
+
+        Example: year=2024/month=01/data.parquet under collection/
+        """
+        result = _infer_collection_id_from_relative_path(
+            "timeseries/weather/year=2024/month=01/data.parquet"
+        )
+        assert result == "timeseries/weather"
+
+    def test_partition_at_root_level(self) -> None:
+        """Partition directory directly under root."""
+        # If file is at root with only partition dirs, collection ID is empty
+        result = _infer_collection_id_from_relative_path("kdtree_cell=42/data.parquet")
+        assert result == ""
+
+    def test_preserves_non_partition_dirs_after_partition(self) -> None:
+        """Non-partition directories are preserved even if they appear after a partition.
+
+        This is an edge case - typically partitions are at the leaf level,
+        but we should handle the weird case gracefully.
+        """
+        # collection/partition=val/subdir/file.parquet
+        # → "collection/subdir" (partition stripped, subdir preserved)
+        result = _infer_collection_id_from_relative_path("collection/year=2024/subdir/data.parquet")
+        # After stripping year=2024, we get "collection/subdir"
+        assert result == "collection/subdir"
+
+    def test_deep_nesting_with_partition(self) -> None:
+        """Deep nesting with partition at various levels."""
+        # env/air/quality/region=north/pm25.parquet → "env/air/quality"
+        result = _infer_collection_id_from_relative_path(
+            "env/air/quality/region=north/pm25.parquet"
+        )
+        assert result == "env/air/quality"
+
+
+class TestCollectionIdValidationIntegration:
+    """Integration tests ensuring Hive partitions don't trigger validation errors."""
+
+    def test_partition_key_not_in_collection_id(self) -> None:
+        """Partition keys with = don't end up in collection ID.
+
+        The collection_id module rejects '=' characters, so if partition
+        directories leak into the collection ID, validation will fail.
+        """
+        from portolan_cli.collection_id import validate_collection_id
+
+        # Infer collection ID from a path with Hive partition
+        collection_id = _infer_collection_id_from_relative_path(
+            "sites/contours/gms_feature_id=abc123/data.parquet"
+        )
+
+        # The collection ID should be valid (no '=' character)
+        is_valid, error = validate_collection_id(collection_id)
+        assert is_valid, f"Collection ID '{collection_id}' should be valid: {error}"
+        assert "=" not in collection_id

--- a/tests/unit/test_hive_partition_collection_id.py
+++ b/tests/unit/test_hive_partition_collection_id.py
@@ -144,6 +144,47 @@ class TestInferCollectionIdFromRelativePath:
         )
         assert result == "env/air/quality"
 
+    def test_empty_segments_from_double_slash(self) -> None:
+        """Double slashes create empty segments that are filtered out.
+
+        This is an edge case where malformed paths with // could produce
+        empty segments. We filter them to normalize collection IDs.
+        """
+        # foo//bar/data.parquet → split gives ["foo", "", "bar"]
+        # Empty segments are filtered out to produce clean collection IDs
+        result = _infer_collection_id_from_relative_path("foo//bar/data.parquet")
+        assert result == "foo/bar"  # Empty segment filtered out
+
+    def test_false_positive_legitimate_equals_directory(self) -> None:
+        """Directories with = that aren't Hive partitions ARE stripped.
+
+        IMPORTANT: This documents intentional behavior that may surprise users.
+        Any directory matching key=value format is treated as a Hive partition,
+        even if it's just a naming convention unrelated to partitioning.
+
+        Examples that WILL be stripped (potentially surprising):
+        - version=2.0/  → stripped (looks like partition)
+        - config=prod/  → stripped (looks like partition)
+        - type=residential/ → stripped (looks like partition)
+
+        Users who use = in directory names without intending Hive partitioning
+        should rename their directories or use a different separator (-, _).
+        """
+        # This IS stripped because it matches key=value pattern
+        result = _infer_collection_id_from_relative_path("project/version=2.0/data.parquet")
+        assert result == "project"  # version=2.0 stripped!
+
+        # More examples of "false positive" stripping
+        assert (
+            _infer_collection_id_from_relative_path("data/config=production/settings.json")
+            == "data"
+        )
+
+        assert (
+            _infer_collection_id_from_relative_path("buildings/type=residential/parcels.parquet")
+            == "buildings"
+        )
+
 
 class TestCollectionIdValidationIntegration:
     """Integration tests ensuring Hive partitions don't trigger validation errors."""


### PR DESCRIPTION
## Summary

Fixes #448 — Hive partition detection now works with **any** `key=value/` directory pattern, not just a hard-coded allowlist.

- Collection ID inference in `_infer_collection_id_from_relative_path()` now filters out Hive partition segments
- Leverages existing `is_hive_partition_dir()` which uses generic regex `^([a-zA-Z_][a-zA-Z0-9_]*)=(.+)$`
- Custom partition keys like `gms_feature_id=<uuid>` are now correctly recognized

**Before:** `sites/contours/gms_feature_id=abc123/data.parquet` → collection ID: `sites/contours/gms_feature_id=abc123` ❌ (rejected by validation)

**After:** `sites/contours/gms_feature_id=abc123/data.parquet` → collection ID: `sites/contours` ✓

## Test plan

- [x] 17 new unit tests in `tests/unit/test_hive_partition_collection_id.py`
- [x] All 4195 existing unit tests pass
- [x] All 532 scan-related tests pass
- [x] Ruff lint + mypy type checks pass
- [x] All 26 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection ID inference now properly handles Hive partition directories, stripping key=value formatted path segments from computed collection identifiers.

* **Tests**
  * Added comprehensive unit tests covering Hive partition detection and collection ID inference, including standard partitions, custom keys, UUID values, and spatial partition types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->