### PR TITLE
fix(check): tolerate remote/extension assets and unknown STAC extensions

### DIFF
--- a/portolan_cli/metadata/scan.py
+++ b/portolan_cli/metadata/scan.py
@@ -57,6 +57,19 @@ _SYSTEM_FILES = frozenset(
     {"catalog.json", "collection.json", "versions.json", "config.yaml", "metadata.yaml"}
 )
 
+# Media types whose assets are not local files on disk. The STAC Iceberg
+# extension publishes the table itself as an `application/x-iceberg` asset
+# whose href points at a backend-managed warehouse (often a relative,
+# scheme-less path) — there is no single local file to existence- or
+# freshness-check, so the scanner must skip it just like a scheme-qualified
+# href. Without this guard a relative iceberg href is path-joined to the
+# collection dir and reported as a (false) MISSING data file.
+_NON_LOCAL_MEDIA_TYPES = frozenset(
+    {
+        "application/x-iceberg",
+    }
+)
+
 
 def scan_catalog_metadata(catalog_path: Path) -> MetadataReport:
     """Scan a catalog using STAC manifests as ground truth.
@@ -115,10 +128,12 @@ def _scan_collection(collection_dir: Path, report: MetadataReport) -> None:
         href = _href(asset)
         if not href:
             continue
-        if _is_scheme_qualified(href):
-            # Asset lives outside the local filesystem (e.g. iceberg's
-            # file:///warehouse, or a remote gs://, s3://, https:// asset).
-            # No local existence or freshness check applies.
+        if _is_non_local_asset(asset):
+            # Asset lives outside the local filesystem: a scheme-qualified
+            # href (file:///warehouse, gs://, s3://, https://) or an
+            # extension/backend-managed media type such as
+            # application/x-iceberg (whose href may be a relative warehouse
+            # path). No local existence or freshness check applies.
             continue
         asset_path = (collection_dir / href).resolve()
         registered.add(asset_path)
@@ -215,7 +230,9 @@ def _scan_item(
         href = _href(asset)
         if not href:
             continue
-        if _is_scheme_qualified(href):
+        if _is_non_local_asset(asset):
+            # Scheme-qualified or extension/backend-managed (e.g.
+            # application/x-iceberg) asset: not a local file on disk.
             continue
         asset_path = (item_dir / href).resolve()
         registered.add(asset_path)
@@ -382,6 +399,32 @@ def _is_scheme_qualified(href: str) -> bool:
     collection/item directory.
     """
     return bool(_URI_SCHEME_RE.match(href))
+
+
+def _is_non_local_asset(asset: Any) -> bool:
+    """True if the asset should not be treated as a local file on disk.
+
+    Two independent signals mark an asset as non-local, either of which is
+    sufficient:
+
+    - A scheme-qualified href (``s3://``, ``gs://``, ``https://``, …) — the
+      data lives outside the catalog's filesystem.
+    - A media type that denotes an extension/backend-managed asset, e.g.
+      ``application/x-iceberg`` (STAC Iceberg extension). The href there may
+      be a relative, scheme-less warehouse path, so the scheme check alone
+      misses it.
+
+    Such assets are skipped by the local-data-file logic (no existence or
+    freshness check), so a remote/extension href is never mistaken for a
+    missing local file.
+    """
+    if not isinstance(asset, dict):
+        return False
+    media_type = asset.get("type")
+    if isinstance(media_type, str) and media_type in _NON_LOCAL_MEDIA_TYPES:
+        return True
+    href = _href(asset)
+    return href is not None and _is_scheme_qualified(href)
 
 
 def _safe_read_json(path: Path) -> dict[str, Any] | None:

--- a/portolan_cli/metadata/scan.py
+++ b/portolan_cli/metadata/scan.py
@@ -64,6 +64,10 @@ _SYSTEM_FILES = frozenset(
 # freshness-check, so the scanner must skip it just like a scheme-qualified
 # href. Without this guard a relative iceberg href is path-joined to the
 # collection dir and reported as a (false) MISSING data file.
+#
+# Trade-off: skipping means `check` no longer detects a genuinely missing
+# Iceberg warehouse — integrity of the table is owned by the Iceberg backend
+# (ADR-0046), not this scanner.
 _NON_LOCAL_MEDIA_TYPES = frozenset(
     {
         "application/x-iceberg",
@@ -421,8 +425,14 @@ def _is_non_local_asset(asset: Any) -> bool:
     if not isinstance(asset, dict):
         return False
     media_type = asset.get("type")
-    if isinstance(media_type, str) and media_type in _NON_LOCAL_MEDIA_TYPES:
-        return True
+    if isinstance(media_type, str):
+        # Media types are case-insensitive and may carry parameters
+        # (RFC 9110), e.g. ``application/x-iceberg; version=2`` or differing
+        # case from a hand-authored catalog. Normalize before matching so the
+        # guard isn't defeated by harmless variation.
+        normalized = media_type.split(";", 1)[0].strip().lower()
+        if normalized in _NON_LOCAL_MEDIA_TYPES:
+            return True
     href = _href(asset)
     return href is not None and _is_scheme_qualified(href)
 

--- a/portolan_cli/validation/stac_rules.py
+++ b/portolan_cli/validation/stac_rules.py
@@ -15,6 +15,31 @@ from stac_check.lint import Linter  # type: ignore[import-untyped]
 from portolan_cli.validation.results import Severity, ValidationResult
 from portolan_cli.validation.rules import ValidationRule
 
+# Substrings that mark a validation failure as "an extension schema could not
+# be resolved" rather than "the document is invalid". STAC extensions are
+# referenced by URL in `stac_extensions`; the validator fetches each schema
+# over the network. An extension that is unpublished, proposed, or simply
+# unreachable (offline runs) must NOT fail validation of the document itself.
+#
+# This covers the STAC Iceberg extension and the proposed git-backed-catalog
+# extension (portolan-sdi/portolan-spec#20), whose schemas may 404. It is the
+# extension analogue of StacSchemaRule.ACCEPTABLE_ERRORS' relative-href IRI
+# tolerance — the document is well-formed, we just can't fetch a remote schema.
+_SCHEMA_RESOLUTION_ERROR_MARKERS: frozenset[str] = frozenset(
+    {
+        "could not resolve schema",  # stac-validator FastValidator message
+        "failed to resolve",
+    }
+)
+
+
+def _is_schema_resolution_error(message: str | None) -> bool:
+    """True if `message` indicates an extension schema could not be fetched."""
+    if not message:
+        return False
+    lowered = message.lower()
+    return any(marker in lowered for marker in _SCHEMA_RESOLUTION_ERROR_MARKERS)
+
 
 class StacSchemaRule(ValidationRule):
     """Validate STAC objects against JSON Schema spec.
@@ -69,6 +94,12 @@ class StacSchemaRule(ValidationRule):
                 fast=not self.strict,
             )
         except Exception as e:
+            # An unresolvable extension schema (e.g. the STAC Iceberg or
+            # proposed git extension) surfaces here as a RuntimeError during
+            # construction. Don't fail the document for a schema we can't
+            # fetch — unless --strict, where the user opts into full checks.
+            if not self.strict and _is_schema_resolution_error(str(e)):
+                return self._pass("Schema valid (unresolved extension schema accepted)")
             return self._fail(
                 f"STAC validation failed: {e}",
                 fix_hint="Check that all STAC files have valid JSON syntax",
@@ -79,6 +110,8 @@ class StacSchemaRule(ValidationRule):
             error_msg = linter.error_msg or "STAC schema validation failed"
             if self._is_acceptable_error(error_msg):
                 return self._pass("Schema valid (relative hrefs accepted)")
+            if not self.strict and _is_schema_resolution_error(error_msg):
+                return self._pass("Schema valid (unresolved extension schema accepted)")
             recommendation = getattr(linter, "recommendation", None)
             return self._fail(error_msg, fix_hint=recommendation)
 
@@ -90,8 +123,11 @@ class StacSchemaRule(ValidationRule):
         real_failures = []
         for f in failed:
             msg = f.get("error_message", "")
-            if not self._is_acceptable_error(msg):
-                real_failures.append(f)
+            if self._is_acceptable_error(msg):
+                continue
+            if not self.strict and _is_schema_resolution_error(msg):
+                continue
+            real_failures.append(f)
 
         if real_failures:
             first_error = real_failures[0]
@@ -160,6 +196,11 @@ class StacLintRule(ValidationRule):
                 fast_linting=True,  # Always run BP checks
             )
         except Exception as e:
+            # Best-practice linting can't run if an extension schema can't be
+            # fetched, but that is not a lint violation — pass rather than
+            # block the catalog on an unreachable/unpublished extension.
+            if not self.strict and _is_schema_resolution_error(str(e)):
+                return self._pass("Lint skipped (unresolved extension schema)")
             return self._fail(f"STAC lint failed: {e}")
 
         # Get best practices dict (not an attribute, must call method)

--- a/portolan_cli/validation/stac_rules.py
+++ b/portolan_cli/validation/stac_rules.py
@@ -7,38 +7,62 @@ Uses stac-check as the validation engine. Two rules:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from stac_check.lint import Linter  # type: ignore[import-untyped]
 
 from portolan_cli.validation.results import Severity, ValidationResult
 from portolan_cli.validation.rules import ValidationRule
 
-# Substrings that mark a validation failure as "an extension schema could not
-# be resolved" rather than "the document is invalid". STAC extensions are
-# referenced by URL in `stac_extensions`; the validator fetches each schema
-# over the network. An extension that is unpublished, proposed, or simply
-# unreachable (offline runs) must NOT fail validation of the document itself.
-#
-# This covers the STAC Iceberg extension and the proposed git-backed-catalog
-# extension (portolan-sdi/portolan-spec#20), whose schemas may 404. It is the
-# extension analogue of StacSchemaRule.ACCEPTABLE_ERRORS' relative-href IRI
-# tolerance — the document is well-formed, we just can't fetch a remote schema.
-_SCHEMA_RESOLUTION_ERROR_MARKERS: frozenset[str] = frozenset(
-    {
-        "could not resolve schema",  # stac-validator FastValidator message
-        "failed to resolve",
-    }
+# Phrase the schema validator emits when it cannot fetch a JSON Schema over the
+# network. stac-validator raises ``Could not resolve schema: <uri>. Reason:
+# <err>`` (stac_validator/fast_validator.py) for BOTH core spec schemas and
+# extension schemas, so the phrase ALONE cannot tell the two apart — the URI
+# must be classified (see `_CORE_SCHEMA_HOSTS`). This replaces the earlier
+# broad ``failed to resolve`` substring, which matched no real validator output
+# and would have tolerated unrelated ``$ref``-resolution document defects.
+_SCHEMA_RESOLUTION_ERROR_MARKER = "could not resolve schema"
+
+# Hosts that serve the CORE STAC spec schemas (catalog/collection/item). When
+# one of THESE cannot be fetched the document was never validated at all, so we
+# must NOT treat it as acceptable — doing so turns `check` into a silent no-op
+# whenever schemas.stacspec.org is unreachable (offline CI, outage, or a bogus
+# `stac_version`). Only NON-core (extension) schema failures are tolerable: an
+# unpublished/proposed extension (STAC Iceberg, the git-backed-catalog
+# extension) that 404s leaves the document itself well-formed.
+_CORE_SCHEMA_HOSTS: frozenset[str] = frozenset({"schemas.stacspec.org"})
+
+# Pull the failing schema URI out of the marker message so it can be classified
+# as a core vs extension schema. The URI runs to the next whitespace; the
+# trailing ``.`` before `` Reason:`` is stripped by the caller.
+_RESOLUTION_URI_RE = re.compile(
+    rf"{_SCHEMA_RESOLUTION_ERROR_MARKER}:\s*(?P<uri>\S+)",
+    re.IGNORECASE,
 )
 
 
 def _is_schema_resolution_error(message: str | None) -> bool:
-    """True if `message` indicates an extension schema could not be fetched."""
+    """True if `message` is a *tolerable* extension-schema fetch failure.
+
+    Tolerable means the schema that could not be fetched is a STAC *extension*
+    schema. A failure to fetch a CORE spec schema (``schemas.stacspec.org``)
+    means the document was never validated, so it is NOT tolerable — otherwise
+    an offline run would pass every catalog, valid or not. If the marker is
+    present but the URI cannot be isolated, we are conservative and do not
+    tolerate (we can't prove it was only an extension schema).
+    """
     if not message:
         return False
-    lowered = message.lower()
-    return any(marker in lowered for marker in _SCHEMA_RESOLUTION_ERROR_MARKERS)
+    if _SCHEMA_RESOLUTION_ERROR_MARKER not in message.lower():
+        return False
+    match = _RESOLUTION_URI_RE.search(message)
+    if match is None:
+        return False
+    host = (urlsplit(match.group("uri").rstrip(".")).hostname or "").lower()
+    return host not in _CORE_SCHEMA_HOSTS
 
 
 class StacSchemaRule(ValidationRule):

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -489,6 +489,47 @@ class TestVectorCollectionLevelAsset:
             f"relative iceberg href {href!r} wrongly flagged MISSING: {report.to_dict()}"
         )
 
+    def test_iceberg_warehouse_files_inside_collection_not_orphaned(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Data files inside an in-collection Iceberg warehouse aren't ORPHANED.
+
+        When the warehouse href resolves under the collection dir, the table's
+        own ``.parquet`` data files sit on disk but belong to the Iceberg
+        backend, not the STAC manifest. They must not be reported as orphans.
+        This pins the (non-obvious) invariant that the scanner does not sweep
+        nested warehouse contents.
+        """
+        catalog_dir = tmp_path / "catalog"
+        catalog_dir.mkdir()
+        _write_catalog_json(catalog_dir)
+        collection_dir = catalog_dir / "agriculture"
+        collection_dir.mkdir()
+        _write_collection_json(
+            collection_dir,
+            collection_id="agriculture",
+            extra_assets={
+                "data": {
+                    "href": "data/v3/statfi_paavo",
+                    "type": "application/x-iceberg",
+                    "roles": ["data"],
+                }
+            },
+        )
+        # Materialize the warehouse with real Iceberg-style data + metadata.
+        warehouse = collection_dir / "data" / "v3" / "statfi_paavo"
+        (warehouse / "data").mkdir(parents=True)
+        (warehouse / "metadata").mkdir(parents=True)
+        (warehouse / "data" / "00000-0-abc.parquet").write_bytes(b"PAR1")
+        (warehouse / "metadata" / "v1.metadata.json").write_text("{}")
+
+        report = scan_catalog_metadata(catalog_dir)
+        assert report.missing_count == 0, report.to_dict()
+        assert report.orphaned_count == 0, (
+            f"Iceberg warehouse files wrongly flagged ORPHANED: {report.to_dict()}"
+        )
+
 
 # Helpers shared by F1/F3/F4 tests below.
 

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -440,6 +440,55 @@ class TestVectorCollectionLevelAsset:
             f"scheme-qualified href {href!r} wrongly flagged MISSING: {report.to_dict()}"
         )
 
+    @pytest.mark.parametrize(
+        "href",
+        [
+            # Relative, scheme-less warehouse paths — the case the scheme
+            # check alone misses. Must be recognized as non-local via the
+            # application/x-iceberg media type, not path-joined to disk.
+            "data/v3/statfi_paavo",
+            "./warehouse/portolake/agriculture",
+            "../shared/warehouse/agriculture",
+        ],
+    )
+    def test_collection_iceberg_asset_with_relative_href_not_missing(
+        self,
+        tmp_path: Path,
+        href: str,
+    ) -> None:
+        """An Iceberg asset (``application/x-iceberg``) whose href is a
+        relative, scheme-less warehouse path must NOT be treated as a local
+        file and reported MISSING.
+
+        The scheme check (``_is_scheme_qualified``) only catches absolute
+        URIs; an Iceberg table location can serialize to a relative path, so
+        the scanner relies on the extension media type to know the asset is
+        backend-managed and out of the local-filesystem scope. Without this
+        guard, ``check --fix`` tries to open the assembled local path and
+        errors with "Data file not found".
+        """
+        catalog_dir = tmp_path / "catalog"
+        catalog_dir.mkdir()
+        _write_catalog_json(catalog_dir)
+        collection_dir = catalog_dir / "agriculture"
+        collection_dir.mkdir()
+        _write_collection_json(
+            collection_dir,
+            collection_id="agriculture",
+            extra_assets={
+                "data": {
+                    "href": href,
+                    "type": "application/x-iceberg",
+                    "roles": ["data"],
+                }
+            },
+        )
+
+        report = scan_catalog_metadata(catalog_dir)
+        assert report.missing_count == 0, (
+            f"relative iceberg href {href!r} wrongly flagged MISSING: {report.to_dict()}"
+        )
+
 
 # Helpers shared by F1/F3/F4 tests below.
 

--- a/tests/unit/validation/test_stac_rules.py
+++ b/tests/unit/validation/test_stac_rules.py
@@ -136,6 +136,104 @@ class TestStacSchemaRule:
 
 
 @pytest.mark.unit
+class TestUnresolvableExtensionTolerance:
+    """An unresolvable extension schema must not fail document validation.
+
+    STAC extensions are referenced by URL in `stac_extensions` and fetched
+    over the network during schema validation. Extensions that are
+    unpublished, proposed, or simply unreachable (e.g. the STAC Iceberg
+    extension and the proposed git-backed-catalog extension) must NOT make
+    `check` fail an otherwise well-formed catalog — except under --strict.
+    """
+
+    _RESOLUTION_ERROR = (
+        "Could not resolve schema: "
+        "https://stac-extensions.github.io/iceberg/v1.0.0/schema.json. "
+        "Reason: HTTP Error 404: Not Found"
+    )
+
+    def test_schema_rule_tolerates_constructor_resolution_error(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Linter raising 'Could not resolve schema' on construction passes."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError(self._RESOLUTION_ERROR)
+
+        monkeypatch.setattr(stac_rules, "Linter", _raise)
+        result = StacSchemaRule().check(minimal_catalog)
+        assert result.passed
+
+    def test_schema_rule_tolerates_invalid_stac_resolution_error(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """valid_stac=False due to a resolution error passes (non-strict)."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        msg = (
+            "Could not resolve schema: "
+            "https://portolan-sdi.github.io/portolan-spec/git/v1.0.0/schema.json"
+        )
+
+        class _FakeLinter:
+            def __init__(self, *_a: object, **_k: object) -> None:
+                self.valid_stac = False
+                self.error_msg = msg
+
+        monkeypatch.setattr(stac_rules, "Linter", _FakeLinter)
+        result = StacSchemaRule().check(minimal_catalog)
+        assert result.passed
+
+    def test_schema_rule_strict_still_fails_resolution_error(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Under --strict the user opts into full validation: still fails."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError(self._RESOLUTION_ERROR)
+
+        monkeypatch.setattr(stac_rules, "Linter", _raise)
+        result = StacSchemaRule(strict=True).check(minimal_catalog)
+        assert not result.passed
+
+    def test_schema_rule_real_validation_error_still_fails(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A genuine schema error (not a resolution failure) still fails."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        class _FakeLinter:
+            def __init__(self, *_a: object, **_k: object) -> None:
+                self.valid_stac = False
+                self.error_msg = "'id' is a required property"
+                self.recommendation = None
+
+        monkeypatch.setattr(stac_rules, "Linter", _FakeLinter)
+        result = StacSchemaRule().check(minimal_catalog)
+        assert not result.passed
+
+    def test_lint_rule_tolerates_constructor_resolution_error(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lint cannot run if a schema can't resolve, but that's not a fail."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacLintRule
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError(self._RESOLUTION_ERROR)
+
+        monkeypatch.setattr(stac_rules, "Linter", _raise)
+        result = StacLintRule().check(minimal_catalog)
+        assert result.passed
+
+
+@pytest.mark.unit
 class TestStacLintRule:
     """Tests for StacLintRule."""
 

--- a/tests/unit/validation/test_stac_rules.py
+++ b/tests/unit/validation/test_stac_rules.py
@@ -232,6 +232,152 @@ class TestUnresolvableExtensionTolerance:
         result = StacLintRule().check(minimal_catalog)
         assert result.passed
 
+    # --- Core-schema failures must NOT be tolerated (regression guard) ------
+    #
+    # stac-validator raises the SAME "Could not resolve schema: <uri>" message
+    # for an unfetchable CORE spec schema (schemas.stacspec.org) as for an
+    # extension schema. Tolerating the core case would turn `check` into a
+    # silent no-op whenever schemas.stacspec.org is unreachable — passing every
+    # catalog, valid or not. Only the extension case is acceptable.
+    _CORE_RESOLUTION_ERROR = (
+        "Could not resolve schema: "
+        "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json. "
+        "Reason: HTTP Error 404: Not Found"
+    )
+
+    def test_schema_rule_core_schema_resolution_error_still_fails(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A CORE schema fetch failure fails even in non-strict mode."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError(self._CORE_RESOLUTION_ERROR)
+
+        monkeypatch.setattr(stac_rules, "Linter", _raise)
+        result = StacSchemaRule().check(minimal_catalog)
+        assert not result.passed
+
+    def test_lint_rule_core_schema_resolution_error_still_fails(
+        self, minimal_catalog: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lint also fails on a core-schema fetch failure (non-strict)."""
+        from portolan_cli.validation import stac_rules
+        from portolan_cli.validation.stac_rules import StacLintRule
+
+        def _raise(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError(self._CORE_RESOLUTION_ERROR)
+
+        monkeypatch.setattr(stac_rules, "Linter", _raise)
+        result = StacLintRule().check(minimal_catalog)
+        assert not result.passed
+
+
+@pytest.mark.unit
+class TestIsSchemaResolutionError:
+    """Unit tests for the `_is_schema_resolution_error` classifier.
+
+    These pin the classifier against the REAL message format stac-validator
+    emits (``Could not resolve schema: <uri>. Reason: <err>``,
+    stac_validator/fast_validator.py) so the tolerance logic is verified
+    independently of the monkeypatched-Linter tests above.
+    """
+
+    def test_extension_schema_url_is_tolerable(self) -> None:
+        from portolan_cli.validation.stac_rules import _is_schema_resolution_error
+
+        msg = (
+            "Could not resolve schema: "
+            "https://stac-extensions.github.io/iceberg/v1.0.0/schema.json. "
+            "Reason: HTTP Error 404: Not Found"
+        )
+        assert _is_schema_resolution_error(msg) is True
+
+    def test_proposed_extension_url_without_reason_is_tolerable(self) -> None:
+        from portolan_cli.validation.stac_rules import _is_schema_resolution_error
+
+        msg = (
+            "Could not resolve schema: "
+            "https://portolan-sdi.github.io/portolan-spec/git/v1.0.0/schema.json"
+        )
+        assert _is_schema_resolution_error(msg) is True
+
+    def test_core_spec_schema_url_is_not_tolerable(self) -> None:
+        from portolan_cli.validation.stac_rules import _is_schema_resolution_error
+
+        msg = (
+            "Could not resolve schema: "
+            "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json. "
+            "Reason: HTTP Error 404: Not Found"
+        )
+        assert _is_schema_resolution_error(msg) is False
+
+    def test_unrelated_resolve_message_is_not_tolerable(self) -> None:
+        """The old broad 'failed to resolve' net must no longer match."""
+        from portolan_cli.validation.stac_rules import _is_schema_resolution_error
+
+        assert _is_schema_resolution_error("internal $ref failed to resolve") is False
+
+    def test_marker_without_uri_is_not_tolerable(self) -> None:
+        from portolan_cli.validation.stac_rules import _is_schema_resolution_error
+
+        assert _is_schema_resolution_error("could not resolve schema") is False
+
+    def test_none_and_empty_are_not_tolerable(self) -> None:
+        from portolan_cli.validation.stac_rules import _is_schema_resolution_error
+
+        assert _is_schema_resolution_error(None) is False
+        assert _is_schema_resolution_error("") is False
+
+
+@pytest.mark.network
+class TestUnresolvableExtensionToleranceRealLinter:
+    """End-to-end tolerance behavior through the REAL stac-check Linter.
+
+    The monkeypatched tests above verify the tolerance branch in isolation but
+    pin the error string by hand. These drive the real validator so the fix is
+    exercised against stac-check's actual output (and would catch a wording
+    change). Marked `network`: stac-validator fetches schemas over HTTP.
+    """
+
+    def test_unresolvable_extension_passes_non_strict(self, tmp_path: Path) -> None:
+        """A real 404 extension schema does not fail an otherwise valid catalog."""
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        catalog = {
+            "type": "Catalog",
+            "stac_version": "1.0.0",
+            "id": "tmp-catalog",
+            "description": "Temporary test catalog",
+            "stac_extensions": ["https://stac-extensions.github.io/iceberg/v1.0.0/schema.json"],
+            "links": [],
+        }
+        (tmp_path / "catalog.json").write_text(json.dumps(catalog))
+        result = StacSchemaRule().check(tmp_path)
+        assert result.passed, result.message
+
+    def test_unfetchable_core_schema_fails_non_strict(self, tmp_path: Path) -> None:
+        """A bogus stac_version makes the CORE schema 404 — must still fail.
+
+        Regression guard for the offline-no-op hazard: if the core schema
+        can't be fetched the document was never validated, so non-strict
+        `check` must NOT report it as valid.
+        """
+        from portolan_cli.validation.stac_rules import StacSchemaRule
+
+        catalog = {
+            "type": "Catalog",
+            "stac_version": "9.9.9",  # no such core schema published
+            "id": "tmp-catalog",
+            "description": "Temporary test catalog",
+            "stac_extensions": [],
+            "links": [],
+        }
+        (tmp_path / "catalog.json").write_text(json.dumps(catalog))
+        result = StacSchemaRule().check(tmp_path)
+        assert not result.passed, result.message
+
 
 @pytest.mark.unit
 class TestStacLintRule:


### PR DESCRIPTION
## Description
`portolan check --metadata [--fix]` could mistreat external/extension STAC assets as local data files and fail on extensions whose JSON Schema can't be fetched. This fixes both so catalogs that use the STAC Iceberg extension (and the proposed git-backed-catalog extension, portolan-sdi/portolan-spec#20) validate cleanly.

## Reproduction
A STAC Collection with an Iceberg data asset and the iceberg/git extensions:

```jsonc
// collection.json
{
  "type": "Collection", "stac_version": "1.0.0", "id": "statfi_paavo",
  "stac_extensions": ["https://stac-extensions.github.io/iceberg/v1.0.0/schema.json"],
  "assets": {
    "data": {
      "href": "data/v3/statfi_paavo",          // relative warehouse path
      "type": "application/x-iceberg", "roles": ["data"]
    }
  }
  // ...extent, links...
}
```

Before this PR:
- `portolan check --metadata --fix` → `Failed to fix: Data file not found: <collection-dir>/data/v3/statfi_paavo` — the (relative) warehouse href was path-joined to the collection dir and the Iceberg table treated as a missing local file.
- `portolan check --metadata` → `stac_schema: STAC validation failed: Could not resolve schema: https://stac-extensions.github.io/iceberg/v1.0.0/schema.json. Reason: HTTP Error 404` — an unresolvable extension schema failed the whole document (the iceberg backend itself emits such extension URLs, so `check` fails on its own output).

A `v0.7.0` symptom report showed the same `Data file not found:` against a fully remote `https://…` href; the existing `_is_scheme_qualified` guard already covers absolute URIs, but a **scheme-less** Iceberg href slipped through.

## Fix
1. **`metadata/scan.py`** — add `_is_non_local_asset()` and use it in `_scan_collection` / `_scan_item`. An asset is non-local if its href is scheme-qualified (`s3://`, `gs://`, `https://`, `file://`, …) **or** its media type is an extension/backend-managed type (`application/x-iceberg`). Such assets are skipped by the local-data-file logic, so a remote/extension href is never opened as a local file. This generalizes the existing scheme-only guard to also catch relative Iceberg hrefs.
2. **`validation/stac_rules.py`** — `StacSchemaRule` and `StacLintRule` now treat "could not resolve schema" failures as acceptable (the document is well-formed; we just can't fetch a remote/unpublished extension schema). Covers both the constructor-raises path and the `valid_stac=False` / recursive `validate_all` paths. `--strict` still fails so users can opt into full validation. This mirrors the existing relative-href IRI tolerance in `StacSchemaRule.ACCEPTABLE_ERRORS`.

Unknown/namespaced fields (`iceberg:*`, `git:*`) on catalogs/collections are already preserved (pystac `extra_fields`) and no longer trip validation once their extension schemas are tolerated.

## Technical Details
- `_is_non_local_asset` keys off media type first, then falls back to the existing `_is_scheme_qualified` href check; behavior for plain local `.parquet`/`.tif` assets is unchanged (a genuinely missing local parquet is still reported MISSING).
- Schema-resolution tolerance is gated on `not self.strict`; a genuine schema error (e.g. missing `id`) still fails.

## Breaking Changes
**Does this PR introduce breaking changes?** No

## Related Issue(s)
- portolan-sdi/portolan-spec#20 (proposed git-backed-catalog extension; namespaced `git:*` fields)

## Checklist
- [x] Tests added/updated (`tests/unit/validation/test_stac_rules.py::TestUnresolvableExtensionTolerance`, `tests/integration/test_metadata_scan_unification.py::...::test_collection_iceberg_asset_with_relative_href_not_missing`)
- [x] All tests pass (`uv run pytest tests/unit/validation tests/unit/test_cli_check.py tests/unit/test_validation_runner.py tests/integration/test_metadata_scan_unification.py` — 90 passed); ruff + mypy clean on changed files
- [ ] Documentation updated (no user-facing doc changes needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false "MISSING" and "ORPHANED" reports for Iceberg warehouse and other non-local assets, including relative scheme-less warehouse paths.

* **Improvements**
  * STAC schema validation now tolerates unresolved extension schemas when running in non-strict mode (skips rather than fails).

* **Tests**
  * Added unit and integration tests covering Iceberg asset handling and unresolvable-extension schema tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->