### PR TITLE
fix(thumbnail): apply plot-before-basemap fix to PMTiles path

### DIFF
--- a/portolan_cli/thumbnail.py
+++ b/portolan_cli/thumbnail.py
@@ -513,17 +513,7 @@ def _render_geometries(
     ax.set_aspect("equal")
     ax.axis("off")
 
-    # Add basemap first (behind data) if bounds available
-    if bounds is not None and config.basemap_provider != "none":
-        add_basemap(
-            ax,
-            bounds,
-            config.basemap_provider,
-            config.basemap_opacity,
-            config.basemap_zoom_adjust,
-            crs="EPSG:4326",  # PMTiles are always WGS84
-        )
-
+    # Plot data FIRST (establishes axes extent for basemap zoom calculation)
     patches: list[Any] = []
     for geom in geometries:
         geom_type, coords = geom["type"], geom["coordinates"]
@@ -541,7 +531,24 @@ def _render_geometries(
             patches, facecolor="#3388ff", edgecolor="#2266cc", alpha=0.6, linewidth=0.5
         )
         ax.add_collection(pc)
+
+    # Set axis limits from bounds (required before adding basemap)
+    if bounds is not None:
+        ax.set_xlim(bounds[0], bounds[2])
+        ax.set_ylim(bounds[1], bounds[3])
+    else:
         ax.autoscale()
+
+    # Add basemap AFTER data (contextily needs axes extent for zoom calculation)
+    if bounds is not None and config.basemap_provider != "none":
+        add_basemap(
+            ax,
+            bounds,
+            config.basemap_provider,
+            config.basemap_opacity,
+            config.basemap_zoom_adjust,
+            crs="EPSG:4326",  # PMTiles are always WGS84
+        )
 
     plt.savefig(
         output_path,

--- a/tests/unit/test_thumbnail.py
+++ b/tests/unit/test_thumbnail.py
@@ -164,6 +164,88 @@ class TestGenerateThumbnailFromPmtiles:
 
 
 # =============================================================================
+# Regression Tests: Basemap Ordering (PR #468)
+# =============================================================================
+
+
+class TestBasemapOrdering:
+    """Regression tests for basemap rendering order.
+
+    Issue: contextily computes zoom level from current axis extent. If basemap
+    is added BEFORE axis limits are set, it uses wrong bounds and renders the
+    map in the wrong location.
+
+    Fix (PR #468): Plot data first, set axis limits, THEN add basemap.
+    """
+
+    @pytest.mark.unit
+    def test_render_geometries_sets_limits_before_basemap(self, tmp_path: Path) -> None:
+        """_render_geometries sets axis limits BEFORE calling add_basemap.
+
+        This is critical: contextily needs the axis extent to compute the
+        correct zoom level. If we add the basemap first, it uses default
+        limits and renders in the wrong location.
+        """
+        pytest.importorskip("matplotlib")
+
+        from portolan_cli.thumbnail import ThumbnailConfig, _render_geometries
+
+        output_path = tmp_path / "test.jpg"
+        bounds = (-122.5, 37.5, -122.0, 38.0)  # San Francisco area
+        geometries = [
+            {
+                "type": "Polygon",
+                "coordinates": [[[-122.4, 37.7], [-122.1, 37.7], [-122.1, 37.9], [-122.4, 37.7]]],
+            }
+        ]
+        config = ThumbnailConfig(basemap_provider="CartoDB.Positron")
+
+        # Track axis state when add_basemap is called
+        captured_xlim: tuple[float, float] | None = None
+        captured_ylim: tuple[float, float] | None = None
+
+        def capture_axis_state(
+            ax: MagicMock,
+            bounds: tuple[float, float, float, float],
+            *args: object,
+            **kwargs: object,
+        ) -> None:
+            nonlocal captured_xlim, captured_ylim
+            captured_xlim = ax.get_xlim()
+            captured_ylim = ax.get_ylim()
+
+        with patch("portolan_cli.thumbnail.add_basemap", side_effect=capture_axis_state):
+            _render_geometries(geometries, output_path, config, bounds=bounds)
+
+        # Verify axis limits were set BEFORE add_basemap was called
+        assert captured_xlim is not None, "add_basemap was never called"
+        assert captured_ylim is not None, "add_basemap was never called"
+
+        # Limits should match the bounds we passed
+        assert captured_xlim[0] == pytest.approx(bounds[0], abs=0.01)  # minx
+        assert captured_xlim[1] == pytest.approx(bounds[2], abs=0.01)  # maxx
+        assert captured_ylim[0] == pytest.approx(bounds[1], abs=0.01)  # miny
+        assert captured_ylim[1] == pytest.approx(bounds[3], abs=0.01)  # maxy
+
+    @pytest.mark.unit
+    def test_render_geometries_no_basemap_when_no_bounds(self, tmp_path: Path) -> None:
+        """_render_geometries skips basemap when bounds is None."""
+        pytest.importorskip("matplotlib")
+
+        from portolan_cli.thumbnail import ThumbnailConfig, _render_geometries
+
+        output_path = tmp_path / "test.jpg"
+        geometries = [{"type": "Point", "coordinates": [0, 0]}]
+        config = ThumbnailConfig(basemap_provider="CartoDB.Positron")
+
+        with patch("portolan_cli.thumbnail.add_basemap") as mock_basemap:
+            _render_geometries(geometries, output_path, config, bounds=None)
+
+            # add_basemap should NOT be called when bounds is None
+            mock_basemap.assert_not_called()
+
+
+# =============================================================================
 # Phase 3: GeoParquet Thumbnail Generation Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Fixed PMTiles thumbnail rendering showing data in wrong location
- The fix from commit 3ba78de was only applied to the GeoParquet path
- PMTiles path was adding basemap before plotting data, causing contextily to compute incorrect zoom levels

## Changes
- Plot data first, set axis limits from bounds, then add basemap (matching GeoParquet path)

## Test plan
- [x] Regenerated thumbnails for pergamino-ide catalog
- [x] Verified thumbnails now show data correctly centered

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved basemap rendering accuracy for thumbnail maps by adjusting the rendering sequence and ensuring correct zoom level calculations based on geometry extents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->