### PR TITLE
docs(spec): require llms.txt for AI/LLM integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0049](context/shared/adr/0049-stac-geoparquet-scalability.md) | STAC-GeoParquet required for collections >1000 items |
 | [0050](context/shared/adr/0050-pmtiles-visualization-requirement.md) | PMTiles required for vector datasets >100 MB |
 | [0051](context/shared/adr/0051-self-contained-catalog-type.md) | SELF_CONTAINED catalog type (relative links, portable) |
+| [0052](context/shared/adr/0052-llms-txt-requirement.md) | Require llms.txt for AI/LLM integration at catalog and collection levels |
 
 ## Common Commands
 

--- a/context/shared/adr/0052-llms-txt-requirement.md
+++ b/context/shared/adr/0052-llms-txt-requirement.md
@@ -17,17 +17,19 @@ AI agents and LLMs are increasingly used to discover, query, and analyze geospat
 - STAC metadata describes structure but not semantics — agents need both
 - Markdown is the most natural format for LLMs to consume
 - The llms.txt convention is simple, co-located with the data, and versioned alongside it
-- Early experience with [portolan-nl](https://github.com/cholmes/portolan-nl) shows this pattern works well in practice
+- Early experience with [portolan-nl](https://source.coop/cholmes/portolan-nl) shows this pattern works well in practice
 
 ## Consequences
 
 - All catalogs and collections must maintain an `llms.txt` file
 - The file must be linked in STAC JSON with `rel: "llms"` and `type: "text/markdown"`
 - Content recommendations are provided but expected to evolve rapidly as best practices emerge
-- Validation rules added: RULE-0080 (error for missing llms.txt) and RULE-0081 (warning for recommended content)
+- Validation rules added:
+  - RULE-0080/0081: error-level rules requiring llms.txt link at catalog and collection levels
+  - RULE-0082/0083: warning-level rules for recommended content in llms.txt files
 
 ## References
 
 - [ai-integration.md](../../../spec/ai-integration.md) — Full specification
 - [llmstxt.org](https://llmstxt.org/) — The llms.txt standard
-- [portolan-nl](https://github.com/cholmes/portolan-nl) — Example implementation
+- [portolan-nl](https://source.coop/cholmes/portolan-nl) — Example implementation on Source Cooperative

--- a/context/shared/adr/0052-llms-txt-requirement.md
+++ b/context/shared/adr/0052-llms-txt-requirement.md
@@ -1,0 +1,33 @@
+# ADR-0052: Require llms.txt for AI/LLM Integration
+
+**Date**: 2026-06-05
+**Status**: Accepted
+
+## Decision
+
+Every Portolan catalog and collection **MUST** include an `llms.txt` file linked via `rel: "llms"` in the STAC JSON.
+
+## Context
+
+AI agents and LLMs are increasingly used to discover, query, and analyze geospatial data. Machine-readable STAC metadata alone is not enough — agents need plain-language context about what a dataset contains, how to query it, what the fields mean, and what pitfalls to avoid. The [llms.txt](https://llmstxt.org/) standard provides a convention for LLM-friendly documentation.
+
+## Rationale
+
+- AI agents are a primary audience for cloud-native geodata catalogs
+- STAC metadata describes structure but not semantics — agents need both
+- Markdown is the most natural format for LLMs to consume
+- The llms.txt convention is simple, co-located with the data, and versioned alongside it
+- Early experience with [portolan-nl](https://github.com/cholmes/portolan-nl) shows this pattern works well in practice
+
+## Consequences
+
+- All catalogs and collections must maintain an `llms.txt` file
+- The file must be linked in STAC JSON with `rel: "llms"` and `type: "text/markdown"`
+- Content recommendations are provided but expected to evolve rapidly as best practices emerge
+- Validation rules added: RULE-0080 (error for missing llms.txt) and RULE-0081 (warning for recommended content)
+
+## References
+
+- [ai-integration.md](../../../spec/ai-integration.md) — Full specification
+- [llmstxt.org](https://llmstxt.org/) — The llms.txt standard
+- [portolan-nl](https://github.com/cholmes/portolan-nl) — Example implementation

--- a/spec/README.md
+++ b/spec/README.md
@@ -23,6 +23,7 @@ cloud-native geospatial data.
   - [Raster data](formats/raster.md)
   - [Point clouds](formats/pointcloud.md)
 - [Best practices](best-practices.md) - Recommended conventions
+- [AI & LLM integration](ai-integration.md) - llms.txt requirements for agent discoverability
 
 ## Architectural Decisions
 
@@ -33,6 +34,7 @@ Spec-related decisions are tracked in the CLI repository's ADR directory:
 - [ADR-0049: STAC-GeoParquet as Scalability Requirement](../context/shared/adr/0049-stac-geoparquet-scalability.md)
 - [ADR-0050: PMTiles as Visualization Requirement](../context/shared/adr/0050-pmtiles-visualization-requirement.md)
 - [ADR-0051: SELF_CONTAINED Catalog Type](../context/shared/adr/0051-self-contained-catalog-type.md)
+- [ADR-0052: Require llms.txt for AI/LLM Integration](../context/shared/adr/0052-llms-txt-requirement.md)
 
 For all architectural decisions, see [context/shared/adr/](../context/shared/adr/).
 

--- a/spec/ai-integration.md
+++ b/spec/ai-integration.md
@@ -1,0 +1,59 @@
+# AI & LLM Integration
+
+This section covers practices for making Portolan catalogs discoverable and usable by AI agents and large language models. This is a rapidly evolving area — the recommendations here represent early patterns that have proven effective and will be refined as the community gains experience.
+
+## llms.txt
+
+[llms.txt](https://llmstxt.org/) is an emerging standard for providing LLM-friendly documentation alongside web resources. In Portolan, every catalog and collection includes an `llms.txt` file that gives AI agents the context they need to discover, understand, and query the data.
+
+### Requirements
+
+Every catalog and collection **MUST** include an `llms.txt` file in markdown format.
+
+The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
+
+```json
+{
+  "rel": "llms",
+  "href": "./llms.txt",
+  "type": "text/markdown",
+  "title": "Agent/LLM usage guide"
+}
+```
+
+- The `href` **MUST** use a relative path (consistent with `SELF_CONTAINED` catalog type)
+- The `type` **MUST** be `text/markdown`
+- `llms.txt` is a **link**, not an asset — it describes the data, it is not the data itself
+
+### Content Recommendations
+
+These recommendations are early and expected to evolve. They reflect patterns that have worked well in practice but are not exhaustive.
+
+#### Catalog-Level llms.txt
+
+A catalog-level `llms.txt` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
+
+- A summary of what the catalog contains and who publishes it
+- A list of all collections with brief descriptions (what each contains, feature count, key fields)
+- Data access patterns (base URLs, S3 paths, code examples)
+- Coordinate system conventions used across the catalog
+- License information
+- Pointers to collection-level `llms.txt` files for detailed documentation
+
+#### Collection-Level llms.txt
+
+A collection-level `llms.txt` provides everything an AI agent needs to work with a specific dataset. It **SHOULD** include:
+
+- **What the dataset is** — a plain-language description, including source, provider, and license
+- **How to access the data** — URLs and working code examples for loading the data (e.g., DuckDB SQL, Python)
+- **Schema documentation** — all field names, types, and meanings, ideally as a table
+- **Data quality notes** — sentinel values, privacy suppressions, known quirks, or caveats that would trip up a naive query
+- **Example queries** — practical, working examples showing common analysis patterns
+- **Related datasets** — cross-references to complementary collections, including join keys and how to combine them
+
+#### General Guidance
+
+- **SHOULD** be written for an AI agent audience — concise, structured, and practical
+- **SHOULD** favor concrete examples over abstract descriptions
+- **SHOULD** include working code that an agent can adapt, not just pseudocode
+- **SHOULD** call out non-obvious pitfalls (e.g., coordinate systems in meters vs. degrees, coded values, null conventions)

--- a/spec/core.md
+++ b/spec/core.md
@@ -12,9 +12,11 @@ project/
 │   ├── config.yaml
 │   └── state.json
 ├── catalog.json
+├── llms.txt
 ├── versions.json
 └── {collection_id}/
     ├── collection.json
+    ├── llms.txt
     ├── versions.json
     └── {item_id}/
         └── data.parquet
@@ -91,6 +93,13 @@ This is standard STAC practice for provenance and enables consumers to trace dat
 
 - **MUST** include a `README.md` at the catalog root
 - README content requirements: Title, description, license, and data provenance at minimum
+
+## AI & LLM Integration
+
+- **MUST** include an `llms.txt` file at both the catalog root and each collection directory
+- **MUST** link `llms.txt` in the STAC JSON `links` array with `rel: "llms"`
+
+See [ai-integration.md](ai-integration.md) for full requirements and content recommendations.
 
 ## Versioning
 

--- a/spec/schema/catalog.schema.json
+++ b/spec/schema/catalog.schema.json
@@ -45,7 +45,7 @@
         "rel": {
           "type": "string",
           "description": "Link relation type",
-          "examples": ["root", "self", "child", "parent", "item"]
+          "examples": ["root", "self", "child", "parent", "item", "llms"]
         },
         "href": {
           "type": "string",
@@ -79,6 +79,28 @@
                 "not": {
                   "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://"
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "llms" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "LLM integration link - MUST point to llms.txt with text/markdown type",
+            "required": ["type"],
+            "properties": {
+              "href": {
+                "type": "string",
+                "pattern": "(^|/)llms\\.txt$",
+                "description": "Must point to llms.txt file"
+              },
+              "type": {
+                "const": "text/markdown"
               }
             }
           }

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -116,6 +116,17 @@
           "then": {
             "$ref": "#/$defs/VersionHistoryLink"
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": { "const": "llms" }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "$ref": "#/$defs/LlmsLink"
+          }
         }
       ]
     },
@@ -135,6 +146,28 @@
         }
       },
       "required": ["rel", "href"]
+    },
+    "LlmsLink": {
+      "type": "object",
+      "description": "Link to llms.txt for AI/LLM integration - MUST be present",
+      "properties": {
+        "rel": {
+          "const": "llms"
+        },
+        "href": {
+          "type": "string",
+          "pattern": "(^|/)llms\\.txt$",
+          "description": "Must point to llms.txt file"
+        },
+        "type": {
+          "const": "text/markdown"
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title, e.g., 'Agent/LLM usage guide'"
+        }
+      },
+      "required": ["rel", "href", "type"]
     },
     "PortolanAsset": {
       "type": "object",

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -409,3 +409,74 @@ rules:
     references:
       - core.md#version-history-link
       - versions.md
+
+  # =============================================================================
+  # AI & LLM Integration Rules
+  # =============================================================================
+
+  - id: RULE-0080
+    level: error
+    scope: catalog
+    description: Catalogs MUST include llms.txt link
+    rationale: |
+      AI agents and LLMs are a primary audience for Portolan catalogs.
+      The llms.txt file provides context that STAC metadata alone cannot:
+      plain-language descriptions, usage examples, and pitfalls to avoid.
+    validation: |
+      For catalog.json:
+        assert any link has rel="llms"
+        if link with rel="llms" exists:
+          assert link.href ends with "llms.txt"
+          assert link.type == "text/markdown"
+          assert file exists at link.href
+    references:
+      - ai-integration.md
+      - core.md#ai-llm-integration
+
+  - id: RULE-0081
+    level: error
+    scope: collection
+    description: Collections MUST include llms.txt link
+    rationale: |
+      Collection-level llms.txt provides everything an agent needs to work
+      with a specific dataset: schema docs, query examples, data quality notes.
+    validation: |
+      For each collection.json:
+        assert any link has rel="llms"
+        if link with rel="llms" exists:
+          assert link.href ends with "llms.txt"
+          assert link.type == "text/markdown"
+          assert file exists at link.href
+    references:
+      - ai-integration.md
+      - core.md#ai-llm-integration
+
+  - id: RULE-0082
+    level: warning
+    scope: catalog
+    description: Catalog llms.txt SHOULD include recommended content
+    rationale: |
+      Effective llms.txt files follow established patterns for maximum utility.
+      Missing key sections reduce the file's value to AI agents.
+    validation: |
+      For catalog llms.txt:
+        warn if file does not mention collections or datasets
+        warn if no code examples present
+        warn if no license information present
+    references:
+      - ai-integration.md#catalog-level-llmstxt
+
+  - id: RULE-0083
+    level: warning
+    scope: collection
+    description: Collection llms.txt SHOULD include recommended content
+    rationale: |
+      Collection llms.txt should enable agents to immediately work with the data.
+      Schema documentation and query examples are particularly valuable.
+    validation: |
+      For collection llms.txt:
+        warn if no schema/field documentation present
+        warn if no code/query examples present
+        warn if no data access URLs present
+    references:
+      - ai-integration.md#collection-level-llmstxt


### PR DESCRIPTION
## Summary

- Adds `ai-integration.md` — a new spec page requiring every catalog and collection to include an `llms.txt` file linked via `rel: "llms"` in the STAC JSON
- Updates the directory tree in `core.md` to show `llms.txt` at both catalog and collection levels, and adds a brief "AI & LLM Integration" section
- Records ADR-0052 with rationale for requiring llms.txt
- Adds schema validation for `llms` link relations in catalog.schema.json and collection.schema.json
- Adds RULE-0080 through RULE-0083 to rules.yaml for llms.txt validation

The page is framed broadly as "AI & LLM Integration" since llms.txt is the first mechanism but others may follow. Content recommendations are flagged as early and expected to evolve. Links to [llmstxt.org](https://llmstxt.org/) for the general standard.

Patterns extracted from [portolan-nl](https://github.com/cholmes/portolan-nl).

## Context

This is the **portolan-cli counterpart** to [portolan-spec#19](https://github.com/portolan-sdi/portolan-spec/pull/19), migrated per [ADR-0048](context/shared/adr/0048-cli-as-spec-source.md) which established `portolan-cli/spec/` as the source of truth.

## After Merge

When merged, the `sync-spec.yml` workflow will automatically create a PR in `portolan-spec` to propagate these changes. PR #19 on portolan-spec should then be closed as obsolete.

## Test plan

- [x] JSON schemas validate
- [x] rules.yaml is valid YAML
- [x] CLAUDE.md ADR index validates (52 ADRs)
- [ ] Review `ai-integration.md` for completeness and tone
- [ ] Verify link JSON example matches portolan-nl usage
- [ ] Check RFC 2119 language consistency with existing spec

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)