### PR TITLE
fix(spec): add complete spec content from portolan-spec

### DIFF
--- a/spec/DECISIONS.md
+++ b/spec/DECISIONS.md
@@ -1,0 +1,151 @@
+# Architectural Decision Records
+
+This document captures key architectural decisions made during the development of the Portolan specification.
+
+## Format
+
+Each decision includes:
+- **Decision**: What was decided
+- **Context**: Why this decision was needed
+- **Rationale**: Why this approach was chosen
+- **Date**: When the decision was made
+- **Status**: Accepted, Superseded, or Under Review
+
+---
+
+## Template for New Decisions
+
+**Date**: YYYY-MM-DD
+**Status**: Under Review | Accepted | Superseded
+
+**Decision**: [What was decided]
+
+**Context**: [Why this decision was needed]
+
+**Rationale**: [Why this approach was chosen over alternatives]
+
+**Consequences**: [What this decision enables or constrains]
+
+---
+
+## Decisions
+
+### ADR-001: Flat Catalog Hierarchy
+
+**Date**: 2025-02-13
+**Status**: Accepted
+
+**Decision**: Portolan catalogs use a flat hierarchy—collections contain items directly, with no nested sub-collections.
+
+**Context**: STAC supports arbitrary nesting of catalogs and collections. We needed to decide whether to allow this flexibility or constrain the structure.
+
+**Rationale**:
+- Simplifies tooling (no recursive traversal needed)
+- Clear versioning boundaries (each collection has one versions.json)
+- Easier to understand and navigate
+- Avoids ambiguity about where metadata belongs
+
+**Consequences**: Users who want nested organization must flatten their structure (e.g., `census-2020-tracts` instead of `census/2020/tracts`).
+
+---
+
+### ADR-002: versions.json as Single Source of Truth
+
+**Date**: 2025-02-13
+**Status**: Accepted
+
+**Decision**: Each collection has a single `versions.json` file that serves as version history, sync manifest, and integrity checksums.
+
+**Context**: We needed to track what files exist, what changed between versions, and what's synced to remote storage.
+
+**Rationale**:
+- Single file to understand (no reconciling multiple sources)
+- Atomic updates (one file write per version bump)
+- Simple sync (diff one JSON file to know what to push)
+- Corruption detection (checksums catch tampering or bit rot)
+
+**Consequences**:
+- File grows with version count (mitigated by future prune command)
+- Single-writer constraint (multi-user deferred to portolake plugin)
+
+See: [versions.md](versions.md)
+
+---
+
+### ADR-003: Accept Non-Cloud-Native Formats with Warnings
+
+**Date**: 2025-02-13
+**Status**: Accepted
+
+**Decision**: Portolan accepts non-cloud-native formats (GeoJSON, Shapefile, GeoPackage) but emits warnings encouraging conversion.
+
+**Context**: Many users have legacy data in non-cloud-native formats. We needed to decide whether to reject these or accept them.
+
+**Rationale**:
+- Reduces friction for new users
+- Guides users toward best practices over time
+- Validation still passes (warns, doesn't fail)
+- Conversion can happen later
+
+**Consequences**: Catalogs may contain non-optimal formats. Tooling should encourage (not force) conversion.
+
+See: [ADR-0014 in portolan-cli](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0014-accept-non-cloud-native-formats.md)
+
+---
+
+### ADR-004: STAC-GeoParquet as Scalability Best Practice
+
+**Date**: 2025-02-13
+**Status**: Accepted
+
+**Decision**: STAC-GeoParquet is a best practice for collections with many items, becoming required at >1000 items.
+
+**Context**: Large collections with thousands of STAC items are slow to search without an API. STAC-GeoParquet enables efficient queries.
+
+**Rationale**:
+- Best practice now, required later (phased approach)
+- Tooling still maturing
+- Enables search without STAC API server
+- Threshold of 1000 items balances overhead vs. benefit
+
+**Consequences**: Large catalogs must include `items.parquet`. Tooling needs to generate and maintain this file.
+
+See: [best-practices.md#stac-geoparquet](best-practices.md#stac-geoparquet)
+
+---
+
+### ADR-005: PMTiles as Visualization Best Practice
+
+**Date**: 2025-02-13
+**Status**: Accepted
+
+**Decision**: PMTiles derivatives are a best practice for vector datasets, becoming required at >100 MB.
+
+**Context**: Large GeoParquet files are slow to render on web maps. PMTiles provide efficient tile-based rendering.
+
+**Rationale**:
+- Best practice now, required later (phased approach)
+- Tippecanoe dependency has platform-specific installation requirements
+- Threshold of 100 MB balances generation cost vs. rendering benefit
+
+**Consequences**: Large vector datasets must include PMTiles. Tooling needs to handle tippecanoe installation.
+
+See: [best-practices.md#pmtiles](best-practices.md#pmtiles)
+
+---
+
+### ADR-006: SELF_CONTAINED Catalog Type
+
+**Date**: 2025-02-13
+**Status**: Accepted
+
+**Decision**: Portolan catalogs must use pystac's `SELF_CONTAINED` catalog type with relative links.
+
+**Context**: STAC supports multiple catalog types with different linking strategies.
+
+**Rationale**:
+- Portability: catalogs can be moved between buckets/hosts
+- No absolute filesystem paths leak into metadata
+- Simpler to understand and debug
+
+**Consequences**: All links are relative. Tooling must normalize hrefs before saving.

--- a/spec/README.md
+++ b/spec/README.md
@@ -6,9 +6,32 @@ The **portolan-cli repository is the source of truth** for the spec. The
 [portolan-spec](https://github.com/portolan-sdi/portolan-spec) repository is a
 read-only mirror, automatically synced via CI on every merge to main.
 
-## Contents
+## What is Portolan?
 
-- `schema/` — Machine-readable JSON schemas and validation rules
+Portolan is a STAC profile—not a competing specification. It adds requirements
+and best practices on top of [STAC](https://stacspec.org/) for publishing
+cloud-native geospatial data.
+
+## Specification
+
+- [Core requirements](core.md) - Mandatory requirements for all Portolan catalogs
+- [Catalog structure](structure.md) - Directory layout and file organization
+- [Version manifest](versions.md) - `versions.json` schema for version tracking
+- [File extensions](extensions.md) - Recognized file types and classification
+- [Format addenda](formats/) - Per-format specifications
+  - [Vector data](formats/vector.md)
+  - [Raster data](formats/raster.md)
+  - [Point clouds](formats/pointcloud.md)
+- [Best practices](best-practices.md) - Recommended conventions
+- [Architectural decisions](DECISIONS.md) - Key design decisions and rationale
+
+## Machine-Readable Schemas
+
+- `schema/` — JSON schemas and validation rules for `versions.json`, `catalog.json`, etc.
+
+## Examples
+
+See [examples/](examples/) for reference implementations.
 
 ## Making Changes
 
@@ -18,14 +41,4 @@ To propose spec changes:
 2. Changes to `spec/` trigger review from spec maintainers
 3. On merge, CI syncs to portolan-spec automatically
 
-See [ADR-0048](../context/shared/adr/0048-cli-as-spec-source.md) for the
-rationale behind this structure.
-
-## Why CLI-First?
-
-The spec documents what the CLI does, not what it might do. Keeping spec and
-implementation in the same repo enables:
-
-- **Atomic PRs** — Implementation + spec changes land together
-- **Single source of truth** — No sync drift between repos
-- **Simpler contribution model** — One repo, one PR
+See [ADR-0048](../context/shared/adr/0048-cli-as-spec-source.md) for rationale.

--- a/spec/best-practices.md
+++ b/spec/best-practices.md
@@ -1,0 +1,102 @@
+# Best Practices
+
+These are recommended conventions, not requirements. Portolan linters will warn about deviations but will not fail validation.
+
+## Scalability
+
+### STAC-GeoParquet
+
+For catalogs with many items, **SHOULD** include a [stac-geoparquet](https://github.com/stac-utils/stac-geoparquet) file alongside JSON metadata.
+
+- **SHOULD** provide `items.parquet` when a collection contains > 100 items
+- **MUST** provide `items.parquet` when a collection contains > 1000 items
+
+STAC-GeoParquet enables efficient search and filtering without requiring a STAC API server:
+
+```python
+import geopandas as gpd
+
+# Query items by bbox without loading all JSON
+items = gpd.read_parquet(
+    "s3://bucket/collection/items.parquet",
+    bbox=(-122.5, 37.5, -122.0, 38.0)
+)
+```
+
+**Location**: Place `items.parquet` in the collection directory alongside `collection.json`.
+
+**When to use**:
+- Image collections with many individual COGs
+- Time-series data with frequent updates
+- Any collection where users need to search/filter items
+
+**Note**: This is currently a best practice while tooling matures. May be promoted to a core requirement in a future spec version.
+
+### PMTiles
+
+For vector datasets, **SHOULD** include PMTiles derivatives for web visualization.
+
+- **SHOULD** provide `.pmtiles` when a GeoParquet file exceeds 10 MB
+- **MUST** provide `.pmtiles` when a GeoParquet file exceeds 100 MB
+
+PMTiles enable efficient web map rendering without server-side tile generation.
+
+**Note**: PMTiles generation requires tippecanoe, which has platform-specific installation requirements. This is currently a best practice while tooling matures.
+
+## Visualization
+
+- **SHOULD** include a thumbnail image generated from default styling
+- **SHOULD** provide default styling via `style.json`
+  - Compatible with MapLibre GL JS and deck.gl
+  - Enables immediate visualization without custom configuration
+
+## Documentation
+
+- **SHOULD** include collection-level READMEs for datasets with:
+  - Multiple years of data
+  - Multiple source agencies or methodologies
+  - Complex versioning or update schedules
+
+## Metadata
+
+- **SHOULD** provide machine-readable metadata in Parquet format for datasets with:
+  - Many coded/categorical variables
+  - Complex classification schemes
+  - Variables requiring detailed definitions
+
+- **SHOULD** include column descriptions
+  - May become a core requirement as tooling matures
+  - Helps AI systems and users understand data structure
+
+## Multi-file Relationships
+
+### Join Relationships
+
+When geometry and attribute data are in separate files:
+
+- **SHOULD** document the join columns explicitly in the README
+- **SHOULD** include a working code example showing how to join the files
+
+Example:
+
+```markdown
+## Data Structure
+
+Geometry and attribute data are stored separately:
+- `departamentos.parquet` - polygon geometries with `codigo_depto` key
+- `attributes.parquet` - demographic attributes with `codigo_depto` key
+
+### Joining the data
+
+```python
+import geopandas as gpd
+import pandas as pd
+
+# Read files
+geometry = gpd.read_parquet("departamentos.parquet")
+attributes = pd.read_parquet("attributes.parquet")
+
+# Join on codigo_depto
+data = geometry.merge(attributes, on="codigo_depto")
+```
+```

--- a/spec/core.md
+++ b/spec/core.md
@@ -1,0 +1,127 @@
+# Core Requirements
+
+These requirements apply to all Portolan catalogs, regardless of data format.
+
+## Catalog Structure
+
+A Portolan catalog is a directory with STAC metadata at the project root and internal tooling state in `.portolan/`. See [structure.md](structure.md) for the full directory layout.
+
+```
+project/
+├── .portolan/
+│   ├── config.yaml
+│   └── state.json
+├── catalog.json
+├── versions.json
+└── {collection_id}/
+    ├── collection.json
+    ├── versions.json
+    └── {item_id}/
+        └── data.parquet
+```
+
+## STAC Compliance
+
+- **MUST** be a valid STAC Catalog or Collection
+- **MUST** follow STAC specification version 1.0.0 or later
+- **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
+
+## Data Storage
+
+Portolan catalogs assume data is hosted in S3-compatible object storage. This is the ground truth for all assets.
+
+## Asset URLs
+
+Asset hrefs **MUST** be absolute S3 URLs:
+
+```json
+"assets": {
+  "data": {
+    "href": "https://bucket-name.s3.region.amazonaws.com/path/to/file.parquet",
+    "type": "application/vnd.apache.parquet",
+    "roles": ["data"]
+  }
+}
+```
+
+## Link Paths
+
+STAC link relations (`root`, `self`, `child`, `parent`) **SHOULD** use relative paths within the catalog structure:
+
+```json
+"links": [
+  {"rel": "root", "href": "./catalog.json", "type": "application/json"},
+  {"rel": "self", "href": "./collection.json", "type": "application/json"},
+  {"rel": "child", "href": "./2022/collection.json", "type": "application/json"}
+]
+```
+
+This keeps the catalog portable if mirrored to a different bucket.
+
+## Providers
+
+**SHOULD** use STAC-standard `providers` array:
+
+```json
+"providers": [
+  {
+    "name": "Organization Name",
+    "roles": ["producer"],
+    "url": "https://example.com"
+  }
+]
+```
+
+## Source Provenance
+
+When data is extracted from an external source that is the canonical location for the data, the collection **MUST** include a `rel: "via"` link pointing to the original source URL:
+
+```json
+{
+  "rel": "via",
+  "href": "https://services-eu1.arcgis.com/example/FeatureServer",
+  "type": "text/html",
+  "title": "Source ArcGIS Feature Service"
+}
+```
+
+This is standard STAC practice for provenance and enables consumers to trace data back to its origin.
+
+## Root Documentation
+
+- **MUST** include a `README.md` at the catalog root
+- README content requirements: TBD (see [QUESTIONS.md](QUESTIONS.md))
+
+## Versioning
+
+- **MUST** include version tracking via `versions.json` manifest file (see [versions.md](versions.md))
+- **SHOULD** include STAC link relations (`predecessor-version`, `successor-version`, `latest-version`) when multiple versions exist
+- **SHOULD** include a link to versions.json in the collection:
+
+```json
+{
+  "rel": "version-history",
+  "href": "./versions.json",
+  "type": "application/json"
+}
+```
+
+The `versions.json` file tracks version history, asset checksums, and sync state per collection.
+
+## Recognized File Extensions
+
+See [extensions.md](extensions.md) for the complete list of file extensions recognized by Portolan tools, including:
+- Primary geospatial formats (GeoParquet, GeoJSON, Shapefile, COG, etc.)
+- Sidecar files (Shapefile components, aux.xml, etc.)
+- Visualization formats (PMTiles, MBTiles)
+- Files that are skipped during import
+
+## Format-Specific Requirements
+
+Additional requirements apply based on data type. See format addenda:
+
+- [Vector data](formats/vector.md)
+- [Raster data](formats/raster.md)
+- [Point cloud data](formats/pointcloud.md)
+
+Format addenda are normative and define **MUST** requirements, not suggestions.

--- a/spec/examples/README.md
+++ b/spec/examples/README.md
@@ -1,0 +1,22 @@
+# Portolan Examples
+
+This directory contains reference implementations of Portolan catalogs.
+
+## Available Examples
+
+### Argentina 2022 Census
+
+A complete implementation of Argentina's 2022 census data as a Portolan catalog.
+
+- **Status**: In progress
+- **Publication**: Will be available on [Source.Cooperative](https://source.coop/) once complete
+- **Formats**: GeoParquet (tabular data + geometries), PMTiles (visualization)
+- **Demonstrates**:
+  - Multi-level geographic hierarchy (nation → province → department → census tract)
+  - Versioning and temporal data management
+  - Machine-readable metadata for coded variables
+  - Default styling and visualization
+
+## Using Examples
+
+Examples serve as canonical references for what valid Portolan catalogs look like. When in doubt about how to structure your catalog or implement a specific feature, refer to these examples.

--- a/spec/extensions.md
+++ b/spec/extensions.md
@@ -1,0 +1,121 @@
+# Recognized File Extensions
+
+Portolan tools classify files by extension to determine how they should be handled during import and validation.
+
+## Primary Geospatial Formats
+
+These extensions are recognized as importable geospatial data:
+
+| Extension | Format | Type | Cloud-Native | Notes |
+|-----------|--------|------|--------------|-------|
+| `.parquet` | GeoParquet | Vector | Yes | Requires geo metadata (content inspection) |
+| `.geojson` | GeoJSON | Vector | No | Converts to GeoParquet |
+| `.json` | GeoJSON | Vector | No | Content inspected for GeoJSON structure |
+| `.shp` | Shapefile | Vector | No | Converts to GeoParquet |
+| `.gpkg` | GeoPackage | Vector | No | Converts to GeoParquet |
+| `.fgb` | FlatGeobuf | Vector | Yes | Cloud-native, passed through |
+| `.csv` | CSV with geometry | Vector | No | Converts to GeoParquet (requires lat/lon or WKT column) |
+| `.tif`, `.tiff` | GeoTIFF/COG | Raster | Depends | Content inspected for COG compliance |
+| `.jp2` | JPEG2000 | Raster | No | Converts to COG |
+
+Files with these extensions are candidates for `portolan dataset add`.
+
+### Non-Cloud-Native Format Handling
+
+Portolan **accepts** non-cloud-native formats (GeoJSON, Shapefile, GeoPackage, etc.) but emits warnings encouraging conversion to cloud-native formats.
+
+**Behavior**:
+- Non-cloud-native files are imported with a warning
+- Users are encouraged to convert to GeoParquet (vector) or COG (raster)
+- Validation passes but reports the warning
+
+**Rationale**: Many users have legacy data in non-cloud-native formats. Rejecting these files would create friction. Instead, we warn and accept, guiding users toward best practices over time.
+
+See [ADR-0014: Accept non-cloud-native formats](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0014-accept-non-cloud-native-formats.md) for the full decision record.
+
+### Content Inspection
+
+Some formats require content inspection to determine cloud-native status:
+
+- **`.parquet`**: Checked for GeoParquet metadata (geo column info)
+- **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry)
+- **`.tif`/`.tiff`**: Validated against COG spec (internal tiling, overviews)
+
+Files that fail content inspection are treated as convertible (vector) or rejected (raster without geo info).
+
+## Sidecar Files
+
+These extensions are recognized as sidecar files belonging to a primary asset:
+
+| Extension | Associated Format |
+|-----------|-------------------|
+| `.dbf` | Shapefile attribute table |
+| `.shx` | Shapefile index |
+| `.prj` | Shapefile projection |
+| `.cpg` | Shapefile code page |
+| `.sbn`, `.sbx` | Shapefile spatial index |
+| `.ovr` | Raster overview (pyramid) |
+| `.xml` | Auxiliary metadata (aux.xml, etc.) |
+
+Sidecar files are **not** imported directly. When importing a `.shp` file, its sidecars are read automatically.
+
+## Visualization Formats
+
+| Extension | Format | Description |
+|-----------|--------|-------------|
+| `.pmtiles` | PMTiles | Cloud-native vector tiles for web rendering |
+| `.mbtiles` | MBTiles | SQLite-based tile archive |
+
+These are **derivatives**, not primary data. PMTiles **SHOULD** be generated from GeoParquet for web display.
+
+## Metadata Files
+
+| Filename | Description |
+|----------|-------------|
+| `catalog.json` | STAC Catalog (root) |
+| `collection.json` | STAC Collection |
+| `versions.json` | Portolan version manifest |
+| `style.json` | MapLibre/deck.gl style definition |
+
+These files have semantic meaning and are not imported as datasets.
+
+## Thumbnail/Preview
+
+| Extension | Handling |
+|-----------|----------|
+| `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif` | Treated as thumbnails if < 1 MiB (1,048,576 bytes) |
+
+Small images are assumed to be previews, not raster data.
+
+## Unsupported Formats
+
+These formats are explicitly rejected with informative error messages:
+
+| Extension | Format | Reason |
+|-----------|--------|--------|
+| `.nc`, `.netcdf` | NetCDF | Not yet supported |
+| `.h5`, `.hdf5` | HDF5 | Not yet supported |
+| `.las`, `.laz` | LAS/LAZ | Use COPC format instead |
+
+## Ignored Files
+
+The following are skipped during directory scans:
+
+| Pattern | Reason |
+|---------|--------|
+| `.exe`, `.dll`, `.so`, `.dylib` | Executables |
+| `.pyc`, `.pyo`, `.class`, `.o`, `.obj` | Compiled files |
+| `__pycache__/`, `.git/`, `.svn/`, `.hg/` | Build/VCS directories |
+| `.idea/`, `.vscode/`, `node_modules/`, `.tox/`, `.pytest_cache/` | IDE/tooling directories |
+| `.tsv`, `.xlsx`, `.xls` | Tabular data (not geospatial) |
+| `.md`, `.txt`, `.rst`, `.html`, `.htm` | Documentation |
+
+Note: `.csv` files are listed as importable above (with geometry columns) but are also commonly non-geospatial. The scan command classifies them as tabular data; the import command performs content inspection.
+
+## Extension vs. Role
+
+STAC uses **asset roles** to describe purpose, not file extensions. The extensions above are used for:
+1. **Import classification** — determining if a file can be added as a dataset
+2. **Format detection** — deciding which conversion pipeline to use
+
+Once imported, the STAC asset's `roles` field (e.g., `["data"]`, `["thumbnail"]`) provides machine-readable semantics.

--- a/spec/formats/pointcloud.md
+++ b/spec/formats/pointcloud.md
@@ -1,0 +1,11 @@
+# Point Cloud Data Format Requirements
+
+## Required Formats
+
+- **MUST** provide data in Cloud Optimized Point Cloud (COPC) format
+  - Follows [COPC specification](https://copc.io/)
+  - Enables efficient streaming and partial reads
+
+## Status
+
+This format addendum is a stub. Full requirements will be developed after completing a reference point cloud dataset implementation.

--- a/spec/formats/raster.md
+++ b/spec/formats/raster.md
@@ -1,0 +1,11 @@
+# Raster Data Format Requirements
+
+## Required Formats
+
+- **MUST** provide data in Cloud Optimized GeoTIFF (COG) format
+  - Follows [COG specification](https://www.cogeo.org/)
+  - Enables efficient range-request access without full download
+
+## Status
+
+This format addendum is a stub. Full requirements will be developed after completing a reference raster dataset implementation.

--- a/spec/formats/vector.md
+++ b/spec/formats/vector.md
@@ -1,0 +1,83 @@
+# Vector Data Format Requirements
+
+## Required Formats
+
+- **MUST** provide data in GeoParquet format
+  - Follows [GeoParquet specification](https://geoparquet.org/)
+  - Enables efficient querying and analysis without a server
+  - **SHOULD** follow the [Best Practices for Distributing GeoParquet](https://github.com/opengeospatial/geoparquet/blob/main/format-specs/distributing-geoparquet.md) recommendations (zstd compression, bbox covering, spatial ordering, appropriate row group sizes)
+
+## Collection-Level Assets
+
+When a vector dataset is represented as a single file (GeoParquet, FlatGeobuf, or any other supported format), it **MUST** be represented as a collection-level asset rather than wrapped in a STAC item. The item indirection adds no value for single-file datasets.
+
+```json
+{
+  "type": "Collection",
+  "id": "tunnels",
+  "assets": {
+    "data": {
+      "href": "./tunnels.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    },
+    "pmtiles": {
+      "href": "./tunnels.pmtiles",
+      "type": "application/vnd.pmtiles",
+      "roles": ["visual"]
+    }
+  }
+}
+```
+
+The directory layout for a single-file collection is flat:
+
+```
+tunnels/
+  collection.json
+  versions.json
+  tunnels.parquet
+  tunnels.pmtiles        (recommended)
+  thumbnail.png          (recommended)
+```
+
+No item directory or item JSON is needed.
+
+## Partitioned Datasets
+
+GeoParquet files larger than approximately 2 GB **SHOULD** be spatially partitioned into multiple files, following the guidance in [Best Practices for Distributing GeoParquet](https://github.com/opengeospatial/geoparquet/blob/main/format-specs/distributing-geoparquet.md#spatial-partitioning).
+
+When a dataset is partitioned:
+
+- Each partition file **MUST** be represented as a STAC item within the collection, with its spatial extent (bbox) reflecting the data in that partition.
+- The collection description **SHOULD** include the glob pattern that tools can use to access all partitions as a single dataset, since most users want a single URL they can pass to their analysis tools rather than enumerating STAC items. For example:
+
+  > Access all partitions: `s3://bucket/buildings/*.parquet`
+
+### Directory Layout for Partitioned Datasets
+
+```
+buildings/
+  collection.json
+  versions.json
+  partition-001.parquet
+  partition-002.parquet
+  partition-003.parquet
+  ...
+```
+
+Each partition file also has a corresponding STAC item linked from the collection, but the collection-level glob asset is the primary entry point for data access.
+
+## Recommended Formats
+
+- **SHOULD** provide PMTiles for visualization
+  - Optimized for web map rendering
+  - Cloud-native, range-request friendly
+  - PMTiles **MUST** be represented as a collection-level asset, not only at the item level — this ensures the visualization derivative is always discoverable alongside the data without navigating into items
+  - When PMTiles are provided, **MUST** add a `rel: "pmtiles"` link following the [web-map-links](https://github.com/stac-extensions/web-map-links) STAC extension
+
+## Styling
+
+- **MAY** include `style.json` for default visualization
+  - Compatible with MapLibre GL JS and deck.gl
+  - See [best practices](../best-practices.md) for styling recommendations

--- a/spec/structure.md
+++ b/spec/structure.md
@@ -1,0 +1,152 @@
+# Catalog Structure
+
+A Portolan catalog is a directory with STAC metadata and cloud-native geospatial data. Internal tooling state lives in `.portolan/`; all STAC-visible files live at the project root.
+
+## Directory Layout
+
+```
+project/
+├── .portolan/
+│   ├── config.yaml                    # Internal: catalog configuration
+│   └── state.json                     # Internal: local sync state
+├── catalog.json                       # STAC Catalog (root metadata)
+├── versions.json                      # Catalog-level versioning
+└── {collection_id}/
+    ├── collection.json                # STAC Collection metadata
+    ├── versions.json                  # Collection-level versioning
+    └── {item_id}/
+        └── {filename}.parquet         # Asset file
+```
+
+## Root Level
+
+| File | Required | Description |
+|------|----------|-------------|
+| `.portolan/` | **MUST** | Internal tooling directory (config, state) |
+| `catalog.json` | **MUST** | STAC Catalog (root metadata) |
+| `versions.json` | **MUST** | Catalog-level version tracking |
+
+The `.portolan` directory **MUST** exist at the project root. Tools **SHOULD** create this directory via `portolan init`.
+
+### `.portolan/` Contents
+
+| File | Required | Description |
+|------|----------|-------------|
+| `config.yaml` | **MUST** | Catalog configuration (sentinel file) |
+| `state.json` | **SHOULD** | Local sync state |
+
+Only Portolan-internal tooling state lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
+
+## Collection Level
+
+Each collection is a top-level subdirectory of the project root, named with the collection ID.
+
+| File | Required | Description |
+|------|----------|-------------|
+| `collection.json` | **MUST** | STAC Collection metadata |
+| `versions.json` | **MUST** | Version history and checksums (see [versions.md](versions.md)) |
+| `{item_id}/` | — | One directory per dataset item |
+
+Collection IDs **SHOULD**:
+- Contain only lowercase letters, numbers, hyphens, and underscores
+- Start with a letter
+- Be unique within the catalog
+
+Note: The CLI does not currently enforce these naming conventions. Validation may be added in a future release.
+
+## Single-File Collections
+
+When a collection contains a single data file (e.g., one GeoParquet file), the data **MUST** be represented as a collection-level asset. No item directory or item JSON is needed. See [vector format requirements](formats/vector.md#collection-level-assets) for details.
+
+```
+{collection_id}/
+  collection.json
+  versions.json
+  {filename}.parquet
+  {filename}.pmtiles          (recommended)
+  thumbnail.png               (recommended)
+```
+
+## Item Level
+
+Items are used when a collection contains multiple data files — for example, partitioned datasets or multi-file raster mosaics.
+
+Each item is a subdirectory of the collection named with the item ID.
+
+| File | Required | Description |
+|------|----------|-------------|
+| Primary data asset | **MUST** | One of: `.parquet` (vector), `.tif` (raster), `.copc.laz` (point cloud) |
+| `{item_id}.pmtiles` | **SHOULD** | Vector tile derivative for web display (vector only) |
+| `thumbnail.png` | **SHOULD** | Preview image (any format: `.png`, `.jpg`, `.webp`) |
+| `style.json` | **MAY** | MapLibre-compatible styling |
+
+Item IDs are derived from the item directory name. By convention, item directories **SHOULD** be named after the primary data file's stem (e.g., source file `census.shp` goes into item directory `census/`).
+
+## Flat Hierarchy
+
+Portolan catalogs use a **flat hierarchy**: collections contain items directly, with no nested sub-collections.
+
+```
+# Correct (flat)
+census-2020/tracts/tracts.parquet
+census-2020/blocks/blocks.parquet
+
+# Incorrect (nested)
+census/2020/tracts/tracts.parquet
+```
+
+This simplifies tooling and avoids ambiguity about where versioning boundaries lie.
+
+## STAC Conventions
+
+Portolan catalogs **MUST** be saved as `SELF_CONTAINED` (pystac terminology), meaning:
+- All links use relative paths
+- The catalog is portable across different hosting locations
+- No absolute filesystem paths leak into metadata
+
+### Defaults
+
+| Property | Default Value |
+|----------|---------------|
+| STAC version | `1.0.0` |
+| Catalog ID | `portolan-catalog` |
+| Collection license | `proprietary` (SPDX identifier) |
+
+These defaults can be overridden during catalog creation or dataset import.
+
+## Examples
+
+A catalog with a single-file vector collection:
+
+```
+project/
+├── .portolan/
+│   ├── config.yaml
+│   └── state.json
+├── catalog.json
+├── versions.json
+└── districts/
+    ├── collection.json
+    ├── versions.json
+    ├── districts.parquet
+    ├── districts.pmtiles
+    └── thumbnail.png
+```
+
+A catalog with a partitioned vector collection (data > 2 GB):
+
+```
+project/
+├── .portolan/
+│   ├── config.yaml
+│   └── state.json
+├── catalog.json
+├── versions.json
+└── buildings/
+    ├── collection.json
+    ├── versions.json
+    ├── buildings.pmtiles
+    ├── partition-001.parquet
+    ├── partition-002.parquet
+    └── partition-003.parquet
+```

--- a/spec/versions.md
+++ b/spec/versions.md
@@ -1,0 +1,195 @@
+# Version Manifest (`versions.json`)
+
+Each collection **MUST** include a `versions.json` file that tracks version history, asset checksums, and sync state.
+
+## Location
+
+```
+{collection_id}/versions.json
+```
+
+Versioning is per-collection, not per-item. When any item in a collection changes, the collection version increments.
+
+## Schema
+
+```json
+{
+  "spec_version": "1.0.0",
+  "current_version": "2.1.0",
+  "versions": [
+    {
+      "version": "2.1.0",
+      "created": "2024-01-15T10:30:00Z",
+      "breaking": false,
+      "assets": {
+        "districts/districts.parquet": {
+          "sha256": "abc123def456...",
+          "size_bytes": 1048576,
+          "href": "boundaries/districts/districts.parquet"
+        }
+      },
+      "changes": ["districts/districts.parquet"]
+    }
+  ]
+}
+```
+
+### Path Resolution
+
+Asset keys and hrefs follow strict conventions to ensure `push` and `pull` can resolve files unambiguously.
+
+**Asset keys** are scoped relative to the collection directory:
+- For single-file collections (no items): the filename alone (e.g., `tunnels.parquet`)
+- For collections with items: `{item_id}/{filename}` (e.g., `districts/districts.parquet`)
+
+**Asset hrefs** are catalog-root-relative paths, enabling tools to resolve files via `catalog_root / href`:
+- For single-file collections: `{collection_id}/{filename}` (e.g., `tunnels/tunnels.parquet`)
+- For collections with items: `{collection_id}/{item_id}/{filename}` (e.g., `boundaries/districts/districts.parquet`)
+
+The collection directory name **MUST NOT** appear in the asset key. The asset key is resolved relative to the collection directory, not the catalog root.
+
+```
+# Correct — asset key is collection-relative
+"tunnels.parquet": {
+  "href": "tunnels/tunnels.parquet"
+}
+
+# Incorrect — asset key duplicates the collection directory
+"tunnels/tunnels.parquet": {
+  "href": "tunnels/tunnels/tunnels.parquet"
+}
+```
+
+## Fields
+
+### Root Level
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `spec_version` | string | **MUST** | Schema version for the versions.json format (currently `"1.0.0"`) |
+| `current_version` | string \| null | **MUST** | The latest version string, or `null` if no versions exist |
+| `versions` | array | **MUST** | List of version entries, oldest first |
+
+### Version Entry
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | string | **MUST** | Semantic version string (e.g., `"1.0.0"`) |
+| `created` | string | **MUST** | ISO 8601 timestamp in UTC (e.g., `"2024-01-15T10:30:00Z"`) |
+| `breaking` | boolean | **MUST** | `true` if this version has breaking changes |
+| `assets` | object | **MUST** | Map of item-scoped asset keys to asset metadata |
+| `changes` | array | **MUST** | List of asset keys that changed in this version |
+
+### Asset Entry
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `sha256` | string | **MUST** | SHA-256 checksum of the file content |
+| `size_bytes` | integer | **MUST** | File size in bytes |
+| `href` | string | **MUST** | Catalog-root-relative path to the asset (e.g., `"boundaries/districts/districts.parquet"`) |
+
+## Versioning Rules
+
+### Version Numbering
+
+Versions **SHOULD** follow [Semantic Versioning](https://semver.org/):
+- **Major** (X.0.0): Breaking changes (schema changes, column removals)
+- **Minor** (0.X.0): New features (new columns, new items)
+- **Patch** (0.0.X): Data updates (same schema, new data)
+
+### Breaking Changes
+
+A change is considered **breaking** if consumers depending on the previous schema would fail:
+- Column removed or renamed
+- Column type changed
+- Geometry type changed
+- CRS changed
+
+Adding new columns is **not** breaking.
+
+### Change Detection
+
+A file is listed in `changes` if:
+- It's new (not in the previous version)
+- Its SHA-256 checksum differs from the previous version
+
+## Sync State
+
+The `versions.json` file serves as the sync manifest:
+1. Compare local `versions.json` against remote
+2. Push files where local checksum differs from remote
+3. Update remote `versions.json` after successful push
+
+## Example: Single-File Collection
+
+A collection at `tunnels/` with one GeoParquet file. The asset key is the filename alone, and the href is catalog-root-relative:
+
+```json
+{
+  "spec_version": "1.0.0",
+  "current_version": "1.0.0",
+  "versions": [
+    {
+      "version": "1.0.0",
+      "created": "2024-01-15T10:30:00Z",
+      "breaking": false,
+      "assets": {
+        "tunnels.parquet": {
+          "sha256": "abc123...",
+          "size_bytes": 1048576,
+          "href": "tunnels/tunnels.parquet"
+        }
+      },
+      "changes": ["tunnels.parquet"]
+    }
+  ]
+}
+```
+
+## Example: Collection with Items
+
+A collection at `boundaries/` with item subdirectories. The asset key includes the item ID, and the href includes both collection and item:
+
+```json
+{
+  "spec_version": "1.0.0",
+  "current_version": "1.1.0",
+  "versions": [
+    {
+      "version": "1.0.0",
+      "created": "2024-01-01T00:00:00Z",
+      "breaking": false,
+      "assets": {
+        "districts/districts.parquet": {
+          "sha256": "abc123...",
+          "size_bytes": 524288,
+          "href": "boundaries/districts/districts.parquet"
+        }
+      },
+      "changes": ["districts/districts.parquet"]
+    },
+    {
+      "version": "1.1.0",
+      "created": "2024-06-15T12:00:00Z",
+      "breaking": false,
+      "assets": {
+        "districts/districts.parquet": {
+          "sha256": "def456...",
+          "size_bytes": 786432,
+          "href": "boundaries/districts/districts.parquet"
+        },
+        "districts/districts.pmtiles": {
+          "sha256": "ghi789...",
+          "size_bytes": 262144,
+          "href": "boundaries/districts/districts.pmtiles"
+        }
+      },
+      "changes": ["districts/districts.parquet", "districts/districts.pmtiles"]
+    }
+  ]
+}
+```
+
+In this example:
+- v1.0.0: Initial import with one parquet file
+- v1.1.0: Updated parquet data and added PMTiles derivative


### PR DESCRIPTION
## Summary

The initial consolidation (#474) only included schemas. This adds the full spec documentation so the sync workflow doesn't delete content from portolan-spec.

## Files Added

| File | Description |
|------|-------------|
| `spec/core.md` | Mandatory requirements |
| `spec/structure.md` | Directory layout |
| `spec/versions.md` | Version manifest spec |
| `spec/extensions.md` | File type classification |
| `spec/best-practices.md` | Recommended conventions |
| `spec/DECISIONS.md` | Architectural decisions |
| `spec/formats/vector.md` | Vector data spec |
| `spec/formats/raster.md` | Raster data spec |
| `spec/formats/pointcloud.md` | Point cloud spec |
| `spec/examples/README.md` | Example implementations |

Also updates `spec/README.md` with links to all documents.

## Why This Is Urgent

**Without this fix, PR #29 in portolan-spec would delete all spec content** — the sync workflow replaces portolan-spec with `portolan-cli/spec/`, which currently only has schemas.

## Test Plan

- [ ] Merge this PR
- [ ] Close PR #29 in portolan-spec (stale)
- [ ] New sync will auto-trigger with complete content
- [ ] Verify new sync PR preserves all spec files

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)