### PR TITLE
feat(partitioning): support arbitrary Hive partition column names (#443)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -531,6 +531,42 @@ collection/
 └── ...
 ```
 
+### Pre-existing Hive Partitions
+
+Portolan automatically detects pre-existing Hive-partitioned data with arbitrary column names (not just kdtree/h3/s2/quadkey/a5). This supports datasets partitioned outside Portolan:
+
+```
+# Pre-existing structure (auto-detected):
+sites/
+├── gms_feature_id=abc-123/
+│   └── contours.parquet
+├── gms_feature_id=def-456/
+│   └── contours.parquet
+└── ...
+
+# Multi-level partitions are also supported:
+timeseries/
+├── year=2023/
+│   ├── month=01/
+│   │   └── data.parquet
+│   └── month=02/
+│       └── data.parquet
+└── year=2024/
+    └── month=01/
+        └── data.parquet
+```
+
+When you run `portolan add sites/`, Portolan detects the Hive structure and adds the appropriate `partition:scheme` and `partition:keys` metadata to `collection.json`.
+
+For explicit control over partition metadata, use the config settings:
+
+```yaml
+# .portolan/config.yaml
+partitioning.columns:
+  - gms_feature_id
+partitioning.description: "Site UUID — matches gms_site_feature_id in aois.parquet"
+```
+
 ### Settings Reference
 
 | Setting | Default | Description |
@@ -540,6 +576,8 @@ collection/
 | `partitioning.threshold_gb` | `2.0` | File size threshold in GB |
 | `partitioning.strategy` | `kdtree` | Spatial partitioning strategy |
 | `partitioning.target_rows` | `120000` | Target rows per partition |
+| `partitioning.columns` | `null` | Explicit partition column names (auto-detect if null) |
+| `partitioning.description` | `null` | Free-text description for partition semantics |
 
 !!! tip "Why KD-tree?"
     KD-tree is **data-driven**: partitions adapt to actual feature density, producing balanced partition sizes. Grid-based strategies (H3, S2, quadkey) are planned but not yet implemented.

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -57,6 +57,8 @@ KNOWN_SETTINGS: frozenset[str] = frozenset(
         "partitioning.threshold_gb",  # Size threshold in GB (default: 2.0)
         "partitioning.strategy",  # Spatial partitioning strategy (default: kdtree)
         "partitioning.target_rows",  # Target rows per partition (default: 120000)
+        "partitioning.columns",  # Custom partition column names (Issue #443, auto-detect if None)
+        "partitioning.description",  # Free-text description for partition key semantics
         "pmtiles.enabled",  # Generate PMTiles for GeoParquet collections
         "pmtiles.min_zoom",  # Minimum zoom level (None = auto-detect)
         "pmtiles.max_zoom",  # Maximum zoom level (None = auto-detect)
@@ -90,6 +92,8 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "partitioning.threshold_gb": 2.0,  # 2GB per OGC best practices
     "partitioning.strategy": "kdtree",  # KD-tree: data-driven, auto-balancing
     "partitioning.target_rows": 120_000,  # geoparquet-io default
+    "partitioning.columns": None,  # Auto-detect from Hive directory structure
+    "partitioning.description": None,  # No semantic description by default
     "pmtiles.enabled": False,  # Disabled by default (requires tippecanoe)
     "pmtiles.min_zoom": None,  # None = tippecanoe auto-detection
     "pmtiles.max_zoom": None,  # None = tippecanoe auto-detection

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -1557,35 +1557,83 @@ def _ensure_partition_metadata(
     collection: pystac.Collection,
     collection_dir: Path,
     items: list[PreparedDataset],
-) -> None:
+) -> list[str]:
     """Add partition metadata to collection from items or auto-detection.
 
     Issue #232: Adds partition extension if any items have partition metadata.
     Issue #443: Auto-detects pre-existing Hive partitions if no metadata was set
     from items. This handles the case where users add pre-partitioned data not
-    created by Portolan.
+    created by Portolan. Also creates glob assets for bulk access.
 
     Args:
         collection: The STAC collection to update.
         collection_dir: Directory containing the collection.
         items: List of prepared datasets for this collection.
+
+    Returns:
+        List of warning messages (e.g., schema inconsistency warnings).
     """
+    from portolan_cli.partitioning import (
+        build_glob_pattern,
+        detect_partitioning,
+        validate_partition_schemas,
+    )
+
+    warnings: list[str] = []
+
     # First, check if any items have explicit partition metadata
     for p in items:
         if p.partition_metadata is not None:
             add_partition_metadata_to_collection(collection, p.partition_metadata)
-            return  # Only one partition metadata per collection
+            # Validate schema consistency for partitioned data
+            validation = validate_partition_schemas(collection_dir)
+            if not validation.is_consistent and validation.partition_count > 0:
+                warnings.append(
+                    f"Schema inconsistency in partitioned data: {validation.error_message}"
+                )
+            return warnings  # Only one partition metadata per collection
 
     # No explicit metadata - try auto-detection for pre-existing Hive partitions
-    from portolan_cli.partitioning import detect_partitioning
-
     detected = detect_partitioning(collection_dir)
     if detected:
         add_partition_metadata_to_collection(collection, detected)
-        logger.debug(
-            f"Auto-detected Hive partitions in {collection_dir}: "
-            f"{detected.get('partition:keys', [])}"
-        )
+        partition_keys = detected.get("partition:keys", [])
+        partition_columns = [k["name"] for k in partition_keys]
+        file_count = detected.get("partition:file_count", 0)
+
+        logger.debug(f"Auto-detected Hive partitions in {collection_dir}: {partition_columns}")
+
+        # Create glob asset for bulk access (Issue #443)
+        # Only add if not already present (avoid duplicates on re-add)
+        glob_pattern = build_glob_pattern(partition_columns=partition_columns)
+        glob_asset_key = "partitioned_data"
+
+        # Check if glob asset already exists
+        existing_glob = None
+        for key, asset in collection.assets.items():
+            if asset.href and "*" in asset.href:
+                existing_glob = key
+                break
+
+        if existing_glob is None:
+            import pystac
+
+            glob_asset = pystac.Asset(
+                href=glob_pattern,
+                media_type="application/vnd.apache.parquet",
+                roles=["data"],
+                title="Partitioned GeoParquet",
+                description=f"Glob pattern for {file_count} partitioned files",
+            )
+            collection.assets[glob_asset_key] = glob_asset
+            logger.debug(f"Added glob asset with pattern: {glob_pattern}")
+
+        # Validate schema consistency for auto-detected partitions
+        validation = validate_partition_schemas(collection_dir)
+        if not validation.is_consistent and validation.partition_count > 0:
+            warnings.append(f"Schema inconsistency in partitioned data: {validation.error_message}")
+
+    return warnings
 
 
 def finalize_datasets(
@@ -1668,8 +1716,13 @@ def finalize_datasets(
                 add_table_extension(collection, aggregated, merge_strategy=merge_strategy)
 
         # Add partition extension if any items have partition metadata (Issue #232)
-        # Issue #443: Also auto-detect pre-existing Hive partitions
-        _ensure_partition_metadata(collection, collection_dir, items)
+        # Issue #443: Also auto-detect pre-existing Hive partitions and validate schemas
+        partition_warnings = _ensure_partition_metadata(collection, collection_dir, items)
+        if partition_warnings:
+            from portolan_cli.output import warn as warn_output
+
+            for warning_msg in partition_warnings:
+                warn_output(warning_msg)
 
         # Compute collection summaries from items (per ADR-0036)
         # Moved here from push.py for separation of concerns - summaries are now

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -836,21 +836,20 @@ def _derive_item_id_and_asset_level(
 
     # If path contains Hive partitions, apply special handling
     if hive_partitions:
-        # Per ADR-0031: Vector formats in Hive partitions are collection-level assets
-        # All partitioned files are one logical dataset accessed via glob pattern
-        if format_type == FormatType.VECTOR:
-            is_collection_level_asset = True
-            item_id = path.stem  # Use file stem for collection-level
+        # Issue #443: For multi-level Hive partitions (e.g., year=2023/month=01/),
+        # using path.parent.name would give "month=01" for ALL year branches,
+        # causing duplicate item IDs. Instead, use the full relative path as item_id.
+        #
+        # For single-level partitions (e.g., kdtree_cell=XXX/), path.parent.name
+        # is unique, so no special handling needed - fall through to normal logic.
+        if len(hive_partitions) > 1 or non_hive_parts:
+            # Multi-level partitions or mixed structure: use full relative path
+            # e.g., year=2023/month=01/data.parquet -> item_id = "year=2023_month=01"
+            item_id = "_".join(relative_parts)
         else:
-            # For raster or other formats: derive unique item_id from partition values
-            # e.g., year=2023/month=01/file.tif -> item_id = "2023_01" or "2023_01_file"
-            partition_values = [v for _, v in hive_partitions]
-            if non_hive_parts:
-                # Include non-Hive directory names if present
-                item_id = "_".join(non_hive_parts + partition_values)
-            else:
-                # All intermediate dirs are Hive partitions - use values + file stem
-                item_id = "_".join(partition_values + [path.stem])
+            # Single-level Hive partition (most common case, e.g., kdtree):
+            # Use parent directory name as item_id (existing behavior)
+            item_id = path.parent.name
     elif is_collection_level_asset:
         # Generate item ID from PARENT DIRECTORY name (Issue #163)
         # Item boundaries are directories, not filenames.

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -774,6 +774,7 @@ def _derive_item_id_and_asset_level(
     path: Path,
     collection_dir: Path,
     item_id: str | None,
+    format_type: FormatType | None = None,
 ) -> tuple[str, bool]:
     """Derive item ID and detect if asset is collection-level.
 
@@ -781,6 +782,9 @@ def _derive_item_id_and_asset_level(
         path: Path to the asset file.
         collection_dir: Collection directory path.
         item_id: Optional explicit item ID.
+        format_type: Optional format type for Hive partition handling.
+            Vector formats in Hive partitions become collection-level assets
+            per ADR-0031.
 
     Returns:
         Tuple of (item_id, is_collection_level_asset).
@@ -793,7 +797,15 @@ def _derive_item_id_and_asset_level(
         catalog_root/a/file.parquet will NOT be detected as collection-level
         for collection "a/b" (since path.parent != catalog_root/a/b).
         This is intentional - the file would belong to parent collection "a".
+
+    Note:
+        Per Issue #443: Files in Hive partition directories (key=value) are
+        handled specially to avoid duplicate item IDs. Vector formats become
+        collection-level assets; other formats derive unique IDs from the
+        partition values.
     """
+    from portolan_cli.scan_detect import is_hive_partition_dir
+
     # If item_id is explicitly provided, treat as item-level (not collection-level)
     # This ensures --item-id creates a subdirectory structure
     if item_id is not None:
@@ -805,11 +817,45 @@ def _derive_item_id_and_asset_level(
     # Auto-detect: collection-level if file is directly in collection directory
     is_collection_level_asset = path.parent.resolve() == collection_dir.resolve()
 
-    # Generate item ID from PARENT DIRECTORY name (Issue #163)
-    # Item boundaries are directories, not filenames.
-    # Example: collection/item_dir/file.parquet -> item_id = "item_dir"
-    # For collection-level assets, use file stem to avoid duplicate directory name
-    if is_collection_level_asset:
+    # Check for Hive partition directories in path relative to collection
+    # Per Issue #443: Handle Hive partitions consistently with collection_id filtering
+    try:
+        relative_parts = list(path.parent.resolve().relative_to(collection_dir.resolve()).parts)
+    except ValueError:
+        relative_parts = []
+
+    # Separate Hive partitions from regular directories
+    hive_partitions: list[tuple[str, str]] = []  # (key, value) pairs
+    non_hive_parts: list[str] = []
+    for part in relative_parts:
+        partition = is_hive_partition_dir(part)
+        if partition is not None:
+            hive_partitions.append(partition)
+        else:
+            non_hive_parts.append(part)
+
+    # If path contains Hive partitions, apply special handling
+    if hive_partitions:
+        # Per ADR-0031: Vector formats in Hive partitions are collection-level assets
+        # All partitioned files are one logical dataset accessed via glob pattern
+        if format_type == FormatType.VECTOR:
+            is_collection_level_asset = True
+            item_id = path.stem  # Use file stem for collection-level
+        else:
+            # For raster or other formats: derive unique item_id from partition values
+            # e.g., year=2023/month=01/file.tif -> item_id = "2023_01" or "2023_01_file"
+            partition_values = [v for _, v in hive_partitions]
+            if non_hive_parts:
+                # Include non-Hive directory names if present
+                item_id = "_".join(non_hive_parts + partition_values)
+            else:
+                # All intermediate dirs are Hive partitions - use values + file stem
+                item_id = "_".join(partition_values + [path.stem])
+    elif is_collection_level_asset:
+        # Generate item ID from PARENT DIRECTORY name (Issue #163)
+        # Item boundaries are directories, not filenames.
+        # Example: collection/item_dir/file.parquet -> item_id = "item_dir"
+        # For collection-level assets, use file stem to avoid duplicate directory name
         # Use file stem for collection-level assets to avoid collection/collection/ nesting
         item_id = path.stem
     else:
@@ -1298,6 +1344,7 @@ def prepare_dataset(
         path=path,
         collection_dir=collection_dir,
         item_id=item_id,
+        format_type=format_type,  # Issue #443: Handle Hive partitions
     )
     item_dir = path.parent
 
@@ -1608,7 +1655,7 @@ def _ensure_partition_metadata(
         glob_pattern = build_glob_pattern(partition_columns=partition_columns)
         glob_asset_key = "partitioned_data"
 
-        # Check if glob asset already exists
+        # Check if glob asset already exists (any asset with * in href)
         existing_glob = None
         for key, asset in collection.assets.items():
             if asset.href and "*" in asset.href:
@@ -1616,6 +1663,19 @@ def _ensure_partition_metadata(
                 break
 
         if existing_glob is None:
+            # Check if target key is occupied by a non-glob asset (avoid clobbering)
+            # Per Issue #443: Don't overwrite user-defined assets at this key
+            existing_at_key = collection.assets.get(glob_asset_key)
+            if existing_at_key is not None and (
+                not existing_at_key.href or "*" not in existing_at_key.href
+            ):
+                # Key is occupied by non-glob asset - use alternate key
+                glob_asset_key = "partitioned_data_glob"
+                logger.debug(
+                    f"Key 'partitioned_data' occupied by non-glob asset, "
+                    f"using '{glob_asset_key}' instead"
+                )
+
             import pystac
 
             glob_asset = pystac.Asset(

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -1553,6 +1553,41 @@ def _warn_about_stale_assets(
     return warnings
 
 
+def _ensure_partition_metadata(
+    collection: pystac.Collection,
+    collection_dir: Path,
+    items: list[PreparedDataset],
+) -> None:
+    """Add partition metadata to collection from items or auto-detection.
+
+    Issue #232: Adds partition extension if any items have partition metadata.
+    Issue #443: Auto-detects pre-existing Hive partitions if no metadata was set
+    from items. This handles the case where users add pre-partitioned data not
+    created by Portolan.
+
+    Args:
+        collection: The STAC collection to update.
+        collection_dir: Directory containing the collection.
+        items: List of prepared datasets for this collection.
+    """
+    # First, check if any items have explicit partition metadata
+    for p in items:
+        if p.partition_metadata is not None:
+            add_partition_metadata_to_collection(collection, p.partition_metadata)
+            return  # Only one partition metadata per collection
+
+    # No explicit metadata - try auto-detection for pre-existing Hive partitions
+    from portolan_cli.partitioning import detect_partitioning
+
+    detected = detect_partitioning(collection_dir)
+    if detected:
+        add_partition_metadata_to_collection(collection, detected)
+        logger.debug(
+            f"Auto-detected Hive partitions in {collection_dir}: "
+            f"{detected.get('partition:keys', [])}"
+        )
+
+
 def finalize_datasets(
     catalog_root: Path,
     prepared: list[PreparedDataset],
@@ -1633,10 +1668,8 @@ def finalize_datasets(
                 add_table_extension(collection, aggregated, merge_strategy=merge_strategy)
 
         # Add partition extension if any items have partition metadata (Issue #232)
-        for p in items:
-            if p.partition_metadata is not None:
-                add_partition_metadata_to_collection(collection, p.partition_metadata)
-                break  # Only one partition metadata per collection
+        # Issue #443: Also auto-detect pre-existing Hive partitions
+        _ensure_partition_metadata(collection, collection_dir, items)
 
         # Compute collection summaries from items (per ADR-0036)
         # Moved here from push.py for separation of concerns - summaries are now
@@ -2863,6 +2896,10 @@ def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
     - **Raster data**: Grandparent directory = collection, parent = item
       Example: 2025/tile1/scene.tif -> collection = "2025", item = "tile1"
 
+    Per Issue #443, Hive partition directories (key=value format) are filtered
+    out and NOT included in the collection ID:
+      Example: sites/contours/gms_feature_id=abc/data.parquet -> "sites/contours"
+
     Directory-based formats like FileGDB (*.gdb) are treated as vector data
     (collection-level assets).
 
@@ -2876,17 +2913,23 @@ def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
         imagery/2025/tile1/scene.tif -> "imagery/2025"
         satellite/scene-001/B04.tif -> "satellite"
 
+        # Hive partitions (filtered out)
+        sites/contours/gms_feature_id=abc/data.parquet -> "sites/contours"
+        data/year=2024/month=01/file.parquet -> "data"
+
     Args:
         path: Path to the file or directory-based data asset (e.g., FileGDB).
         catalog_root: Root directory of the catalog.
 
     Returns:
-        Collection ID (nested path relative to catalog root).
+        Collection ID (nested path relative to catalog root, excluding Hive partitions).
 
     Raises:
         ValueError: If path is not inside catalog root, at root level, or
             if raster data lacks required item subdirectory structure.
     """
+    from portolan_cli.scan_detect import is_hive_partition_dir
+
     # Get path relative to catalog root
     try:
         relative = path.resolve().relative_to(catalog_root.resolve())
@@ -2932,6 +2975,12 @@ def infer_nested_collection_id(path: Path, catalog_root: Path) -> str:
         # Vector files: parent directory = collection
         # Return parent as collection (all but last component)
         collection_parts = parts[:-1] if is_asset else parts
+
+    # Filter out Hive partition directories (key=value pattern)
+    # Per Issue #443: partitions should not be part of collection ID
+    collection_parts = tuple(
+        part for part in collection_parts if is_hive_partition_dir(part) is None
+    )
 
     if not collection_parts:
         raise ValueError(f"Data asset {path} must be in a subdirectory (collection)")

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 
 if TYPE_CHECKING:
     pass
@@ -389,6 +390,10 @@ def detect_partitioning(directory: Path) -> dict[str, Any] | None:
     Returns:
         Partition metadata dict if partitioning detected, None otherwise.
     """
+    # Guard: directory must exist
+    if not directory.exists() or not directory.is_dir():
+        return None
+
     # Look for Hive-style directories: column=value
     hive_pattern = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)=.+$")
 
@@ -396,8 +401,14 @@ def detect_partitioning(directory: Path) -> dict[str, Any] | None:
     partition_keys: list[str] = []
     all_partition_dirs: list[Path] = []
 
+    # Max depth to prevent unbounded recursion (symlink loops, deeply nested structures)
+    MAX_PARTITION_DEPTH = 20
+
     def _scan_level(current_dir: Path, depth: int = 0) -> None:
         """Recursively scan for Hive partition directories."""
+        if depth >= MAX_PARTITION_DEPTH:
+            return  # Prevent unbounded recursion
+
         for item in current_dir.iterdir():
             if item.is_dir():
                 match = hive_pattern.match(item.name)
@@ -454,8 +465,6 @@ def validate_partition_schemas(directory: Path) -> SchemaValidationResult:
         - error_message: Description of mismatch if inconsistent
         - partition_count: Number of partitions validated
     """
-    import pyarrow.parquet as pq
-
     # First detect the partition structure
     partition_info = detect_partitioning(directory)
     if partition_info is None:
@@ -526,18 +535,18 @@ def validate_partition_schemas(directory: Path) -> SchemaValidationResult:
 def _schemas_equal(schema1: pa.Schema, schema2: pa.Schema) -> bool:
     """Check if two PyArrow schemas are equal.
 
-    Compares field names and types.
+    Compares field names and types in an order-independent way.
+    Two schemas are equal if they have the same fields with the same types,
+    regardless of column order.
     """
     if len(schema1) != len(schema2):
         return False
 
-    for i in range(len(schema1)):
-        field1 = schema1.field(i)
-        field2 = schema2.field(i)
-        if field1.name != field2.name or field1.type != field2.type:
-            return False
+    # Build name->type maps for order-independent comparison
+    fields1 = {f.name: f.type for f in schema1}
+    fields2 = {f.name: f.type for f in schema2}
 
-    return True
+    return fields1 == fields2
 
 
 def _describe_schema_diff(

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -4,22 +4,52 @@ This module provides automatic spatial partitioning of large GeoParquet files
 using geoparquet-io's KD-tree partitioning. Per ADR-0031, partitioned datasets
 use Hive-style directories where each partition becomes a STAC Item.
 
+Issue #443: Supports arbitrary Hive partition column names (not just kdtree/h3/s2/quadkey/a5),
+multi-level partitions (year=*/month=*), and schema consistency validation.
+
 Usage:
     from portolan_cli.partitioning import should_partition, partition_geoparquet
 
     if should_partition(file_path, threshold_gb=2.0):
         partitions = partition_geoparquet(file_path, output_dir)
         # Each partition path can be used to create a STAC Item
+
+    # For pre-existing partitioned data with arbitrary columns:
+    from portolan_cli.partitioning import detect_partitioning, build_glob_pattern
+
+    metadata = detect_partitioning(directory)  # Auto-detects any Hive columns
+    glob = build_glob_pattern(partition_columns=["gms_feature_id"])
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
 
 if TYPE_CHECKING:
     pass
+
+
+@dataclass
+class SchemaValidationResult:
+    """Result of validating schema consistency across partitions."""
+
+    is_consistent: bool
+    """True if all partitions have identical schemas."""
+
+    schema: pa.Schema | None
+    """The unified schema if consistent, None otherwise."""
+
+    error_message: str
+    """Description of schema inconsistency if not consistent."""
+
+    partition_count: int = 0
+    """Number of partitions validated."""
+
 
 # Default partitioning settings (per plan and geoparquet-io defaults)
 DEFAULT_THRESHOLD_GB = 2.0
@@ -174,86 +204,184 @@ def get_partition_info(partition_path: Path) -> dict[str, str]:
     }
 
 
-def build_glob_pattern(strategy: str = DEFAULT_STRATEGY) -> str:
+def build_glob_pattern(
+    strategy: str = DEFAULT_STRATEGY,
+    partition_columns: list[str] | None = None,
+) -> str:
     """Build glob pattern for collection-level asset href.
 
     Per Issue #351, partitioned datasets expose a glob URL for bulk access.
+    Per Issue #443, supports arbitrary partition column names and multi-level partitions.
 
     Args:
-        strategy: Partitioning strategy used.
+        strategy: Partitioning strategy used (for backwards compatibility).
+        partition_columns: Explicit list of partition column names. Takes precedence
+            over strategy. For multi-level partitions, provide columns in order
+            (e.g., ["year", "month"]).
 
     Returns:
-        Relative glob pattern like "./kdtree_cell=*/*.parquet" for Hive-style partitions.
+        Relative glob pattern like "./kdtree_cell=*/*.parquet" for Hive-style partitions,
+        or "./year=*/month=*/*.parquet" for multi-level partitions.
 
     Note:
         The pattern matches ALL .parquet files in partition directories.
         geoparquet-io creates files named by cell ID (e.g., "0000000000.parquet").
         Do not place additional parquet files in partition directories.
     """
+    if partition_columns:
+        # Build multi-level glob pattern from explicit columns
+        pattern_parts = [f"{col}=*" for col in partition_columns]
+        return "./" + "/".join(pattern_parts) + "/*.parquet"
+
+    # Backwards compatibility: use strategy to determine column name
     partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
     return f"./{partition_col}=*/*.parquet"
 
 
 def build_remote_glob(
-    remote_base: str, collection_id: str, strategy: str = DEFAULT_STRATEGY
+    remote_base: str,
+    collection_id: str,
+    strategy: str = DEFAULT_STRATEGY,
+    partition_columns: list[str] | None = None,
 ) -> str:
     """Build absolute remote glob URL for portolan:glob field.
+
+    Per Issue #443, supports arbitrary partition column names and multi-level partitions.
 
     Args:
         remote_base: Remote storage base URL (e.g., "s3://bucket/").
         collection_id: The collection identifier.
-        strategy: Partitioning strategy used.
+        strategy: Partitioning strategy used (for backwards compatibility).
+        partition_columns: Explicit list of partition column names. Takes precedence
+            over strategy. For multi-level partitions, provide columns in order.
 
     Returns:
-        Absolute glob URL like "s3://bucket/collection/kdtree_cell=*/*.parquet".
+        Absolute glob URL like "s3://bucket/collection/kdtree_cell=*/*.parquet",
+        or "s3://bucket/collection/year=*/month=*/*.parquet" for multi-level.
     """
     # Normalize: ensure no trailing slash on base
     base = remote_base.rstrip("/")
+
+    if partition_columns:
+        # Build multi-level glob pattern from explicit columns
+        pattern_parts = [f"{col}=*" for col in partition_columns]
+        return f"{base}/{collection_id}/" + "/".join(pattern_parts) + "/*.parquet"
+
+    # Backwards compatibility: use strategy to determine column name
     partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
     return f"{base}/{collection_id}/{partition_col}=*/*.parquet"
 
 
-def get_partition_metadata(output_dir: Path, strategy: str = DEFAULT_STRATEGY) -> dict[str, object]:
+def get_partition_metadata(
+    output_dir: Path,
+    strategy: str | None = None,
+    partition_columns: list[str] | None = None,
+    description: str | None = None,
+    descriptions: dict[str, str] | None = None,
+) -> dict[str, object]:
     """Extract partition metadata from Hive-style output directory.
 
     Returns metadata conforming to the STAC Partition Extension schema:
     https://portolan-sdi.github.io/stac-partition-extension/v1.0.0/schema.json
 
+    Per Issue #443, supports arbitrary partition column names and custom descriptions.
+
     Args:
         output_dir: Directory containing Hive-style partitioned output.
-        strategy: Partitioning strategy used (kdtree, h3, etc.).
+        strategy: Partitioning strategy used (kdtree, h3, etc.). Optional if
+            partition_columns is provided.
+        partition_columns: Explicit list of partition column names. If not provided,
+            auto-detects from directory structure.
+        description: Free-text description for single-column partitions.
+        descriptions: Per-column descriptions for multi-level partitions.
+            Keys are column names, values are descriptions.
 
     Returns:
         Dict with partition extension fields:
         - partition:scheme: "hive"
-        - partition:strategy: The strategy used
+        - partition:strategy: The strategy used (if known)
         - partition:keys: List of partition key definitions
         - partition:file_count: Total number of partition files
     """
-    partition_col = PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")
-    partition_dirs = list(output_dir.glob(f"{partition_col}=*"))
+    # Auto-detect partition columns if not provided
+    if partition_columns is None:
+        detected = detect_partitioning(output_dir)
+        if detected:
+            partition_columns = [k["name"] for k in detected["partition:keys"]]
+        else:
+            # Fall back to strategy-based column
+            strategy = strategy or DEFAULT_STRATEGY
+            partition_columns = [PARTITION_COLUMNS.get(strategy, f"{strategy}_cell")]
 
-    file_count = sum(len(list(d.glob("*.parquet"))) for d in partition_dirs)
+    # Detect strategy from column names if not provided
+    detected_strategy = strategy
+    if detected_strategy is None:
+        for strategy_name, col in PARTITION_COLUMNS.items():
+            if col in partition_columns:
+                detected_strategy = strategy_name
+                break
 
-    return {
+    # Count files across all partition directories
+    file_count = _count_partition_files(output_dir, partition_columns)
+
+    # Build partition key definitions
+    keys: list[dict[str, str]] = []
+    for col in partition_columns:
+        key_def: dict[str, str] = {"name": col, "type": "string"}
+
+        # Add description if provided
+        if descriptions and col in descriptions:
+            key_def["description"] = descriptions[col]
+        elif description and len(partition_columns) == 1:
+            key_def["description"] = description
+        elif detected_strategy and col == PARTITION_COLUMNS.get(detected_strategy):
+            key_def["description"] = (
+                f"{detected_strategy.upper()} spatial partition cell identifier"
+            )
+
+        keys.append(key_def)
+
+    result: dict[str, Any] = {
         "partition:scheme": "hive",
-        "partition:strategy": strategy,
-        "partition:keys": [
-            {
-                "name": partition_col,
-                "type": "string",
-                "description": f"{strategy.upper()} spatial partition cell identifier",
-            }
-        ],
+        "partition:keys": keys,
         "partition:file_count": file_count,
     }
 
+    # Only include strategy if detected (avoid null in JSON output)
+    if detected_strategy is not None:
+        result["partition:strategy"] = detected_strategy
 
-def detect_partitioning(directory: Path) -> dict[str, object] | None:
+    return result
+
+
+def _count_partition_files(directory: Path, partition_columns: list[str]) -> int:
+    """Count parquet files across all partition directories.
+
+    Handles both single-level and multi-level partitions.
+
+    Args:
+        directory: Root directory containing partitions.
+        partition_columns: List of partition column names.
+
+    Returns:
+        Total count of .parquet files in leaf partition directories.
+    """
+    if not partition_columns:
+        return 0
+
+    # Build glob pattern to find all parquet files
+    pattern_parts = [f"{col}=*" for col in partition_columns]
+    pattern = "/".join(pattern_parts) + "/*.parquet"
+
+    return len(list(directory.glob(pattern)))
+
+
+def detect_partitioning(directory: Path) -> dict[str, Any] | None:
     """Detect existing Hive-style partitioning in a directory.
 
     Scans for directories matching the pattern "column=value/" and extracts
-    partition metadata if found.
+    partition metadata if found. Per Issue #443, supports multi-level partitions
+    like year=*/month=*/*.parquet.
 
     Args:
         directory: Directory to scan for partitions.
@@ -261,30 +389,35 @@ def detect_partitioning(directory: Path) -> dict[str, object] | None:
     Returns:
         Partition metadata dict if partitioning detected, None otherwise.
     """
-    import re
-
     # Look for Hive-style directories: column=value
     hive_pattern = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)=.+$")
 
+    # Detect partition levels by walking the tree
     partition_keys: list[str] = []
-    partition_dirs: list[Path] = []
+    all_partition_dirs: list[Path] = []
 
-    for item in directory.iterdir():
-        if item.is_dir():
-            match = hive_pattern.match(item.name)
-            if match:
-                key_name = match.group(1)
-                if key_name not in partition_keys:
-                    partition_keys.append(key_name)
-                partition_dirs.append(item)
+    def _scan_level(current_dir: Path, depth: int = 0) -> None:
+        """Recursively scan for Hive partition directories."""
+        for item in current_dir.iterdir():
+            if item.is_dir():
+                match = hive_pattern.match(item.name)
+                if match:
+                    key_name = match.group(1)
+                    # Track keys in order of first encounter (preserves level order)
+                    if key_name not in partition_keys:
+                        partition_keys.append(key_name)
+                    all_partition_dirs.append(item)
+                    # Recurse to find nested partition levels
+                    _scan_level(item, depth + 1)
+
+    _scan_level(directory)
 
     if not partition_keys:
         return None
 
-    # Count total files
-    file_count = 0
-    for pdir in partition_dirs:
-        file_count += len(list(pdir.glob("*.parquet")))
+    # Count parquet files at leaf level
+    # Build glob pattern for all partition levels
+    file_count = _count_partition_files(directory, partition_keys)
 
     # Try to detect strategy from column name
     strategy = None
@@ -293,7 +426,7 @@ def detect_partitioning(directory: Path) -> dict[str, object] | None:
             strategy = strategy_name
             break
 
-    result: dict[str, object] = {
+    result: dict[str, Any] = {
         "partition:scheme": "hive",
         "partition:keys": [{"name": key, "type": "string"} for key in partition_keys],
         "partition:file_count": file_count,
@@ -302,3 +435,137 @@ def detect_partitioning(directory: Path) -> dict[str, object] | None:
     if strategy is not None:
         result["partition:strategy"] = strategy
     return result
+
+
+def validate_partition_schemas(directory: Path) -> SchemaValidationResult:
+    """Validate schema consistency across all partitions in a Hive-partitioned dataset.
+
+    Per Issue #443, reads Parquet metadata (not data) from each partition file
+    to verify all partitions have identical schemas. This is fast because Parquet
+    stores schema in the file footer.
+
+    Args:
+        directory: Root directory containing Hive-style partitioned data.
+
+    Returns:
+        SchemaValidationResult with:
+        - is_consistent: True if all schemas match
+        - schema: The unified schema if consistent
+        - error_message: Description of mismatch if inconsistent
+        - partition_count: Number of partitions validated
+    """
+    import pyarrow.parquet as pq
+
+    # First detect the partition structure
+    partition_info = detect_partitioning(directory)
+    if partition_info is None:
+        return SchemaValidationResult(
+            is_consistent=True,
+            schema=None,
+            error_message="",
+            partition_count=0,
+        )
+
+    partition_columns = [k["name"] for k in partition_info["partition:keys"]]
+
+    # Build glob pattern to find all parquet files
+    pattern_parts = [f"{col}=*" for col in partition_columns]
+    pattern = "/".join(pattern_parts) + "/*.parquet"
+
+    parquet_files = list(directory.glob(pattern))
+    if not parquet_files:
+        return SchemaValidationResult(
+            is_consistent=True,
+            schema=None,
+            error_message="",
+            partition_count=0,
+        )
+
+    # Read schema from first file as reference
+    reference_file = parquet_files[0]
+    try:
+        reference_schema = pq.read_schema(reference_file)
+    except Exception as e:
+        return SchemaValidationResult(
+            is_consistent=False,
+            schema=None,
+            error_message=f"Failed to read schema from {reference_file}: {e}",
+            partition_count=len(parquet_files),
+        )
+
+    # Compare all other files against reference
+    for pq_file in parquet_files[1:]:
+        try:
+            file_schema = pq.read_schema(pq_file)
+        except Exception as e:
+            return SchemaValidationResult(
+                is_consistent=False,
+                schema=None,
+                error_message=f"Failed to read schema from {pq_file}: {e}",
+                partition_count=len(parquet_files),
+            )
+
+        # Compare schemas
+        if not _schemas_equal(reference_schema, file_schema):
+            diff = _describe_schema_diff(reference_schema, file_schema, reference_file, pq_file)
+            return SchemaValidationResult(
+                is_consistent=False,
+                schema=None,
+                error_message=diff,
+                partition_count=len(parquet_files),
+            )
+
+    return SchemaValidationResult(
+        is_consistent=True,
+        schema=reference_schema,
+        error_message="",
+        partition_count=len(parquet_files),
+    )
+
+
+def _schemas_equal(schema1: pa.Schema, schema2: pa.Schema) -> bool:
+    """Check if two PyArrow schemas are equal.
+
+    Compares field names and types.
+    """
+    if len(schema1) != len(schema2):
+        return False
+
+    for i in range(len(schema1)):
+        field1 = schema1.field(i)
+        field2 = schema2.field(i)
+        if field1.name != field2.name or field1.type != field2.type:
+            return False
+
+    return True
+
+
+def _describe_schema_diff(
+    schema1: pa.Schema,
+    schema2: pa.Schema,
+    file1: Path,
+    file2: Path,
+) -> str:
+    """Generate a human-readable description of schema differences."""
+    fields1 = {f.name: f.type for f in schema1}
+    fields2 = {f.name: f.type for f in schema2}
+
+    diffs: list[str] = []
+
+    # Fields in first but not second
+    only_in_first = set(fields1.keys()) - set(fields2.keys())
+    if only_in_first:
+        diffs.append(f"Columns only in {file1.name}: {sorted(only_in_first)}")
+
+    # Fields in second but not first
+    only_in_second = set(fields2.keys()) - set(fields1.keys())
+    if only_in_second:
+        diffs.append(f"Columns only in {file2.name}: {sorted(only_in_second)}")
+
+    # Fields with different types
+    common_fields = set(fields1.keys()) & set(fields2.keys())
+    for field in sorted(common_fields):
+        if fields1[field] != fields2[field]:
+            diffs.append(f"Column '{field}' type mismatch: {fields1[field]} vs {fields2[field]}")
+
+    return "; ".join(diffs) if diffs else "Unknown schema difference"

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -474,13 +474,14 @@ def add_partition_metadata_to_collection(
                     if isinstance(new_key, dict) and "name" in new_key:
                         key_name = new_key["name"]
                         merged_key = dict(new_key)
-                        # Preserve existing description if not in new key
-                        if key_name in existing_descriptions and "description" not in merged_key:
-                            merged_key["description"] = existing_descriptions[key_name]
-                        # Also preserve if new key has empty/generic description
-                        elif (
-                            key_name in existing_descriptions
-                            and merged_key.get("description", "").strip() == ""
+                        # Preserve existing hand-authored description if:
+                        # 1. New key has no description at all
+                        # 2. New key has empty/whitespace description
+                        # 3. New key has auto-generated generic description (ends with "identifier")
+                        new_desc = merged_key.get("description", "").strip()
+                        is_generic_desc = new_desc.endswith("identifier") or new_desc == ""
+                        if key_name in existing_descriptions and (
+                            "description" not in merged_key or is_generic_desc
                         ):
                             merged_key["description"] = existing_descriptions[key_name]
                         merged_keys.append(merged_key)

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -449,14 +449,44 @@ def add_partition_metadata_to_collection(
     Adds partition:* fields from the provided metadata dict and registers
     the partition extension URL in stac_extensions.
 
+    Per Issue #443: Preserves existing hand-authored descriptions on partition:keys
+    when merging new partition metadata.
+
     Args:
         collection: The collection to add partition metadata to.
         partition_metadata: Dict with partition:* fields from get_partition_metadata().
     """
+    # Get existing partition keys descriptions to preserve
+    existing_descriptions: dict[str, str] = {}
+    existing_keys = collection.extra_fields.get("partition:keys", [])
+    if isinstance(existing_keys, list):
+        for key in existing_keys:
+            if isinstance(key, dict) and "name" in key and "description" in key:
+                existing_descriptions[key["name"]] = key["description"]
+
     # Add partition:* fields to collection extra_fields
     for key, value in partition_metadata.items():
         if key.startswith("partition:"):
-            collection.extra_fields[key] = value
+            # Special handling for partition:keys to preserve descriptions
+            if key == "partition:keys" and isinstance(value, list):
+                merged_keys: list[dict[str, str]] = []
+                for new_key in value:
+                    if isinstance(new_key, dict) and "name" in new_key:
+                        key_name = new_key["name"]
+                        merged_key = dict(new_key)
+                        # Preserve existing description if not in new key
+                        if key_name in existing_descriptions and "description" not in merged_key:
+                            merged_key["description"] = existing_descriptions[key_name]
+                        # Also preserve if new key has empty/generic description
+                        elif (
+                            key_name in existing_descriptions
+                            and merged_key.get("description", "").strip() == ""
+                        ):
+                            merged_key["description"] = existing_descriptions[key_name]
+                        merged_keys.append(merged_key)
+                collection.extra_fields[key] = merged_keys
+            else:
+                collection.extra_fields[key] = value
 
     # Register partition extension
     ext_url = EXTENSION_URLS["partition"]

--- a/tests/integration/test_add_hive_partitions.py
+++ b/tests/integration/test_add_hive_partitions.py
@@ -1,0 +1,546 @@
+"""Integration tests for arbitrary Hive partition support in portolan add (Issue #443).
+
+Tests the full workflow:
+1. Adding pre-existing Hive-partitioned data with arbitrary column names
+2. Merge behavior preserving hand-authored partition metadata
+3. Glob pattern generation for arbitrary partitions
+4. Schema consistency validation across partitions
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def initialized_catalog(tmp_path: Path) -> Path:
+    """Create an initialized Portolan catalog using CLI."""
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+    return tmp_path
+
+
+def create_partitioned_parquet(
+    base_dir: Path, partition_col: str, partition_values: list[str]
+) -> None:
+    """Create a Hive-partitioned GeoParquet dataset with consistent schema.
+
+    Creates valid GeoParquet files with point geometries so they're recognized
+    as vector data by Portolan.
+
+    Args:
+        base_dir: Base directory for the partitioned dataset.
+        partition_col: Name of the partition column.
+        partition_values: List of partition values to create.
+    """
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    for i, val in enumerate(partition_values):
+        partition_dir = base_dir / f"{partition_col}={val}"
+        partition_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create GeoDataFrame with point geometries
+        gdf = gpd.GeoDataFrame(
+            {
+                "id": [i * 10 + j for j in range(5)],
+                "name": [f"item_{i}_{j}" for j in range(5)],
+                "value": [float(i * 10 + j) for j in range(5)],
+            },
+            geometry=[Point(j, i) for j in range(5)],
+            crs="EPSG:4326",
+        )
+        gdf.to_parquet(partition_dir / "data.parquet")
+
+
+def create_multilevel_partitioned_parquet(
+    base_dir: Path,
+    level1_col: str,
+    level1_values: list[str],
+    level2_col: str,
+    level2_values: list[str],
+) -> None:
+    """Create a multi-level Hive-partitioned GeoParquet dataset.
+
+    Args:
+        base_dir: Base directory for the partitioned dataset.
+        level1_col: Name of first partition level column.
+        level1_values: Values for first partition level.
+        level2_col: Name of second partition level column.
+        level2_values: Values for second partition level.
+    """
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    for i, l1_val in enumerate(level1_values):
+        for j, l2_val in enumerate(level2_values):
+            partition_dir = base_dir / f"{level1_col}={l1_val}" / f"{level2_col}={l2_val}"
+            partition_dir.mkdir(parents=True, exist_ok=True)
+
+            # Create GeoDataFrame with point geometries
+            gdf = gpd.GeoDataFrame(
+                {"id": [1, 2], "measurement": [1.5, 2.5]},
+                geometry=[Point(i, j), Point(i + 0.1, j + 0.1)],
+                crs="EPSG:4326",
+            )
+            gdf.to_parquet(partition_dir / "data.parquet")
+
+
+class TestAddArbitraryHivePartitions:
+    """Tests for adding pre-existing Hive-partitioned data with arbitrary column names."""
+
+    @pytest.mark.integration
+    def test_add_detects_arbitrary_partition_column(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add detects arbitrary partition column names like gms_feature_id."""
+        # Create partitions directly under the collection directory
+        collection_dir = initialized_catalog / "sites"
+        collection_dir.mkdir()
+
+        # Create Hive-partitioned data with domain-meaningful column
+        create_partitioned_parquet(
+            collection_dir,
+            partition_col="gms_feature_id",
+            partition_values=["abc-123", "def-456", "ghi-789"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Verify partition metadata was detected
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        assert collection_json.get("partition:scheme") == "hive"
+        partition_keys = collection_json.get("partition:keys", [])
+        key_names = [k["name"] for k in partition_keys]
+        assert "gms_feature_id" in key_names
+
+    @pytest.mark.integration
+    @pytest.mark.xfail(
+        reason="Automatic glob asset generation not yet implemented - Issue #443 future work"
+    )
+    def test_add_generates_glob_for_arbitrary_column(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add generates correct glob pattern for arbitrary partition columns.
+
+        NOTE: This test is xfail because automatic glob asset generation is future work.
+        Currently users need to manually add glob assets to collection.json.
+        """
+        collection_dir = initialized_catalog / "observations"
+        collection_dir.mkdir()
+
+        create_partitioned_parquet(
+            collection_dir,
+            partition_col="station_id",
+            partition_values=["st001", "st002"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Check that glob asset has correct pattern
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        assets = collection_json.get("assets", {})
+
+        # Find the glob asset (should have a glob pattern in href)
+        glob_assets = [a for a in assets.values() if "*" in a.get("href", "")]
+        assert len(glob_assets) >= 1, "Should have at least one glob asset"
+
+        glob_asset = glob_assets[0]
+        assert "station_id=*" in glob_asset["href"]
+
+
+class TestAddMultilevelHivePartitions:
+    """Tests for multi-level Hive partition support."""
+
+    @pytest.mark.integration
+    def test_add_detects_multilevel_partitions(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add detects multi-level Hive partitions like year=*/month=*."""
+        collection_dir = initialized_catalog / "timeseries"
+        collection_dir.mkdir()
+
+        create_multilevel_partitioned_parquet(
+            collection_dir,
+            level1_col="year",
+            level1_values=["2023", "2024"],
+            level2_col="month",
+            level2_values=["01", "02", "03"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Verify both partition levels detected
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        assert collection_json.get("partition:scheme") == "hive"
+
+        partition_keys = collection_json.get("partition:keys", [])
+        key_names = [k["name"] for k in partition_keys]
+        assert "year" in key_names
+        assert "month" in key_names
+
+    @pytest.mark.integration
+    def test_add_detects_multilevel_partition_metadata(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add detects multi-level partitions and adds metadata."""
+        collection_dir = initialized_catalog / "sensors"
+        collection_dir.mkdir()
+
+        create_multilevel_partitioned_parquet(
+            collection_dir,
+            level1_col="region",
+            level1_values=["north", "south"],
+            level2_col="sensor_type",
+            level2_values=["temp", "humidity"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Verify partition metadata was added
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        assert collection_json.get("partition:scheme") == "hive"
+        partition_keys = collection_json.get("partition:keys", [])
+        key_names = [k["name"] for k in partition_keys]
+        assert "region" in key_names
+        assert "sensor_type" in key_names
+
+    @pytest.mark.integration
+    @pytest.mark.xfail(
+        reason="Automatic glob asset generation not yet implemented - Issue #443 future work"
+    )
+    def test_add_generates_multilevel_glob(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add generates correct glob for multi-level partitions.
+
+        NOTE: This test is xfail because automatic glob asset generation is future work.
+        """
+        collection_dir = initialized_catalog / "sensors"
+        collection_dir.mkdir()
+
+        create_multilevel_partitioned_parquet(
+            collection_dir,
+            level1_col="region",
+            level1_values=["north", "south"],
+            level2_col="sensor_type",
+            level2_values=["temp", "humidity"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        assets = collection_json.get("assets", {})
+
+        glob_assets = [a for a in assets.values() if "*" in a.get("href", "")]
+        assert len(glob_assets) >= 1
+
+        glob_href = glob_assets[0]["href"]
+        assert "region=*" in glob_href
+        assert "sensor_type=*" in glob_href
+
+
+class TestMergePreservesPartitionMetadata:
+    """Tests that merge strategy preserves hand-authored partition metadata."""
+
+    @pytest.mark.integration
+    def test_smart_merge_preserves_partition_description(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """Smart merge preserves hand-authored partition key descriptions."""
+        collection_dir = initialized_catalog / "sites"
+        collection_dir.mkdir()
+
+        # Create partitioned data directly under collection
+        create_partitioned_parquet(
+            collection_dir,
+            partition_col="site_id",
+            partition_values=["a", "b"],
+        )
+
+        # First add
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        # Hand-author partition description
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        partition_keys = collection_json.get("partition:keys", [])
+        for key in partition_keys:
+            if key["name"] == "site_id":
+                key["description"] = "Site UUID — matches site_feature_id in sites.parquet"
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json, indent=2))
+
+        # Add another partition
+        create_partitioned_parquet(
+            collection_dir,
+            partition_col="site_id",
+            partition_values=["a", "b", "c"],  # Added "c"
+        )
+
+        # Re-add with smart merge (default)
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        # Verify description preserved
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        partition_keys = collection_json.get("partition:keys", [])
+        site_key = next((k for k in partition_keys if k["name"] == "site_id"), None)
+        assert site_key is not None
+        assert "Site UUID" in site_key.get("description", "")
+
+    @pytest.mark.integration
+    @pytest.mark.xfail(
+        reason="Automatic glob asset generation not yet implemented - Issue #443 future work"
+    )
+    def test_smart_merge_preserves_glob_asset_metadata(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """Smart merge preserves hand-authored glob asset title and description.
+
+        NOTE: This test is xfail because automatic glob asset generation is future work.
+        Once implemented, users will be able to add custom title/description to glob
+        assets and have them preserved across re-adds.
+        """
+        collection_dir = initialized_catalog / "contours"
+        collection_dir.mkdir()
+
+        create_partitioned_parquet(
+            collection_dir,
+            partition_col="feature_id",
+            partition_values=["001", "002"],
+        )
+
+        # First add
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        # Hand-author asset metadata
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        for _asset_key, asset in collection_json.get("assets", {}).items():
+            if "*" in asset.get("href", ""):
+                asset["title"] = "Contour Lines by Feature"
+                asset["description"] = "Partitioned contour data for each feature polygon."
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json, indent=2))
+
+        # Re-add
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+
+        # Verify metadata preserved
+        collection_json = json.loads((collection_dir / "collection.json").read_text())
+        glob_assets = [
+            a for a in collection_json.get("assets", {}).values() if "*" in a.get("href", "")
+        ]
+        assert len(glob_assets) >= 1
+        assert glob_assets[0].get("title") == "Contour Lines by Feature"
+        assert "Partitioned contour data" in glob_assets[0].get("description", "")
+
+
+class TestSchemaConsistencyValidation:
+    """Tests for schema consistency validation during add."""
+
+    @pytest.mark.integration
+    def test_add_warns_on_inconsistent_schemas(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add warns when partition schemas are inconsistent."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        collection_dir = initialized_catalog / "mixed"
+        collection_dir.mkdir()
+
+        # Create partitions with inconsistent schemas (different columns)
+        partition1 = collection_dir / "part=001"
+        partition1.mkdir()
+        gdf1 = gpd.GeoDataFrame(
+            {"id": [1], "name": ["a"]},
+            geometry=[Point(0, 0)],
+            crs="EPSG:4326",
+        )
+        gdf1.to_parquet(partition1 / "data.parquet")
+
+        partition2 = collection_dir / "part=002"
+        partition2.mkdir()
+        gdf2 = gpd.GeoDataFrame(
+            {"id": [2], "extra_col": [1.5]},  # Different column!
+            geometry=[Point(1, 1)],
+            crs="EPSG:4326",
+        )
+        gdf2.to_parquet(partition2 / "data.parquet")
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+
+        # Should succeed but with warning about schema inconsistency
+        assert result.exit_code == 0
+        # Check for warning in output (schema mismatch warning)
+        assert (
+            "schema" in result.output.lower()
+            or "inconsistent" in result.output.lower()
+            or result.exit_code == 0
+        )
+
+    @pytest.mark.integration
+    def test_add_succeeds_with_consistent_schemas(
+        self,
+        runner: CliRunner,
+        initialized_catalog: Path,
+    ) -> None:
+        """portolan add succeeds cleanly when all partition schemas match."""
+        collection_dir = initialized_catalog / "consistent"
+        collection_dir.mkdir()
+
+        create_partitioned_parquet(
+            collection_dir,
+            partition_col="region",
+            partition_values=["north", "south", "east", "west"],
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(initialized_catalog),
+                "--force",
+                str(collection_dir),
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        # Should not have schema warnings
+        assert "inconsistent" not in result.output.lower()

--- a/tests/integration/test_add_hive_partitions.py
+++ b/tests/integration/test_add_hive_partitions.py
@@ -140,19 +140,12 @@ class TestAddArbitraryHivePartitions:
         assert "gms_feature_id" in key_names
 
     @pytest.mark.integration
-    @pytest.mark.xfail(
-        reason="Automatic glob asset generation not yet implemented - Issue #443 future work"
-    )
     def test_add_generates_glob_for_arbitrary_column(
         self,
         runner: CliRunner,
         initialized_catalog: Path,
     ) -> None:
-        """portolan add generates correct glob pattern for arbitrary partition columns.
-
-        NOTE: This test is xfail because automatic glob asset generation is future work.
-        Currently users need to manually add glob assets to collection.json.
-        """
+        """portolan add generates correct glob pattern for arbitrary partition columns."""
         collection_dir = initialized_catalog / "observations"
         collection_dir.mkdir()
 
@@ -270,18 +263,12 @@ class TestAddMultilevelHivePartitions:
         assert "sensor_type" in key_names
 
     @pytest.mark.integration
-    @pytest.mark.xfail(
-        reason="Automatic glob asset generation not yet implemented - Issue #443 future work"
-    )
     def test_add_generates_multilevel_glob(
         self,
         runner: CliRunner,
         initialized_catalog: Path,
     ) -> None:
-        """portolan add generates correct glob for multi-level partitions.
-
-        NOTE: This test is xfail because automatic glob asset generation is future work.
-        """
+        """portolan add generates correct glob for multi-level partitions."""
         collection_dir = initialized_catalog / "sensors"
         collection_dir.mkdir()
 
@@ -388,20 +375,12 @@ class TestMergePreservesPartitionMetadata:
         assert "Site UUID" in site_key.get("description", "")
 
     @pytest.mark.integration
-    @pytest.mark.xfail(
-        reason="Automatic glob asset generation not yet implemented - Issue #443 future work"
-    )
     def test_smart_merge_preserves_glob_asset_metadata(
         self,
         runner: CliRunner,
         initialized_catalog: Path,
     ) -> None:
-        """Smart merge preserves hand-authored glob asset title and description.
-
-        NOTE: This test is xfail because automatic glob asset generation is future work.
-        Once implemented, users will be able to add custom title/description to glob
-        assets and have them preserved across re-adds.
-        """
+        """Smart merge preserves hand-authored glob asset title and description."""
         collection_dir = initialized_catalog / "contours"
         collection_dir.mkdir()
 
@@ -507,10 +486,9 @@ class TestSchemaConsistencyValidation:
         # Should succeed but with warning about schema inconsistency
         assert result.exit_code == 0
         # Check for warning in output (schema mismatch warning)
-        assert (
-            "schema" in result.output.lower()
-            or "inconsistent" in result.output.lower()
-            or result.exit_code == 0
+        # The warning should mention schema inconsistency
+        assert "schema" in result.output.lower() or "inconsistent" in result.output.lower(), (
+            f"Expected schema inconsistency warning in output, got: {result.output}"
         )
 
     @pytest.mark.integration

--- a/tests/unit/test_hive_partition_collection_id.py
+++ b/tests/unit/test_hive_partition_collection_id.py
@@ -213,23 +213,24 @@ class TestCollectionIdValidationIntegration:
 class TestDeriveItemIdHivePartitions:
     """Tests for _derive_item_id_and_asset_level with Hive partitions.
 
-    Issue #443: Files in Hive partition directories must produce unique item IDs
-    and vector formats should become collection-level assets per ADR-0031.
+    Issue #443: Files in Hive partition directories must produce unique item IDs.
+    Single-level partitions (e.g., kdtree_cell=XXX/) use parent dir name (existing behavior).
+    Multi-level partitions (e.g., year=2023/month=01/) use full relative path to avoid collisions.
     """
 
-    def test_vector_in_hive_partition_is_collection_level(self, tmp_path: Path) -> None:
-        """Vector formats in Hive partitions become collection-level assets.
+    def test_single_level_hive_partition_uses_parent_name(self, tmp_path: Path) -> None:
+        """Single-level Hive partitions use parent directory name as item_id.
 
-        Per ADR-0031: partitioned vector data is one logical dataset.
+        This is the common case for kdtree partitioning and should work as before.
         """
         from portolan_cli.dataset import _derive_item_id_and_asset_level
         from portolan_cli.formats import FormatType
 
         collection_dir = tmp_path / "collection"
         collection_dir.mkdir()
-        partition_dir = collection_dir / "year=2023" / "month=01"
+        partition_dir = collection_dir / "kdtree_cell=0000000001"
         partition_dir.mkdir(parents=True)
-        parquet_file = partition_dir / "data.parquet"
+        parquet_file = partition_dir / "0000000001.parquet"
         parquet_file.write_bytes(b"x")
 
         item_id, is_collection_level = _derive_item_id_and_asset_level(
@@ -239,14 +240,14 @@ class TestDeriveItemIdHivePartitions:
             format_type=FormatType.VECTOR,
         )
 
-        # Vector format in Hive partition should be collection-level
-        assert is_collection_level is True
-        assert item_id == "data"  # file stem used for collection-level
+        # Single-level partition: use parent dir name, NOT collection-level
+        assert is_collection_level is False
+        assert item_id == "kdtree_cell=0000000001"
 
-    def test_raster_in_hive_partition_has_unique_item_id(self, tmp_path: Path) -> None:
-        """Raster formats in Hive partitions get unique item IDs from partition values.
+    def test_multi_level_hive_partition_has_unique_item_id(self, tmp_path: Path) -> None:
+        """Multi-level Hive partitions get unique item IDs from full relative path.
 
-        Files at year=2023/month=01/file.tif and year=2024/month=01/file.tif
+        Files at year=2023/month=01/file.parquet and year=2024/month=01/file.parquet
         must NOT both get item_id="month=01" (that would be a duplicate).
         """
         from portolan_cli.dataset import _derive_item_id_and_asset_level
@@ -261,8 +262,8 @@ class TestDeriveItemIdHivePartitions:
         partition1.mkdir(parents=True)
         partition2.mkdir(parents=True)
 
-        file1 = partition1 / "data.tif"
-        file2 = partition2 / "data.tif"
+        file1 = partition1 / "data.parquet"
+        file2 = partition2 / "data.parquet"
         file1.write_bytes(b"x")
         file2.write_bytes(b"x")
 
@@ -270,14 +271,14 @@ class TestDeriveItemIdHivePartitions:
             path=file1,
             collection_dir=collection_dir,
             item_id=None,
-            format_type=FormatType.RASTER,
+            format_type=FormatType.VECTOR,
         )
 
         item_id_2, is_coll_2 = _derive_item_id_and_asset_level(
             path=file2,
             collection_dir=collection_dir,
             item_id=None,
-            format_type=FormatType.RASTER,
+            format_type=FormatType.VECTOR,
         )
 
         # Both should be item-level (not collection-level)
@@ -287,14 +288,41 @@ class TestDeriveItemIdHivePartitions:
         # Item IDs MUST be different (this was the bug)
         assert item_id_1 != item_id_2
 
-        # Item IDs should include partition values to be unique
-        assert "2023" in item_id_1
-        assert "01" in item_id_1
-        assert "2024" in item_id_2
-        assert "01" in item_id_2
+        # Item IDs should be full relative paths joined with underscore
+        assert item_id_1 == "year=2023_month=01"
+        assert item_id_2 == "year=2024_month=01"
 
-    def test_no_format_type_falls_back_to_unique_item_id(self, tmp_path: Path) -> None:
-        """When format_type is None, Hive partitions still produce unique IDs."""
+    def test_single_level_partition_unique_per_cell(self, tmp_path: Path) -> None:
+        """Single-level partitions have unique item_ids per partition cell."""
+        from portolan_cli.dataset import _derive_item_id_and_asset_level
+
+        collection_dir = tmp_path / "collection"
+        collection_dir.mkdir()
+
+        partition1 = collection_dir / "kdtree_cell=001"
+        partition2 = collection_dir / "kdtree_cell=002"
+        partition1.mkdir(parents=True)
+        partition2.mkdir(parents=True)
+
+        file1 = partition1 / "data.parquet"
+        file2 = partition2 / "data.parquet"
+        file1.write_bytes(b"x")
+        file2.write_bytes(b"x")
+
+        item_id_1, _ = _derive_item_id_and_asset_level(
+            path=file1, collection_dir=collection_dir, item_id=None
+        )
+        item_id_2, _ = _derive_item_id_and_asset_level(
+            path=file2, collection_dir=collection_dir, item_id=None
+        )
+
+        # Each partition cell has unique item_id
+        assert item_id_1 == "kdtree_cell=001"
+        assert item_id_2 == "kdtree_cell=002"
+        assert item_id_1 != item_id_2
+
+    def test_no_format_type_single_level(self, tmp_path: Path) -> None:
+        """Single-level Hive partition without format_type uses parent dir name."""
         from portolan_cli.dataset import _derive_item_id_and_asset_level
 
         collection_dir = tmp_path / "collection"
@@ -310,9 +338,9 @@ class TestDeriveItemIdHivePartitions:
             format_type=None,  # Unknown format
         )
 
-        # Without format_type, treated as non-vector (unique ID path)
+        # Single-level partition: uses parent dir name
         assert is_collection_level is False
-        assert "north" in item_id  # partition value included
+        assert item_id == "region=north"  # parent dir name for single-level
 
     def test_explicit_item_id_overrides_hive_logic(self, tmp_path: Path) -> None:
         """Explicit item_id takes precedence over Hive partition detection."""

--- a/tests/unit/test_hive_partition_collection_id.py
+++ b/tests/unit/test_hive_partition_collection_id.py
@@ -9,6 +9,8 @@ The fix: strip any `key=value/` path segments when inferring collection ID.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from portolan_cli.scan import _infer_collection_id_from_relative_path
 from portolan_cli.scan_detect import is_hive_partition_dir
 
@@ -206,3 +208,152 @@ class TestCollectionIdValidationIntegration:
         is_valid, error = validate_collection_id(collection_id)
         assert is_valid, f"Collection ID '{collection_id}' should be valid: {error}"
         assert "=" not in collection_id
+
+
+class TestDeriveItemIdHivePartitions:
+    """Tests for _derive_item_id_and_asset_level with Hive partitions.
+
+    Issue #443: Files in Hive partition directories must produce unique item IDs
+    and vector formats should become collection-level assets per ADR-0031.
+    """
+
+    def test_vector_in_hive_partition_is_collection_level(self, tmp_path: Path) -> None:
+        """Vector formats in Hive partitions become collection-level assets.
+
+        Per ADR-0031: partitioned vector data is one logical dataset.
+        """
+        from portolan_cli.dataset import _derive_item_id_and_asset_level
+        from portolan_cli.formats import FormatType
+
+        collection_dir = tmp_path / "collection"
+        collection_dir.mkdir()
+        partition_dir = collection_dir / "year=2023" / "month=01"
+        partition_dir.mkdir(parents=True)
+        parquet_file = partition_dir / "data.parquet"
+        parquet_file.write_bytes(b"x")
+
+        item_id, is_collection_level = _derive_item_id_and_asset_level(
+            path=parquet_file,
+            collection_dir=collection_dir,
+            item_id=None,
+            format_type=FormatType.VECTOR,
+        )
+
+        # Vector format in Hive partition should be collection-level
+        assert is_collection_level is True
+        assert item_id == "data"  # file stem used for collection-level
+
+    def test_raster_in_hive_partition_has_unique_item_id(self, tmp_path: Path) -> None:
+        """Raster formats in Hive partitions get unique item IDs from partition values.
+
+        Files at year=2023/month=01/file.tif and year=2024/month=01/file.tif
+        must NOT both get item_id="month=01" (that would be a duplicate).
+        """
+        from portolan_cli.dataset import _derive_item_id_and_asset_level
+        from portolan_cli.formats import FormatType
+
+        collection_dir = tmp_path / "collection"
+        collection_dir.mkdir()
+
+        # Create two files in different partition branches with same leaf dir name
+        partition1 = collection_dir / "year=2023" / "month=01"
+        partition2 = collection_dir / "year=2024" / "month=01"
+        partition1.mkdir(parents=True)
+        partition2.mkdir(parents=True)
+
+        file1 = partition1 / "data.tif"
+        file2 = partition2 / "data.tif"
+        file1.write_bytes(b"x")
+        file2.write_bytes(b"x")
+
+        item_id_1, is_coll_1 = _derive_item_id_and_asset_level(
+            path=file1,
+            collection_dir=collection_dir,
+            item_id=None,
+            format_type=FormatType.RASTER,
+        )
+
+        item_id_2, is_coll_2 = _derive_item_id_and_asset_level(
+            path=file2,
+            collection_dir=collection_dir,
+            item_id=None,
+            format_type=FormatType.RASTER,
+        )
+
+        # Both should be item-level (not collection-level)
+        assert is_coll_1 is False
+        assert is_coll_2 is False
+
+        # Item IDs MUST be different (this was the bug)
+        assert item_id_1 != item_id_2
+
+        # Item IDs should include partition values to be unique
+        assert "2023" in item_id_1
+        assert "01" in item_id_1
+        assert "2024" in item_id_2
+        assert "01" in item_id_2
+
+    def test_no_format_type_falls_back_to_unique_item_id(self, tmp_path: Path) -> None:
+        """When format_type is None, Hive partitions still produce unique IDs."""
+        from portolan_cli.dataset import _derive_item_id_and_asset_level
+
+        collection_dir = tmp_path / "collection"
+        partition_dir = collection_dir / "region=north"
+        partition_dir.mkdir(parents=True)
+        data_file = partition_dir / "measurements.csv"
+        data_file.write_bytes(b"x")
+
+        item_id, is_collection_level = _derive_item_id_and_asset_level(
+            path=data_file,
+            collection_dir=collection_dir,
+            item_id=None,
+            format_type=None,  # Unknown format
+        )
+
+        # Without format_type, treated as non-vector (unique ID path)
+        assert is_collection_level is False
+        assert "north" in item_id  # partition value included
+
+    def test_explicit_item_id_overrides_hive_logic(self, tmp_path: Path) -> None:
+        """Explicit item_id takes precedence over Hive partition detection."""
+        from portolan_cli.dataset import _derive_item_id_and_asset_level
+        from portolan_cli.formats import FormatType
+
+        collection_dir = tmp_path / "collection"
+        partition_dir = collection_dir / "year=2023"
+        partition_dir.mkdir(parents=True)
+        data_file = partition_dir / "data.parquet"
+        data_file.write_bytes(b"x")
+
+        item_id, is_collection_level = _derive_item_id_and_asset_level(
+            path=data_file,
+            collection_dir=collection_dir,
+            item_id="explicit-id",  # User-provided
+            format_type=FormatType.VECTOR,
+        )
+
+        # Explicit ID used regardless of Hive detection
+        assert item_id == "explicit-id"
+        assert is_collection_level is False  # Explicit = item-level
+
+    def test_non_hive_path_unchanged(self, tmp_path: Path) -> None:
+        """Paths without Hive partitions work as before."""
+        from portolan_cli.dataset import _derive_item_id_and_asset_level
+        from portolan_cli.formats import FormatType
+
+        collection_dir = tmp_path / "collection"
+        item_dir = collection_dir / "my_item"
+        item_dir.mkdir(parents=True)
+        data_file = item_dir / "data.parquet"
+        data_file.write_bytes(b"x")
+
+        item_id, is_collection_level = _derive_item_id_and_asset_level(
+            path=data_file,
+            collection_dir=collection_dir,
+            item_id=None,
+            format_type=FormatType.VECTOR,
+        )
+
+        # Regular directory structure unchanged
+        assert item_id == "my_item"  # parent dir name
+        assert is_collection_level is False

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -727,3 +727,86 @@ class TestGlobTransformationPartitionExtension:
         expected_glob = "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
         assert asset["partition:glob"] == expected_glob
         assert asset["portolan:glob"] == expected_glob
+
+
+class TestGlobAssetKeyCollision:
+    """Tests for glob asset insertion avoiding key collision (Issue #443)."""
+
+    @pytest.mark.unit
+    def test_glob_asset_uses_alternate_key_when_target_occupied(self, tmp_path: Path) -> None:
+        """When 'partitioned_data' key has non-glob asset, use alternate key.
+
+        Per Issue #443: Don't overwrite user-defined assets when auto-adding
+        glob assets for Hive partitions.
+        """
+        import pystac
+
+        from portolan_cli.dataset import _ensure_partition_metadata
+
+        # Create Hive partition structure
+        collection_dir = tmp_path / "collection"
+        (collection_dir / "year=2023").mkdir(parents=True)
+        (collection_dir / "year=2023" / "data.parquet").write_bytes(b"x")
+
+        # Create collection with existing non-glob asset at target key
+        collection = pystac.Collection(
+            id="test",
+            description="Test collection",
+            extent=pystac.Extent(
+                spatial=pystac.SpatialExtent(bboxes=[[-180, -90, 180, 90]]),
+                temporal=pystac.TemporalExtent(intervals=[[None, None]]),
+            ),
+        )
+        # Add a non-glob asset at the target key "partitioned_data"
+        collection.assets["partitioned_data"] = pystac.Asset(
+            href="./existing_data.csv",  # Non-glob href
+            media_type="text/csv",
+            roles=["data"],
+            title="User-defined asset",
+        )
+
+        # Run _ensure_partition_metadata with empty items (auto-detection path)
+        _ensure_partition_metadata(collection, collection_dir, items=[])
+
+        # Original asset should NOT be clobbered
+        assert collection.assets["partitioned_data"].href == "./existing_data.csv"
+        assert collection.assets["partitioned_data"].title == "User-defined asset"
+
+        # Glob asset should be added at alternate key
+        assert "partitioned_data_glob" in collection.assets
+        assert "*" in collection.assets["partitioned_data_glob"].href
+
+    @pytest.mark.unit
+    def test_glob_asset_reuses_key_when_already_glob(self, tmp_path: Path) -> None:
+        """When 'partitioned_data' key already has glob asset, skip adding."""
+        import pystac
+
+        from portolan_cli.dataset import _ensure_partition_metadata
+
+        # Create Hive partition structure
+        collection_dir = tmp_path / "collection"
+        (collection_dir / "year=2023").mkdir(parents=True)
+        (collection_dir / "year=2023" / "data.parquet").write_bytes(b"x")
+
+        # Create collection with existing glob asset
+        collection = pystac.Collection(
+            id="test",
+            description="Test collection",
+            extent=pystac.Extent(
+                spatial=pystac.SpatialExtent(bboxes=[[-180, -90, 180, 90]]),
+                temporal=pystac.TemporalExtent(intervals=[[None, None]]),
+            ),
+        )
+        collection.assets["existing_glob"] = pystac.Asset(
+            href="./year=*/*.parquet",  # Already a glob
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+        )
+
+        # Run _ensure_partition_metadata with empty items (auto-detection path)
+        _ensure_partition_metadata(collection, collection_dir, items=[])
+
+        # No new glob asset should be added (one already exists)
+        assert "partitioned_data" not in collection.assets
+        assert "partitioned_data_glob" not in collection.assets
+        assert "existing_glob" in collection.assets

--- a/tests/unit/test_partitioning_arbitrary.py
+++ b/tests/unit/test_partitioning_arbitrary.py
@@ -1,0 +1,417 @@
+"""Tests for arbitrary Hive partition column support (Issue #443).
+
+Tests the ability to:
+- Detect and handle arbitrary partition column names (not just kdtree/h3/s2/quadkey/a5)
+- Generate glob patterns for arbitrary column names
+- Support multi-level Hive partitions
+- Validate schema consistency across partitions
+- Configure partition columns via config.yaml
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+
+class TestArbitraryPartitionColumnDetection:
+    """Tests for detecting arbitrary Hive partition column names."""
+
+    @pytest.mark.unit
+    def test_detect_partitioning_arbitrary_column_name(self, tmp_path: Path) -> None:
+        """detect_partitioning works with arbitrary column names like gms_feature_id."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        # Create Hive structure with domain-meaningful partition key
+        (tmp_path / "gms_feature_id=00b3a7de-1234-5678-9abc-def012345678").mkdir()
+        (
+            tmp_path / "gms_feature_id=00b3a7de-1234-5678-9abc-def012345678" / "contours.parquet"
+        ).write_bytes(b"x")
+        (tmp_path / "gms_feature_id=020e386a-9876-5432-fedc-ba0987654321").mkdir()
+        (
+            tmp_path / "gms_feature_id=020e386a-9876-5432-fedc-ba0987654321" / "contours.parquet"
+        ).write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is not None
+        assert result["partition:scheme"] == "hive"
+        # Strategy should be omitted for unknown column names
+        assert "partition:strategy" not in result
+        assert result["partition:file_count"] == 2
+        assert len(result["partition:keys"]) == 1
+        assert result["partition:keys"][0]["name"] == "gms_feature_id"
+
+    @pytest.mark.unit
+    def test_detect_partitioning_preserves_column_order(self, tmp_path: Path) -> None:
+        """detect_partitioning preserves detected column name exactly."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        # Use a column name with underscores and numbers
+        (tmp_path / "site_id_v2=abc123").mkdir()
+        (tmp_path / "site_id_v2=abc123" / "data.parquet").write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is not None
+        assert result["partition:keys"][0]["name"] == "site_id_v2"
+
+
+class TestMultiLevelHivePartitions:
+    """Tests for multi-level Hive partition support."""
+
+    @pytest.mark.unit
+    def test_detect_multilevel_partitions(self, tmp_path: Path) -> None:
+        """detect_partitioning detects multi-level Hive partitions like year=*/month=*."""
+        from portolan_cli.partitioning import detect_partitioning
+
+        # Create multi-level Hive structure
+        (tmp_path / "year=2024" / "month=01").mkdir(parents=True)
+        (tmp_path / "year=2024" / "month=01" / "data.parquet").write_bytes(b"x")
+        (tmp_path / "year=2024" / "month=02").mkdir(parents=True)
+        (tmp_path / "year=2024" / "month=02" / "data.parquet").write_bytes(b"x")
+        (tmp_path / "year=2025" / "month=01").mkdir(parents=True)
+        (tmp_path / "year=2025" / "month=01" / "data.parquet").write_bytes(b"x")
+
+        result = detect_partitioning(tmp_path)
+
+        assert result is not None
+        assert result["partition:scheme"] == "hive"
+        assert result["partition:file_count"] == 3
+        # Should detect both partition levels
+        key_names = [k["name"] for k in result["partition:keys"]]
+        assert "year" in key_names
+        assert "month" in key_names
+
+    @pytest.mark.unit
+    def test_build_glob_pattern_multilevel(self) -> None:
+        """build_glob_pattern generates correct pattern for multi-level partitions."""
+        from portolan_cli.partitioning import build_glob_pattern
+
+        result = build_glob_pattern(partition_columns=["year", "month"])
+
+        assert result == "./year=*/month=*/*.parquet"
+
+    @pytest.mark.unit
+    def test_build_glob_pattern_single_arbitrary_column(self) -> None:
+        """build_glob_pattern works with single arbitrary column name."""
+        from portolan_cli.partitioning import build_glob_pattern
+
+        result = build_glob_pattern(partition_columns=["gms_feature_id"])
+
+        assert result == "./gms_feature_id=*/*.parquet"
+
+    @pytest.mark.unit
+    def test_build_remote_glob_multilevel(self) -> None:
+        """build_remote_glob works with multi-level partition columns."""
+        from portolan_cli.partitioning import build_remote_glob
+
+        result = build_remote_glob(
+            remote_base="s3://bucket/catalog",
+            collection_id="timeseries",
+            partition_columns=["year", "month"],
+        )
+
+        assert result == "s3://bucket/catalog/timeseries/year=*/month=*/*.parquet"
+
+    @pytest.mark.unit
+    def test_build_remote_glob_arbitrary_column(self) -> None:
+        """build_remote_glob works with arbitrary partition column name."""
+        from portolan_cli.partitioning import build_remote_glob
+
+        result = build_remote_glob(
+            remote_base="s3://bucket/catalog",
+            collection_id="sites",
+            partition_columns=["gms_feature_id"],
+        )
+
+        assert result == "s3://bucket/catalog/sites/gms_feature_id=*/*.parquet"
+
+
+class TestBackwardsCompatibility:
+    """Tests ensuring backwards compatibility with strategy-based API."""
+
+    @pytest.mark.unit
+    def test_build_glob_pattern_strategy_still_works(self) -> None:
+        """build_glob_pattern still works with strategy parameter for backwards compat."""
+        from portolan_cli.partitioning import build_glob_pattern
+
+        # Old API with strategy should still work
+        result = build_glob_pattern(strategy="kdtree")
+
+        assert result == "./kdtree_cell=*/*.parquet"
+
+    @pytest.mark.unit
+    def test_build_remote_glob_strategy_still_works(self) -> None:
+        """build_remote_glob still works with strategy parameter for backwards compat."""
+        from portolan_cli.partitioning import build_remote_glob
+
+        result = build_remote_glob("s3://bucket/catalog", "buildings", strategy="kdtree")
+
+        assert result == "s3://bucket/catalog/buildings/kdtree_cell=*/*.parquet"
+
+    @pytest.mark.unit
+    def test_partition_columns_takes_precedence_over_strategy(self) -> None:
+        """When both partition_columns and strategy are provided, partition_columns wins."""
+        from portolan_cli.partitioning import build_glob_pattern
+
+        # partition_columns should take precedence
+        result = build_glob_pattern(
+            strategy="kdtree",
+            partition_columns=["custom_col"],
+        )
+
+        assert result == "./custom_col=*/*.parquet"
+
+
+class TestSchemaConsistencyValidation:
+    """Tests for schema consistency validation across partitions."""
+
+    @pytest.mark.unit
+    def test_validate_partition_schemas_consistent(self, tmp_path: Path) -> None:
+        """validate_partition_schemas passes when all partitions have same schema."""
+        from portolan_cli.partitioning import validate_partition_schemas
+
+        # Create partitions with identical schemas
+        schema = pa.schema(
+            [
+                ("id", pa.int64()),
+                ("name", pa.string()),
+                ("value", pa.float64()),
+            ]
+        )
+
+        for i, partition_id in enumerate(["001", "002", "003"]):
+            partition_dir = tmp_path / f"partition_id={partition_id}"
+            partition_dir.mkdir()
+            table = pa.table({"id": [i], "name": [f"name{i}"], "value": [float(i)]}, schema=schema)
+            pq.write_table(table, partition_dir / "data.parquet")
+
+        # Should not raise
+        result = validate_partition_schemas(tmp_path)
+        assert result.is_consistent is True
+        assert result.schema is not None
+        assert len(result.schema) == 3
+
+    @pytest.mark.unit
+    def test_validate_partition_schemas_inconsistent_columns(self, tmp_path: Path) -> None:
+        """validate_partition_schemas detects when partitions have different columns."""
+        from portolan_cli.partitioning import validate_partition_schemas
+
+        # Create partitions with different schemas
+        partition1 = tmp_path / "id=001"
+        partition1.mkdir()
+        table1 = pa.table({"id": [1], "name": ["a"]})
+        pq.write_table(table1, partition1 / "data.parquet")
+
+        partition2 = tmp_path / "id=002"
+        partition2.mkdir()
+        table2 = pa.table({"id": [2], "extra_col": ["b"]})  # Different column!
+        pq.write_table(table2, partition2 / "data.parquet")
+
+        result = validate_partition_schemas(tmp_path)
+        assert result.is_consistent is False
+        assert "extra_col" in result.error_message or "name" in result.error_message
+
+    @pytest.mark.unit
+    def test_validate_partition_schemas_inconsistent_types(self, tmp_path: Path) -> None:
+        """validate_partition_schemas detects when partitions have different column types."""
+        from portolan_cli.partitioning import validate_partition_schemas
+
+        partition1 = tmp_path / "id=001"
+        partition1.mkdir()
+        table1 = pa.table({"value": pa.array([1, 2, 3], type=pa.int64())})
+        pq.write_table(table1, partition1 / "data.parquet")
+
+        partition2 = tmp_path / "id=002"
+        partition2.mkdir()
+        table2 = pa.table({"value": pa.array(["a", "b", "c"], type=pa.string())})  # Different type!
+        pq.write_table(table2, partition2 / "data.parquet")
+
+        result = validate_partition_schemas(tmp_path)
+        assert result.is_consistent is False
+        assert "value" in result.error_message
+
+    @pytest.mark.unit
+    def test_validate_partition_schemas_returns_unified_schema(self, tmp_path: Path) -> None:
+        """validate_partition_schemas returns the unified schema when consistent."""
+        from portolan_cli.partitioning import validate_partition_schemas
+
+        schema = pa.schema(
+            [
+                ("geometry", pa.binary()),
+                ("name", pa.string()),
+            ]
+        )
+
+        for partition_id in ["a", "b"]:
+            partition_dir = tmp_path / f"site={partition_id}"
+            partition_dir.mkdir()
+            table = pa.table({"geometry": [b"wkb"], "name": [partition_id]}, schema=schema)
+            pq.write_table(table, partition_dir / "data.parquet")
+
+        result = validate_partition_schemas(tmp_path)
+        assert result.is_consistent is True
+        assert result.schema is not None
+        field_names = [f.name for f in result.schema]
+        assert "geometry" in field_names
+        assert "name" in field_names
+
+
+class TestPartitionConfigSupport:
+    """Tests for config-based partition column specification."""
+
+    @pytest.mark.unit
+    def test_config_partition_columns_setting(self, tmp_path: Path) -> None:
+        """Config supports partitioning.columns setting for custom column names."""
+        from portolan_cli.config import DEFAULT_SETTINGS, KNOWN_SETTINGS
+
+        # Verify the setting is registered
+        assert "partitioning.columns" in KNOWN_SETTINGS
+
+        # Default should be None (auto-detect)
+        assert DEFAULT_SETTINGS.get("partitioning.columns") is None
+
+    @pytest.mark.unit
+    def test_config_partition_description_setting(self, tmp_path: Path) -> None:
+        """Config supports partitioning.description for semantic documentation."""
+        from portolan_cli.config import KNOWN_SETTINGS
+
+        assert "partitioning.description" in KNOWN_SETTINGS
+
+    @pytest.mark.unit
+    def test_get_partition_metadata_uses_config_columns(self, tmp_path: Path) -> None:
+        """get_partition_metadata uses config-specified columns when provided."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        # Create Hive structure
+        (tmp_path / "gms_feature_id=abc").mkdir()
+        (tmp_path / "gms_feature_id=abc" / "data.parquet").write_bytes(b"x")
+
+        # Pass explicit partition columns (simulating config-provided value)
+        result = get_partition_metadata(
+            tmp_path,
+            partition_columns=["gms_feature_id"],
+            description="Site UUID — matches gms_site_feature_id in aois.parquet",
+        )
+
+        assert result["partition:keys"][0]["name"] == "gms_feature_id"
+        assert "Site UUID" in result["partition:keys"][0]["description"]
+
+    @pytest.mark.unit
+    def test_get_partition_metadata_auto_detects_without_config(self, tmp_path: Path) -> None:
+        """get_partition_metadata auto-detects columns when not specified in config."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        (tmp_path / "custom_key=value1").mkdir()
+        (tmp_path / "custom_key=value1" / "data.parquet").write_bytes(b"x")
+
+        # No partition_columns specified — should auto-detect
+        result = get_partition_metadata(tmp_path)
+
+        assert result["partition:keys"][0]["name"] == "custom_key"
+
+
+class TestPartitionMetadataDescription:
+    """Tests for free-text partition column descriptions."""
+
+    @pytest.mark.unit
+    def test_partition_key_includes_description(self, tmp_path: Path) -> None:
+        """Partition key metadata includes description field."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        (tmp_path / "site_id=abc").mkdir()
+        (tmp_path / "site_id=abc" / "data.parquet").write_bytes(b"x")
+
+        result = get_partition_metadata(
+            tmp_path,
+            partition_columns=["site_id"],
+            description="Unique site identifier from the sites registry",
+        )
+
+        key_def = result["partition:keys"][0]
+        assert key_def["name"] == "site_id"
+        assert key_def["description"] == "Unique site identifier from the sites registry"
+
+    @pytest.mark.unit
+    def test_multilevel_partition_descriptions(self, tmp_path: Path) -> None:
+        """Multi-level partitions can have per-column descriptions."""
+        from portolan_cli.partitioning import get_partition_metadata
+
+        (tmp_path / "year=2024" / "region=west").mkdir(parents=True)
+        (tmp_path / "year=2024" / "region=west" / "data.parquet").write_bytes(b"x")
+
+        result = get_partition_metadata(
+            tmp_path,
+            partition_columns=["year", "region"],
+            descriptions={
+                "year": "Calendar year of observation",
+                "region": "Geographic region code",
+            },
+        )
+
+        keys_by_name = {k["name"]: k for k in result["partition:keys"]}
+        assert keys_by_name["year"]["description"] == "Calendar year of observation"
+        assert keys_by_name["region"]["description"] == "Geographic region code"
+
+
+class TestGlobTransformArbitraryColumns:
+    """Tests for glob transformation with arbitrary column names."""
+
+    @pytest.mark.unit
+    def test_transform_glob_assets_arbitrary_column(self) -> None:
+        """_transform_collection_glob_assets handles arbitrary column names in href."""
+        import json
+
+        from portolan_cli.push import _transform_collection_glob_assets
+
+        collection_json = {
+            "type": "Collection",
+            "id": "sites",
+            "assets": {
+                "contours": {
+                    "href": "./gms_feature_id=*/contours.parquet",
+                    "type": "application/vnd.apache.parquet",
+                },
+            },
+        }
+
+        content = json.dumps(collection_json).encode("utf-8")
+        result = _transform_collection_glob_assets(content, "s3://bucket/catalog", "sites")
+        result_json = json.loads(result)
+
+        asset = result_json["assets"]["contours"]
+        expected_glob = "s3://bucket/catalog/sites/gms_feature_id=*/contours.parquet"
+
+        assert asset["partition:glob"] == expected_glob
+        assert asset["portolan:glob"] == expected_glob
+
+    @pytest.mark.unit
+    def test_transform_glob_assets_multilevel(self) -> None:
+        """_transform_collection_glob_assets handles multi-level partition paths."""
+        import json
+
+        from portolan_cli.push import _transform_collection_glob_assets
+
+        collection_json = {
+            "type": "Collection",
+            "id": "timeseries",
+            "assets": {
+                "data": {
+                    "href": "./year=*/month=*/data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                },
+            },
+        }
+
+        content = json.dumps(collection_json).encode("utf-8")
+        result = _transform_collection_glob_assets(content, "gs://bucket/catalog", "timeseries")
+        result_json = json.loads(result)
+
+        asset = result_json["assets"]["data"]
+        expected_glob = "gs://bucket/catalog/timeseries/year=*/month=*/data.parquet"
+
+        assert asset["partition:glob"] == expected_glob


### PR DESCRIPTION
## Summary

- Enables portolan to detect and handle pre-existing Hive-partitioned data with arbitrary column names (not just kdtree/h3/s2/quadkey/a5)
- Supports multi-level Hive partitions (e.g., `year=*/month=*`)
- Adds schema consistency validation across partitions
- Preserves hand-authored partition descriptions during re-add operations

Closes #443

## Key Changes

**partitioning.py:**
- `detect_partitioning()` now recursively scans for multi-level Hive partitions
- `build_glob_pattern()` and `build_remote_glob()` accept `partition_columns` list
- `get_partition_metadata()` supports `descriptions` dict for per-column docs
- New `validate_partition_schemas()` validates schema consistency using Parquet metadata

**dataset.py:**
- `infer_nested_collection_id()` filters Hive partition segments from collection IDs
- `finalize_datasets()` auto-detects pre-existing Hive partitions via `_ensure_partition_metadata()` helper

**stac.py:**
- `add_partition_metadata_to_collection()` preserves existing descriptions during smart merge

**config.py:**
- New settings: `partitioning.columns` and `partitioning.description`

## Test Plan

- [x] 22 new unit tests in `tests/unit/test_partitioning_arbitrary.py`
- [x] 9 integration tests in `tests/integration/test_add_hive_partitions.py` (6 pass, 3 xfail for future glob asset work)
- [x] All existing 32 partitioning tests pass (backwards compatibility)
- [x] mypy, ruff, xenon all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Hive-partitioned datasets with arbitrary column names and multi-level partition structures.
  * Automatic detection of pre-existing partition configurations and schema validation across partitioned files.
  * New configuration options to override or describe partition metadata.

* **Documentation**
  * Updated spatial partitioning configuration reference.

* **Tests**
  * Added comprehensive test coverage for Hive-partitioned dataset scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->