### PR TITLE
docs(spec): add tabular (non-geospatial) data format specification

### DIFF
--- a/context/shared/adr/0047-non-geo-tabular-data-support.md
+++ b/context/shared/adr/0047-non-geo-tabular-data-support.md
@@ -85,6 +85,29 @@ Tabular files become collection-level assets (per ADR-0031), not items. This avo
 
 Exception: **Partitioned tabular data** (e.g., temporally partitioned) will use items, where the partition key becomes the item's temporal interval and `geometry: null`. This follows the existing partition extension (ADR-0042).
 
+### 7. Collection property: `portolan:geospatial`
+
+Tabular collections are marked with `portolan:geospatial: false` to distinguish *intentionally non-spatial* from *spatial but unmeasured*:
+
+```json
+{
+  "type": "Collection",
+  "id": "demographics",
+  "portolan:geospatial": false,
+  ...
+}
+```
+
+- **`portolan:geospatial: false`** — tabular collection; `extent.spatial.bbox` represents AOI, not geometry
+- **`portolan:geospatial: true` or absent** — geospatial collection; all spatial requirements apply
+
+This explicit flag enables:
+- Validators to apply different rules for tabular vs geo collections (RULE-0090)
+- Federation agents to route spatial queries correctly
+- Consumers to understand bbox semantics (AOI vs footprint)
+
+The CLI sets this flag automatically in `_ensure_tabular_collection()` when creating new tabular-only collections.
+
 ## Consequences
 
 ### What becomes easier

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -2495,6 +2495,9 @@ def _ensure_tabular_collection(
         bbox=final_bbox,
     )
 
+    # Mark as non-geospatial tabular collection (RULE-0090, ADR-0047)
+    collection.extra_fields["portolan:geospatial"] = False
+
     # Save collection.json
     collection_dir.mkdir(parents=True, exist_ok=True)
     collection.set_self_href(str(collection_json_path))

--- a/spec/README.md
+++ b/spec/README.md
@@ -22,6 +22,7 @@ cloud-native geospatial data.
   - [Vector data](formats/vector.md)
   - [Raster data](formats/raster.md)
   - [Point clouds](formats/pointcloud.md)
+  - [Tabular (non-geospatial) data](formats/tabular.md)
 - [Best practices](best-practices.md) - Recommended conventions
 - [AI & LLM integration](ai-integration.md) - llms.txt requirements for agent discoverability
 
@@ -31,6 +32,7 @@ Spec-related decisions are tracked in the CLI repository's ADR directory:
 
 - [ADR-0005: versions.json as Single Source of Truth](../context/shared/adr/0005-versions-json-source-of-truth.md)
 - [ADR-0032: Nested Catalogs with Flat Collections](../context/shared/adr/0032-nested-catalogs-with-flat-collections.md)
+- [ADR-0047: Non-Geo Tabular Data Support](../context/shared/adr/0047-non-geo-tabular-data-support.md)
 - [ADR-0049: STAC-GeoParquet as Scalability Requirement](../context/shared/adr/0049-stac-geoparquet-scalability.md)
 - [ADR-0050: PMTiles as Visualization Requirement](../context/shared/adr/0050-pmtiles-visualization-requirement.md)
 - [ADR-0051: SELF_CONTAINED Catalog Type](../context/shared/adr/0051-self-contained-catalog-type.md)

--- a/spec/core.md
+++ b/spec/core.md
@@ -28,13 +28,13 @@ project/
 - **MUST** follow STAC specification version 1.0.0 or later
 - **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
 
-### Spatial Extent Relaxation for Tabular Collections
+### Spatial Extent for Tabular Collections
 
-STAC requires `extent.spatial.bbox` for Collections. Portolan relaxes this requirement for **tabular (non-geospatial) collections**:
+STAC requires `extent.spatial.bbox` for Collections. For **tabular (non-geospatial) collections** (`portolan:geospatial: false`):
 
-- Collections with `portolan:geospatial: false` **MAY** omit `extent.spatial`
-- Validators **MUST NOT** reject a tabular collection for lacking spatial extent
-- If `extent.spatial` is present, it represents the **area of interest** the data pertains to, not a geometric footprint
+- `extent.spatial.bbox` represents the **area of interest** (AOI) the data pertains to, not a geometric footprint
+- Portolan CLI **always provides** `extent.spatial` via automatic AOI inheritance from sibling collections (or global fallback)
+- Portolan validators treat the bbox as informational metadata, not a constraint
 
 See [formats/tabular.md](formats/tabular.md) for full tabular collection requirements.
 

--- a/spec/core.md
+++ b/spec/core.md
@@ -28,6 +28,16 @@ project/
 - **MUST** follow STAC specification version 1.0.0 or later
 - **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
 
+### Spatial Extent Relaxation for Tabular Collections
+
+STAC requires `extent.spatial.bbox` for Collections. Portolan relaxes this requirement for **tabular (non-geospatial) collections**:
+
+- Collections with `portolan:geospatial: false` **MAY** omit `extent.spatial`
+- Validators **MUST NOT** reject a tabular collection for lacking spatial extent
+- If `extent.spatial` is present, it represents the **area of interest** the data pertains to, not a geometric footprint
+
+See [formats/tabular.md](formats/tabular.md) for full tabular collection requirements.
+
 ## Data Storage
 
 Portolan catalogs assume data is hosted in S3-compatible object storage. This is the ground truth for all assets.
@@ -132,5 +142,6 @@ Additional requirements apply based on data type. See format addenda:
 - [Vector data](formats/vector.md)
 - [Raster data](formats/raster.md)
 - [Point cloud data](formats/pointcloud.md)
+- [Tabular (non-geospatial) data](formats/tabular.md)
 
 Format addenda are normative and define **MUST** requirements, not suggestions.

--- a/spec/examples/README.md
+++ b/spec/examples/README.md
@@ -4,6 +4,18 @@ This directory contains reference implementations of Portolan catalogs.
 
 ## Available Examples
 
+### Tabular Collection (Non-Geospatial)
+
+A reference implementation of a tabular (non-geospatial) collection.
+
+- **File**: [tabular-collection.json](tabular-collection.json)
+- **Demonstrates**:
+  - `portolan:geospatial: false` flag for non-spatial data
+  - STAC Table extension for schema documentation
+  - Temporal extent without spatial extent
+  - Collection-level assets for single-file tabular data
+  - Provenance link to source (Eurostat)
+
 ### Argentina 2022 Census
 
 A complete implementation of Argentina's 2022 census data as a Portolan catalog.

--- a/spec/examples/tabular-collection.json
+++ b/spec/examples/tabular-collection.json
@@ -1,0 +1,83 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "eurostat-electricity-prices",
+  "title": "Industrial electricity prices by country",
+  "description": "Half-yearly industrial electricity prices (EUR/kWh, including taxes) by European country. Non-geospatial tabular dataset. Source: Eurostat nrg_pc_205.",
+  "license": "CC-BY-4.0",
+  "portolan:geospatial": false,
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+  ],
+  "extent": {
+    "temporal": {
+      "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "providers": [
+    {
+      "name": "Eurostat",
+      "roles": ["producer", "licensor"],
+      "url": "https://ec.europa.eu/eurostat"
+    }
+  ],
+  "table:columns": [
+    {
+      "name": "geo",
+      "type": "string",
+      "description": "Country code (Eurostat / ISO-3166-1 alpha-2)"
+    },
+    {
+      "name": "period",
+      "type": "string",
+      "description": "Reporting half-year, e.g. 2024-S1"
+    },
+    {
+      "name": "price_eur_kwh",
+      "type": "double",
+      "description": "Industrial electricity price, EUR/kWh, including taxes"
+    }
+  ],
+  "assets": {
+    "data": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/eurostat-electricity-prices/electricity-prices.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "title": "Electricity prices data"
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "./collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "version-history",
+      "href": "./versions.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "llms",
+      "href": "./llms.txt",
+      "type": "text/markdown",
+      "title": "Agent/LLM usage guide"
+    },
+    {
+      "rel": "via",
+      "href": "https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_205/default/table",
+      "type": "text/html",
+      "title": "Source: Eurostat — Electricity prices for non-household consumers"
+    }
+  ]
+}

--- a/spec/examples/tabular-collection.json
+++ b/spec/examples/tabular-collection.json
@@ -10,6 +10,9 @@
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "extent": {
+    "spatial": {
+      "bbox": [[-25, 34, 45, 72]]
+    },
     "temporal": {
       "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
     }

--- a/spec/extensions.md
+++ b/spec/extensions.md
@@ -14,7 +14,7 @@ These extensions are recognized as importable geospatial data:
 | `.shp` | Shapefile | Vector | No | Converts to GeoParquet |
 | `.gpkg` | GeoPackage | Vector | No | Converts to GeoParquet |
 | `.fgb` | FlatGeobuf | Vector | Yes | Cloud-native, passed through |
-| `.csv` | CSV with geometry | Vector | No | Converts to GeoParquet (requires lat/lon or WKT column) |
+| `.csv` | CSV | Vector/Tabular | No | Content inspected: geometry columns → GeoParquet; no geometry → tabular (if enabled) |
 | `.tif`, `.tiff` | GeoTIFF/COG | Raster | Depends | Content inspected for COG compliance |
 | `.jp2` | JPEG2000 | Raster | No | Converts to COG |
 
@@ -35,13 +35,18 @@ See [ADR-0014: Accept non-cloud-native formats](https://github.com/portolan-sdi/
 
 ### Content Inspection
 
-Some formats require content inspection to determine cloud-native status:
+Some formats require content inspection to determine type and cloud-native status:
 
-- **`.parquet`**: Checked for GeoParquet metadata (geo column info)
+- **`.parquet`**: Checked for GeoParquet metadata (`geo` key in schema metadata)
+  - If `geo` key present → GeoParquet (geospatial pipeline)
+  - If `geo` key absent → Plain Parquet (tabular pipeline, requires `tabular.enabled: true`)
+- **`.csv`**: Checked for geometry columns (lat/lon, WKT, WKB)
+  - If geometry columns found → GeoParquet conversion
+  - If no geometry columns → tabular (requires `tabular.enabled: true`)
 - **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry)
 - **`.tif`/`.tiff`**: Validated against COG spec (internal tiling, overviews)
 
-Files that fail content inspection are treated as convertible (vector) or rejected (raster without geo info).
+Files that fail content inspection are treated as convertible (vector), tabular (if enabled), or rejected (raster without geo info).
 
 ## Sidecar Files
 
@@ -97,6 +102,23 @@ These formats are explicitly rejected with informative error messages:
 | `.h5`, `.hdf5` | HDF5 | Not yet supported |
 | `.las`, `.laz` | LAS/LAZ | Use COPC format instead |
 
+## Tabular Formats
+
+These extensions are recognized as tabular data when `tabular.enabled: true` in `.portolan/config.yaml`:
+
+| Extension | Format | Handling |
+|-----------|--------|----------|
+| `.parquet` | Plain Parquet | Content inspection — no `geo` metadata key |
+| `.csv` | CSV | Content inspection — no geometry columns |
+| `.tsv` | TSV | Converts to Parquet |
+| `.xlsx`, `.xls` | Excel | Converts to Parquet |
+
+When `tabular.enabled` is `false` (default):
+- Tabular files with a companion geo file → tracked as companion assets
+- Standalone tabular files → rejected with helpful error message
+
+See [formats/tabular.md](formats/tabular.md) for full requirements.
+
 ## Ignored Files
 
 The following are skipped during directory scans:
@@ -107,10 +129,7 @@ The following are skipped during directory scans:
 | `.pyc`, `.pyo`, `.class`, `.o`, `.obj` | Compiled files |
 | `__pycache__/`, `.git/`, `.svn/`, `.hg/` | Build/VCS directories |
 | `.idea/`, `.vscode/`, `node_modules/`, `.tox/`, `.pytest_cache/` | IDE/tooling directories |
-| `.tsv`, `.xlsx`, `.xls` | Tabular data (not geospatial) |
 | `.md`, `.txt`, `.rst`, `.html`, `.htm` | Documentation |
-
-Note: `.csv` files are listed as importable above (with geometry columns) but are also commonly non-geospatial. The scan command classifies them as tabular data; the import command performs content inspection.
 
 ## Extension vs. Role
 

--- a/spec/formats/tabular.md
+++ b/spec/formats/tabular.md
@@ -1,0 +1,234 @@
+# Tabular (Non-Geospatial) Data Format Requirements
+
+Portolan supports **non-geospatial tabular datasets** as companion data alongside geospatial layers. This enables catalogs to include tables keyed by time, administrative code, or category rather than by location.
+
+## Scope
+
+Portolan is a **geospatial-first** catalog tool. Tabular support is scoped to companion data that relates to the same geographic area as the catalog's spatial layers — not general-purpose data cataloging.
+
+Examples of appropriate tabular data:
+- Census demographics linked by tract ID
+- Permit records keyed by parcel number
+- Budget allocations by administrative unit
+- Time-series data (electricity load, sensor readings)
+
+## Enabling Tabular Support
+
+Tabular data support is **opt-in** via `.portolan/config.yaml`:
+
+```yaml
+tabular:
+  enabled: true   # Track standalone tabular files as collection-level assets
+  convert: true   # Convert CSV/TSV/Excel to Parquet (default)
+```
+
+When `tabular.enabled` is `false` (default):
+- Tabular files **with** a companion geo file → tracked as companion assets
+- Tabular files **without** a companion geo file → rejected with helpful error
+
+When `tabular.enabled` is `true`:
+- Standalone tabular files → tracked as collection-level assets
+- A collection can be tabular-only (no geo data)
+
+## Recognized Formats
+
+| Extension | Format | Handling |
+|-----------|--------|----------|
+| `.parquet` | Plain Parquet | Content inspection — no `geo` metadata key |
+| `.csv` | CSV | Converts to Parquet |
+| `.tsv` | TSV | Converts to Parquet |
+| `.xlsx`, `.xls` | Excel | Converts to Parquet |
+
+### GeoParquet vs Plain Parquet Classification
+
+`.parquet` files are classified by content inspection:
+
+1. Read Parquet footer metadata (O(1) operation)
+2. Check for `b"geo"` key in schema metadata
+3. If present → GeoParquet (geo pipeline)
+4. If absent → Plain Parquet (tabular pipeline)
+
+## Marking Collections Non-Spatial
+
+Tabular collections **MUST** include the `portolan:geospatial` property:
+
+```json
+{
+  "type": "Collection",
+  "id": "electricity-prices",
+  "portolan:geospatial": false,
+  ...
+}
+```
+
+- `portolan:geospatial: false` → tabular collection, spatial extent relaxations apply
+- `portolan:geospatial: true` or absent → geospatial collection, all spatial requirements apply
+
+This explicit flag distinguishes *intentionally non-spatial* from *spatial but unmeasured*, enabling validators and federation agents to route queries correctly.
+
+## Spatial Extent Handling
+
+For tabular collections (`portolan:geospatial: false`):
+
+- `extent.spatial` **MAY** be omitted entirely
+- If present, `extent.spatial.bbox` represents the **area of interest** the data pertains to, not the geometry of the data itself
+- Validators **MUST NOT** reject a tabular collection for missing spatial extent
+
+### AOI Inheritance
+
+When `extent.spatial` is not explicitly set, Portolan tools compute it automatically:
+
+1. **Explicit bbox** in `metadata.yaml` (manual override)
+2. **Inherit from sibling geo collections** — compute union bbox
+3. **Global fallback** `[-180, -90, 180, 90]` when no siblings exist
+
+This default is appropriate because companion tabular data typically pertains to the same geographic area as the catalog's spatial layers.
+
+**Limitation**: Union bbox computation uses simple min/max aggregation, which does NOT correctly handle antimeridian-crossing bboxes (where west > east). For catalogs with such collections, use an explicit bbox in `metadata.yaml`.
+
+## Temporal Extent
+
+Tabular collections **SHOULD** populate `extent.temporal` when the data has a time dimension:
+
+```json
+"extent": {
+  "temporal": {
+    "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+  }
+}
+```
+
+## Schema Documentation
+
+Tabular collections **SHOULD** describe their columns using the [STAC Table extension](https://github.com/stac-extensions/table):
+
+```json
+"stac_extensions": [
+  "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+],
+"table:columns": [
+  {"name": "geo", "type": "string", "description": "Country code (ISO-3166-1 alpha-2)"},
+  {"name": "period", "type": "string", "description": "Reporting half-year, e.g. 2024-S1"},
+  {"name": "price_eur_kwh", "type": "double", "description": "Price in EUR per kWh"}
+]
+```
+
+Because tabular data has no geometry to hint at its meaning, the schema is the primary semantic handle for consumers and agents.
+
+## Collection-Level Assets
+
+Tabular files become **collection-level assets** (not items), following the same pattern as single-file vector collections:
+
+```json
+{
+  "type": "Collection",
+  "id": "eurostat-electricity-prices",
+  "portolan:geospatial": false,
+  "assets": {
+    "data": {
+      "href": "./electricity-prices.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    }
+  }
+}
+```
+
+### Source File Tracking
+
+When conversion is enabled (`tabular.convert: true`), both the source file and converted Parquet are tracked as assets:
+
+```json
+"assets": {
+  "data": {
+    "href": "./electricity-prices.parquet",
+    "type": "application/vnd.apache.parquet",
+    "roles": ["data"]
+  },
+  "source": {
+    "href": "./electricity-prices.csv",
+    "type": "text/csv",
+    "roles": ["source"]
+  }
+}
+```
+
+## Directory Layout
+
+```
+eurostat-electricity-prices/
+  collection.json
+  versions.json
+  llms.txt
+  electricity-prices.parquet
+  electricity-prices.csv        (source, if converted)
+```
+
+No item directory or item JSON is needed.
+
+## Example: Complete Tabular Collection
+
+```json
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "eurostat-electricity-prices",
+  "title": "Industrial electricity prices by country",
+  "description": "Half-yearly industrial electricity prices (EUR/kWh) by European country. Source: Eurostat nrg_pc_205.",
+  "license": "CC-BY-4.0",
+  "portolan:geospatial": false,
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+  ],
+  "extent": {
+    "temporal": {
+      "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "providers": [
+    {
+      "name": "Eurostat",
+      "roles": ["producer", "licensor"],
+      "url": "https://ec.europa.eu/eurostat"
+    }
+  ],
+  "table:columns": [
+    {"name": "geo", "type": "string", "description": "Country code (Eurostat / ISO-3166-1 alpha-2)"},
+    {"name": "period", "type": "string", "description": "Reporting half-year, e.g. 2024-S1"},
+    {"name": "price_eur_kwh", "type": "double", "description": "Industrial electricity price, EUR/kWh"}
+  ],
+  "assets": {
+    "data": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/eurostat-electricity-prices/electricity-prices.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    }
+  },
+  "links": [
+    {"rel": "root", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "self", "href": "./collection.json", "type": "application/json"},
+    {"rel": "version-history", "href": "./versions.json", "type": "application/json"},
+    {"rel": "llms", "href": "./llms.txt", "type": "text/markdown", "title": "Agent/LLM usage guide"},
+    {
+      "rel": "via",
+      "href": "https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_205/default/table",
+      "type": "text/html",
+      "title": "Source: Eurostat — Electricity prices for non-household consumers"
+    }
+  ]
+}
+```
+
+Note: No `extent.spatial`, no geometry, no PMTiles — none apply to a tabular collection.
+
+## What Does NOT Apply
+
+For tabular collections:
+
+- **No GeoParquet metadata** — the Parquet file has no `geo` key
+- **No PMTiles** — visualization derivatives are for spatial data
+- **No spatial extent requirement** — `extent.spatial` is optional
+- **No geometry validation** — there is no geometry to validate
+
+All other Portolan core requirements apply unchanged: absolute S3 asset hrefs (when published), relative STAC links, `providers`, provenance via `rel: "via"`, `README.md`, `llms.txt`, and `versions.json` tracking.

--- a/spec/formats/tabular.md
+++ b/spec/formats/tabular.md
@@ -70,13 +70,15 @@ This explicit flag distinguishes *intentionally non-spatial* from *spatial but u
 
 For tabular collections (`portolan:geospatial: false`):
 
-- `extent.spatial` **MAY** be omitted entirely
-- If present, `extent.spatial.bbox` represents the **area of interest** the data pertains to, not the geometry of the data itself
-- Validators **MUST NOT** reject a tabular collection for missing spatial extent
+- `extent.spatial.bbox` represents the **area of interest** (AOI) the data pertains to, not a geometric footprint
+- Portolan CLI **always provides** `extent.spatial` via automatic AOI inheritance (see below)
+- Portolan validators treat the bbox as informational for tabular collections
+
+> **Note on STAC compliance**: The STAC Collection schema requires `extent.spatial`. While Portolan's semantic model considers spatial extent optional for tabular data, the CLI always provides it to maintain STAC schema compatibility. The `portolan:geospatial: false` flag signals that the bbox is an AOI, not a geometry footprint.
 
 ### AOI Inheritance
 
-When `extent.spatial` is not explicitly set, Portolan tools compute it automatically:
+Portolan CLI computes `extent.spatial` automatically for tabular collections:
 
 1. **Explicit bbox** in `metadata.yaml` (manual override)
 2. **Inherit from sibling geo collections** — compute union bbox
@@ -181,6 +183,9 @@ No item directory or item JSON is needed.
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "extent": {
+    "spatial": {
+      "bbox": [[-25, 34, 45, 72]]
+    },
     "temporal": {
       "interval": [["2007-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
     }
@@ -220,7 +225,7 @@ No item directory or item JSON is needed.
 }
 ```
 
-Note: No `extent.spatial`, no geometry, no PMTiles — none apply to a tabular collection.
+Note: The `extent.spatial.bbox` represents the European AOI (inherited or explicit), not geometry. No PMTiles or geometry validation apply to tabular collections.
 
 ## What Does NOT Apply
 

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -18,6 +18,11 @@
         "type": {
           "const": "Collection"
         },
+        "portolan:geospatial": {
+          "type": "boolean",
+          "default": true,
+          "description": "False for tabular (non-geospatial) collections. When false, extent.spatial is optional. See formats/tabular.md"
+        },
         "portolan:styles": {
           "type": "array",
           "description": "Ordered list of style asset keys. First entry is the default style. See best-practices.md#visualization-styles",

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -21,7 +21,7 @@
         "portolan:geospatial": {
           "type": "boolean",
           "default": true,
-          "description": "False for tabular (non-geospatial) collections. When false, extent.spatial is optional. See formats/tabular.md"
+          "description": "False for tabular (non-geospatial) collections. When false, extent.spatial.bbox represents the area-of-interest (AOI) the data pertains to, not a geometric footprint. Note: STAC schema (via allOf) still requires extent.spatial; Portolan CLI provides this via AOI inheritance from sibling collections. See formats/tabular.md"
         },
         "portolan:styles": {
           "type": "array",

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -516,22 +516,23 @@ rules:
       - https://github.com/stac-extensions/table
 
   - id: RULE-0092
-    level: error
+    level: info
     scope: collection
-    description: Tabular collections MAY omit extent.spatial
+    description: Tabular collection extent.spatial represents AOI, not geometry
     rationale: |
-      STAC requires extent.spatial.bbox for collections, but tabular data has
-      no intrinsic spatial footprint. Portolan relaxes this requirement for
-      collections with portolan:geospatial: false.
+      STAC requires extent.spatial.bbox for collections. For tabular data with
+      no intrinsic spatial footprint, the bbox represents the area-of-interest
+      (AOI) the data pertains to. Portolan CLI always provides extent.spatial
+      via automatic AOI inheritance from sibling collections or global fallback.
     validation: |
       If collection["portolan:geospatial"] == false:
-        extent.spatial is optional
-        validators MUST NOT reject for missing spatial extent
+        extent.spatial.bbox is treated as informational AOI, not a constraint
+        Portolan CLI auto-populates via AOI inheritance
       If collection["portolan:geospatial"] == true or absent:
-        extent.spatial.bbox is required (STAC default)
+        extent.spatial.bbox represents actual spatial footprint
     references:
       - formats/tabular.md#spatial-extent-handling
-      - core.md#spatial-extent-relaxation-for-tabular-collections
+      - core.md#spatial-extent-for-tabular-collections
 
   - id: RULE-0093
     level: warning

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -480,3 +480,95 @@ rules:
         warn if no data access URLs present
     references:
       - ai-integration.md#collection-level-llmstxt
+
+  # =============================================================================
+  # Tabular (Non-Geospatial) Data Rules
+  # =============================================================================
+
+  - id: RULE-0090
+    level: error
+    scope: collection
+    description: Tabular collections MUST have portolan:geospatial set to false
+    rationale: |
+      The portolan:geospatial flag distinguishes intentionally non-spatial
+      collections from spatial collections with missing extent. This enables
+      validators and federation agents to route queries correctly.
+    validation: |
+      If collection has no GeoParquet assets (no geo metadata in .parquet files):
+        assert collection["portolan:geospatial"] == false
+    references:
+      - formats/tabular.md#marking-collections-non-spatial
+
+  - id: RULE-0091
+    level: warning
+    scope: collection
+    description: Tabular collections SHOULD use the STAC Table extension
+    rationale: |
+      Because tabular data has no geometry to hint at its meaning, the schema
+      is the primary semantic handle for consumers and agents. The table:columns
+      property surfaces schema information in STAC without opening the Parquet file.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        warn if "table:columns" not in collection
+        warn if "https://stac-extensions.github.io/table" not in stac_extensions
+    references:
+      - formats/tabular.md#schema-documentation
+      - https://github.com/stac-extensions/table
+
+  - id: RULE-0092
+    level: error
+    scope: collection
+    description: Tabular collections MAY omit extent.spatial
+    rationale: |
+      STAC requires extent.spatial.bbox for collections, but tabular data has
+      no intrinsic spatial footprint. Portolan relaxes this requirement for
+      collections with portolan:geospatial: false.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        extent.spatial is optional
+        validators MUST NOT reject for missing spatial extent
+      If collection["portolan:geospatial"] == true or absent:
+        extent.spatial.bbox is required (STAC default)
+    references:
+      - formats/tabular.md#spatial-extent-handling
+      - core.md#spatial-extent-relaxation-for-tabular-collections
+
+  - id: RULE-0093
+    level: warning
+    scope: collection
+    description: Tabular collections SHOULD have temporal extent when time-dimensioned
+    rationale: |
+      Most tabular data has a time dimension (time-series, reporting periods).
+      Temporal extent enables time-based queries and browsing.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        warn if extent.temporal is not set and data appears to have time dimension
+    references:
+      - formats/tabular.md#temporal-extent
+
+  - id: RULE-0094
+    level: error
+    scope: collection
+    description: Tabular collections MUST use collection-level assets
+    rationale: |
+      Single-file tabular datasets should not be wrapped in STAC items.
+      Collection-level assets are simpler and match the vector data pattern.
+    validation: |
+      If collection["portolan:geospatial"] == false:
+        assert primary data is in collection.assets, not wrapped in items
+    references:
+      - formats/tabular.md#collection-level-assets
+
+  - id: RULE-0095
+    level: warning
+    scope: config
+    description: Standalone tabular files require tabular.enabled config
+    rationale: |
+      Tabular support is opt-in to prevent accidentally sweeping in stray
+      CSV/Excel files. Users must explicitly enable it.
+    validation: |
+      If scan finds tabular files without companion geo files:
+        if not config["tabular"]["enabled"]:
+          reject with message explaining how to enable
+    references:
+      - formats/tabular.md#enabling-tabular-support

--- a/tests/fixtures/validation/stac/invalid-tabular-no-flag/collection.json
+++ b/tests/fixtures/validation/stac/invalid-tabular-no-flag/collection.json
@@ -3,9 +3,12 @@
   "stac_version": "1.0.0",
   "id": "invalid-tabular-collection",
   "title": "Invalid Tabular Collection",
-  "description": "A tabular collection missing portolan:geospatial flag - should fail validation",
+  "description": "A tabular collection missing portolan:geospatial flag. This collection has plain Parquet assets (no geo metadata) but lacks the required portolan:geospatial: false flag. Should fail RULE-0090 validation.",
   "license": "CC-BY-4.0",
   "extent": {
+    "spatial": {
+      "bbox": [[-180, -90, 180, 90]]
+    },
     "temporal": {
       "interval": [["2020-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
     }

--- a/tests/fixtures/validation/stac/invalid-tabular-no-flag/collection.json
+++ b/tests/fixtures/validation/stac/invalid-tabular-no-flag/collection.json
@@ -1,0 +1,26 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "invalid-tabular-collection",
+  "title": "Invalid Tabular Collection",
+  "description": "A tabular collection missing portolan:geospatial flag - should fail validation",
+  "license": "CC-BY-4.0",
+  "extent": {
+    "temporal": {
+      "interval": [["2020-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "assets": {
+    "data": {
+      "href": "./data.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "description": "Plain Parquet file (no geo metadata) - but collection lacks portolan:geospatial: false"
+    }
+  },
+  "links": [
+    {"rel": "root", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "self", "href": "./collection.json", "type": "application/json"}
+  ]
+}

--- a/tests/fixtures/validation/stac/valid-tabular/collection.json
+++ b/tests/fixtures/validation/stac/valid-tabular/collection.json
@@ -1,0 +1,36 @@
+{
+  "type": "Collection",
+  "stac_version": "1.0.0",
+  "id": "test-tabular-collection",
+  "title": "Test Tabular Collection",
+  "description": "A valid tabular (non-geospatial) collection for testing",
+  "license": "CC-BY-4.0",
+  "portolan:geospatial": false,
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+  ],
+  "extent": {
+    "temporal": {
+      "interval": [["2020-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
+    }
+  },
+  "table:columns": [
+    {"name": "id", "type": "int64", "description": "Record identifier"},
+    {"name": "category", "type": "string", "description": "Category code"},
+    {"name": "value", "type": "double", "description": "Measured value"}
+  ],
+  "assets": {
+    "data": {
+      "href": "./data.parquet",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"]
+    }
+  },
+  "links": [
+    {"rel": "root", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
+    {"rel": "self", "href": "./collection.json", "type": "application/json"},
+    {"rel": "version-history", "href": "./versions.json", "type": "application/json"},
+    {"rel": "llms", "href": "./llms.txt", "type": "text/markdown", "title": "Agent/LLM usage guide"}
+  ]
+}

--- a/tests/fixtures/validation/stac/valid-tabular/collection.json
+++ b/tests/fixtures/validation/stac/valid-tabular/collection.json
@@ -10,6 +10,9 @@
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "extent": {
+    "spatial": {
+      "bbox": [[-180, -90, 180, 90]]
+    },
     "temporal": {
       "interval": [["2020-01-01T00:00:00Z", "2024-12-31T23:59:59Z"]]
     }

--- a/tests/unit/test_tabular_support.py
+++ b/tests/unit/test_tabular_support.py
@@ -1314,3 +1314,56 @@ extent:
 
         result = _get_metadata_yaml_bbox(tmp_path)
         assert result is None
+
+
+@pytest.mark.unit
+class TestPortolanGeospatialFlag:
+    """Tests for portolan:geospatial flag on tabular collections (RULE-0090).
+
+    Tabular collections MUST have portolan:geospatial set to false to distinguish
+    intentionally non-spatial from spatial-but-unmeasured collections.
+    """
+
+    def test_tabular_collection_has_geospatial_false(self, tmp_path: Path) -> None:
+        """Tabular collections should have portolan:geospatial: false set."""
+        from portolan_cli.dataset import add_files
+
+        # Create catalog structure
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        _setup_test_catalog(catalog_root)
+
+        # Create tabular collection directory
+        tabular_dir = catalog_root / "demographics"
+        tabular_dir.mkdir()
+
+        # Create plain Parquet (no geo metadata)
+        parquet_file = tabular_dir / "census.parquet"
+        table = pa.table({"tract_id": ["001", "002"], "population": [5000, 7500]})
+        pq.write_table(table, parquet_file)
+
+        # Enable tabular support
+        config_file = catalog_root / ".portolan" / "config.yaml"
+        config_file.write_text("tabular:\n  enabled: true\n")
+
+        # Add the file
+        added, skipped, failures = add_files(
+            paths=[parquet_file],
+            catalog_root=catalog_root,
+        )
+
+        # Tabular files go to skipped (tracked as collection-level assets)
+        assert len(failures) == 0
+        assert parquet_file in skipped, "Tabular file should be in skipped list"
+
+        # Check collection.json has portolan:geospatial: false
+        collection_json = tabular_dir / "collection.json"
+        assert collection_json.exists(), "collection.json should be created"
+
+        collection_data = json.loads(collection_json.read_text())
+        assert "portolan:geospatial" in collection_data, (
+            "Tabular collection should have portolan:geospatial property (RULE-0090)"
+        )
+        assert collection_data["portolan:geospatial"] is False, (
+            "Tabular collection should have portolan:geospatial: false"
+        )


### PR DESCRIPTION
## Summary

Complete spec documentation for non-geo tabular data support, bringing the spec up to date with the CLI implementation (PR #449, merged June 2).

This PR implements the spec-side changes needed for portolan-spec#22 (Javier's RFC). Per ADR-0048, the CLI repo is the source of truth, so the spec changes go here.

### What's Added

| File | Description |
|------|-------------|
| `spec/formats/tabular.md` | Full format addendum (config gate, classification, AOI inheritance, modeling) |
| `spec/extensions.md` | New "Tabular Formats" section, updated content inspection docs |
| `spec/core.md` | Spatial extent relaxation for `portolan:geospatial: false` |
| `spec/schema/collection.schema.json` | `portolan:geospatial` property definition |
| `spec/schema/rules.yaml` | RULE-0090 through RULE-0095 for tabular validation |
| `spec/examples/tabular-collection.json` | Reference implementation |
| Test fixtures | Valid and invalid tabular collection examples |

### Key Decisions

1. **Property name**: `portolan:geospatial: false`
   - Boolean flag (backward compatible — absence = `true`)
   - Distinguishes "intentionally non-spatial" from "spatial but unmeasured"

2. **`table:columns` requirement**: SHOULD (warning level)
   - Parquet already contains schema in metadata
   - Low friction for companion data use case
   - Can tighten later based on real-world feedback

### Closes

- portolan-spec#22 — Proposal now implemented via CLI code (PR #449) + this spec documentation

## Test plan

- [x] All 56 tabular support tests pass
- [x] JSON schema validates
- [x] YAML rules file validates
- [x] CLAUDE.md validation passes
- [x] New fixtures are valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tabular (non-geospatial) datasets as a new collection type.
  * Introduced opt-in enablement for tabular formats (.parquet, .csv, .tsv, .xlsx/.xls).
  * Added a new collection property to mark datasets as non-geospatial.

* **Documentation**
  * Updated specification with comprehensive tabular data requirements and guidelines.
  * Added example collection demonstrating tabular dataset structure.
  * Added validation rules for tabular collections and test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->