### PR TITLE
test(spec): add spec compliance tests for CLI output validation

### DIFF
--- a/tests/spec_compliance/conftest.py
+++ b/tests/spec_compliance/conftest.py
@@ -1,0 +1,381 @@
+"""Fixtures for spec compliance tests.
+
+These tests validate CLI output against the machine-readable schemas from
+portolan-spec (https://github.com/portolan-sdi/portolan-spec/issues/23).
+
+The schemas are vendored in tests/spec_compliance/schemas/ for reproducibility.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+# =============================================================================
+# Schema Loading Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="session")
+def schemas_dir() -> Path:
+    """Return path to vendored schemas directory."""
+    return Path(__file__).parent / "schemas"
+
+
+@pytest.fixture(scope="session")
+def versions_schema(schemas_dir: Path) -> dict[str, Any]:
+    """Load the collection-level versions.json schema.
+
+    This schema is for collection-level versions.json (with version history).
+    It is self-contained and doesn't require external references.
+    """
+    schema_path = schemas_dir / "versions.schema.json"
+    return json.loads(schema_path.read_text())
+
+
+@pytest.fixture(scope="session")
+def catalog_versions_schema(schemas_dir: Path) -> dict[str, Any]:
+    """Load the catalog-level versions.json schema.
+
+    This schema is for root-level versions.json (collection index).
+    Different structure from collection-level versions.json.
+    """
+    schema_path = schemas_dir / "catalog-versions.schema.json"
+    return json.loads(schema_path.read_text())
+
+
+@pytest.fixture(scope="session")
+def collection_schema(schemas_dir: Path) -> dict[str, Any]:
+    """Load the collection.json schema.
+
+    Note: This schema references the external STAC collection schema.
+    For compliance testing, we validate against the Portolan extensions only.
+    """
+    schema_path = schemas_dir / "collection.schema.json"
+    return json.loads(schema_path.read_text())
+
+
+@pytest.fixture(scope="session")
+def catalog_schema(schemas_dir: Path) -> dict[str, Any]:
+    """Load the catalog.json schema.
+
+    Note: This schema references the external STAC catalog schema.
+    For compliance testing, we validate against the Portolan extensions only.
+    """
+    schema_path = schemas_dir / "catalog.schema.json"
+    return json.loads(schema_path.read_text())
+
+
+@pytest.fixture(scope="session")
+def validation_rules(schemas_dir: Path) -> list[dict[str, Any]]:
+    """Load semantic validation rules from rules.yaml.
+
+    These rules cannot be expressed in JSON Schema and require
+    programmatic validation (e.g., path consistency, uniqueness).
+    """
+    rules_path = schemas_dir / "rules.yaml"
+    data = yaml.safe_load(rules_path.read_text())
+    return data.get("rules", [])
+
+
+# =============================================================================
+# Portolan-Only Schema Fixtures (without external STAC refs)
+# =============================================================================
+
+
+@pytest.fixture(scope="session")
+def portolan_collection_schema() -> dict[str, Any]:
+    """Portolan-specific collection schema without external STAC reference.
+
+    This validates only the Portolan extensions, not the base STAC schema.
+    Useful for compliance testing where we can't resolve external $refs.
+    """
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["type", "stac_version", "id", "description", "license", "extent", "links"],
+        "properties": {
+            "type": {"const": "Collection"},
+            "stac_version": {
+                "type": "string",
+                "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+            },
+            "id": {"type": "string", "minLength": 1},
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "license": {"type": "string"},
+            "extent": {
+                "type": "object",
+                "required": ["spatial", "temporal"],
+                "properties": {
+                    "spatial": {
+                        "type": "object",
+                        "required": ["bbox"],
+                        "properties": {
+                            "bbox": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {"type": "number"},
+                                },
+                            }
+                        },
+                    },
+                    "temporal": {
+                        "type": "object",
+                        "required": ["interval"],
+                        "properties": {
+                            "interval": {
+                                "type": "array",
+                                "items": {
+                                    "type": "array",
+                                    "items": {"type": ["string", "null"]},
+                                },
+                            }
+                        },
+                    },
+                },
+            },
+            "links": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["rel", "href"],
+                    "properties": {
+                        "rel": {"type": "string"},
+                        "href": {"type": "string", "minLength": 1},
+                        "type": {"type": "string"},
+                        "title": {"type": "string"},
+                    },
+                },
+            },
+            "assets": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "required": ["href"],
+                    "properties": {
+                        "href": {"type": "string", "minLength": 1},
+                        "type": {"type": "string"},
+                        "title": {"type": "string"},
+                        "description": {"type": "string"},
+                        "roles": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                },
+            },
+            "stac_extensions": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+            "summaries": {"type": "object"},
+            "providers": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": {"type": "string"},
+                        "roles": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "url": {"type": "string"},
+                        "description": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="session")
+def portolan_catalog_schema() -> dict[str, Any]:
+    """Portolan-specific catalog schema without external STAC reference.
+
+    This validates only the Portolan extensions, not the base STAC schema.
+    """
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "required": ["type", "stac_version", "id", "description", "links"],
+        "properties": {
+            "type": {"const": "Catalog"},
+            "stac_version": {
+                "type": "string",
+                "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+            },
+            "id": {"type": "string", "minLength": 1},
+            "title": {"type": "string"},
+            "description": {"type": "string"},
+            "links": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["rel", "href"],
+                    "properties": {
+                        "rel": {"type": "string"},
+                        "href": {"type": "string", "minLength": 1},
+                        "type": {"type": "string"},
+                        "title": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+# =============================================================================
+# Schema Validation Helpers
+# =============================================================================
+
+
+@pytest.fixture(scope="session")
+def validate_versions() -> Callable[[dict[str, Any], dict[str, Any]], list[str]]:
+    """Return a validation function for versions.json.
+
+    Returns a list of validation error messages (empty if valid).
+    """
+    from jsonschema import Draft202012Validator
+
+    def _validate(data: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+        validator = Draft202012Validator(schema)
+        errors = list(validator.iter_errors(data))
+        return [f"{e.json_path}: {e.message}" for e in errors]
+
+    return _validate
+
+
+@pytest.fixture(scope="session")
+def validate_stac() -> Callable[[dict[str, Any], dict[str, Any]], list[str]]:
+    """Return a validation function for STAC documents (catalog/collection).
+
+    Returns a list of validation error messages (empty if valid).
+    """
+    from jsonschema import Draft202012Validator
+
+    def _validate(data: dict[str, Any], schema: dict[str, Any]) -> list[str]:
+        validator = Draft202012Validator(schema)
+        errors = list(validator.iter_errors(data))
+        return [f"{e.json_path}: {e.message}" for e in errors]
+
+    return _validate
+
+
+# =============================================================================
+# Semantic Rule Validators (from rules.yaml)
+# =============================================================================
+
+
+@pytest.fixture(scope="session")
+def validate_rule_0012() -> Callable[[dict[str, Any]], list[str]]:
+    """RULE-0012: current_version MUST match the last entry in versions array."""
+
+    def _validate(versions_data: dict[str, Any]) -> list[str]:
+        errors: list[str] = []
+        current = versions_data.get("current_version")
+        versions = versions_data.get("versions", [])
+
+        if current is not None:
+            if not versions:
+                errors.append("RULE-0012: current_version is set but versions array is empty")
+            elif current != versions[-1].get("version"):
+                errors.append(
+                    f"RULE-0012: current_version '{current}' does not match "
+                    f"last version '{versions[-1].get('version')}'"
+                )
+        elif versions:
+            errors.append("RULE-0012: current_version is null but versions array is not empty")
+
+        return errors
+
+    return _validate
+
+
+@pytest.fixture(scope="session")
+def validate_rule_0013() -> Callable[[dict[str, Any]], list[str]]:
+    """RULE-0013: changes array MUST only reference keys that exist in assets."""
+
+    def _validate(versions_data: dict[str, Any]) -> list[str]:
+        errors: list[str] = []
+
+        for i, version in enumerate(versions_data.get("versions", [])):
+            assets = set(version.get("assets", {}).keys())
+            changes = version.get("changes", [])
+
+            for change in changes:
+                if change not in assets:
+                    errors.append(
+                        f"RULE-0013: version[{i}].changes references '{change}' "
+                        f"which is not in assets"
+                    )
+
+        return errors
+
+    return _validate
+
+
+@pytest.fixture(scope="session")
+def validate_rule_0014() -> Callable[[dict[str, Any]], list[str]]:
+    """RULE-0014: Version strings MUST be unique within versions array."""
+
+    def _validate(versions_data: dict[str, Any]) -> list[str]:
+        errors: list[str] = []
+        versions = versions_data.get("versions", [])
+        version_strings = [v.get("version") for v in versions]
+
+        if len(version_strings) != len(set(version_strings)):
+            seen: set[str] = set()
+            duplicates: set[str] = set()
+            for v in version_strings:
+                if v in seen:
+                    duplicates.add(v)
+                seen.add(v)
+            errors.append(f"RULE-0014: Duplicate version strings: {duplicates}")
+
+        return errors
+
+    return _validate
+
+
+@pytest.fixture(scope="session")
+def validate_rule_0040() -> Callable[[dict[str, Any]], list[str]]:
+    """RULE-0040: Catalog MUST use SELF_CONTAINED type (relative links)."""
+    import re
+
+    def _validate(catalog_data: dict[str, Any]) -> list[str]:
+        errors: list[str] = []
+
+        for link in catalog_data.get("links", []):
+            rel = link.get("rel", "")
+            href = link.get("href", "")
+
+            # Only check structural links
+            if rel not in ("root", "self", "parent", "child"):
+                continue
+
+            # Check for absolute paths
+            if href.startswith("/"):
+                errors.append(f"RULE-0040: Link rel='{rel}' has Unix absolute path: {href}")
+            elif href.startswith("file://"):
+                errors.append(f"RULE-0040: Link rel='{rel}' has file:// URL: {href}")
+            elif re.match(r"^[A-Za-z]:", href):
+                errors.append(f"RULE-0040: Link rel='{rel}' has Windows absolute path: {href}")
+            elif href.startswith("\\\\"):
+                errors.append(f"RULE-0040: Link rel='{rel}' has Windows UNC path: {href}")
+            elif re.match(r"^[a-zA-Z][a-zA-Z0-9+.-]*://", href):
+                errors.append(f"RULE-0040: Link rel='{rel}' has URI scheme: {href}")
+
+        return errors
+
+    return _validate

--- a/tests/spec_compliance/conftest.py
+++ b/tests/spec_compliance/conftest.py
@@ -14,9 +14,21 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 import yaml
+from click.testing import CliRunner
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+
+# =============================================================================
+# Shared Test Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a Click test runner (shared across all spec compliance tests)."""
+    return CliRunner()
 
 
 # =============================================================================
@@ -38,7 +50,8 @@ def versions_schema(schemas_dir: Path) -> dict[str, Any]:
     It is self-contained and doesn't require external references.
     """
     schema_path = schemas_dir / "versions.schema.json"
-    return json.loads(schema_path.read_text())
+    result: dict[str, Any] = json.loads(schema_path.read_text())
+    return result
 
 
 @pytest.fixture(scope="session")
@@ -49,29 +62,8 @@ def catalog_versions_schema(schemas_dir: Path) -> dict[str, Any]:
     Different structure from collection-level versions.json.
     """
     schema_path = schemas_dir / "catalog-versions.schema.json"
-    return json.loads(schema_path.read_text())
-
-
-@pytest.fixture(scope="session")
-def collection_schema(schemas_dir: Path) -> dict[str, Any]:
-    """Load the collection.json schema.
-
-    Note: This schema references the external STAC collection schema.
-    For compliance testing, we validate against the Portolan extensions only.
-    """
-    schema_path = schemas_dir / "collection.schema.json"
-    return json.loads(schema_path.read_text())
-
-
-@pytest.fixture(scope="session")
-def catalog_schema(schemas_dir: Path) -> dict[str, Any]:
-    """Load the catalog.json schema.
-
-    Note: This schema references the external STAC catalog schema.
-    For compliance testing, we validate against the Portolan extensions only.
-    """
-    schema_path = schemas_dir / "catalog.schema.json"
-    return json.loads(schema_path.read_text())
+    result: dict[str, Any] = json.loads(schema_path.read_text())
+    return result
 
 
 @pytest.fixture(scope="session")
@@ -82,8 +74,9 @@ def validation_rules(schemas_dir: Path) -> list[dict[str, Any]]:
     programmatic validation (e.g., path consistency, uniqueness).
     """
     rules_path = schemas_dir / "rules.yaml"
-    data = yaml.safe_load(rules_path.read_text())
-    return data.get("rules", [])
+    data: dict[str, Any] = yaml.safe_load(rules_path.read_text())
+    result: list[dict[str, Any]] = data.get("rules", [])
+    return result
 
 
 # =============================================================================

--- a/tests/spec_compliance/schemas/README.md
+++ b/tests/spec_compliance/schemas/README.md
@@ -1,0 +1,57 @@
+# Portolan Spec Schemas (Vendored)
+
+This directory contains vendored copies of the machine-readable schemas from
+[portolan-spec](https://github.com/portolan-sdi/portolan-spec).
+
+## Source
+
+These schemas were created as part of [Issue #23](https://github.com/portolan-sdi/portolan-spec/issues/23)
+and merged in [PR #24](https://github.com/portolan-sdi/portolan-spec/pull/24).
+
+Original location: `https://github.com/portolan-sdi/portolan-spec/tree/main/schema`
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `versions.schema.json` | JSON Schema for `versions.json` manifest |
+| `collection.schema.json` | JSON Schema for STAC Collections with Portolan extensions |
+| `catalog.schema.json` | JSON Schema for STAC Catalogs with Portolan extensions |
+| `rules.yaml` | Semantic validation rules (cannot be expressed in JSON Schema) |
+
+## Why Vendor?
+
+Vendoring provides:
+
+1. **Reproducibility** - Tests work without network access
+2. **Stability** - Schema changes don't break CI unexpectedly
+3. **Speed** - No HTTP fetching during test runs
+
+## Updating
+
+To update these schemas from upstream:
+
+```bash
+cd tests/spec_compliance/schemas
+
+# Fetch latest schemas
+for f in versions.schema.json collection.schema.json catalog.schema.json rules.yaml; do
+  gh api repos/portolan-sdi/portolan-spec/contents/schema/$f \
+    --jq '.content' | base64 -d > $f
+done
+```
+
+Then run the compliance tests to verify the CLI still conforms:
+
+```bash
+uv run pytest tests/spec_compliance/ -v
+```
+
+## Schema Notes
+
+The collection and catalog schemas reference external STAC schemas:
+- `https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json`
+- `https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json`
+
+For compliance testing, we use "Portolan-only" schemas (defined in `conftest.py`)
+that validate Portolan-specific requirements without requiring external $ref resolution.

--- a/tests/spec_compliance/schemas/catalog-versions.schema.json
+++ b/tests/spec_compliance/schemas/catalog-versions.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/catalog-versions.schema.json",
+  "title": "Portolan Catalog Versions Index",
+  "description": "Schema for the root-level versions.json that indexes collection sync state. Different from collection-level versions.json.",
+  "type": "object",
+  "required": ["schema_version", "catalog_id", "created", "collections"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version for this format",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
+      "examples": ["1.0.0"]
+    },
+    "catalog_id": {
+      "type": "string",
+      "description": "Catalog identifier (matches catalog.json id)",
+      "minLength": 1
+    },
+    "created": {
+      "type": "string",
+      "description": "ISO 8601 timestamp when catalog was initialized",
+      "format": "date-time"
+    },
+    "collections": {
+      "type": "object",
+      "description": "Map of collection IDs to their sync state",
+      "additionalProperties": {
+        "type": "object",
+        "description": "Collection sync state",
+        "properties": {
+          "current_version": {
+            "type": ["string", "null"],
+            "description": "Current version of this collection"
+          },
+          "synced_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this collection was last synced"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/spec_compliance/schemas/catalog.schema.json
+++ b/tests/spec_compliance/schemas/catalog.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/catalog.schema.json",
+  "title": "Portolan STAC Catalog",
+  "description": "Schema for Portolan-compliant STAC Catalogs. Extends the STAC Catalog schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
+  "allOf": [
+    {
+      "$ref": "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+    },
+    {
+      "$ref": "#/$defs/PortolanCatalogExtensions"
+    }
+  ],
+  "$defs": {
+    "PortolanCatalogExtensions": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Catalog"
+        },
+        "stac_version": {
+          "type": "string",
+          "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+          "description": "STAC version MUST be 1.x.x format (e.g., 1.0.0, 1.1.0)"
+        },
+        "id": {
+          "type": "string",
+          "description": "Catalog identifier. Defaults to 'portolan-catalog' if not specified.",
+          "default": "portolan-catalog"
+        },
+        "links": {
+          "type": "array",
+          "description": "Catalog links. MUST use relative paths (SELF_CONTAINED catalog type).",
+          "items": {
+            "$ref": "#/$defs/CatalogLink"
+          }
+        }
+      }
+    },
+    "CatalogLink": {
+      "type": "object",
+      "description": "STAC Link with Portolan requirements for SELF_CONTAINED catalogs",
+      "required": ["rel", "href"],
+      "properties": {
+        "rel": {
+          "type": "string",
+          "description": "Link relation type",
+          "examples": ["root", "self", "child", "parent", "item"]
+        },
+        "href": {
+          "type": "string",
+          "description": "Link target. SHOULD be relative path for portability (SELF_CONTAINED requirement).",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "Media type of the linked resource",
+          "examples": ["application/json", "application/geo+json"]
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "rel": {
+                "enum": ["root", "self", "parent", "child"]
+              }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "properties": {
+              "href": {
+                "description": "For structural links (root, self, parent, child), href MUST be a relative path for portability",
+                "not": {
+                  "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://"
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/spec_compliance/schemas/collection.schema.json
+++ b/tests/spec_compliance/schemas/collection.schema.json
@@ -96,6 +96,17 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "version-history" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "$ref": "#/$defs/VersionHistoryLink"
+          }
         }
       ]
     },

--- a/tests/spec_compliance/schemas/collection.schema.json
+++ b/tests/spec_compliance/schemas/collection.schema.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/collection.schema.json",
+  "title": "Portolan STAC Collection",
+  "description": "Schema for Portolan-compliant STAC Collections. Extends the STAC Collection schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
+  "allOf": [
+    {
+      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json"
+    },
+    {
+      "$ref": "#/$defs/PortolanCollectionExtensions"
+    }
+  ],
+  "$defs": {
+    "PortolanCollectionExtensions": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "Collection"
+        },
+        "stac_version": {
+          "type": "string",
+          "pattern": "^1\\.[0-9]+\\.[0-9]+$",
+          "description": "STAC version MUST be 1.x.x format (e.g., 1.0.0, 1.1.0)"
+        },
+        "links": {
+          "type": "array",
+          "description": "Collection links with Portolan requirements. SHOULD include version-history link (see RULE-0070 in rules.yaml).",
+          "items": {
+            "$ref": "#/$defs/CollectionLink"
+          }
+        },
+        "assets": {
+          "type": "object",
+          "description": "Collection-level assets. Required for single-file collections.",
+          "additionalProperties": {
+            "$ref": "#/$defs/PortolanAsset"
+          }
+        },
+        "providers": {
+          "type": "array",
+          "description": "STAC-standard providers array (SHOULD be present)",
+          "items": {
+            "$ref": "#/$defs/Provider"
+          }
+        }
+      }
+    },
+    "CollectionLink": {
+      "type": "object",
+      "required": ["rel", "href"],
+      "properties": {
+        "rel": {
+          "type": "string",
+          "description": "Link relation type"
+        },
+        "href": {
+          "type": "string",
+          "description": "Link target. SHOULD be relative for root/self/child/parent relations."
+        },
+        "type": {
+          "type": "string",
+          "description": "Media type of the linked resource"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "via" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "Source provenance link - MUST be present when data is extracted from an external canonical source",
+            "required": ["rel", "href"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "pmtiles" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "PMTiles link per web-map-links STAC extension - MUST be present when PMTiles are provided",
+            "required": ["type"],
+            "properties": {
+              "type": {
+                "const": "application/vnd.pmtiles"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "VersionHistoryLink": {
+      "type": "object",
+      "description": "Link to versions.json - SHOULD be present",
+      "properties": {
+        "rel": {
+          "const": "version-history"
+        },
+        "href": {
+          "type": "string",
+          "pattern": "(^|/)versions\\.json$"
+        },
+        "type": {
+          "const": "application/json"
+        }
+      },
+      "required": ["rel", "href"]
+    },
+    "PortolanAsset": {
+      "type": "object",
+      "description": "STAC Asset with Portolan requirements",
+      "required": ["href"],
+      "properties": {
+        "href": {
+          "type": "string",
+          "description": "Asset URL. In published catalogs, MUST be an absolute S3 URL. In local catalogs, may be relative.",
+          "minLength": 1
+        },
+        "type": {
+          "type": "string",
+          "description": "Media type of the asset",
+          "examples": [
+            "application/vnd.apache.parquet",
+            "application/vnd.pmtiles",
+            "image/tiff; application=geotiff; profile=cloud-optimized",
+            "application/geo+json"
+          ]
+        },
+        "roles": {
+          "type": "array",
+          "description": "Asset roles",
+          "items": {
+            "type": "string"
+          },
+          "examples": [["data"], ["visual"], ["thumbnail"]]
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title"
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of the asset"
+        }
+      }
+    },
+    "Provider": {
+      "type": "object",
+      "description": "STAC Provider information",
+      "required": ["name"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Organization name"
+        },
+        "roles": {
+          "type": "array",
+          "description": "Provider roles",
+          "items": {
+            "type": "string",
+            "enum": ["licensor", "producer", "processor", "host"]
+          }
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Organization URL"
+        },
+        "description": {
+          "type": "string",
+          "description": "Provider description"
+        }
+      }
+    }
+  }
+}

--- a/tests/spec_compliance/schemas/rules.yaml
+++ b/tests/spec_compliance/schemas/rules.yaml
@@ -1,0 +1,350 @@
+# Portolan Validation Rules
+#
+# Rules that cannot be expressed in JSON Schema but are normative requirements.
+# These rules are intended for programmatic validation in the CLI and registry.
+#
+# Rule structure:
+#   id: Unique identifier (RULE-XXXX)
+#   level: error | warning
+#   scope: Where the rule applies (catalog, collection, item, asset, versions)
+#   description: Human-readable description
+#   rationale: Why this rule exists
+#   validation: How to validate (pseudo-code or description)
+#   references: Links to spec documentation
+
+rules:
+  # =============================================================================
+  # Asset URL Rules
+  # =============================================================================
+
+  - id: RULE-0001
+    level: error
+    scope: asset
+    description: Asset hrefs in published catalogs MUST be absolute HTTPS URLs to S3-compatible storage
+    rationale: |
+      Portolan catalogs are designed for S3-compatible object storage.
+      Absolute URLs ensure assets can be fetched without ambiguity.
+    validation: |
+      For each asset.href in collection.json or item.json:
+        if catalog.is_published:
+          assert href.startswith("https://")
+          # Accepted providers (non-exhaustive):
+          # - AWS S3: *.s3.amazonaws.com, *.s3.*.amazonaws.com
+          # - DigitalOcean Spaces: *.digitaloceanspaces.com
+          # - Cloudflare R2: *.r2.cloudflarestorage.com
+          # - Backblaze B2: *.backblazeb2.com
+          # - Wasabi: *.wasabisys.com
+          # - MinIO: any hostname (custom deployments)
+    references:
+      - core.md#asset-urls
+
+  - id: RULE-0002
+    level: warning
+    scope: asset
+    description: Asset hrefs in local catalogs SHOULD be relative paths
+    rationale: |
+      Relative paths keep local catalogs portable before publishing.
+    validation: |
+      For each asset.href in collection.json or item.json:
+        if not catalog.is_published:
+          warn if href.startswith("https://")
+    references:
+      - core.md#asset-urls
+
+  # =============================================================================
+  # versions.json Path Rules
+  # =============================================================================
+
+  - id: RULE-0010
+    level: error
+    scope: versions
+    description: Asset keys in versions.json MUST be collection-relative
+    rationale: |
+      Asset keys are scoped relative to the collection directory.
+      The collection directory name MUST NOT appear in the asset key.
+    validation: |
+      For each asset_key in version.assets:
+        assert not asset_key.startswith(collection_id + "/")
+    references:
+      - versions.md#path-resolution
+    examples:
+      valid:
+        - "tunnels.parquet"  # Single-file collection
+        - "districts/districts.parquet"  # Item within collection
+      invalid:
+        - "tunnels/tunnels.parquet"  # Duplicates collection directory
+
+  - id: RULE-0011
+    level: error
+    scope: versions
+    description: Asset hrefs in versions.json MUST be catalog-root-relative
+    rationale: |
+      hrefs enable tools to resolve files via `catalog_root / href`.
+      They must include the collection directory.
+    validation: |
+      For each asset in version.assets:
+        assert asset.href.startswith(collection_id + "/")
+    references:
+      - versions.md#path-resolution
+    examples:
+      valid:
+        - "tunnels/tunnels.parquet"
+        - "boundaries/districts/districts.parquet"
+
+  - id: RULE-0012
+    level: error
+    scope: versions
+    description: current_version MUST match the last entry in versions array
+    rationale: |
+      current_version is a convenience field that MUST be consistent with
+      the versions array. Inconsistency causes sync failures and confuses tooling.
+    validation: |
+      if current_version is not null:
+        assert versions is not empty
+        assert current_version == versions[-1].version
+      else:
+        assert versions is empty
+    references:
+      - versions.md#current-version
+
+  - id: RULE-0013
+    level: error
+    scope: versions
+    description: changes array MUST only reference keys that exist in assets
+    rationale: |
+      The changes array documents which assets changed in a version.
+      Referencing non-existent keys indicates data corruption or typos.
+    validation: |
+      For each version in versions:
+        for change_key in version.changes:
+          assert change_key in version.assets
+
+  - id: RULE-0014
+    level: error
+    scope: versions
+    description: Version strings MUST be unique within versions array
+    rationale: |
+      Each version represents a distinct point in time. Duplicate version
+      strings make history ambiguous and break rollback functionality.
+    validation: |
+      version_strings = [v.version for v in versions]
+      assert len(version_strings) == len(set(version_strings))
+
+  - id: RULE-0015
+    level: warning
+    scope: versions
+    description: Versions SHOULD be ordered chronologically (oldest first)
+    rationale: |
+      The spec defines versions array as "oldest first" for consistent tooling.
+      Out-of-order versions may cause incorrect diff calculations.
+    validation: |
+      timestamps = [parse_iso8601(v.created) for v in versions]
+      assert timestamps == sorted(timestamps)
+
+  # =============================================================================
+  # Collection ID Rules
+  # =============================================================================
+
+  - id: RULE-0020
+    level: warning
+    scope: collection
+    description: Collection IDs SHOULD follow naming conventions
+    rationale: |
+      Consistent naming improves discoverability and avoids filesystem issues.
+    validation: |
+      assert collection_id matches /^[a-z][a-z0-9_-]*$/
+    references:
+      - structure.md#collection-level
+    note: |
+      The CLI does not currently enforce these naming conventions.
+      Validation may be added in a future release.
+
+  # =============================================================================
+  # Content Inspection Rules
+  # =============================================================================
+
+  - id: RULE-0030
+    level: error
+    scope: asset
+    description: GeoParquet files MUST contain geo metadata
+    rationale: |
+      A .parquet file without GeoParquet metadata is just a Parquet file.
+      Content inspection ensures we don't import non-geospatial data.
+    validation: |
+      For each .parquet file:
+        metadata = read_parquet_metadata(file)
+        assert "geo" in metadata.schema.metadata
+    references:
+      - extensions.md#content-inspection
+
+  - id: RULE-0031
+    level: error
+    scope: asset
+    description: COG files MUST have internal tiling and overviews
+    rationale: |
+      Cloud-Optimized GeoTIFF requires internal structure for range-request access.
+    validation: |
+      For each .tif/.tiff file:
+        assert is_valid_cog(file)  # Use rio-cogeo or similar
+    references:
+      - extensions.md#content-inspection
+      - formats/raster.md
+
+  - id: RULE-0032
+    level: warning
+    scope: asset
+    description: Non-cloud-native formats SHOULD be converted
+    rationale: |
+      GeoJSON, Shapefile, GeoPackage work but cloud-native formats
+      (GeoParquet, COG) are preferred for performance.
+    validation: |
+      For each file with extension in [.geojson, .shp, .gpkg, .json]:
+        warn "Consider converting to GeoParquet"
+    references:
+      - extensions.md#non-cloud-native-format-handling
+
+  # =============================================================================
+  # Structural Rules
+  # =============================================================================
+
+  - id: RULE-0040
+    level: error
+    scope: catalog
+    description: Catalog MUST use SELF_CONTAINED type (relative links)
+    rationale: |
+      SELF_CONTAINED catalogs are portable across hosting locations.
+      No absolute filesystem paths should leak into metadata.
+    validation: |
+      For each link in catalog.json with rel in [root, self, parent, child]:
+        # Unix absolute paths
+        assert not link.href.startswith("/")
+        # file:// URLs
+        assert not link.href.startswith("file://")
+        # Windows absolute paths (C:\, D:\, etc.)
+        assert not re.match(r'^[A-Za-z]:', link.href)
+        # Windows UNC paths (\\server\share)
+        assert not link.href.startswith("\\\\")
+        # Any URI scheme (http://, ftp://, s3://, etc.)
+        assert not re.match(r'^[a-zA-Z][a-zA-Z0-9+.-]*://', link.href)
+    references:
+      - structure.md#stac-conventions
+      - core.md#link-paths
+
+  - id: RULE-0041
+    level: error
+    scope: catalog
+    description: Catalog MUST have flat hierarchy (no nested sub-collections)
+    rationale: |
+      Flat hierarchy simplifies tooling and versioning boundaries.
+    validation: |
+      For each collection in catalog:
+        assert collection has no child collections
+        # Collections contain items directly
+    references:
+      - structure.md#flat-hierarchy
+
+  - id: RULE-0042
+    level: error
+    scope: collection
+    description: Single-file datasets MUST be collection-level assets
+    rationale: |
+      Item indirection adds no value for single-file datasets.
+    validation: |
+      If collection contains exactly one data file:
+        assert file is in collection.assets, not wrapped in item
+    references:
+      - structure.md#single-file-collections
+      - formats/vector.md#collection-level-assets
+
+  # =============================================================================
+  # Required Files Rules
+  # =============================================================================
+
+  - id: RULE-0050
+    level: error
+    scope: catalog
+    description: Catalog root MUST contain required files
+    rationale: |
+      Standard structure enables tooling interoperability.
+    validation: |
+      assert exists(catalog_root / ".portolan/config.yaml")
+      assert exists(catalog_root / "catalog.json")
+      assert exists(catalog_root / "versions.json")
+    references:
+      - structure.md#root-level
+
+  - id: RULE-0051
+    level: error
+    scope: collection
+    description: Each collection MUST contain required files
+    rationale: |
+      Collections need metadata and version tracking.
+    validation: |
+      For each collection directory:
+        assert exists(collection_dir / "collection.json")
+        assert exists(collection_dir / "versions.json")
+    references:
+      - structure.md#collection-level
+
+  - id: RULE-0052
+    level: warning
+    scope: catalog
+    description: Catalog root SHOULD contain README.md
+    rationale: |
+      Documentation helps users understand the catalog contents.
+    validation: |
+      warn if not exists(catalog_root / "README.md")
+    references:
+      - core.md#root-documentation
+
+  # =============================================================================
+  # PMTiles Rules
+  # =============================================================================
+
+  - id: RULE-0060
+    level: error
+    scope: collection
+    description: PMTiles MUST be collection-level assets when provided
+    rationale: |
+      Visualization derivatives should be discoverable at collection level
+      without navigating into items.
+    validation: |
+      If any .pmtiles file exists:
+        assert "pmtiles" in collection.assets or
+               any asset has role "visual" with .pmtiles href
+    references:
+      - formats/vector.md#recommended-formats
+
+  - id: RULE-0061
+    level: error
+    scope: collection
+    description: PMTiles MUST have rel="pmtiles" link when provided
+    rationale: |
+      Follows web-map-links STAC extension for discoverability.
+    validation: |
+      If collection has PMTiles asset:
+        assert any link has rel="pmtiles"
+    references:
+      - formats/vector.md#recommended-formats
+
+  # =============================================================================
+  # Version History Rules
+  # =============================================================================
+
+  - id: RULE-0070
+    level: warning
+    scope: collection
+    description: Collections SHOULD include a version-history link
+    rationale: |
+      The version-history link (rel="version-history") enables discovery of
+      the versions.json manifest. While not strictly required, it improves
+      STAC client compatibility and enables version-aware browsing.
+    validation: |
+      For each collection.json:
+        warn if no link has rel="version-history"
+        if link with rel="version-history" exists:
+          assert link.href ends with "versions.json"
+          assert link.type == "application/json"
+    references:
+      - core.md#version-history-link
+      - versions.md

--- a/tests/spec_compliance/schemas/versions.schema.json
+++ b/tests/spec_compliance/schemas/versions.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://portolan.dev/schema/versions.schema.json",
+  "title": "Portolan Versions Manifest",
+  "description": "Schema for versions.json - tracks version history, asset checksums, and sync state per collection. See https://github.com/portolan-sdi/portolan-spec/blob/main/versions.md",
+  "type": "object",
+  "required": ["spec_version", "current_version", "versions"],
+  "additionalProperties": false,
+  "properties": {
+    "spec_version": {
+      "type": "string",
+      "description": "Schema version for the versions.json format",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$",
+      "examples": ["1.0.0"]
+    },
+    "current_version": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "The latest version string (semantic versioning)",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        },
+        {
+          "type": "null",
+          "description": "Null if no versions exist yet"
+        }
+      ]
+    },
+    "versions": {
+      "type": "array",
+      "description": "List of version entries, oldest first",
+      "items": {
+        "$ref": "#/$defs/VersionEntry"
+      }
+    }
+  },
+  "$defs": {
+    "VersionEntry": {
+      "type": "object",
+      "description": "A single version entry in the version history",
+      "required": ["version", "created", "breaking", "assets", "changes"],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Semantic version string (e.g., '1.0.0', '1.0.0-beta', '1.0.0+build.123')",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+        },
+        "created": {
+          "type": "string",
+          "description": "ISO 8601 timestamp in UTC (must end with 'Z')",
+          "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$",
+          "examples": ["2024-01-15T10:30:00Z", "2024-01-15T10:30:00.123Z"]
+        },
+        "breaking": {
+          "type": "boolean",
+          "description": "True if this version has breaking changes (schema changes, column removals, CRS changes)"
+        },
+        "assets": {
+          "type": "object",
+          "description": "Map of asset keys to asset metadata. Keys are collection-relative paths.",
+          "additionalProperties": {
+            "$ref": "#/$defs/AssetEntry"
+          }
+        },
+        "changes": {
+          "type": "array",
+          "description": "List of asset keys that changed in this version (new or modified)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "schema": {
+          "$ref": "#/$defs/SchemaInfo",
+          "description": "Optional schema fingerprint for breaking change detection (ADR-0005)"
+        },
+        "message": {
+          "type": "string",
+          "description": "Optional human-readable description of the change"
+        }
+      }
+    },
+    "AssetEntry": {
+      "type": "object",
+      "description": "Metadata for a single asset (file) within a version",
+      "required": ["sha256", "size_bytes", "href"],
+      "additionalProperties": false,
+      "properties": {
+        "sha256": {
+          "type": "string",
+          "description": "SHA-256 checksum of the file content",
+          "pattern": "^[a-fA-F0-9]{64}$"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "description": "File size in bytes",
+          "minimum": 0
+        },
+        "href": {
+          "type": "string",
+          "description": "Catalog-root-relative path to the asset (e.g., 'boundaries/districts/districts.parquet')",
+          "minLength": 1
+        },
+        "source_path": {
+          "type": "string",
+          "description": "Optional relative path to the original source file (e.g., the GeoJSON that was converted to this GeoParquet)"
+        },
+        "source_mtime": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Optional Unix timestamp of the source file when conversion occurred. Used to detect when source has changed. NOTE: Accepts number (not just integer) because Python's os.stat().st_mtime returns floats."
+        },
+        "mtime": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Optional Unix timestamp of the asset file itself. Used for fast-path change detection (ADR-0017). NOTE: Accepts number (not just integer) because Python's os.stat().st_mtime returns floats. This relaxation should be upstreamed to portolan-spec."
+        }
+      }
+    },
+    "SchemaInfo": {
+      "type": "object",
+      "description": "Schema information for breaking change detection (ADR-0005)",
+      "required": ["type", "fingerprint"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Schema type identifier (e.g., 'geoparquet', 'cog')",
+          "examples": ["geoparquet", "cog"]
+        },
+        "fingerprint": {
+          "type": "object",
+          "description": "Type-specific schema fingerprint for change detection",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/tests/spec_compliance/test_catalog_schema.py
+++ b/tests/spec_compliance/test_catalog_schema.py
@@ -57,7 +57,8 @@ class TestCatalogSchemaCompliance:
     ) -> None:
         """catalog.json remains valid after adding a collection."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             # Copy to subdirectory (required by portolan add)
             collection_dir = Path("points")
@@ -104,7 +105,8 @@ class TestCatalogRequiredFields:
     ) -> None:
         """catalog.json type field MUST be 'Catalog'."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -123,7 +125,8 @@ class TestCatalogRequiredFields:
         import re
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -148,7 +151,8 @@ class TestCatalogLinks:
     ) -> None:
         """Each link MUST have rel and href."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -166,7 +170,8 @@ class TestCatalogLinks:
     ) -> None:
         """Catalog MUST have root and self links."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -187,7 +192,8 @@ class TestCatalogLinks:
     ) -> None:
         """RULE-0040: Structural links MUST be relative (SELF_CONTAINED)."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -204,7 +210,8 @@ class TestCatalogLinks:
     ) -> None:
         """After adding a collection, catalog MUST have child link to collection.json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
@@ -238,12 +245,14 @@ class TestCatalogLinks:
     ) -> None:
         """RULE-0040: No absolute paths should leak into catalog.json after add."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -283,7 +292,8 @@ class TestCatalogIdExtraction:
     ) -> None:
         """Catalog ID MUST be non-empty."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -304,7 +314,8 @@ class TestCatalogDescription:
     ) -> None:
         """Catalog MUST have a description."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
@@ -348,19 +359,22 @@ class TestCatalogMultipleCollections:
     ) -> None:
         """Catalog with multiple collections should have multiple child links."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             # Add first collection
             points_dir = Path("points")
             points_dir.mkdir()
             shutil.copy(valid_points_geojson, points_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(points_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(points_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add points failed: {result.output}"
 
             # Add second collection
             polygons_dir = Path("polygons")
             polygons_dir.mkdir()
             shutil.copy(valid_polygons_geojson, polygons_dir / "polygons.geojson")
-            runner.invoke(cli, ["add", str(polygons_dir / "polygons.geojson")])
+            result = runner.invoke(cli, ["add", str(polygons_dir / "polygons.geojson")])
+            assert result.exit_code == 0, f"add polygons failed: {result.output}"
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())

--- a/tests/spec_compliance/test_catalog_schema.py
+++ b/tests/spec_compliance/test_catalog_schema.py
@@ -25,11 +25,6 @@ if TYPE_CHECKING:
 class TestCatalogSchemaCompliance:
     """Test that catalog.json output complies with the spec schema."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_init_creates_valid_catalog_json(
         self,
@@ -81,11 +76,6 @@ class TestCatalogSchemaCompliance:
 
 class TestCatalogRequiredFields:
     """Test that catalog.json contains all required STAC fields."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_catalog_has_required_stac_fields(
@@ -149,11 +139,6 @@ class TestCatalogRequiredFields:
 
 class TestCatalogLinks:
     """Test that catalog links comply with SELF_CONTAINED requirements."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_links_have_required_fields(
@@ -270,11 +255,6 @@ class TestCatalogLinks:
 class TestCatalogIdExtraction:
     """Test that catalog ID is properly extracted from directory name."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_catalog_id_from_directory_name(
         self,
@@ -316,11 +296,6 @@ class TestCatalogIdExtraction:
 class TestCatalogDescription:
     """Test that catalog description is properly set."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_catalog_has_description(
         self,
@@ -360,11 +335,6 @@ class TestCatalogDescription:
 
 class TestCatalogMultipleCollections:
     """Test catalog behavior with multiple collections."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_multiple_child_links(

--- a/tests/spec_compliance/test_catalog_schema.py
+++ b/tests/spec_compliance/test_catalog_schema.py
@@ -1,0 +1,406 @@
+"""Spec compliance tests for catalog.json output.
+
+Validates that CLI-generated catalog.json files conform to the schema
+defined in portolan-spec/schema/catalog.schema.json.
+
+See: https://github.com/portolan-sdi/portolan-spec/issues/23
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestCatalogSchemaCompliance:
+    """Test that catalog.json output complies with the spec schema."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_init_creates_valid_catalog_json(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        portolan_catalog_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan init creates a schema-compliant catalog.json."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            catalog_path = Path("catalog.json")
+            assert catalog_path.exists(), "catalog.json not created"
+
+            data = json.loads(catalog_path.read_text())
+            errors = validate_stac(data, portolan_catalog_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_catalog_with_collection_is_valid(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        portolan_catalog_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """catalog.json remains valid after adding a collection."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            # Copy to subdirectory (required by portolan add)
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+            errors = validate_stac(data, portolan_catalog_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+
+class TestCatalogRequiredFields:
+    """Test that catalog.json contains all required STAC fields."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_catalog_has_required_stac_fields(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """catalog.json MUST have type, stac_version, id, description, links."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            required_fields = ["type", "stac_version", "id", "description", "links"]
+            missing = [f for f in required_fields if f not in data]
+
+            assert not missing, f"Missing required STAC fields: {missing}"
+
+    @pytest.mark.integration
+    def test_catalog_type_is_catalog(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """catalog.json type field MUST be 'Catalog'."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            assert data.get("type") == "Catalog", (
+                f"type should be 'Catalog', got: {data.get('type')}"
+            )
+
+    @pytest.mark.integration
+    def test_catalog_stac_version_format(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """stac_version MUST match pattern ^1\\.[0-9]+\\.[0-9]+$."""
+        import re
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            stac_version = data.get("stac_version")
+            pattern = re.compile(r"^1\.[0-9]+\.[0-9]+$")
+
+            assert stac_version is not None, "stac_version is missing"
+            assert pattern.match(stac_version), (
+                f"stac_version '{stac_version}' does not match pattern 1.x.x"
+            )
+
+
+class TestCatalogLinks:
+    """Test that catalog links comply with SELF_CONTAINED requirements."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_links_have_required_fields(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Each link MUST have rel and href."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            links = data.get("links", [])
+            for i, link in enumerate(links):
+                assert "rel" in link, f"Link {i} missing 'rel' field"
+                assert "href" in link, f"Link {i} missing 'href' field"
+
+    @pytest.mark.integration
+    def test_has_root_and_self_links(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Catalog MUST have root and self links."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            links = data.get("links", [])
+            rels = {link.get("rel") for link in links}
+
+            assert "root" in rels, "Catalog missing root link"
+            # self link is recommended but not strictly required
+            # assert "self" in rels, "Catalog missing self link"
+
+    @pytest.mark.integration
+    def test_rule_0040_structural_links_are_relative(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: Structural links MUST be relative (SELF_CONTAINED)."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            errors = validate_rule_0040(data)
+            assert not errors, "Rule validation failed:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_child_links_point_to_collections(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """After adding a collection, catalog MUST have child link to collection.json."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            links = data.get("links", [])
+            child_links = [link for link in links if link.get("rel") == "child"]
+
+            assert child_links, "Catalog missing child link after adding collection"
+
+            # Child links should point to collection.json
+            for link in child_links:
+                href = link.get("href", "")
+                assert href.endswith("collection.json"), (
+                    f"Child link should end with 'collection.json': {href}"
+                )
+
+    @pytest.mark.integration
+    def test_no_absolute_paths_leak_after_add(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: No absolute paths should leak into catalog.json after add."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            errors = validate_rule_0040(data)
+            assert not errors, "Rule validation failed:\n" + "\n".join(errors)
+
+
+class TestCatalogIdExtraction:
+    """Test that catalog ID is properly extracted from directory name."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_catalog_id_from_directory_name(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Catalog ID should be derived from the directory name."""
+        catalog_dir = tmp_path / "my-test-catalog"
+        catalog_dir.mkdir()
+
+        result = runner.invoke(cli, ["init", "--auto", str(catalog_dir)])
+        assert result.exit_code == 0, f"init failed: {result.output}"
+
+        catalog_path = catalog_dir / "catalog.json"
+        data = json.loads(catalog_path.read_text())
+
+        assert data.get("id") == "my-test-catalog", (
+            f"Catalog ID should be 'my-test-catalog', got: {data.get('id')}"
+        )
+
+    @pytest.mark.integration
+    def test_catalog_id_is_non_empty(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Catalog ID MUST be non-empty."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            catalog_id = data.get("id")
+            assert catalog_id is not None, "Catalog ID is missing"
+            assert catalog_id, "Catalog ID is empty"
+
+
+class TestCatalogDescription:
+    """Test that catalog description is properly set."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_catalog_has_description(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Catalog MUST have a description."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            description = data.get("description")
+            assert description is not None, "Catalog description is missing"
+            assert isinstance(description, str), "Catalog description must be a string"
+
+    @pytest.mark.integration
+    def test_custom_description_is_set(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        """Custom description should be set in catalog.json."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                cli,
+                ["init", "--auto", "--description", "My custom catalog description"],
+            )
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            assert data.get("description") == "My custom catalog description"
+
+
+class TestCatalogMultipleCollections:
+    """Test catalog behavior with multiple collections."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_multiple_child_links(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        valid_polygons_geojson: Path,
+        portolan_catalog_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """Catalog with multiple collections should have multiple child links."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            # Add first collection
+            points_dir = Path("points")
+            points_dir.mkdir()
+            shutil.copy(valid_points_geojson, points_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(points_dir / "points.geojson")])
+
+            # Add second collection
+            polygons_dir = Path("polygons")
+            polygons_dir.mkdir()
+            shutil.copy(valid_polygons_geojson, polygons_dir / "polygons.geojson")
+            runner.invoke(cli, ["add", str(polygons_dir / "polygons.geojson")])
+
+            catalog_path = Path("catalog.json")
+            data = json.loads(catalog_path.read_text())
+
+            # Validate schema
+            errors = validate_stac(data, portolan_catalog_schema)
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+            # Check for multiple child links
+            links = data.get("links", [])
+            child_links = [link for link in links if link.get("rel") == "child"]
+
+            assert len(child_links) >= 2, f"Expected at least 2 child links, got {len(child_links)}"

--- a/tests/spec_compliance/test_collection_schema.py
+++ b/tests/spec_compliance/test_collection_schema.py
@@ -25,11 +25,6 @@ if TYPE_CHECKING:
 class TestCollectionSchemaCompliance:
     """Test that collection.json output complies with the spec schema."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_add_geojson_creates_valid_collection_json(
         self,
@@ -99,11 +94,6 @@ class TestCollectionSchemaCompliance:
 
 class TestCollectionRequiredFields:
     """Test that collection.json contains all required STAC fields."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_collection_has_required_stac_fields(
@@ -195,11 +185,6 @@ class TestCollectionRequiredFields:
 class TestCollectionExtent:
     """Test that collection extent is properly formatted."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_extent_has_spatial_and_temporal(
         self,
@@ -273,11 +258,6 @@ class TestCollectionExtent:
 
 class TestCollectionLinks:
     """Test that collection links are properly formatted."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_links_have_required_fields(
@@ -368,11 +348,6 @@ class TestCollectionLinks:
 
 class TestCollectionAssets:
     """Test that collection assets are properly formatted."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_assets_have_required_href(

--- a/tests/spec_compliance/test_collection_schema.py
+++ b/tests/spec_compliance/test_collection_schema.py
@@ -104,7 +104,8 @@ class TestCollectionRequiredFields:
     ) -> None:
         """collection.json MUST have type, stac_version, id, description, license, extent, links."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
@@ -138,12 +139,14 @@ class TestCollectionRequiredFields:
     ) -> None:
         """collection.json type field MUST be 'Collection'."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -163,12 +166,14 @@ class TestCollectionRequiredFields:
         import re
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -194,12 +199,14 @@ class TestCollectionExtent:
     ) -> None:
         """extent MUST have spatial and temporal sub-objects."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -217,12 +224,14 @@ class TestCollectionExtent:
     ) -> None:
         """extent.spatial MUST have bbox array."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -241,12 +250,14 @@ class TestCollectionExtent:
     ) -> None:
         """extent.temporal MUST have interval array."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -268,12 +279,14 @@ class TestCollectionLinks:
     ) -> None:
         """Each link MUST have rel and href."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -292,12 +305,14 @@ class TestCollectionLinks:
     ) -> None:
         """Collection MUST have a root link to the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -318,12 +333,14 @@ class TestCollectionLinks:
         import re
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -358,12 +375,14 @@ class TestCollectionAssets:
     ) -> None:
         """Each asset MUST have an href field."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
             shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
-            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())
@@ -382,12 +401,14 @@ class TestCollectionAssets:
     ) -> None:
         """GeoParquet assets SHOULD have media type application/vnd.apache.parquet."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("buildings")
             collection_dir.mkdir()
             shutil.copy(valid_points_parquet, collection_dir / "buildings.parquet")
-            runner.invoke(cli, ["add", str(collection_dir / "buildings.parquet")])
+            result = runner.invoke(cli, ["add", str(collection_dir / "buildings.parquet")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
 
             collection_path = collection_dir / "collection.json"
             data = json.loads(collection_path.read_text())

--- a/tests/spec_compliance/test_collection_schema.py
+++ b/tests/spec_compliance/test_collection_schema.py
@@ -1,0 +1,438 @@
+"""Spec compliance tests for collection.json output.
+
+Validates that CLI-generated collection.json files conform to the schema
+defined in portolan-spec/schema/collection.schema.json.
+
+See: https://github.com/portolan-sdi/portolan-spec/issues/23
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestCollectionSchemaCompliance:
+    """Test that collection.json output complies with the spec schema."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_add_geojson_creates_valid_collection_json(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        portolan_collection_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan add creates a schema-compliant collection.json for GeoJSON."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # Initialize catalog
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            # Copy test fixture to a subdirectory (required by portolan add)
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            # Add the file
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Find collection.json
+            collection_path = collection_dir / "collection.json"
+            assert collection_path.exists(), f"collection.json not found at {collection_path}"
+
+            data = json.loads(collection_path.read_text())
+            errors = validate_stac(data, portolan_collection_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_add_geoparquet_creates_valid_collection_json(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+        portolan_collection_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan add creates a schema-compliant collection.json for GeoParquet."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # Initialize catalog
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            # Copy test fixture to a subdirectory
+            collection_dir = Path("buildings")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_parquet, collection_dir / "buildings.parquet")
+
+            # Add the file
+            result = runner.invoke(cli, ["add", str(collection_dir / "buildings.parquet")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Find collection.json
+            collection_path = collection_dir / "collection.json"
+            assert collection_path.exists(), "collection.json not found"
+
+            data = json.loads(collection_path.read_text())
+            errors = validate_stac(data, portolan_collection_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+
+class TestCollectionRequiredFields:
+    """Test that collection.json contains all required STAC fields."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_collection_has_required_stac_fields(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """collection.json MUST have type, stac_version, id, description, license, extent, links."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            required_fields = [
+                "type",
+                "stac_version",
+                "id",
+                "description",
+                "license",
+                "extent",
+                "links",
+            ]
+            missing = [f for f in required_fields if f not in data]
+
+            assert not missing, f"Missing required STAC fields: {missing}"
+
+    @pytest.mark.integration
+    def test_collection_type_is_collection(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """collection.json type field MUST be 'Collection'."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            assert data.get("type") == "Collection", (
+                f"type should be 'Collection', got: {data.get('type')}"
+            )
+
+    @pytest.mark.integration
+    def test_collection_stac_version_format(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """stac_version MUST match pattern ^1\\.[0-9]+\\.[0-9]+$."""
+        import re
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            stac_version = data.get("stac_version")
+            pattern = re.compile(r"^1\.[0-9]+\.[0-9]+$")
+
+            assert stac_version is not None, "stac_version is missing"
+            assert pattern.match(stac_version), (
+                f"stac_version '{stac_version}' does not match pattern 1.x.x"
+            )
+
+
+class TestCollectionExtent:
+    """Test that collection extent is properly formatted."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_extent_has_spatial_and_temporal(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """extent MUST have spatial and temporal sub-objects."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            extent = data.get("extent", {})
+            assert "spatial" in extent, "extent.spatial is missing"
+            assert "temporal" in extent, "extent.temporal is missing"
+
+    @pytest.mark.integration
+    def test_spatial_extent_has_bbox(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """extent.spatial MUST have bbox array."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            spatial = data.get("extent", {}).get("spatial", {})
+            assert "bbox" in spatial, "extent.spatial.bbox is missing"
+            assert isinstance(spatial["bbox"], list), "bbox must be an array"
+            assert len(spatial["bbox"]) > 0, "bbox must not be empty"
+
+    @pytest.mark.integration
+    def test_temporal_extent_has_interval(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """extent.temporal MUST have interval array."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            temporal = data.get("extent", {}).get("temporal", {})
+            assert "interval" in temporal, "extent.temporal.interval is missing"
+            assert isinstance(temporal["interval"], list), "interval must be an array"
+
+
+class TestCollectionLinks:
+    """Test that collection links are properly formatted."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_links_have_required_fields(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """Each link MUST have rel and href."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            links = data.get("links", [])
+            for i, link in enumerate(links):
+                assert "rel" in link, f"Link {i} missing 'rel' field"
+                assert "href" in link, f"Link {i} missing 'href' field"
+
+    @pytest.mark.integration
+    def test_has_root_link(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """Collection MUST have a root link to the catalog."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            links = data.get("links", [])
+            root_links = [link for link in links if link.get("rel") == "root"]
+
+            assert root_links, "Collection missing root link"
+
+    @pytest.mark.integration
+    def test_structural_links_are_relative(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """Root, self, parent links SHOULD be relative paths (SELF_CONTAINED)."""
+        import re
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            links = data.get("links", [])
+            structural_rels = {"root", "self", "parent", "child"}
+
+            for link in links:
+                rel = link.get("rel", "")
+                href = link.get("href", "")
+
+                if rel not in structural_rels:
+                    continue
+
+                # Check for absolute paths (should be relative)
+                assert not href.startswith("/"), f"Link rel='{rel}' has Unix absolute path: {href}"
+                assert not href.startswith("file://"), f"Link rel='{rel}' has file:// URL: {href}"
+                assert not re.match(r"^[A-Za-z]:", href), (
+                    f"Link rel='{rel}' has Windows absolute path: {href}"
+                )
+
+
+class TestCollectionAssets:
+    """Test that collection assets are properly formatted."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_assets_have_required_href(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """Each asset MUST have an href field."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            assets = data.get("assets", {})
+            for asset_key, asset in assets.items():
+                assert "href" in asset, f"Asset '{asset_key}' missing 'href' field"
+                assert asset["href"], f"Asset '{asset_key}' has empty href"
+
+    @pytest.mark.integration
+    def test_geoparquet_asset_has_correct_media_type(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+    ) -> None:
+        """GeoParquet assets SHOULD have media type application/vnd.apache.parquet."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("buildings")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_parquet, collection_dir / "buildings.parquet")
+            runner.invoke(cli, ["add", str(collection_dir / "buildings.parquet")])
+
+            collection_path = collection_dir / "collection.json"
+            data = json.loads(collection_path.read_text())
+
+            assets = data.get("assets", {})
+            parquet_assets = [
+                (k, v) for k, v in assets.items() if v.get("href", "").endswith(".parquet")
+            ]
+
+            assert parquet_assets, "No parquet assets found"
+
+            for asset_key, asset in parquet_assets:
+                media_type = asset.get("type")
+                # Accept either the full media type or the common variant
+                valid_types = [
+                    "application/vnd.apache.parquet",
+                    "application/x-parquet",
+                    "application/parquet",
+                ]
+                assert media_type in valid_types, (
+                    f"Asset '{asset_key}' has unexpected media type: {media_type}. "
+                    f"Expected one of: {valid_types}"
+                )

--- a/tests/spec_compliance/test_validators.py
+++ b/tests/spec_compliance/test_validators.py
@@ -1,0 +1,314 @@
+"""Negative tests for spec compliance validators.
+
+These tests verify that validators REJECT invalid data. Without these,
+the compliance tests are tautological - they could pass even if validators
+were broken (always returning empty error lists).
+
+See: ADR-0001 (agentic-first: defend against tautological tests)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestSchemaValidatorRejectsInvalid:
+    """Verify that schema validators reject malformed data."""
+
+    @pytest.mark.integration
+    def test_versions_validator_rejects_missing_required(
+        self,
+        versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """versions.json validator MUST reject data missing required fields."""
+        invalid_data = {"spec_version": "1.0.0"}  # Missing current_version and versions
+
+        errors = validate_versions(invalid_data, versions_schema)
+
+        assert errors, "Validator should reject data missing required fields"
+        assert any(
+            "required" in e.lower() or "current_version" in e or "versions" in e for e in errors
+        )
+
+    @pytest.mark.integration
+    def test_versions_validator_rejects_invalid_semver(
+        self,
+        versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """versions.json validator MUST reject invalid semver patterns."""
+        invalid_data = {
+            "spec_version": "not-a-semver",  # Invalid pattern
+            "current_version": "1.0.0",
+            "versions": [],
+        }
+
+        errors = validate_versions(invalid_data, versions_schema)
+
+        assert errors, "Validator should reject invalid semver format"
+
+    @pytest.mark.integration
+    def test_versions_validator_rejects_invalid_timestamp(
+        self,
+        versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """versions.json validator MUST reject non-UTC timestamps."""
+        invalid_data = {
+            "spec_version": "1.0.0",
+            "current_version": "1.0.0",
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "created": "2024-01-15T10:30:00+05:00",  # NOT UTC (missing Z)
+                    "breaking": False,
+                    "assets": {},
+                    "changes": [],
+                }
+            ],
+        }
+
+        errors = validate_versions(invalid_data, versions_schema)
+
+        assert errors, "Validator should reject non-UTC timestamp (missing Z)"
+
+    @pytest.mark.integration
+    def test_versions_validator_rejects_invalid_sha256(
+        self,
+        versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """versions.json validator MUST reject invalid SHA-256 checksums."""
+        invalid_data = {
+            "spec_version": "1.0.0",
+            "current_version": "1.0.0",
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "created": "2024-01-15T10:30:00Z",
+                    "breaking": False,
+                    "assets": {
+                        "data.parquet": {
+                            "sha256": "not-a-valid-sha256",  # Invalid format
+                            "size_bytes": 1000,
+                            "href": "collection/data.parquet",
+                        }
+                    },
+                    "changes": ["data.parquet"],
+                }
+            ],
+        }
+
+        errors = validate_versions(invalid_data, versions_schema)
+
+        assert errors, "Validator should reject invalid SHA-256 format"
+
+    @pytest.mark.integration
+    def test_stac_validator_rejects_wrong_type(
+        self,
+        portolan_catalog_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """STAC validator MUST reject wrong type field."""
+        invalid_data = {
+            "type": "Collection",  # Should be "Catalog"
+            "stac_version": "1.0.0",
+            "id": "test-catalog",
+            "description": "Test",
+            "links": [],
+        }
+
+        errors = validate_stac(invalid_data, portolan_catalog_schema)
+
+        assert errors, "Validator should reject wrong 'type' field"
+
+    @pytest.mark.integration
+    def test_stac_validator_rejects_invalid_stac_version(
+        self,
+        portolan_collection_schema: dict[str, Any],
+        validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """STAC validator MUST reject invalid stac_version pattern."""
+        invalid_data = {
+            "type": "Collection",
+            "stac_version": "0.9.0",  # Should be 1.x.x
+            "id": "test-collection",
+            "description": "Test",
+            "license": "MIT",
+            "extent": {
+                "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                "temporal": {"interval": [[None, None]]},
+            },
+            "links": [],
+        }
+
+        errors = validate_stac(invalid_data, portolan_collection_schema)
+
+        assert errors, "Validator should reject stac_version that doesn't match 1.x.x"
+
+
+class TestSemanticRuleValidatorsRejectInvalid:
+    """Verify that semantic rule validators reject violations."""
+
+    @pytest.mark.integration
+    def test_rule_0012_rejects_mismatched_current_version(
+        self,
+        validate_rule_0012: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0012: MUST reject when current_version doesn't match last version."""
+        invalid_data = {
+            "current_version": "1.0.0",  # Mismatch!
+            "versions": [
+                {"version": "1.0.0"},
+                {"version": "2.0.0"},  # Last version is 2.0.0
+            ],
+        }
+
+        errors = validate_rule_0012(invalid_data)
+
+        assert errors, "RULE-0012 should reject current_version mismatch"
+        assert any("RULE-0012" in e for e in errors)
+
+    @pytest.mark.integration
+    def test_rule_0012_rejects_null_with_versions(
+        self,
+        validate_rule_0012: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0012: MUST reject null current_version when versions exist."""
+        invalid_data = {
+            "current_version": None,
+            "versions": [{"version": "1.0.0"}],
+        }
+
+        errors = validate_rule_0012(invalid_data)
+
+        assert errors, "RULE-0012 should reject null current_version with non-empty versions"
+
+    @pytest.mark.integration
+    def test_rule_0013_rejects_invalid_change_reference(
+        self,
+        validate_rule_0013: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0013: MUST reject changes referencing non-existent assets."""
+        invalid_data = {
+            "versions": [
+                {
+                    "assets": {"real-file.parquet": {}},
+                    "changes": ["non-existent-file.parquet"],  # Not in assets!
+                }
+            ],
+        }
+
+        errors = validate_rule_0013(invalid_data)
+
+        assert errors, "RULE-0013 should reject changes referencing non-existent assets"
+        assert any("RULE-0013" in e for e in errors)
+
+    @pytest.mark.integration
+    def test_rule_0014_rejects_duplicate_versions(
+        self,
+        validate_rule_0014: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0014: MUST reject duplicate version strings."""
+        invalid_data = {
+            "versions": [
+                {"version": "1.0.0"},
+                {"version": "1.0.0"},  # Duplicate!
+            ],
+        }
+
+        errors = validate_rule_0014(invalid_data)
+
+        assert errors, "RULE-0014 should reject duplicate version strings"
+        assert any("RULE-0014" in e for e in errors)
+
+    @pytest.mark.integration
+    def test_rule_0040_rejects_absolute_unix_path(
+        self,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: MUST reject Unix absolute paths in structural links."""
+        invalid_data = {
+            "links": [
+                {"rel": "root", "href": "/absolute/path/catalog.json"},  # Unix absolute
+            ],
+        }
+
+        errors = validate_rule_0040(invalid_data)
+
+        assert errors, "RULE-0040 should reject Unix absolute paths"
+        assert any("RULE-0040" in e for e in errors)
+
+    @pytest.mark.integration
+    def test_rule_0040_rejects_file_url(
+        self,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: MUST reject file:// URLs in structural links."""
+        invalid_data = {
+            "links": [
+                {"rel": "self", "href": "file:///home/user/catalog.json"},
+            ],
+        }
+
+        errors = validate_rule_0040(invalid_data)
+
+        assert errors, "RULE-0040 should reject file:// URLs"
+
+    @pytest.mark.integration
+    def test_rule_0040_rejects_windows_absolute_path(
+        self,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: MUST reject Windows absolute paths in structural links."""
+        invalid_data = {
+            "links": [
+                {"rel": "child", "href": "C:\\Users\\data\\collection.json"},
+            ],
+        }
+
+        errors = validate_rule_0040(invalid_data)
+
+        assert errors, "RULE-0040 should reject Windows absolute paths"
+
+    @pytest.mark.integration
+    def test_rule_0040_allows_relative_paths(
+        self,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: SHOULD allow relative paths in structural links."""
+        valid_data = {
+            "links": [
+                {"rel": "root", "href": "./catalog.json"},
+                {"rel": "self", "href": "catalog.json"},
+                {"rel": "child", "href": "points/collection.json"},
+                {"rel": "parent", "href": "../catalog.json"},
+            ],
+        }
+
+        errors = validate_rule_0040(valid_data)
+
+        assert not errors, f"RULE-0040 should allow relative paths, got: {errors}"
+
+    @pytest.mark.integration
+    def test_rule_0040_ignores_non_structural_links(
+        self,
+        validate_rule_0040: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0040: SHOULD ignore non-structural link relations."""
+        valid_data = {
+            "links": [
+                {"rel": "license", "href": "https://example.com/license"},
+                {"rel": "documentation", "href": "https://docs.example.com"},
+            ],
+        }
+
+        errors = validate_rule_0040(valid_data)
+
+        assert not errors, "RULE-0040 should ignore non-structural links"

--- a/tests/spec_compliance/test_versions_schema.py
+++ b/tests/spec_compliance/test_versions_schema.py
@@ -32,11 +32,6 @@ if TYPE_CHECKING:
 class TestCatalogVersionsSchemaCompliance:
     """Test that catalog-level versions.json complies with the schema."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_init_creates_valid_catalog_versions_json(
         self,
@@ -61,11 +56,6 @@ class TestCatalogVersionsSchemaCompliance:
 
 class TestCollectionVersionsSchemaCompliance:
     """Test that collection-level versions.json complies with the spec schema."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_add_creates_valid_versions_json(
@@ -136,11 +126,6 @@ class TestCollectionVersionsSchemaCompliance:
 
 class TestVersionsSemanticRules:
     """Test semantic rules from rules.yaml that can't be expressed in JSON Schema."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_rule_0012_current_version_consistency(
@@ -221,11 +206,6 @@ class TestVersionsSemanticRules:
 class TestVersionsTimestampFormat:
     """Test that timestamps comply with the ISO 8601 UTC format (ending in 'Z')."""
 
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
-
     @pytest.mark.integration
     def test_created_timestamp_format(
         self,
@@ -265,11 +245,6 @@ class TestVersionsTimestampFormat:
 
 class TestVersionsChecksumFormat:
     """Test that checksums comply with the SHA-256 hex format."""
-
-    @pytest.fixture
-    def runner(self) -> CliRunner:
-        """Create a Click test runner."""
-        return CliRunner()
 
     @pytest.mark.integration
     def test_sha256_checksum_format(

--- a/tests/spec_compliance/test_versions_schema.py
+++ b/tests/spec_compliance/test_versions_schema.py
@@ -137,7 +137,8 @@ class TestVersionsSemanticRules:
     ) -> None:
         """RULE-0012: current_version MUST match last entry in versions array."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
@@ -162,7 +163,8 @@ class TestVersionsSemanticRules:
     ) -> None:
         """RULE-0013: changes array MUST only reference keys that exist in assets."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
@@ -187,7 +189,8 @@ class TestVersionsSemanticRules:
     ) -> None:
         """RULE-0014: Version strings MUST be unique within versions array."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
@@ -217,7 +220,8 @@ class TestVersionsTimestampFormat:
         import re
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()
@@ -257,7 +261,8 @@ class TestVersionsChecksumFormat:
         import re
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
 
             collection_dir = Path("points")
             collection_dir.mkdir()

--- a/tests/spec_compliance/test_versions_schema.py
+++ b/tests/spec_compliance/test_versions_schema.py
@@ -1,0 +1,306 @@
+"""Spec compliance tests for versions.json output.
+
+Validates that CLI-generated versions.json files conform to the schema
+defined in portolan-spec/schema/versions.schema.json.
+
+Note: There are TWO different versions.json structures:
+- Catalog-level (root): schema_version, catalog_id, created, collections
+- Collection-level: spec_version, current_version, versions
+
+The portolan-spec schema (versions.schema.json) describes the collection-level
+format. Catalog-level uses catalog-versions.schema.json.
+
+See: https://github.com/portolan-sdi/portolan-spec/issues/23
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class TestCatalogVersionsSchemaCompliance:
+    """Test that catalog-level versions.json complies with the schema."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_init_creates_valid_catalog_versions_json(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        catalog_versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan init creates a schema-compliant catalog-level versions.json."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            versions_path = Path("versions.json")
+            assert versions_path.exists(), "versions.json not created"
+
+            data = json.loads(versions_path.read_text())
+            errors = validate_versions(data, catalog_versions_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+
+class TestCollectionVersionsSchemaCompliance:
+    """Test that collection-level versions.json complies with the spec schema."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_add_creates_valid_versions_json(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan add creates a schema-compliant collection versions.json."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # Initialize catalog
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            # Copy test fixture to a subdirectory (required by portolan add)
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            # Add the file
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Check collection versions.json
+            versions_path = collection_dir / "versions.json"
+            assert versions_path.exists(), f"Collection versions.json not found at {versions_path}"
+
+            data = json.loads(versions_path.read_text())
+            errors = validate_versions(data, versions_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_add_geoparquet_creates_valid_versions_json(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+        versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan add with GeoParquet creates a schema-compliant versions.json."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            # Initialize catalog
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            # Copy test fixture to a subdirectory
+            collection_dir = Path("buildings")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_parquet, collection_dir / "buildings.parquet")
+
+            # Add the file
+            result = runner.invoke(cli, ["add", str(collection_dir / "buildings.parquet")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Check collection versions.json
+            versions_path = collection_dir / "versions.json"
+            assert versions_path.exists(), "Collection versions.json not found"
+
+            data = json.loads(versions_path.read_text())
+            errors = validate_versions(data, versions_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
+
+class TestVersionsSemanticRules:
+    """Test semantic rules from rules.yaml that can't be expressed in JSON Schema."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_rule_0012_current_version_consistency(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        validate_rule_0012: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0012: current_version MUST match last entry in versions array."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            versions_path = collection_dir / "versions.json"
+            data = json.loads(versions_path.read_text())
+
+            errors = validate_rule_0012(data)
+            assert not errors, "Rule validation failed:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_rule_0013_changes_reference_assets(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        validate_rule_0013: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0013: changes array MUST only reference keys that exist in assets."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            versions_path = collection_dir / "versions.json"
+            data = json.loads(versions_path.read_text())
+
+            errors = validate_rule_0013(data)
+            assert not errors, "Rule validation failed:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_rule_0014_version_uniqueness(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        validate_rule_0014: Callable[[dict[str, Any]], list[str]],
+    ) -> None:
+        """RULE-0014: Version strings MUST be unique within versions array."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            versions_path = collection_dir / "versions.json"
+            data = json.loads(versions_path.read_text())
+
+            errors = validate_rule_0014(data)
+            assert not errors, "Rule validation failed:\n" + "\n".join(errors)
+
+
+class TestVersionsTimestampFormat:
+    """Test that timestamps comply with the ISO 8601 UTC format (ending in 'Z')."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_created_timestamp_format(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """Version timestamps MUST be ISO 8601 UTC (ending with 'Z')."""
+        import re
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            versions_path = collection_dir / "versions.json"
+            data = json.loads(versions_path.read_text())
+
+            # The schema pattern from versions.schema.json
+            timestamp_pattern = re.compile(
+                r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$"
+            )
+
+            for i, version in enumerate(data.get("versions", [])):
+                created = version.get("created")
+                assert created is not None, f"Version {i} missing 'created' field"
+                assert timestamp_pattern.match(created), (
+                    f"Version {i} has invalid timestamp format: {created}. "
+                    f"Expected ISO 8601 UTC (e.g., '2024-01-15T10:30:00Z')"
+                )
+
+
+class TestVersionsChecksumFormat:
+    """Test that checksums comply with the SHA-256 hex format."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a Click test runner."""
+        return CliRunner()
+
+    @pytest.mark.integration
+    def test_sha256_checksum_format(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+    ) -> None:
+        """Asset checksums MUST be 64-character lowercase hex strings."""
+        import re
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            runner.invoke(cli, ["init", "--auto"])
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            versions_path = collection_dir / "versions.json"
+            data = json.loads(versions_path.read_text())
+
+            # SHA-256 pattern from schema (accepts both upper and lowercase)
+            sha256_pattern = re.compile(r"^[a-fA-F0-9]{64}$")
+
+            for version in data.get("versions", []):
+                for asset_key, asset in version.get("assets", {}).items():
+                    sha256 = asset.get("sha256")
+                    assert sha256 is not None, f"Asset '{asset_key}' missing 'sha256'"
+                    assert sha256_pattern.match(sha256), (
+                        f"Asset '{asset_key}' has invalid SHA-256 format: {sha256}"
+                    )


### PR DESCRIPTION
## Summary

Phase 2 of portolan-spec Issue #23: Add tests that validate CLI output against machine-readable schemas from [portolan-spec/schema/](https://github.com/portolan-sdi/portolan-spec/tree/main/schema).

- **51 integration tests** covering catalog.json, collection.json, and versions.json
- **15 negative tests** verifying validators actually reject invalid input
- Schemas vendored locally for reproducibility and CI stability
- Validates both JSON Schema compliance and semantic rules from `rules.yaml`

### What's tested

| File | Tests |
|------|-------|
| `catalog.json` | Type, STAC version, links, child links, SELF_CONTAINED paths (RULE-0040) |
| `collection.json` | Required fields, extent, links, assets, media types |
| `versions.json` | Catalog-level + collection-level formats, timestamps, checksums |
| Semantic rules | RULE-0012 (version consistency), RULE-0013 (changes ⊆ assets), RULE-0014 (uniqueness) |
| Validators | Negative tests ensuring invalid schemas/rules are rejected |

### Phase 3: Schema Sync Workflow

This PR also adds `.github/workflows/sync-schemas-to-spec.yml` — automated sync from CLI → Spec.

When schemas change in `tests/spec_compliance/schemas/` on main:
1. Workflow triggers
2. Copies canonical schemas to portolan-spec/schema/
3. Opens PR with changes

**Requires setup:** Add `SPEC_REPO_PAT` secret with write access to portolan-spec:
1. Create Fine-grained PAT with `portolan-sdi/portolan-spec` access
2. Permissions: Contents (R/W), Pull requests (R/W)
3. Add as repository secret in portolan-cli

### Notable findings

The tests immediately caught a spec drift: `mtime` fields are defined as `integer` in the spec but Python's `os.stat().st_mtime` returns floats. Documented in vendored schema with note to sync upstream.

### Follow-up

- [x] Open upstream issue in portolan-spec to relax `mtime`/`source_mtime` from `integer` to `number` → portolan-sdi/portolan-spec#26
- [ ] Create `SPEC_REPO_PAT` secret for schema sync workflow

## Test plan

- [x] All 51 spec compliance tests pass (`uv run pytest tests/spec_compliance/ -v`)
- [x] Lint clean (`uv run ruff check tests/spec_compliance/`)
- [x] Type check clean (`uv run mypy tests/spec_compliance/`)

## References

- portolan-sdi/portolan-spec#23 (machine-readable schemas)
- portolan-sdi/portolan-spec#24 (Phase 1 - schema creation, merged)
- portolan-sdi/portolan-spec#26 (mtime type fix)

🤖 Generated with [Claude Code](https://claude.ai/code)