### PR TITLE
feat(extract): extract styles from WMS/WFS and ESRI REST endpoints

### DIFF
--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -54,7 +54,7 @@ This will:
 1. Discover all layers in the service
 2. Extract each layer to GeoParquet format
 3. Apply Hilbert spatial sorting for efficient queries
-4. Extract layer styles as Mapbox GL JSON (from `drawingInfo.renderer`)
+4. Extract layer styles as Mapbox GL JSON and register as STAC assets
 5. Initialize a Portolan catalog with STAC metadata
 6. Add `via` provenance links to each collection (pointing to source layer URL)
 7. Seed `.portolan/metadata.yaml` with values from the service

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -54,10 +54,11 @@ This will:
 1. Discover all layers in the service
 2. Extract each layer to GeoParquet format
 3. Apply Hilbert spatial sorting for efficient queries
-4. Initialize a Portolan catalog with STAC metadata
-5. Add `via` provenance links to each collection (pointing to source layer URL)
-6. Seed `.portolan/metadata.yaml` with values from the service
-7. Generate an extraction report in `.portolan/extraction-report.json`
+4. Extract layer styles as Mapbox GL JSON (from `drawingInfo.renderer`)
+5. Initialize a Portolan catalog with STAC metadata
+6. Add `via` provenance links to each collection (pointing to source layer URL)
+7. Seed `.portolan/metadata.yaml` with values from the service
+8. Generate an extraction report in `.portolan/extraction-report.json`
 
 ### Filtering Layers
 

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -281,6 +281,9 @@ portolan extract arcgis URL --timeout 120
 
 # Retry failed requests (default: 3 attempts)
 portolan extract arcgis URL --retries 5
+
+# Skip style extraction (default: styles are extracted)
+portolan extract arcgis URL --no-styles
 ```
 
 ### Resume Failed Extractions

--- a/docs/guides/extract-wfs.md
+++ b/docs/guides/extract-wfs.md
@@ -58,6 +58,9 @@ Portolan automatically:
     Since v0.6.0, `portolan extract wfs` automatically fetches ISO 19139 metadata records
     from the WFS service, populating license, description, keywords, and contact info.
 
+!!! tip "Skipping Style Extraction"
+    To skip WMS style extraction (e.g., for faster runs or when styles aren't needed), use `--no-styles`.
+
 ## Step 3: Enrich Metadata
 
 The extraction creates two metadata files:

--- a/docs/guides/extract-wfs.md
+++ b/docs/guides/extract-wfs.md
@@ -50,8 +50,9 @@ Portolan automatically:
 
 1. **Downloads features** via WFS with pagination
 2. **Converts to GeoParquet** with Hilbert spatial ordering
-3. **Generates STAC catalog** with proper metadata
-4. **Seeds metadata.yaml** from ISO 19139 records (if available)
+3. **Extracts styles** from companion WMS (via GetStyles) as Mapbox GL JSON
+4. **Generates STAC catalog** with proper metadata
+5. **Seeds metadata.yaml** from ISO 19139 records (if available)
 
 !!! tip "Metadata Auto-Extraction"
     Since v0.6.0, `portolan extract wfs` automatically fetches ISO 19139 metadata records

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -296,6 +296,31 @@ def generate_cog_thumbnail(
     return thumb_path
 
 
+def _discover_style_for_thumbnail(collection_dir: Path) -> Path | None:
+    """Find a style file for thumbnail generation.
+
+    Searches for styles/default.json or styles/source.json in the collection
+    directory, preferring default.json (the extracted style, per Issue #497).
+
+    Args:
+        collection_dir: Path to collection directory.
+
+    Returns:
+        Path to style file if found, None otherwise.
+    """
+    styles_dir = collection_dir / "styles"
+    if not styles_dir.exists():
+        return None
+
+    # Prefer default.json (extracted style), then source.json
+    for name in ("default.json", "source.json"):
+        style_path = styles_dir / name
+        if style_path.exists():
+            return style_path
+
+    return None
+
+
 def convert_file(
     source: Path,
     output_dir: Path | None = None,
@@ -394,10 +419,13 @@ def convert_file(
                         get_thumbnail_config(catalog_path) if catalog_path else ThumbnailConfig()
                     )
                     if thumb_config.enabled and isinstance(output_path, Path):
+                        # Discover style for thumbnail (Issue #495)
+                        style_path = _discover_style_for_thumbnail(output_path.parent)
                         generate_vector_thumbnail(
                             pmtiles_path=None,  # PMTiles generated separately if enabled
                             geoparquet_path=output_path,
                             config=thumb_config,
+                            style_path=style_path,
                         )
                 except Exception as e:
                     logger.warning("Thumbnail generation failed for %s: %s", source.name, e)

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -204,6 +204,7 @@ class ExtractionOptions:
         dry_run: If True, list layers without extracting
         sort_hilbert: Whether to apply Hilbert spatial sorting
         raw: If True, skip auto-init (only create extraction files, no STAC catalog)
+        no_styles: If True, skip style extraction from ESRI drawingInfo
     """
 
     workers: int = 3
@@ -213,6 +214,7 @@ class ExtractionOptions:
     raw: bool = False
     dry_run: bool = False
     sort_hilbert: bool = True
+    no_styles: bool = False
 
 
 @dataclass
@@ -427,15 +429,15 @@ def _extract_one_layer(
         _emit_progress(on_progress, index, total, layer.name, "success")
 
         # Extract style from ESRI layer (Issue #490)
-        layer_url = f"{url.rstrip('/')}/{layer.id}"
-        try:
-            extract_esri_style(
+        if not options.no_styles:
+            layer_url = f"{url.rstrip('/')}/{layer.id}"
+            style_result = extract_esri_style(
                 layer_url=layer_url,
                 collection_path=collection_dir,
                 source_layer=layer_slug,
             )
-        except Exception as e:
-            logger.debug("Style extraction failed for %s: %s", layer.name, e)
+            if style_result:
+                logger.debug("Extracted style for %s: %s", layer.name, style_result.path)
 
         return LayerResult(
             id=layer.id,
@@ -1027,6 +1029,20 @@ def _extract_services_root(
 
         if result.success:
             features, size_bytes, duration = result.value  # type: ignore[misc]
+
+            # Extract style from ESRI layer (Issue #490)
+            if not options.no_styles:
+                layer_url = f"{service_url}/{layer.id}"
+                # collection_dir is service_dir for single-layer, or nested dir for multi
+                coll_dir = service_dir if is_single_layer else service_dir / layer_slug
+                style_result = extract_esri_style(
+                    layer_url=layer_url,
+                    collection_path=coll_dir,
+                    source_layer=layer_slug,
+                )
+                if style_result:
+                    logger.debug("Extracted style for %s: %s", layer.name, style_result.path)
+
             layer_results.append(
                 LayerResult(
                     id=layer.id,

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -626,6 +626,17 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
         catalog_root=output_dir,
     )
 
+    # Register extracted styles as STAC assets (Issue #490)
+    from portolan_cli.style import discover_styles, register_style_assets
+
+    for result in report.layers:
+        if result.status == "success" and result.output_path:
+            collection_dir = output_dir / Path(result.output_path).parent
+            styles = discover_styles(collection_dir)
+            if styles:
+                register_style_assets(collection_dir, styles)
+                logger.debug("Registered %d style(s) for %s", len(styles), result.name)
+
     # Seed metadata.yaml from extracted service metadata
     _seed_metadata_from_extraction(output_dir, report)
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -53,6 +53,7 @@ from portolan_cli.extract.common.report import (
 )
 from portolan_cli.extract.common.resume import ResumeState, get_resume_state, should_process_layer
 from portolan_cli.extract.common.retry import RetryConfig, retry_with_backoff
+from portolan_cli.extract.common.styles import extract_esri_style
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -424,6 +425,18 @@ def _extract_one_layer(
     if result.success:
         features, size_bytes, duration = result.value  # type: ignore[misc]
         _emit_progress(on_progress, index, total, layer.name, "success")
+
+        # Extract style from ESRI layer (Issue #490)
+        layer_url = f"{url.rstrip('/')}/{layer.id}"
+        try:
+            extract_esri_style(
+                layer_url=layer_url,
+                collection_path=collection_dir,
+                source_layer=layer_slug,
+            )
+        except Exception as e:
+            logger.debug("Style extraction failed for %s: %s", layer.name, e)
+
         return LayerResult(
             id=layer.id,
             name=layer.name,

--- a/portolan_cli/extract/common/converters/__init__.py
+++ b/portolan_cli/extract/common/converters/__init__.py
@@ -14,6 +14,8 @@ To add a new source format (e.g., QGIS QML):
 """
 
 from portolan_cli.extract.common.converters.base import (
+    esri_color_to_hex,
+    esri_color_to_opacity,
     make_circle_layer,
     make_fill_layer,
     make_line_layer,
@@ -38,6 +40,9 @@ __all__ = [
     "make_line_layer",
     "make_match_expression",
     "make_step_expression",
+    # Color utilities
+    "esri_color_to_hex",
+    "esri_color_to_opacity",
     # ESRI converter
     "convert_esri_renderer",
     "ESRIConverterError",

--- a/portolan_cli/extract/common/converters/__init__.py
+++ b/portolan_cli/extract/common/converters/__init__.py
@@ -22,6 +22,7 @@ from portolan_cli.extract.common.converters.base import (
     make_mapbox_style,
     make_match_expression,
     make_step_expression,
+    make_symbol_layer,
 )
 from portolan_cli.extract.common.converters.esri import (
     ESRIConverterError,
@@ -38,6 +39,7 @@ __all__ = [
     "make_fill_layer",
     "make_circle_layer",
     "make_line_layer",
+    "make_symbol_layer",
     "make_match_expression",
     "make_step_expression",
     # Color utilities

--- a/portolan_cli/extract/common/converters/__init__.py
+++ b/portolan_cli/extract/common/converters/__init__.py
@@ -1,0 +1,47 @@
+"""Style format converters for extraction.
+
+This package provides converters from source style formats (SLD, ESRI REST)
+to Mapbox GL JSON. The architecture is designed for extensibility:
+
+- base.py: Shared Mapbox GL building blocks (DRY)
+- sld.py: OGC SLD XML → Mapbox GL
+- esri.py: ESRI REST renderer JSON → Mapbox GL
+
+To add a new source format (e.g., QGIS QML):
+1. Create converters/qml.py
+2. Use base.py helpers for Mapbox GL generation
+3. Only write parsing logic for the new format
+"""
+
+from portolan_cli.extract.common.converters.base import (
+    make_circle_layer,
+    make_fill_layer,
+    make_line_layer,
+    make_mapbox_style,
+    make_match_expression,
+    make_step_expression,
+)
+from portolan_cli.extract.common.converters.esri import (
+    ESRIConverterError,
+    convert_esri_renderer,
+)
+from portolan_cli.extract.common.converters.sld import (
+    SLDConverterError,
+    convert_sld,
+)
+
+__all__ = [
+    # Base builders
+    "make_mapbox_style",
+    "make_fill_layer",
+    "make_circle_layer",
+    "make_line_layer",
+    "make_match_expression",
+    "make_step_expression",
+    # ESRI converter
+    "convert_esri_renderer",
+    "ESRIConverterError",
+    # SLD converter
+    "convert_sld",
+    "SLDConverterError",
+]

--- a/portolan_cli/extract/common/converters/base.py
+++ b/portolan_cli/extract/common/converters/base.py
@@ -1,0 +1,266 @@
+"""Shared Mapbox GL style building blocks.
+
+This module provides reusable functions for constructing Mapbox GL style
+documents. All source format converters (SLD, ESRI, etc.) use these
+primitives to generate consistent output.
+
+The design follows DRY principles: parsing logic lives in format-specific
+modules, while Mapbox GL generation is centralized here.
+
+Mapbox GL Style Spec Reference:
+https://docs.mapbox.com/mapbox-gl-js/style-spec/
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Type alias for Mapbox GL expressions
+Expression = list[Any]
+ColorValue = str | Expression
+NumericValue = int | float | Expression
+
+
+def esri_color_to_hex(color: list[int]) -> str:
+    """Convert ESRI [r, g, b, a] array to #rrggbb hex string.
+
+    Args:
+        color: ESRI color array [red, green, blue, alpha] with 0-255 values.
+
+    Returns:
+        Hex color string like "#ff0000".
+    """
+    r, g, b = color[0], color[1], color[2]
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def esri_color_to_opacity(color: list[int]) -> float:
+    """Extract opacity from ESRI [r, g, b, a] array.
+
+    Args:
+        color: ESRI color array [red, green, blue, alpha] with 0-255 values.
+
+    Returns:
+        Opacity as float 0.0-1.0.
+    """
+    if len(color) < 4:
+        return 1.0
+    return color[3] / 255.0
+
+
+def hex_to_rgba(hex_color: str, opacity: float) -> str:
+    """Convert hex color and opacity to rgba() CSS string.
+
+    Args:
+        hex_color: Color like "#ff0000" or "ff0000".
+        opacity: Opacity 0.0-1.0.
+
+    Returns:
+        CSS rgba string like "rgba(255, 0, 0, 0.5)".
+    """
+    hex_color = hex_color.lstrip("#")
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+    return f"rgba({r}, {g}, {b}, {opacity})"
+
+
+def make_match_expression(
+    field: str,
+    cases: list[tuple[Any, str]],
+    default: str,
+) -> Expression:
+    """Build a Mapbox GL match expression for categorical styling.
+
+    Creates: ["match", ["get", field], val1, color1, val2, color2, ..., default]
+
+    Args:
+        field: Property name to match on.
+        cases: List of (value, color) tuples.
+        default: Fallback color when no match.
+
+    Returns:
+        Mapbox GL match expression.
+    """
+    expr: list[Any] = ["match", ["get", field]]
+    for value, color in cases:
+        expr.append(value)
+        expr.append(color)
+    expr.append(default)
+    return expr
+
+
+def make_step_expression(
+    field: str,
+    breaks: list[tuple[Any, Any]],
+) -> Expression:
+    """Build a Mapbox GL step expression for graduated styling.
+
+    Creates: ["step", ["get", field], initial, break1, val1, break2, val2, ...]
+
+    The first tuple provides (min_value, initial_output). Subsequent tuples
+    define break points where the output changes.
+
+    Args:
+        field: Property name for class breaks.
+        breaks: List of (threshold, output_value) tuples. First tuple's
+            threshold is the minimum value, subsequent are break points.
+
+    Returns:
+        Mapbox GL step expression.
+    """
+    if not breaks:
+        return ["literal", 0]
+
+    expr: list[Any] = ["step", ["get", field]]
+
+    # First tuple provides the initial value (output below first break)
+    _, initial = breaks[0]
+    expr.append(initial)
+
+    # Remaining tuples are break points
+    for threshold, value in breaks[1:]:
+        expr.append(threshold)
+        expr.append(value)
+
+    return expr
+
+
+def make_fill_layer(
+    layer_id: str,
+    source_layer: str,
+    fill_color: ColorValue,
+    fill_opacity: float = 1.0,
+    outline_color: str | None = None,
+) -> dict[str, Any]:
+    """Build a Mapbox GL fill layer for polygon data.
+
+    Args:
+        layer_id: Unique layer identifier.
+        source_layer: Name of source layer in vector tiles.
+        fill_color: Fill color (hex string or expression).
+        fill_opacity: Fill opacity 0.0-1.0.
+        outline_color: Optional outline color.
+
+    Returns:
+        Mapbox GL layer dict.
+    """
+    paint: dict[str, Any] = {
+        "fill-color": fill_color,
+        "fill-opacity": fill_opacity,
+    }
+    if outline_color:
+        paint["fill-outline-color"] = outline_color
+
+    return {
+        "id": layer_id,
+        "type": "fill",
+        "source": "data",
+        "source-layer": source_layer,
+        "paint": paint,
+    }
+
+
+def make_circle_layer(
+    layer_id: str,
+    source_layer: str,
+    circle_color: ColorValue,
+    circle_radius: NumericValue = 5,
+    circle_opacity: float = 1.0,
+    stroke_color: str | None = None,
+    stroke_width: float | None = None,
+) -> dict[str, Any]:
+    """Build a Mapbox GL circle layer for point data.
+
+    Args:
+        layer_id: Unique layer identifier.
+        source_layer: Name of source layer in vector tiles.
+        circle_color: Circle fill color (hex string or expression).
+        circle_radius: Circle radius in pixels (number or expression).
+        circle_opacity: Circle opacity 0.0-1.0.
+        stroke_color: Optional stroke color.
+        stroke_width: Optional stroke width.
+
+    Returns:
+        Mapbox GL layer dict.
+    """
+    paint: dict[str, Any] = {
+        "circle-color": circle_color,
+        "circle-radius": circle_radius,
+        "circle-opacity": circle_opacity,
+    }
+    if stroke_color:
+        paint["circle-stroke-color"] = stroke_color
+    if stroke_width is not None:
+        paint["circle-stroke-width"] = stroke_width
+
+    return {
+        "id": layer_id,
+        "type": "circle",
+        "source": "data",
+        "source-layer": source_layer,
+        "paint": paint,
+    }
+
+
+def make_line_layer(
+    layer_id: str,
+    source_layer: str,
+    line_color: ColorValue,
+    line_width: NumericValue = 1,
+    line_opacity: float = 1.0,
+) -> dict[str, Any]:
+    """Build a Mapbox GL line layer for linestring data.
+
+    Args:
+        layer_id: Unique layer identifier.
+        source_layer: Name of source layer in vector tiles.
+        line_color: Line color (hex string or expression).
+        line_width: Line width in pixels (number or expression).
+        line_opacity: Line opacity 0.0-1.0.
+
+    Returns:
+        Mapbox GL layer dict.
+    """
+    return {
+        "id": layer_id,
+        "type": "line",
+        "source": "data",
+        "source-layer": source_layer,
+        "paint": {
+            "line-color": line_color,
+            "line-width": line_width,
+            "line-opacity": line_opacity,
+        },
+    }
+
+
+def make_mapbox_style(
+    name: str,
+    source_layer: str,
+    layers: list[dict[str, Any]],
+    pmtiles_url: str | None = None,
+) -> dict[str, Any]:
+    """Build a complete Mapbox GL style document.
+
+    Args:
+        name: Style name (appears in style["name"]).
+        source_layer: Default source layer name.
+        layers: List of layer dicts (from make_*_layer functions).
+        pmtiles_url: Optional PMTiles URL for the source.
+
+    Returns:
+        Complete Mapbox GL style dict with version, sources, and layers.
+    """
+    source: dict[str, Any] = {"type": "vector"}
+    if pmtiles_url:
+        source["url"] = pmtiles_url
+
+    return {
+        "version": 8,
+        "name": name,
+        "sources": {
+            "data": source,
+        },
+        "layers": layers,
+    }

--- a/portolan_cli/extract/common/converters/base.py
+++ b/portolan_cli/extract/common/converters/base.py
@@ -235,6 +235,67 @@ def make_line_layer(
     }
 
 
+def make_symbol_layer(
+    layer_id: str,
+    source_layer: str,
+    text_field: str | Expression,
+    text_color: ColorValue = "#000000",
+    text_size: NumericValue = 12,
+    text_font: list[str] | None = None,
+    text_halo_color: ColorValue | None = None,
+    text_halo_width: NumericValue = 1.0,
+    text_anchor: str = "center",
+    text_offset: tuple[float, float] | None = None,
+) -> dict[str, Any]:
+    """Build a Mapbox GL symbol layer for text labels.
+
+    Args:
+        layer_id: Unique layer identifier.
+        source_layer: Name of source layer in vector tiles.
+        text_field: Text content (string or ["get", "fieldname"] expression).
+        text_color: Text color (hex string or expression).
+        text_size: Font size in pixels (number or expression).
+        text_font: List of font names (falls back to ["Noto Sans Regular"]).
+        text_halo_color: Optional halo (outline) color.
+        text_halo_width: Halo width in pixels.
+        text_anchor: Text anchor position (center, left, right, top, bottom, etc.).
+        text_offset: Optional (x, y) offset in ems.
+
+    Returns:
+        Mapbox GL symbol layer dict.
+    """
+    layout: dict[str, Any] = {
+        "text-field": text_field,
+        "text-size": text_size,
+        "text-anchor": text_anchor,
+    }
+
+    if text_font:
+        layout["text-font"] = text_font
+    else:
+        layout["text-font"] = ["Noto Sans Regular"]
+
+    if text_offset:
+        layout["text-offset"] = list(text_offset)
+
+    paint: dict[str, Any] = {
+        "text-color": text_color,
+    }
+
+    if text_halo_color is not None:
+        paint["text-halo-color"] = text_halo_color
+        paint["text-halo-width"] = text_halo_width
+
+    return {
+        "id": layer_id,
+        "type": "symbol",
+        "source": "data",
+        "source-layer": source_layer,
+        "layout": layout,
+        "paint": paint,
+    }
+
+
 def make_mapbox_style(
     name: str,
     source_layer: str,

--- a/portolan_cli/extract/common/converters/base.py
+++ b/portolan_cli/extract/common/converters/base.py
@@ -130,8 +130,8 @@ def make_fill_layer(
     layer_id: str,
     source_layer: str,
     fill_color: ColorValue,
-    fill_opacity: float = 1.0,
-    outline_color: str | None = None,
+    fill_opacity: NumericValue = 1.0,
+    outline_color: ColorValue | None = None,
 ) -> dict[str, Any]:
     """Build a Mapbox GL fill layer for polygon data.
 
@@ -166,9 +166,9 @@ def make_circle_layer(
     source_layer: str,
     circle_color: ColorValue,
     circle_radius: NumericValue = 5,
-    circle_opacity: float = 1.0,
-    stroke_color: str | None = None,
-    stroke_width: float | None = None,
+    circle_opacity: NumericValue = 1.0,
+    stroke_color: ColorValue | None = None,
+    stroke_width: NumericValue | None = None,
 ) -> dict[str, Any]:
     """Build a Mapbox GL circle layer for point data.
 
@@ -208,7 +208,7 @@ def make_line_layer(
     source_layer: str,
     line_color: ColorValue,
     line_width: NumericValue = 1,
-    line_opacity: float = 1.0,
+    line_opacity: NumericValue = 1.0,
 ) -> dict[str, Any]:
     """Build a Mapbox GL line layer for linestring data.
 

--- a/portolan_cli/extract/common/converters/base.py
+++ b/portolan_cli/extract/common/converters/base.py
@@ -67,25 +67,25 @@ def hex_to_rgba(hex_color: str, opacity: float) -> str:
 
 def make_match_expression(
     field: str,
-    cases: list[tuple[Any, str]],
-    default: str,
+    cases: list[tuple[Any, Any]],
+    default: Any,
 ) -> Expression:
     """Build a Mapbox GL match expression for categorical styling.
 
-    Creates: ["match", ["get", field], val1, color1, val2, color2, ..., default]
+    Creates: ["match", ["get", field], val1, output1, val2, output2, ..., default]
 
     Args:
         field: Property name to match on.
-        cases: List of (value, color) tuples.
-        default: Fallback color when no match.
+        cases: List of (value, output) tuples. Output can be colors (str) or numbers.
+        default: Fallback value when no match.
 
     Returns:
         Mapbox GL match expression.
     """
     expr: list[Any] = ["match", ["get", field]]
-    for value, color in cases:
+    for value, output in cases:
         expr.append(value)
-        expr.append(color)
+        expr.append(output)
     expr.append(default)
     return expr
 

--- a/portolan_cli/extract/common/converters/base.py
+++ b/portolan_cli/extract/common/converters/base.py
@@ -110,7 +110,7 @@ def make_step_expression(
         Mapbox GL step expression.
     """
     if not breaks:
-        return ["literal", 0]
+        raise ValueError("make_step_expression requires at least one break point")
 
     expr: list[Any] = ["step", ["get", field]]
 

--- a/portolan_cli/extract/common/converters/esri.py
+++ b/portolan_cli/extract/common/converters/esri.py
@@ -1,0 +1,474 @@
+"""ESRI REST API renderer to Mapbox GL converter.
+
+Converts ESRI drawingInfo.renderer JSON to Mapbox GL style documents.
+
+Supported renderer types:
+- simple: Single symbol for all features
+- uniqueValue: Categorical classification (match expression)
+- classBreaks: Graduated classification (step expression)
+
+Supported symbol types:
+- esriSFS: Simple fill symbol (polygons)
+- esriSLS: Simple line symbol (lines)
+- esriSMS: Simple marker symbol (points → circles)
+- esriPMS: Picture marker symbol (points → warns, falls back to circle)
+
+Usage:
+    renderer = layer_json["drawingInfo"]["renderer"]
+    style = convert_esri_renderer(renderer, source_layer="my-layer")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal, overload
+
+from portolan_cli.extract.common.converters.base import (
+    esri_color_to_hex,
+    esri_color_to_opacity,
+    make_circle_layer,
+    make_fill_layer,
+    make_line_layer,
+    make_mapbox_style,
+    make_match_expression,
+    make_step_expression,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ESRIConverterError(Exception):
+    """Error during ESRI renderer conversion."""
+
+    pass
+
+
+def _symbol_to_layer_type(symbol: dict[str, Any]) -> str:
+    """Determine Mapbox GL layer type from ESRI symbol type."""
+    symbol_type = symbol.get("type", "")
+    if symbol_type == "esriSFS":
+        return "fill"
+    if symbol_type == "esriSLS":
+        return "line"
+    if symbol_type in ("esriSMS", "esriPMS"):
+        return "circle"
+    return "fill"  # Default fallback
+
+
+def _parse_fill_symbol(
+    symbol: dict[str, Any],
+    layer_id: str,
+    source_layer: str,
+) -> dict[str, Any]:
+    """Parse esriSFS (simple fill symbol) to Mapbox GL fill layer."""
+    color = symbol.get("color", [128, 128, 128, 255])
+    fill_color = esri_color_to_hex(color)
+    fill_opacity = esri_color_to_opacity(color)
+
+    outline = symbol.get("outline", {})
+    outline_color = None
+    if outline and outline.get("color"):
+        outline_color = esri_color_to_hex(outline["color"])
+
+    return make_fill_layer(
+        layer_id=layer_id,
+        source_layer=source_layer,
+        fill_color=fill_color,
+        fill_opacity=fill_opacity,
+        outline_color=outline_color,
+    )
+
+
+def _parse_circle_symbol(
+    symbol: dict[str, Any],
+    layer_id: str,
+    source_layer: str,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Parse esriSMS/esriPMS to Mapbox GL circle layer."""
+    symbol_type = symbol.get("type", "")
+
+    # Picture marker - warn and fall back to circle
+    if symbol_type == "esriPMS":
+        if warnings is not None:
+            warnings.append(
+                f"Picture marker symbol (esriPMS) not fully supported; "
+                f"falling back to circle. URL: {symbol.get('url', 'unknown')}"
+            )
+        # Use a default color for picture markers
+        return make_circle_layer(
+            layer_id=layer_id,
+            source_layer=source_layer,
+            circle_color="#888888",
+            circle_radius=8,
+        )
+
+    # Check for unsupported marker styles
+    style = symbol.get("style", "esriSMSCircle")
+    if style != "esriSMSCircle":
+        if warnings is not None:
+            warnings.append(
+                f"Marker style '{style}' not directly supported; falling back to circle."
+            )
+
+    color = symbol.get("color", [128, 128, 128, 255])
+    circle_color = esri_color_to_hex(color)
+    circle_opacity = esri_color_to_opacity(color)
+
+    # ESRI size is diameter, Mapbox radius is half
+    size = symbol.get("size", 10)
+    radius = size / 2
+
+    outline = symbol.get("outline", {})
+    stroke_color = None
+    stroke_width = None
+    if outline:
+        if outline.get("color"):
+            stroke_color = esri_color_to_hex(outline["color"])
+        stroke_width = outline.get("width")
+
+    return make_circle_layer(
+        layer_id=layer_id,
+        source_layer=source_layer,
+        circle_color=circle_color,
+        circle_radius=radius,
+        circle_opacity=circle_opacity,
+        stroke_color=stroke_color,
+        stroke_width=stroke_width,
+    )
+
+
+def _parse_line_symbol(
+    symbol: dict[str, Any],
+    layer_id: str,
+    source_layer: str,
+) -> dict[str, Any]:
+    """Parse esriSLS (simple line symbol) to Mapbox GL line layer."""
+    color = symbol.get("color", [128, 128, 128, 255])
+    line_color = esri_color_to_hex(color)
+    line_opacity = esri_color_to_opacity(color)
+    line_width = symbol.get("width", 1)
+
+    return make_line_layer(
+        layer_id=layer_id,
+        source_layer=source_layer,
+        line_color=line_color,
+        line_width=line_width,
+        line_opacity=line_opacity,
+    )
+
+
+def _parse_symbol(
+    symbol: dict[str, Any],
+    layer_id: str,
+    source_layer: str,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Route symbol to appropriate parser based on type."""
+    symbol_type = symbol.get("type", "")
+
+    if symbol_type == "esriSFS":
+        return _parse_fill_symbol(symbol, layer_id, source_layer)
+    if symbol_type == "esriSLS":
+        return _parse_line_symbol(symbol, layer_id, source_layer)
+    if symbol_type in ("esriSMS", "esriPMS"):
+        return _parse_circle_symbol(symbol, layer_id, source_layer, warnings)
+
+    # Unknown symbol type - fall back to fill
+    if warnings is not None:
+        warnings.append(f"Unknown symbol type '{symbol_type}'; defaulting to fill.")
+    return make_fill_layer(
+        layer_id=layer_id,
+        source_layer=source_layer,
+        fill_color="#888888",
+        fill_opacity=0.5,
+    )
+
+
+def parse_simple_renderer(
+    renderer: dict[str, Any],
+    source_layer: str,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Convert simple renderer to Mapbox GL style.
+
+    Simple renderers apply the same symbol to all features.
+
+    Args:
+        renderer: ESRI renderer dict with type="simple".
+        source_layer: Name for the source-layer in output.
+        warnings: Optional list to collect conversion warnings.
+
+    Returns:
+        Complete Mapbox GL style dict.
+    """
+    symbol = renderer.get("symbol", {})
+    layer = _parse_symbol(symbol, "layer-0", source_layer, warnings)
+
+    return make_mapbox_style(
+        name="Simple Style",
+        source_layer=source_layer,
+        layers=[layer],
+    )
+
+
+def parse_uniquevalue_renderer(
+    renderer: dict[str, Any],
+    source_layer: str,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Convert uniqueValue renderer to Mapbox GL style with match expression.
+
+    UniqueValue renderers apply different symbols based on attribute values.
+    Converts to a Mapbox GL match expression.
+
+    Args:
+        renderer: ESRI renderer dict with type="uniqueValue".
+        source_layer: Name for the source-layer in output.
+        warnings: Optional list to collect conversion warnings.
+
+    Returns:
+        Complete Mapbox GL style dict.
+    """
+    field = renderer.get("field1", renderer.get("field", "value"))
+    infos = renderer.get("uniqueValueInfos", [])
+
+    if not infos:
+        if warnings is not None:
+            warnings.append("UniqueValue renderer has no value infos; using default.")
+        return make_mapbox_style(
+            name="Empty UniqueValue Style",
+            source_layer=source_layer,
+            layers=[make_fill_layer("layer-0", source_layer, "#888888", 0.5)],
+        )
+
+    # Determine layer type from first symbol
+    first_symbol = infos[0].get("symbol", {})
+    layer_type = _symbol_to_layer_type(first_symbol)
+
+    # Build match expression cases
+    cases: list[tuple[Any, str]] = []
+    for info in infos:
+        value = info.get("value")
+        symbol = info.get("symbol", {})
+        color = symbol.get("color", [128, 128, 128, 255])
+        cases.append((value, esri_color_to_hex(color)))
+
+    color_expr = make_match_expression(field, cases, default="#cccccc")
+
+    # Get opacity from first symbol
+    first_color = first_symbol.get("color", [128, 128, 128, 255])
+    opacity = esri_color_to_opacity(first_color)
+
+    # Build appropriate layer type
+    if layer_type == "fill":
+        layer = make_fill_layer(
+            layer_id="categorical-fill",
+            source_layer=source_layer,
+            fill_color=color_expr,
+            fill_opacity=opacity,
+        )
+    elif layer_type == "circle":
+        layer = make_circle_layer(
+            layer_id="categorical-circle",
+            source_layer=source_layer,
+            circle_color=color_expr,
+            circle_opacity=opacity,
+        )
+    else:
+        layer = make_line_layer(
+            layer_id="categorical-line",
+            source_layer=source_layer,
+            line_color=color_expr,
+            line_opacity=opacity,
+        )
+
+    return make_mapbox_style(
+        name="Categorical Style",
+        source_layer=source_layer,
+        layers=[layer],
+    )
+
+
+def parse_classbreaks_renderer(
+    renderer: dict[str, Any],
+    source_layer: str,
+    warnings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Convert classBreaks renderer to Mapbox GL style with step expression.
+
+    ClassBreaks renderers apply different symbols based on numeric ranges.
+    Converts to a Mapbox GL step expression.
+
+    Args:
+        renderer: ESRI renderer dict with type="classBreaks".
+        source_layer: Name for the source-layer in output.
+        warnings: Optional list to collect conversion warnings.
+
+    Returns:
+        Complete Mapbox GL style dict.
+    """
+    field = renderer.get("field", "value")
+    min_value = renderer.get("minValue", 0)
+    break_infos = renderer.get("classBreakInfos", [])
+
+    if not break_infos:
+        if warnings is not None:
+            warnings.append("ClassBreaks renderer has no break infos; using default.")
+        return make_mapbox_style(
+            name="Empty ClassBreaks Style",
+            source_layer=source_layer,
+            layers=[make_fill_layer("layer-0", source_layer, "#888888", 0.5)],
+        )
+
+    # Determine layer type and property to graduate from first symbol
+    first_symbol = break_infos[0].get("symbol", {})
+    layer_type = _symbol_to_layer_type(first_symbol)
+
+    # For graduated symbols, we typically vary size (circles) or color
+    # Check if sizes vary (graduated symbol) or colors vary (choropleth)
+    sizes = [info.get("symbol", {}).get("size") for info in break_infos]
+    sizes_vary = len({s for s in sizes if s is not None}) > 1
+
+    if layer_type == "circle" and sizes_vary:
+        # Graduated symbol sizes
+        # step returns initial value for inputs < first stop
+        # We need: [(min, size1), (break1, size2), (break2, size3), ...]
+        breaks: list[tuple[Any, Any]] = []
+        for i, info in enumerate(break_infos):
+            if i == 0:
+                # Initial value for the range [minValue, classMaxValue]
+                symbol = info.get("symbol", {})
+                size = symbol.get("size", 10)
+                breaks.append((min_value, size / 2))
+            else:
+                # Break at previous classMaxValue
+                prev_max = break_infos[i - 1].get("classMaxValue", 0)
+                symbol = info.get("symbol", {})
+                size = symbol.get("size", 10)
+                breaks.append((prev_max, size / 2))
+
+        radius_expr = make_step_expression(field, breaks)
+
+        # Get color from first symbol (usually same for all in graduated size)
+        color = first_symbol.get("color", [128, 128, 128, 255])
+        circle_color = esri_color_to_hex(color)
+
+        # Get stroke if present
+        outline = first_symbol.get("outline", {})
+        stroke_color = None
+        stroke_width = None
+        if outline and outline.get("color"):
+            stroke_color = esri_color_to_hex(outline["color"])
+            stroke_width = outline.get("width")
+
+        layer = make_circle_layer(
+            layer_id="graduated-circle",
+            source_layer=source_layer,
+            circle_color=circle_color,
+            circle_radius=radius_expr,
+            stroke_color=stroke_color,
+            stroke_width=stroke_width,
+        )
+    else:
+        # Choropleth (color varies by class)
+        cases: list[tuple[float, str]] = []
+        for info in break_infos:
+            max_val = info.get("classMaxValue", 0)
+            symbol = info.get("symbol", {})
+            color = symbol.get("color", [128, 128, 128, 255])
+            cases.append((max_val, esri_color_to_hex(color)))
+
+        # Build step expression for colors
+        # For color, we need the breaks to work correctly
+        color_breaks: list[tuple[Any, Any]] = []
+        for i, info in enumerate(break_infos):
+            symbol = info.get("symbol", {})
+            color = esri_color_to_hex(symbol.get("color", [128, 128, 128, 255]))
+            if i == 0:
+                color_breaks.append((min_value, color))
+            else:
+                prev_max = break_infos[i - 1].get("classMaxValue", 0)
+                color_breaks.append((prev_max, color))
+
+        color_expr = make_step_expression(field, color_breaks)
+
+        if layer_type == "fill":
+            layer = make_fill_layer(
+                layer_id="choropleth-fill",
+                source_layer=source_layer,
+                fill_color=color_expr,
+                fill_opacity=0.7,
+            )
+        else:
+            layer = make_line_layer(
+                layer_id="graduated-line",
+                source_layer=source_layer,
+                line_color=color_expr,
+            )
+
+    return make_mapbox_style(
+        name="Graduated Style",
+        source_layer=source_layer,
+        layers=[layer],
+    )
+
+
+@overload
+def convert_esri_renderer(
+    renderer: dict[str, Any],
+    source_layer: str,
+    *,
+    return_warnings: Literal[False] = False,
+) -> dict[str, Any]: ...
+
+
+@overload
+def convert_esri_renderer(
+    renderer: dict[str, Any],
+    source_layer: str,
+    *,
+    return_warnings: Literal[True],
+) -> tuple[dict[str, Any], list[str]]: ...
+
+
+def convert_esri_renderer(
+    renderer: dict[str, Any],
+    source_layer: str,
+    *,
+    return_warnings: bool = False,
+) -> dict[str, Any] | tuple[dict[str, Any], list[str]]:
+    """Convert ESRI renderer to Mapbox GL style.
+
+    Main entry point for ESRI → Mapbox GL conversion. Routes to appropriate
+    parser based on renderer type.
+
+    Args:
+        renderer: ESRI drawingInfo.renderer dict.
+        source_layer: Name for the source-layer in output.
+        return_warnings: If True, return (style, warnings) tuple.
+
+    Returns:
+        Mapbox GL style dict, or (style, warnings) tuple if return_warnings=True.
+
+    Raises:
+        ESRIConverterError: If renderer type is not supported.
+    """
+    renderer_type = renderer.get("type", "")
+    warnings: list[str] = []
+
+    if renderer_type == "simple":
+        style = parse_simple_renderer(renderer, source_layer, warnings)
+    elif renderer_type == "uniqueValue":
+        style = parse_uniquevalue_renderer(renderer, source_layer, warnings)
+    elif renderer_type == "classBreaks":
+        style = parse_classbreaks_renderer(renderer, source_layer, warnings)
+    else:
+        raise ESRIConverterError(
+            f"Unsupported ESRI renderer type: '{renderer_type}'. "
+            f"Supported types: simple, uniqueValue, classBreaks."
+        )
+
+    if return_warnings:
+        return style, warnings
+    return style

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -380,6 +380,37 @@ def _extract_style_name(root: ET.Element) -> str:
     return "Converted Style"
 
 
+def _get_uniform_opacity(opacity_cases: list[tuple[Any, float]]) -> float:
+    """Get uniform opacity if all cases have same value, else return 1.0."""
+    if not opacity_cases:
+        return 1.0
+    unique = {op for _, op in opacity_cases}
+    return next(iter(unique)) if len(unique) == 1 else 1.0
+
+
+def _build_categorical_fill(
+    field: str,
+    color_cases: list[tuple[Any, str]],
+    opacity_cases: list[tuple[Any, float]],
+    source_layer: str,
+) -> list[dict[str, Any]]:
+    """Build categorical fill layer with per-rule opacity support."""
+    color_expr = make_match_expression(field, color_cases, default="#cccccc")
+    unique_opacities = {op for _, op in opacity_cases}
+
+    if len(unique_opacities) == 1:
+        return [
+            make_fill_layer(
+                "categorical-fill", source_layer, color_expr, next(iter(unique_opacities))
+            )
+        ]
+
+    opacity_expr = make_match_expression(field, opacity_cases, default=1.0)
+    layer = make_fill_layer("categorical-fill", source_layer, color_expr, 1.0)
+    layer["paint"]["fill-opacity"] = opacity_expr
+    return [layer]
+
+
 def _build_categorical_layers(
     rules: list[ET.Element],
     geom_type: str,
@@ -388,8 +419,8 @@ def _build_categorical_layers(
 ) -> list[dict[str, Any]]:
     """Build layers for categorical (filtered) SLD rules."""
     field: str | None = None
-    cases: list[tuple[Any, str]] = []
-    opacity: float = 1.0
+    color_cases: list[tuple[Any, str]] = []
+    opacity_cases: list[tuple[Any, float]] = []
 
     for rule in rules:
         filter_elem = _find_with_ns(rule, "ogc:Filter")
@@ -403,36 +434,37 @@ def _build_categorical_layers(
         except SLDConverterError:
             continue
 
-        if geom_type == "polygon":
-            symbolizer = _find_symbolizer(rule, "Polygon")
-            if symbolizer is not None:
-                props = parse_polygon_symbolizer(symbolizer)
-                cases.append((value, props["fill_color"]))
-                opacity = props["fill_opacity"]
-        elif geom_type == "point":
-            symbolizer = _find_symbolizer(rule, "Point")
-            if symbolizer is not None:
-                props = parse_point_symbolizer(symbolizer)
-                cases.append((value, props["fill_color"]))
-                if props.get("warning"):
-                    warnings.append(props["warning"])
-        elif geom_type == "line":
-            symbolizer = _find_symbolizer(rule, "Line")
-            if symbolizer is not None:
-                props = parse_line_symbolizer(symbolizer)
-                cases.append((value, props["line_color"]))
+        symbolizer_type = {"polygon": "Polygon", "point": "Point", "line": "Line"}.get(geom_type)
+        symbolizer = _find_symbolizer(rule, symbolizer_type) if symbolizer_type else None
+        if symbolizer is None:
+            continue
 
-    if not field or not cases:
+        if geom_type == "polygon":
+            props = parse_polygon_symbolizer(symbolizer)
+            color_cases.append((value, props["fill_color"]))
+            opacity_cases.append((value, props["fill_opacity"]))
+        elif geom_type == "point":
+            props = parse_point_symbolizer(symbolizer)
+            color_cases.append((value, props["fill_color"]))
+            if props.get("warning"):
+                warnings.append(props["warning"])
+        elif geom_type == "line":
+            props = parse_line_symbolizer(symbolizer)
+            color_cases.append((value, props["line_color"]))
+            opacity_cases.append((value, props["line_opacity"]))
+
+    if not field or not color_cases:
         return []
 
-    color_expr = make_match_expression(field, cases, default="#cccccc")
+    color_expr = make_match_expression(field, color_cases, default="#cccccc")
 
     if geom_type == "polygon":
-        return [make_fill_layer("categorical-fill", source_layer, color_expr, opacity)]
+        return _build_categorical_fill(field, color_cases, opacity_cases, source_layer)
     if geom_type == "point":
         return [make_circle_layer("categorical-circle", source_layer, color_expr)]
     if geom_type == "line":
-        return [make_line_layer("categorical-line", source_layer, color_expr)]
+        opacity = _get_uniform_opacity(opacity_cases)
+        return [make_line_layer("categorical-line", source_layer, color_expr, line_opacity=opacity)]
     return []
 
 

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -23,12 +23,11 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING, Any, Literal, overload
-from xml.etree.ElementTree import Element
 
 import defusedxml.ElementTree as ET
 
 if TYPE_CHECKING:
-    pass  # Element imported above for runtime use and type hints
+    from xml.etree.ElementTree import Element  # nosec B405 - type annotation only
 
 from portolan_cli.extract.common.converters.base import (
     make_circle_layer,

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -1,0 +1,504 @@
+"""OGC SLD XML to Mapbox GL converter.
+
+Converts SLD (Styled Layer Descriptor) XML documents to Mapbox GL style JSON.
+
+Supported symbolizers:
+- PolygonSymbolizer: Fill and stroke for polygons
+- PointSymbolizer: Circle markers for points
+- LineSymbolizer: Line styling for linestrings
+
+Partially supported (warn and continue):
+- TextSymbolizer: Skipped with warning (labels not supported)
+- TTF glyphs in PointSymbolizer: Falls back to circle
+
+OGC Filter support:
+- PropertyIsEqualTo: Extracts field/value for categorical styling
+
+Usage:
+    sld_xml = fetch_wms_getstyles(url, layer)
+    style = convert_sld(sld_xml, source_layer="my-layer")
+"""
+
+from __future__ import annotations
+
+import logging
+import xml.etree.ElementTree as ET
+from typing import Any, Literal, overload
+
+from portolan_cli.extract.common.converters.base import (
+    make_circle_layer,
+    make_fill_layer,
+    make_line_layer,
+    make_mapbox_style,
+    make_match_expression,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SLDConverterError(Exception):
+    """Error during SLD conversion."""
+
+    pass
+
+
+# XML namespaces used in SLD
+NAMESPACES = {
+    "sld": "http://www.opengis.net/sld",
+    "ogc": "http://www.opengis.net/ogc",
+    "gml": "http://www.opengis.net/gml",
+    "se": "http://www.opengis.net/se",
+}
+
+
+def _find_with_ns(element: ET.Element, path: str) -> ET.Element | None:
+    """Find element with namespace-aware path."""
+    return element.find(path, NAMESPACES)
+
+
+def _findall_with_ns(element: ET.Element, path: str) -> list[ET.Element]:
+    """Find all elements with namespace-aware path."""
+    return element.findall(path, NAMESPACES)
+
+
+def _get_css_parameter(element: ET.Element, name: str) -> str | None:
+    """Extract CssParameter value by name attribute."""
+    for param in _findall_with_ns(element, ".//sld:CssParameter"):
+        if param.get("name") == name:
+            return param.text
+    return None
+
+
+def parse_filter_to_value(filter_xml: str | ET.Element) -> tuple[str, Any]:
+    """Extract field name and value from OGC Filter.
+
+    Currently supports PropertyIsEqualTo for categorical classification.
+
+    Args:
+        filter_xml: Filter XML string or Element.
+
+    Returns:
+        Tuple of (field_name, value).
+
+    Raises:
+        SLDConverterError: If filter cannot be parsed.
+    """
+    if isinstance(filter_xml, str):
+        # Parse as fragment - need to handle namespace
+        try:
+            root = ET.fromstring(filter_xml)
+        except ET.ParseError as e:
+            raise SLDConverterError(f"Invalid filter XML: {e}") from e
+    else:
+        root = filter_xml
+
+    # Look for PropertyIsEqualTo
+    prop_eq = _find_with_ns(root, ".//ogc:PropertyIsEqualTo")
+    if prop_eq is None:
+        # Try without namespace prefix (some SLDs don't use it)
+        prop_eq = root.find(".//{http://www.opengis.net/ogc}PropertyIsEqualTo")
+
+    if prop_eq is not None:
+        prop_name = _find_with_ns(prop_eq, "ogc:PropertyName")
+        literal = _find_with_ns(prop_eq, "ogc:Literal")
+
+        if prop_name is not None and literal is not None:
+            field = prop_name.text or ""
+            value_str = literal.text or ""
+
+            # Try to coerce to number if it looks numeric
+            try:
+                if "." in value_str:
+                    value: Any = float(value_str)
+                else:
+                    value = int(value_str)
+            except ValueError:
+                value = value_str
+
+            return field, value
+
+    raise SLDConverterError("Could not extract field/value from filter")
+
+
+def parse_polygon_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
+    """Extract fill and stroke properties from PolygonSymbolizer.
+
+    Args:
+        symbolizer_xml: PolygonSymbolizer XML string or Element.
+
+    Returns:
+        Dict with fill_color, fill_opacity, stroke_color, stroke_width.
+    """
+    if isinstance(symbolizer_xml, str):
+        try:
+            root = ET.fromstring(symbolizer_xml)
+        except ET.ParseError as e:
+            raise SLDConverterError(f"Invalid symbolizer XML: {e}") from e
+    else:
+        root = symbolizer_xml
+
+    result: dict[str, Any] = {
+        "fill_color": "#888888",
+        "fill_opacity": 1.0,
+        "stroke_color": None,
+        "stroke_width": None,
+    }
+
+    # Extract Fill
+    fill = _find_with_ns(root, ".//sld:Fill")
+    if fill is not None:
+        fill_color = _get_css_parameter(fill, "fill")
+        if fill_color:
+            result["fill_color"] = fill_color
+
+        fill_opacity = _get_css_parameter(fill, "fill-opacity")
+        if fill_opacity:
+            try:
+                result["fill_opacity"] = float(fill_opacity)
+            except ValueError:
+                pass
+
+    # Extract Stroke
+    stroke = _find_with_ns(root, ".//sld:Stroke")
+    if stroke is not None:
+        stroke_color = _get_css_parameter(stroke, "stroke")
+        if stroke_color:
+            result["stroke_color"] = stroke_color
+
+        stroke_width = _get_css_parameter(stroke, "stroke-width")
+        if stroke_width:
+            try:
+                result["stroke_width"] = float(stroke_width)
+            except ValueError:
+                pass
+
+    return result
+
+
+def parse_point_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
+    """Extract point marker properties from PointSymbolizer.
+
+    Args:
+        symbolizer_xml: PointSymbolizer XML string or Element.
+
+    Returns:
+        Dict with type, fill_color, size, and optional warning.
+    """
+    if isinstance(symbolizer_xml, str):
+        try:
+            root = ET.fromstring(symbolizer_xml)
+        except ET.ParseError as e:
+            raise SLDConverterError(f"Invalid symbolizer XML: {e}") from e
+    else:
+        root = symbolizer_xml
+
+    result: dict[str, Any] = {
+        "type": "circle",
+        "fill_color": "#888888",
+        "size": 10,
+    }
+
+    # Get WellKnownName
+    wkn = _find_with_ns(root, ".//sld:WellKnownName")
+    if wkn is not None and wkn.text:
+        wkn_text = wkn.text.lower()
+        if wkn_text.startswith("ttf://"):
+            result["warning"] = f"TTF glyph '{wkn.text}' not supported; using circle"
+        elif wkn_text not in ("circle", "square"):
+            result["warning"] = f"WellKnownName '{wkn.text}' mapped to circle"
+
+    # Get fill color from Mark
+    mark = _find_with_ns(root, ".//sld:Mark")
+    if mark is not None:
+        fill = _find_with_ns(mark, "sld:Fill")
+        if fill is not None:
+            fill_color = _get_css_parameter(fill, "fill")
+            if fill_color:
+                result["fill_color"] = fill_color
+
+    # Get size
+    size_elem = _find_with_ns(root, ".//sld:Size")
+    if size_elem is not None and size_elem.text:
+        try:
+            result["size"] = float(size_elem.text)
+        except ValueError:
+            pass
+
+    return result
+
+
+def parse_line_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
+    """Extract line properties from LineSymbolizer.
+
+    Args:
+        symbolizer_xml: LineSymbolizer XML string or Element.
+
+    Returns:
+        Dict with line_color, line_width, line_opacity.
+    """
+    if isinstance(symbolizer_xml, str):
+        try:
+            root = ET.fromstring(symbolizer_xml)
+        except ET.ParseError as e:
+            raise SLDConverterError(f"Invalid symbolizer XML: {e}") from e
+    else:
+        root = symbolizer_xml
+
+    result: dict[str, Any] = {
+        "line_color": "#888888",
+        "line_width": 1,
+        "line_opacity": 1.0,
+    }
+
+    stroke = _find_with_ns(root, ".//sld:Stroke")
+    if stroke is not None:
+        color = _get_css_parameter(stroke, "stroke")
+        if color:
+            result["line_color"] = color
+
+        width = _get_css_parameter(stroke, "stroke-width")
+        if width:
+            try:
+                result["line_width"] = float(width)
+            except ValueError:
+                pass
+
+        opacity = _get_css_parameter(stroke, "stroke-opacity")
+        if opacity:
+            try:
+                result["line_opacity"] = float(opacity)
+            except ValueError:
+                pass
+
+    return result
+
+
+def _extract_rules(root: ET.Element) -> list[ET.Element]:
+    """Extract all Rule elements from SLD document."""
+    rules = _findall_with_ns(root, ".//sld:Rule")
+    if not rules:
+        # Try SE namespace (SLD 1.1)
+        rules = root.findall(".//{http://www.opengis.net/se}Rule")
+    return rules
+
+
+def _determine_style_type(rules: list[ET.Element]) -> str:
+    """Determine if style is categorical (has filters) or simple."""
+    for rule in rules:
+        filter_elem = _find_with_ns(rule, "ogc:Filter")
+        if filter_elem is not None:
+            return "categorical"
+    return "simple"
+
+
+def _determine_geometry_type(rules: list[ET.Element]) -> str:
+    """Determine geometry type from symbolizer types."""
+    for rule in rules:
+        if _find_with_ns(rule, ".//sld:PolygonSymbolizer") is not None:
+            return "polygon"
+        if _find_with_ns(rule, ".//sld:PointSymbolizer") is not None:
+            return "point"
+        if _find_with_ns(rule, ".//sld:LineSymbolizer") is not None:
+            return "line"
+    return "polygon"  # Default
+
+
+def _extract_style_name(root: ET.Element) -> str:
+    """Extract style name from SLD document."""
+    # Try UserStyle Name
+    name_elem = _find_with_ns(root, ".//sld:UserStyle/sld:Name")
+    if name_elem is not None and name_elem.text:
+        return name_elem.text
+
+    # Try NamedLayer Name
+    name_elem = _find_with_ns(root, ".//sld:NamedLayer/sld:Name")
+    if name_elem is not None and name_elem.text:
+        # Remove namespace prefix like "geonode:"
+        name = name_elem.text
+        if ":" in name:
+            name = name.split(":")[-1]
+        return name
+
+    return "Converted Style"
+
+
+def _build_categorical_layers(
+    rules: list[ET.Element],
+    geom_type: str,
+    source_layer: str,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Build layers for categorical (filtered) SLD rules."""
+    field: str | None = None
+    cases: list[tuple[Any, str]] = []
+    opacity: float = 1.0
+
+    for rule in rules:
+        filter_elem = _find_with_ns(rule, "ogc:Filter")
+        if filter_elem is None:
+            continue
+
+        try:
+            rule_field, value = parse_filter_to_value(filter_elem)
+            if field is None:
+                field = rule_field
+        except SLDConverterError:
+            continue
+
+        if geom_type == "polygon":
+            symbolizer = _find_with_ns(rule, ".//sld:PolygonSymbolizer")
+            if symbolizer is not None:
+                props = parse_polygon_symbolizer(symbolizer)
+                cases.append((value, props["fill_color"]))
+                opacity = props["fill_opacity"]
+        elif geom_type == "point":
+            symbolizer = _find_with_ns(rule, ".//sld:PointSymbolizer")
+            if symbolizer is not None:
+                props = parse_point_symbolizer(symbolizer)
+                cases.append((value, props["fill_color"]))
+                if props.get("warning"):
+                    warnings.append(props["warning"])
+        elif geom_type == "line":
+            symbolizer = _find_with_ns(rule, ".//sld:LineSymbolizer")
+            if symbolizer is not None:
+                props = parse_line_symbolizer(symbolizer)
+                cases.append((value, props["line_color"]))
+
+    if not field or not cases:
+        return []
+
+    color_expr = make_match_expression(field, cases, default="#cccccc")
+
+    if geom_type == "polygon":
+        return [make_fill_layer("categorical-fill", source_layer, color_expr, opacity)]
+    if geom_type == "point":
+        return [make_circle_layer("categorical-circle", source_layer, color_expr)]
+    if geom_type == "line":
+        return [make_line_layer("categorical-line", source_layer, color_expr)]
+    return []
+
+
+def _build_simple_layers(
+    rules: list[ET.Element],
+    geom_type: str,
+    source_layer: str,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Build layers for simple (non-filtered) SLD rules."""
+    layers: list[dict[str, Any]] = []
+
+    for rule in rules:
+        if geom_type == "polygon":
+            symbolizer = _find_with_ns(rule, ".//sld:PolygonSymbolizer")
+            if symbolizer is not None:
+                props = parse_polygon_symbolizer(symbolizer)
+                layers.append(
+                    make_fill_layer(
+                        f"fill-{len(layers)}",
+                        source_layer,
+                        props["fill_color"],
+                        props["fill_opacity"],
+                        props.get("stroke_color"),
+                    )
+                )
+        elif geom_type == "point":
+            for symbolizer in _findall_with_ns(rule, ".//sld:PointSymbolizer"):
+                props = parse_point_symbolizer(symbolizer)
+                layers.append(
+                    make_circle_layer(
+                        f"circle-{len(layers)}",
+                        source_layer,
+                        props["fill_color"],
+                        props["size"] / 2,
+                    )
+                )
+                if props.get("warning"):
+                    warnings.append(props["warning"])
+        elif geom_type == "line":
+            symbolizer = _find_with_ns(rule, ".//sld:LineSymbolizer")
+            if symbolizer is not None:
+                props = parse_line_symbolizer(symbolizer)
+                layers.append(
+                    make_line_layer(
+                        f"line-{len(layers)}",
+                        source_layer,
+                        props["line_color"],
+                        props["line_width"],
+                    )
+                )
+
+    return layers
+
+
+@overload
+def convert_sld(
+    sld_xml: str,
+    source_layer: str,
+    *,
+    return_warnings: Literal[False] = False,
+) -> dict[str, Any]: ...
+
+
+@overload
+def convert_sld(
+    sld_xml: str,
+    source_layer: str,
+    *,
+    return_warnings: Literal[True],
+) -> tuple[dict[str, Any], list[str]]: ...
+
+
+def convert_sld(
+    sld_xml: str,
+    source_layer: str,
+    *,
+    return_warnings: bool = False,
+) -> dict[str, Any] | tuple[dict[str, Any], list[str]]:
+    """Convert SLD XML to Mapbox GL style.
+
+    Main entry point for SLD → Mapbox GL conversion.
+
+    Args:
+        sld_xml: Complete SLD XML document as string.
+        source_layer: Name for the source-layer in output.
+        return_warnings: If True, return (style, warnings) tuple.
+
+    Returns:
+        Mapbox GL style dict, or (style, warnings) tuple if return_warnings=True.
+
+    Raises:
+        SLDConverterError: If SLD cannot be parsed or has no rules.
+    """
+    warnings: list[str] = []
+
+    try:
+        root = ET.fromstring(sld_xml)
+    except ET.ParseError as e:
+        raise SLDConverterError(f"Invalid SLD XML: {e}") from e
+
+    rules = _extract_rules(root)
+    if not rules:
+        raise SLDConverterError("No rules found in SLD document")
+
+    style_type = _determine_style_type(rules)
+    geom_type = _determine_geometry_type(rules)
+    style_name = _extract_style_name(root)
+
+    for rule in rules:
+        if _find_with_ns(rule, ".//sld:TextSymbolizer") is not None:
+            warnings.append("TextSymbolizer not supported; labels will be omitted")
+            break
+
+    if style_type == "categorical":
+        layers = _build_categorical_layers(rules, geom_type, source_layer, warnings)
+    else:
+        layers = _build_simple_layers(rules, geom_type, source_layer, warnings)
+
+    if not layers:
+        raise SLDConverterError("No valid symbolizers found in SLD rules")
+
+    style = make_mapbox_style(style_name, source_layer, layers)
+
+    if return_warnings:
+        return style, warnings
+    return style

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -103,6 +103,26 @@ def _findall_symbolizers(element: Element, symbolizer_type: str) -> list[Element
     return _findall_with_ns(element, f".//se:{symbolizer_type}Symbolizer")
 
 
+def _find_sld_or_se(element: Element, local_name: str) -> Element | None:
+    """Find element with SLD namespace, falling back to SE namespace.
+
+    Args:
+        element: Parent element to search within.
+        local_name: Element local name (e.g., "Radius", "Fill").
+
+    Returns:
+        Found element or None.
+
+    Note:
+        Uses explicit `is not None` checks because Element objects with no
+        children are falsy in Python, making `elem or fallback` unreliable.
+    """
+    result = _find_with_ns(element, f"sld:{local_name}")
+    if result is not None:
+        return result
+    return _find_with_ns(element, f"se:{local_name}")
+
+
 def _get_css_parameter(element: Element, name: str) -> str | None:
     """Extract CssParameter/SvgParameter value by name attribute.
 
@@ -436,7 +456,7 @@ def _parse_text_halo(root: Element) -> tuple[str | None, float | None]:
         return None, None
 
     halo_width: float | None = None
-    radius = _find_with_ns(halo, "sld:Radius") or _find_with_ns(halo, "se:Radius")
+    radius = _find_sld_or_se(halo, "Radius")
     if radius is not None and radius.text:
         try:
             halo_width = float(radius.text)
@@ -444,7 +464,7 @@ def _parse_text_halo(root: Element) -> tuple[str | None, float | None]:
             pass
 
     halo_color: str | None = None
-    halo_fill = _find_with_ns(halo, "sld:Fill") or _find_with_ns(halo, "se:Fill")
+    halo_fill = _find_sld_or_se(halo, "Fill")
     if halo_fill is not None:
         color = _get_css_parameter(halo_fill, "fill")
         if color:
@@ -461,12 +481,8 @@ def _parse_text_anchor(root: Element) -> str:
     if anchor_point is None:
         return "center"
 
-    anchor_x_elem = _find_with_ns(anchor_point, "sld:AnchorPointX") or _find_with_ns(
-        anchor_point, "se:AnchorPointX"
-    )
-    anchor_y_elem = _find_with_ns(anchor_point, "sld:AnchorPointY") or _find_with_ns(
-        anchor_point, "se:AnchorPointY"
-    )
+    anchor_x_elem = _find_sld_or_se(anchor_point, "AnchorPointX")
+    anchor_y_elem = _find_sld_or_se(anchor_point, "AnchorPointY")
 
     anchor_x, anchor_y = 0.5, 0.5
     if anchor_x_elem is not None and anchor_x_elem.text:

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -22,8 +22,13 @@ Usage:
 from __future__ import annotations
 
 import logging
-import xml.etree.ElementTree as ET
-from typing import Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
+from xml.etree.ElementTree import Element
+
+import defusedxml.ElementTree as ET
+
+if TYPE_CHECKING:
+    pass  # Element imported above for runtime use and type hints
 
 from portolan_cli.extract.common.converters.base import (
     make_circle_layer,
@@ -51,17 +56,17 @@ NAMESPACES = {
 }
 
 
-def _find_with_ns(element: ET.Element, path: str) -> ET.Element | None:
+def _find_with_ns(element: Element, path: str) -> Element | None:
     """Find element with namespace-aware path."""
     return element.find(path, NAMESPACES)
 
 
-def _findall_with_ns(element: ET.Element, path: str) -> list[ET.Element]:
+def _findall_with_ns(element: Element, path: str) -> list[Element]:
     """Find all elements with namespace-aware path."""
     return element.findall(path, NAMESPACES)
 
 
-def _find_symbolizer(element: ET.Element, symbolizer_type: str) -> ET.Element | None:
+def _find_symbolizer(element: Element, symbolizer_type: str) -> Element | None:
     """Find symbolizer with SLD or SE namespace fallback.
 
     Args:
@@ -79,7 +84,7 @@ def _find_symbolizer(element: ET.Element, symbolizer_type: str) -> ET.Element | 
     return _find_with_ns(element, f".//se:{symbolizer_type}Symbolizer")
 
 
-def _findall_symbolizers(element: ET.Element, symbolizer_type: str) -> list[ET.Element]:
+def _findall_symbolizers(element: Element, symbolizer_type: str) -> list[Element]:
     """Find all symbolizers with SLD or SE namespace fallback.
 
     Args:
@@ -97,7 +102,7 @@ def _findall_symbolizers(element: ET.Element, symbolizer_type: str) -> list[ET.E
     return _findall_with_ns(element, f".//se:{symbolizer_type}Symbolizer")
 
 
-def _get_css_parameter(element: ET.Element, name: str) -> str | None:
+def _get_css_parameter(element: Element, name: str) -> str | None:
     """Extract CssParameter/SvgParameter value by name attribute.
 
     Handles both SLD 1.0 (CssParameter) and SLD 1.1 (SvgParameter).
@@ -113,7 +118,7 @@ def _get_css_parameter(element: ET.Element, name: str) -> str | None:
     return None
 
 
-def parse_filter_to_value(filter_xml: str | ET.Element) -> tuple[str, Any]:
+def parse_filter_to_value(filter_xml: str | Element) -> tuple[str, Any]:
     """Extract field name and value from OGC Filter.
 
     Currently supports PropertyIsEqualTo for categorical classification.
@@ -164,7 +169,7 @@ def parse_filter_to_value(filter_xml: str | ET.Element) -> tuple[str, Any]:
     raise SLDConverterError("Could not extract field/value from filter")
 
 
-def parse_polygon_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
+def parse_polygon_symbolizer(symbolizer_xml: str | Element) -> dict[str, Any]:
     """Extract fill and stroke properties from PolygonSymbolizer.
 
     Args:
@@ -223,7 +228,7 @@ def parse_polygon_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]
     return result
 
 
-def parse_point_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
+def parse_point_symbolizer(symbolizer_xml: str | Element) -> dict[str, Any]:
     """Extract point marker properties from PointSymbolizer.
 
     Args:
@@ -283,7 +288,7 @@ def parse_point_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
     return result
 
 
-def parse_line_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
+def parse_line_symbolizer(symbolizer_xml: str | Element) -> dict[str, Any]:
     """Extract line properties from LineSymbolizer.
 
     Args:
@@ -331,7 +336,7 @@ def parse_line_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
     return result
 
 
-def _extract_rules(root: ET.Element) -> list[ET.Element]:
+def _extract_rules(root: Element) -> list[Element]:
     """Extract all Rule elements from SLD document."""
     rules = _findall_with_ns(root, ".//sld:Rule")
     if not rules:
@@ -340,7 +345,7 @@ def _extract_rules(root: ET.Element) -> list[ET.Element]:
     return rules
 
 
-def _determine_style_type(rules: list[ET.Element]) -> str:
+def _determine_style_type(rules: list[Element]) -> str:
     """Determine if style is categorical (has filters) or simple."""
     for rule in rules:
         filter_elem = _find_with_ns(rule, "ogc:Filter")
@@ -349,7 +354,7 @@ def _determine_style_type(rules: list[ET.Element]) -> str:
     return "simple"
 
 
-def _determine_geometry_type(rules: list[ET.Element]) -> str:
+def _determine_geometry_type(rules: list[Element]) -> str:
     """Determine geometry type from symbolizer types."""
     for rule in rules:
         if _find_symbolizer(rule, "Polygon") is not None:
@@ -361,7 +366,7 @@ def _determine_geometry_type(rules: list[ET.Element]) -> str:
     return "polygon"  # Default
 
 
-def _extract_style_name(root: ET.Element) -> str:
+def _extract_style_name(root: Element) -> str:
     """Extract style name from SLD document."""
     # Try UserStyle Name
     name_elem = _find_with_ns(root, ".//sld:UserStyle/sld:Name")
@@ -412,7 +417,7 @@ def _build_categorical_fill(
 
 
 def _build_categorical_layers(
-    rules: list[ET.Element],
+    rules: list[Element],
     geom_type: str,
     source_layer: str,
     warnings: list[str],
@@ -469,7 +474,7 @@ def _build_categorical_layers(
 
 
 def _build_simple_layers(
-    rules: list[ET.Element],
+    rules: list[Element],
     geom_type: str,
     source_layer: str,
     warnings: list[str],

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -61,9 +61,53 @@ def _findall_with_ns(element: ET.Element, path: str) -> list[ET.Element]:
     return element.findall(path, NAMESPACES)
 
 
+def _find_symbolizer(element: ET.Element, symbolizer_type: str) -> ET.Element | None:
+    """Find symbolizer with SLD or SE namespace fallback.
+
+    Args:
+        element: Parent element to search within.
+        symbolizer_type: One of "Polygon", "Point", "Line".
+
+    Returns:
+        Found symbolizer element or None.
+    """
+    # Try SLD namespace first
+    result = _find_with_ns(element, f".//sld:{symbolizer_type}Symbolizer")
+    if result is not None:
+        return result
+    # Fallback to SE namespace (SLD 1.1)
+    return _find_with_ns(element, f".//se:{symbolizer_type}Symbolizer")
+
+
+def _findall_symbolizers(element: ET.Element, symbolizer_type: str) -> list[ET.Element]:
+    """Find all symbolizers with SLD or SE namespace fallback.
+
+    Args:
+        element: Parent element to search within.
+        symbolizer_type: One of "Polygon", "Point", "Line".
+
+    Returns:
+        List of found symbolizer elements.
+    """
+    # Try SLD namespace first
+    results = _findall_with_ns(element, f".//sld:{symbolizer_type}Symbolizer")
+    if results:
+        return results
+    # Fallback to SE namespace (SLD 1.1)
+    return _findall_with_ns(element, f".//se:{symbolizer_type}Symbolizer")
+
+
 def _get_css_parameter(element: ET.Element, name: str) -> str | None:
-    """Extract CssParameter value by name attribute."""
+    """Extract CssParameter/SvgParameter value by name attribute.
+
+    Handles both SLD 1.0 (CssParameter) and SLD 1.1 (SvgParameter).
+    """
+    # Try SLD 1.0 CssParameter
     for param in _findall_with_ns(element, ".//sld:CssParameter"):
+        if param.get("name") == name:
+            return param.text
+    # Try SLD 1.1 SvgParameter
+    for param in _findall_with_ns(element, ".//se:SvgParameter"):
         if param.get("name") == name:
             return param.text
     return None
@@ -144,8 +188,10 @@ def parse_polygon_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]
         "stroke_width": None,
     }
 
-    # Extract Fill
+    # Extract Fill (SLD 1.0 or SE)
     fill = _find_with_ns(root, ".//sld:Fill")
+    if fill is None:
+        fill = _find_with_ns(root, ".//se:Fill")
     if fill is not None:
         fill_color = _get_css_parameter(fill, "fill")
         if fill_color:
@@ -158,8 +204,10 @@ def parse_polygon_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]
             except ValueError:
                 pass
 
-    # Extract Stroke
+    # Extract Stroke (SLD 1.0 or SE)
     stroke = _find_with_ns(root, ".//sld:Stroke")
+    if stroke is None:
+        stroke = _find_with_ns(root, ".//se:Stroke")
     if stroke is not None:
         stroke_color = _get_css_parameter(stroke, "stroke")
         if stroke_color:
@@ -198,8 +246,10 @@ def parse_point_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
         "size": 10,
     }
 
-    # Get WellKnownName
+    # Get WellKnownName (SLD 1.0 or SE)
     wkn = _find_with_ns(root, ".//sld:WellKnownName")
+    if wkn is None:
+        wkn = _find_with_ns(root, ".//se:WellKnownName")
     if wkn is not None and wkn.text:
         wkn_text = wkn.text.lower()
         if wkn_text.startswith("ttf://"):
@@ -207,17 +257,23 @@ def parse_point_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
         elif wkn_text not in ("circle", "square"):
             result["warning"] = f"WellKnownName '{wkn.text}' mapped to circle"
 
-    # Get fill color from Mark
+    # Get fill color from Mark (SLD 1.0 or SE)
     mark = _find_with_ns(root, ".//sld:Mark")
+    if mark is None:
+        mark = _find_with_ns(root, ".//se:Mark")
     if mark is not None:
         fill = _find_with_ns(mark, "sld:Fill")
+        if fill is None:
+            fill = _find_with_ns(mark, "se:Fill")
         if fill is not None:
             fill_color = _get_css_parameter(fill, "fill")
             if fill_color:
                 result["fill_color"] = fill_color
 
-    # Get size
+    # Get size (SLD 1.0 or SE)
     size_elem = _find_with_ns(root, ".//sld:Size")
+    if size_elem is None:
+        size_elem = _find_with_ns(root, ".//se:Size")
     if size_elem is not None and size_elem.text:
         try:
             result["size"] = float(size_elem.text)
@@ -251,6 +307,8 @@ def parse_line_symbolizer(symbolizer_xml: str | ET.Element) -> dict[str, Any]:
     }
 
     stroke = _find_with_ns(root, ".//sld:Stroke")
+    if stroke is None:
+        stroke = _find_with_ns(root, ".//se:Stroke")
     if stroke is not None:
         color = _get_css_parameter(stroke, "stroke")
         if color:
@@ -294,11 +352,11 @@ def _determine_style_type(rules: list[ET.Element]) -> str:
 def _determine_geometry_type(rules: list[ET.Element]) -> str:
     """Determine geometry type from symbolizer types."""
     for rule in rules:
-        if _find_with_ns(rule, ".//sld:PolygonSymbolizer") is not None:
+        if _find_symbolizer(rule, "Polygon") is not None:
             return "polygon"
-        if _find_with_ns(rule, ".//sld:PointSymbolizer") is not None:
+        if _find_symbolizer(rule, "Point") is not None:
             return "point"
-        if _find_with_ns(rule, ".//sld:LineSymbolizer") is not None:
+        if _find_symbolizer(rule, "Line") is not None:
             return "line"
     return "polygon"  # Default
 
@@ -346,20 +404,20 @@ def _build_categorical_layers(
             continue
 
         if geom_type == "polygon":
-            symbolizer = _find_with_ns(rule, ".//sld:PolygonSymbolizer")
+            symbolizer = _find_symbolizer(rule, "Polygon")
             if symbolizer is not None:
                 props = parse_polygon_symbolizer(symbolizer)
                 cases.append((value, props["fill_color"]))
                 opacity = props["fill_opacity"]
         elif geom_type == "point":
-            symbolizer = _find_with_ns(rule, ".//sld:PointSymbolizer")
+            symbolizer = _find_symbolizer(rule, "Point")
             if symbolizer is not None:
                 props = parse_point_symbolizer(symbolizer)
                 cases.append((value, props["fill_color"]))
                 if props.get("warning"):
                     warnings.append(props["warning"])
         elif geom_type == "line":
-            symbolizer = _find_with_ns(rule, ".//sld:LineSymbolizer")
+            symbolizer = _find_symbolizer(rule, "Line")
             if symbolizer is not None:
                 props = parse_line_symbolizer(symbolizer)
                 cases.append((value, props["line_color"]))
@@ -389,7 +447,7 @@ def _build_simple_layers(
 
     for rule in rules:
         if geom_type == "polygon":
-            symbolizer = _find_with_ns(rule, ".//sld:PolygonSymbolizer")
+            symbolizer = _find_symbolizer(rule, "Polygon")
             if symbolizer is not None:
                 props = parse_polygon_symbolizer(symbolizer)
                 layers.append(
@@ -402,7 +460,7 @@ def _build_simple_layers(
                     )
                 )
         elif geom_type == "point":
-            for symbolizer in _findall_with_ns(rule, ".//sld:PointSymbolizer"):
+            for symbolizer in _findall_symbolizers(rule, "Point"):
                 props = parse_point_symbolizer(symbolizer)
                 layers.append(
                     make_circle_layer(
@@ -415,7 +473,7 @@ def _build_simple_layers(
                 if props.get("warning"):
                     warnings.append(props["warning"])
         elif geom_type == "line":
-            symbolizer = _find_with_ns(rule, ".//sld:LineSymbolizer")
+            symbolizer = _find_symbolizer(rule, "Line")
             if symbolizer is not None:
                 props = parse_line_symbolizer(symbolizer)
                 layers.append(
@@ -485,7 +543,7 @@ def convert_sld(
     style_name = _extract_style_name(root)
 
     for rule in rules:
-        if _find_with_ns(rule, ".//sld:TextSymbolizer") is not None:
+        if _find_symbolizer(rule, "Text") is not None:
             warnings.append("TextSymbolizer not supported; labels will be omitted")
             break
 

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -6,10 +6,11 @@ Supported symbolizers:
 - PolygonSymbolizer: Fill and stroke for polygons
 - PointSymbolizer: Circle markers for points
 - LineSymbolizer: Line styling for linestrings
+- TextSymbolizer: Symbol layers for text labels
 
 Partially supported (warn and continue):
-- TextSymbolizer: Skipped with warning (labels not supported)
 - TTF glyphs in PointSymbolizer: Falls back to circle
+- Unknown fonts in TextSymbolizer: Falls back to Noto Sans Regular
 
 OGC Filter support:
 - PropertyIsEqualTo: Extracts field/value for categorical styling
@@ -35,6 +36,7 @@ from portolan_cli.extract.common.converters.base import (
     make_line_layer,
     make_mapbox_style,
     make_match_expression,
+    make_symbol_layer,
 )
 
 logger = logging.getLogger(__name__)
@@ -335,6 +337,184 @@ def parse_line_symbolizer(symbolizer_xml: str | Element) -> dict[str, Any]:
     return result
 
 
+def _sld_anchor_to_mapbox(anchor_x: float, anchor_y: float) -> str:
+    """Convert SLD anchor point coordinates to Mapbox GL text-anchor.
+
+    SLD anchor: (0, 0) = top-left, (1, 1) = bottom-right, (0.5, 0.5) = center
+    Mapbox anchor: named positions like "center", "left", "bottom-right"
+
+    Args:
+        anchor_x: Horizontal anchor 0.0 (left) to 1.0 (right).
+        anchor_y: Vertical anchor 0.0 (top) to 1.0 (bottom).
+
+    Returns:
+        Mapbox GL text-anchor value.
+    """
+    # Map to horizontal position
+    if anchor_x < 0.33:
+        h = "left"
+    elif anchor_x > 0.66:
+        h = "right"
+    else:
+        h = ""
+
+    # Map to vertical position
+    if anchor_y < 0.33:
+        v = "top"
+    elif anchor_y > 0.66:
+        v = "bottom"
+    else:
+        v = ""
+
+    # Combine into Mapbox anchor name
+    if h and v:
+        return f"{v}-{h}"
+    elif h:
+        return h
+    elif v:
+        return v
+    else:
+        return "center"
+
+
+def _parse_text_label(root: Element) -> list[str]:
+    """Extract Label/PropertyName from TextSymbolizer."""
+    label = _find_with_ns(root, ".//sld:Label")
+    if label is None:
+        label = _find_with_ns(root, ".//se:Label")
+    if label is not None:
+        prop_name = _find_with_ns(label, "ogc:PropertyName")
+        if prop_name is not None and prop_name.text:
+            return ["get", prop_name.text]
+    return ["get", ""]
+
+
+def _parse_text_font(root: Element) -> tuple[float, list[str]]:
+    """Extract Font properties from TextSymbolizer."""
+    text_size = 12.0
+    text_font = ["Noto Sans Regular"]
+
+    font = _find_with_ns(root, ".//sld:Font")
+    if font is None:
+        font = _find_with_ns(root, ".//se:Font")
+    if font is None:
+        return text_size, text_font
+
+    font_size = _get_css_parameter(font, "font-size")
+    if font_size:
+        try:
+            text_size = float(font_size)
+        except ValueError:
+            pass
+
+    font_family = _get_css_parameter(font, "font-family")
+    if font_family:
+        logger.debug(f"Font '{font_family}' mapped to Noto Sans Regular")
+
+    return text_size, text_font
+
+
+def _parse_text_fill(root: Element) -> str:
+    """Extract direct Fill color from TextSymbolizer (not Halo fill)."""
+    for fill in _findall_with_ns(root, "sld:Fill"):
+        fill_color = _get_css_parameter(fill, "fill")
+        if fill_color:
+            return fill_color
+    for fill in _findall_with_ns(root, "se:Fill"):
+        fill_color = _get_css_parameter(fill, "fill")
+        if fill_color:
+            return fill_color
+    return "#000000"
+
+
+def _parse_text_halo(root: Element) -> tuple[str | None, float | None]:
+    """Extract Halo properties from TextSymbolizer."""
+    halo = _find_with_ns(root, ".//sld:Halo")
+    if halo is None:
+        halo = _find_with_ns(root, ".//se:Halo")
+    if halo is None:
+        return None, None
+
+    halo_width: float | None = None
+    radius = _find_with_ns(halo, "sld:Radius") or _find_with_ns(halo, "se:Radius")
+    if radius is not None and radius.text:
+        try:
+            halo_width = float(radius.text)
+        except ValueError:
+            pass
+
+    halo_color: str | None = None
+    halo_fill = _find_with_ns(halo, "sld:Fill") or _find_with_ns(halo, "se:Fill")
+    if halo_fill is not None:
+        color = _get_css_parameter(halo_fill, "fill")
+        if color:
+            halo_color = color
+
+    return halo_color, halo_width
+
+
+def _parse_text_anchor(root: Element) -> str:
+    """Extract LabelPlacement/AnchorPoint from TextSymbolizer."""
+    anchor_point = _find_with_ns(root, ".//sld:AnchorPoint")
+    if anchor_point is None:
+        anchor_point = _find_with_ns(root, ".//se:AnchorPoint")
+    if anchor_point is None:
+        return "center"
+
+    anchor_x_elem = _find_with_ns(anchor_point, "sld:AnchorPointX") or _find_with_ns(
+        anchor_point, "se:AnchorPointX"
+    )
+    anchor_y_elem = _find_with_ns(anchor_point, "sld:AnchorPointY") or _find_with_ns(
+        anchor_point, "se:AnchorPointY"
+    )
+
+    anchor_x, anchor_y = 0.5, 0.5
+    if anchor_x_elem is not None and anchor_x_elem.text:
+        try:
+            anchor_x = float(anchor_x_elem.text)
+        except ValueError:
+            pass
+    if anchor_y_elem is not None and anchor_y_elem.text:
+        try:
+            anchor_y = float(anchor_y_elem.text)
+        except ValueError:
+            pass
+
+    return _sld_anchor_to_mapbox(anchor_x, anchor_y)
+
+
+def parse_text_symbolizer(symbolizer_xml: str | Element) -> dict[str, Any]:
+    """Extract text label properties from TextSymbolizer.
+
+    Args:
+        symbolizer_xml: TextSymbolizer XML string or Element.
+
+    Returns:
+        Dict with text_field, text_color, text_size, text_font,
+        text_halo_color, text_halo_width, text_anchor.
+    """
+    if isinstance(symbolizer_xml, str):
+        try:
+            root = ET.fromstring(symbolizer_xml)
+        except ET.ParseError as e:
+            raise SLDConverterError(f"Invalid symbolizer XML: {e}") from e
+    else:
+        root = symbolizer_xml
+
+    text_size, text_font = _parse_text_font(root)
+    halo_color, halo_width = _parse_text_halo(root)
+
+    return {
+        "text_field": _parse_text_label(root),
+        "text_color": _parse_text_fill(root),
+        "text_size": text_size,
+        "text_font": text_font,
+        "text_anchor": _parse_text_anchor(root),
+        "text_halo_color": halo_color,
+        "text_halo_width": halo_width,
+    }
+
+
 def _extract_rules(root: Element) -> list[Element]:
     """Extract all Rule elements from SLD document."""
     rules = _findall_with_ns(root, ".//sld:Rule")
@@ -537,8 +717,17 @@ def _build_categorical_layers(
     size_cases: list[tuple[Any, float]] = []
     line_width_cases: list[tuple[Any, float]] = []
 
+    # Track TextSymbolizer from rules (may be in filtered or unfiltered rules)
+    text_symbolizer: Element | None = None
+
     for rule in rules:
         filter_elem = _find_with_ns(rule, "ogc:Filter")
+
+        # Check for TextSymbolizer in any rule (filtered or not)
+        rule_text_sym = _find_symbolizer(rule, "Text")
+        if rule_text_sym is not None:
+            text_symbolizer = rule_text_sym
+
         if filter_elem is None:
             continue
         try:
@@ -574,8 +763,12 @@ def _build_categorical_layers(
     if not field or not color_cases:
         return []
 
+    layers: list[dict[str, Any]] = []
+    geom_layer_id: str = ""
+
     if geom_type == "polygon":
-        return _build_categorical_fill(
+        geom_layer_id = "categorical-fill"
+        layers = _build_categorical_fill(
             field,
             color_cases,
             opacity_cases,
@@ -584,13 +777,34 @@ def _build_categorical_layers(
             source_layer,
             warnings,
         )
-    if geom_type == "point":
-        return _build_categorical_circle(field, color_cases, size_cases, source_layer)
-    if geom_type == "line":
-        return _build_categorical_line(
+    elif geom_type == "point":
+        geom_layer_id = "categorical-circle"
+        layers = _build_categorical_circle(field, color_cases, size_cases, source_layer)
+    elif geom_type == "line":
+        geom_layer_id = "categorical-line"
+        layers = _build_categorical_line(
             field, color_cases, opacity_cases, line_width_cases, source_layer
         )
-    return []
+
+    # Add label layer if TextSymbolizer was found
+    if text_symbolizer is not None and layers:
+        text_props = parse_text_symbolizer(text_symbolizer)
+        label_layer_id = f"{geom_layer_id}-labels"
+        layers.append(
+            make_symbol_layer(
+                label_layer_id,
+                source_layer,
+                text_field=text_props["text_field"],
+                text_color=text_props["text_color"],
+                text_size=text_props["text_size"],
+                text_font=text_props["text_font"],
+                text_halo_color=text_props.get("text_halo_color"),
+                text_halo_width=text_props.get("text_halo_width") or 1.0,
+                text_anchor=text_props["text_anchor"],
+            )
+        )
+
+    return layers
 
 
 def _build_simple_layers(
@@ -603,13 +817,16 @@ def _build_simple_layers(
     layers: list[dict[str, Any]] = []
 
     for rule in rules:
+        geom_layer_id: str | None = None
+
         if geom_type == "polygon":
             symbolizer = _find_symbolizer(rule, "Polygon")
             if symbolizer is not None:
                 props = parse_polygon_symbolizer(symbolizer)
+                geom_layer_id = f"fill-{len(layers)}"
                 layers.append(
                     make_fill_layer(
-                        f"fill-{len(layers)}",
+                        geom_layer_id,
                         source_layer,
                         props["fill_color"],
                         props["fill_opacity"],
@@ -619,9 +836,10 @@ def _build_simple_layers(
         elif geom_type == "point":
             for symbolizer in _findall_symbolizers(rule, "Point"):
                 props = parse_point_symbolizer(symbolizer)
+                geom_layer_id = f"circle-{len(layers)}"
                 layers.append(
                     make_circle_layer(
-                        f"circle-{len(layers)}",
+                        geom_layer_id,
                         source_layer,
                         props["fill_color"],
                         props["size"] / 2,
@@ -633,14 +851,34 @@ def _build_simple_layers(
             symbolizer = _find_symbolizer(rule, "Line")
             if symbolizer is not None:
                 props = parse_line_symbolizer(symbolizer)
+                geom_layer_id = f"line-{len(layers)}"
                 layers.append(
                     make_line_layer(
-                        f"line-{len(layers)}",
+                        geom_layer_id,
                         source_layer,
                         props["line_color"],
                         props["line_width"],
                     )
                 )
+
+        # Check for TextSymbolizer and add label layer
+        text_symbolizer = _find_symbolizer(rule, "Text")
+        if text_symbolizer is not None and geom_layer_id is not None:
+            text_props = parse_text_symbolizer(text_symbolizer)
+            label_layer_id = f"{geom_layer_id}-labels"
+            layers.append(
+                make_symbol_layer(
+                    label_layer_id,
+                    source_layer,
+                    text_field=text_props["text_field"],
+                    text_color=text_props["text_color"],
+                    text_size=text_props["text_size"],
+                    text_font=text_props["text_font"],
+                    text_halo_color=text_props.get("text_halo_color"),
+                    text_halo_width=text_props.get("text_halo_width") or 1.0,
+                    text_anchor=text_props["text_anchor"],
+                )
+            )
 
     return layers
 
@@ -698,11 +936,6 @@ def convert_sld(
     style_type = _determine_style_type(rules)
     geom_type = _determine_geometry_type(rules)
     style_name = _extract_style_name(root)
-
-    for rule in rules:
-        if _find_symbolizer(rule, "Text") is not None:
-            warnings.append("TextSymbolizer not supported; labels will be omitted")
-            break
 
     if style_type == "categorical":
         layers = _build_categorical_layers(rules, geom_type, source_layer, warnings)

--- a/portolan_cli/extract/common/converters/sld.py
+++ b/portolan_cli/extract/common/converters/sld.py
@@ -396,23 +396,130 @@ def _build_categorical_fill(
     field: str,
     color_cases: list[tuple[Any, str]],
     opacity_cases: list[tuple[Any, float]],
+    stroke_color_cases: list[tuple[Any, str | None]],
+    stroke_width_cases: list[tuple[Any, float | None]],
+    source_layer: str,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Build categorical fill layer with per-rule property support.
+
+    Builds match expressions for fill color, opacity, stroke color, and stroke width
+    when values vary across rules. Uses uniform values when all rules share the same
+    value to keep the style simpler.
+    """
+    color_expr = make_match_expression(field, color_cases, default="#cccccc")
+
+    # Opacity: use expression if values vary, else uniform
+    unique_opacities = {op for _, op in opacity_cases}
+    opacity_value: float | list[Any]
+    if len(unique_opacities) == 1:
+        opacity_value = next(iter(unique_opacities))
+    else:
+        opacity_value = make_match_expression(field, opacity_cases, default=1.0)
+
+    # Stroke color: filter out None values, build expression if non-empty and varying
+    stroke_color_defined = [(v, c) for v, c in stroke_color_cases if c is not None]
+    stroke_color_value: str | list[Any] | None = None
+    if stroke_color_defined:
+        unique_stroke_colors = {c for _, c in stroke_color_defined}
+        if len(unique_stroke_colors) == 1:
+            stroke_color_value = next(iter(unique_stroke_colors))
+        elif len(stroke_color_defined) < len(stroke_color_cases):
+            warnings.append("Some rules missing stroke-color; using default for unspecified")
+            stroke_color_value = make_match_expression(
+                field, stroke_color_defined, default="#000000"
+            )
+        else:
+            stroke_color_value = make_match_expression(
+                field, stroke_color_defined, default="#000000"
+            )
+
+    # Stroke width: filter out None values, build expression if non-empty and varying
+    stroke_width_defined = [(v, w) for v, w in stroke_width_cases if w is not None]
+    stroke_width_value: float | list[Any] | None = None
+    if stroke_width_defined:
+        unique_stroke_widths = {w for _, w in stroke_width_defined}
+        if len(unique_stroke_widths) == 1:
+            stroke_width_value = next(iter(unique_stroke_widths))
+        elif len(stroke_width_defined) < len(stroke_width_cases):
+            warnings.append("Some rules missing stroke-width; using default for unspecified")
+            stroke_width_value = make_match_expression(field, stroke_width_defined, default=1.0)
+        else:
+            stroke_width_value = make_match_expression(field, stroke_width_defined, default=1.0)
+
+    # Build base layer with computed expressions
+    layer = make_fill_layer(
+        "categorical-fill",
+        source_layer,
+        color_expr,
+        opacity_value,
+        stroke_color_value,
+    )
+
+    # Add stroke-width if we have one (not a standard fill property, use line layer)
+    # Note: fill-outline only supports color, not width. For stroke width, we'd need
+    # a separate line layer. Log this limitation.
+    if stroke_width_value is not None:
+        warnings.append(
+            "Mapbox fill layers only support outline color, not width; "
+            "stroke-width ignored for categorical fills"
+        )
+
+    return [layer]
+
+
+def _build_categorical_circle(
+    field: str,
+    color_cases: list[tuple[Any, str]],
+    size_cases: list[tuple[Any, float]],
     source_layer: str,
 ) -> list[dict[str, Any]]:
-    """Build categorical fill layer with per-rule opacity support."""
+    """Build categorical circle layer for point data."""
     color_expr = make_match_expression(field, color_cases, default="#cccccc")
+    unique_sizes = {s for _, s in size_cases}
+    size_value: float | list[Any]
+    if len(unique_sizes) == 1:
+        size_value = next(iter(unique_sizes))
+    else:
+        size_value = make_match_expression(field, size_cases, default=5.0)
+    return [
+        make_circle_layer("categorical-circle", source_layer, color_expr, circle_radius=size_value)
+    ]
+
+
+def _build_categorical_line(
+    field: str,
+    color_cases: list[tuple[Any, str]],
+    opacity_cases: list[tuple[Any, float]],
+    width_cases: list[tuple[Any, float]],
+    source_layer: str,
+) -> list[dict[str, Any]]:
+    """Build categorical line layer with per-rule width and opacity."""
+    color_expr = make_match_expression(field, color_cases, default="#cccccc")
+
+    unique_widths = {w for _, w in width_cases}
+    width_value: float | list[Any]
+    if len(unique_widths) == 1:
+        width_value = next(iter(unique_widths))
+    else:
+        width_value = make_match_expression(field, width_cases, default=1.0)
+
     unique_opacities = {op for _, op in opacity_cases}
-
+    opacity_value: float | list[Any]
     if len(unique_opacities) == 1:
-        return [
-            make_fill_layer(
-                "categorical-fill", source_layer, color_expr, next(iter(unique_opacities))
-            )
-        ]
+        opacity_value = next(iter(unique_opacities))
+    else:
+        opacity_value = make_match_expression(field, opacity_cases, default=1.0)
 
-    opacity_expr = make_match_expression(field, opacity_cases, default=1.0)
-    layer = make_fill_layer("categorical-fill", source_layer, color_expr, 1.0)
-    layer["paint"]["fill-opacity"] = opacity_expr
-    return [layer]
+    return [
+        make_line_layer(
+            "categorical-line",
+            source_layer,
+            color_expr,
+            line_width=width_value,
+            line_opacity=opacity_value,
+        )
+    ]
 
 
 def _build_categorical_layers(
@@ -425,12 +532,15 @@ def _build_categorical_layers(
     field: str | None = None
     color_cases: list[tuple[Any, str]] = []
     opacity_cases: list[tuple[Any, float]] = []
+    stroke_color_cases: list[tuple[Any, str | None]] = []
+    stroke_width_cases: list[tuple[Any, float | None]] = []
+    size_cases: list[tuple[Any, float]] = []
+    line_width_cases: list[tuple[Any, float]] = []
 
     for rule in rules:
         filter_elem = _find_with_ns(rule, "ogc:Filter")
         if filter_elem is None:
             continue
-
         try:
             rule_field, value = parse_filter_to_value(filter_elem)
             if field is None:
@@ -447,28 +557,39 @@ def _build_categorical_layers(
             props = parse_polygon_symbolizer(symbolizer)
             color_cases.append((value, props["fill_color"]))
             opacity_cases.append((value, props["fill_opacity"]))
+            stroke_color_cases.append((value, props.get("stroke_color")))
+            stroke_width_cases.append((value, props.get("stroke_width")))
         elif geom_type == "point":
             props = parse_point_symbolizer(symbolizer)
             color_cases.append((value, props["fill_color"]))
+            size_cases.append((value, props["size"]))
             if props.get("warning"):
                 warnings.append(props["warning"])
         elif geom_type == "line":
             props = parse_line_symbolizer(symbolizer)
             color_cases.append((value, props["line_color"]))
             opacity_cases.append((value, props["line_opacity"]))
+            line_width_cases.append((value, props["line_width"]))
 
     if not field or not color_cases:
         return []
 
-    color_expr = make_match_expression(field, color_cases, default="#cccccc")
-
     if geom_type == "polygon":
-        return _build_categorical_fill(field, color_cases, opacity_cases, source_layer)
+        return _build_categorical_fill(
+            field,
+            color_cases,
+            opacity_cases,
+            stroke_color_cases,
+            stroke_width_cases,
+            source_layer,
+            warnings,
+        )
     if geom_type == "point":
-        return [make_circle_layer("categorical-circle", source_layer, color_expr)]
+        return _build_categorical_circle(field, color_cases, size_cases, source_layer)
     if geom_type == "line":
-        opacity = _get_uniform_opacity(opacity_cases)
-        return [make_line_layer("categorical-line", source_layer, color_expr, line_opacity=opacity)]
+        return _build_categorical_line(
+            field, color_cases, opacity_cases, line_width_cases, source_layer
+        )
     return []
 
 

--- a/portolan_cli/extract/common/styles.py
+++ b/portolan_cli/extract/common/styles.py
@@ -1,17 +1,24 @@
-"""Style extraction orchestration for remote services.
+"""Style and legend extraction orchestration for remote services.
 
 This module provides the high-level API for extracting styles from
 WMS and ESRI REST endpoints and writing them as Mapbox GL JSON files.
+Also extracts legend images from WMS GetLegendGraphic endpoint.
 
-The flow is:
+Style extraction flow:
 1. Fetch style from source (WMS GetStyles or ESRI layer JSON)
 2. Convert to Mapbox GL using format-specific converter
 3. Write to {collection}/styles/{name}.json
-4. Return StyleInfo for STAC asset registration
+4. Return ExtractedStyle for STAC asset registration
+
+Legend extraction flow (Issue #498):
+1. Fetch legend image from WMS GetLegendGraphic endpoint
+2. Write to {collection}/legends/{name}.png
+3. Return ExtractedLegend for STAC asset registration
 
 Usage:
     # During WFS extraction
     style_info = extract_wms_style(wms_url, layer_name, collection_path)
+    legend_info = extract_wms_legend(wms_url, layer_name, collection_path)
 
     # During ArcGIS extraction
     style_info = extract_esri_style(layer_url, collection_path)
@@ -63,6 +70,50 @@ class ExtractedStyle:
     warnings: list[str]
 
 
+@dataclass
+class ExtractedLegend:
+    """Result of legend extraction.
+
+    Attributes:
+        path: Path to written legend PNG file.
+        name: Legend name (used as asset key).
+        media_type: MIME type (always "image/png").
+        width: Image width in pixels (None if not determined).
+        height: Image height in pixels (None if not determined).
+    """
+
+    path: Path
+    name: str
+    media_type: str
+    width: int | None = None
+    height: int | None = None
+
+
+def _wfs_url_to_wms_path(wfs_url: str) -> tuple[str, str]:
+    """Convert WFS URL to WMS path.
+
+    GeoServer/GeoNode typically expose WMS at the same base URL as WFS.
+    We replace the service parameter and adjust the path.
+
+    Args:
+        wfs_url: WFS service endpoint URL.
+
+    Returns:
+        Tuple of (scheme://netloc, wms_path).
+    """
+    parsed = urlparse(wfs_url)
+
+    # Try to detect if this is a GeoServer URL and adjust path
+    # GeoServer pattern: .../geoserver/wfs -> .../geoserver/wms
+    path = parsed.path
+    if "/wfs" in path.lower():
+        path = path.replace("/wfs", "/wms").replace("/WFS", "/wms")
+    elif "/ows" in path.lower():
+        path = path.replace("/ows", "/wms").replace("/OWS", "/wms")
+
+    return f"{parsed.scheme}://{parsed.netloc}", path
+
+
 def _build_wms_getstyles_url(wfs_url: str, layer_name: str) -> str:
     """Build WMS GetStyles URL from WFS endpoint.
 
@@ -77,14 +128,7 @@ def _build_wms_getstyles_url(wfs_url: str, layer_name: str) -> str:
         WMS GetStyles URL.
     """
     parsed = urlparse(wfs_url)
-
-    # Try to detect if this is a GeoServer URL and adjust path
-    # GeoServer pattern: .../geoserver/wfs -> .../geoserver/wms
-    path = parsed.path
-    if "/wfs" in path.lower():
-        path = path.replace("/wfs", "/wms").replace("/WFS", "/wms")
-    elif "/ows" in path.lower():
-        path = path.replace("/ows", "/wms").replace("/OWS", "/wms")
+    _, path = _wfs_url_to_wms_path(wfs_url)
 
     # Build GetStyles parameters
     params = {
@@ -92,6 +136,35 @@ def _build_wms_getstyles_url(wfs_url: str, layer_name: str) -> str:
         "version": "1.1.1",
         "request": "GetStyles",
         "layers": layer_name,
+    }
+
+    new_parsed = parsed._replace(path=path, query=urlencode(params))
+    return urlunparse(new_parsed)
+
+
+def _build_wms_getlegendgraphic_url(wfs_url: str, layer_name: str) -> str:
+    """Build WMS GetLegendGraphic URL from WFS endpoint.
+
+    GeoServer/GeoNode typically expose WMS at the same base URL as WFS.
+    We replace the service parameter and add GetLegendGraphic request.
+
+    Args:
+        wfs_url: WFS service endpoint URL.
+        layer_name: Layer name (may include workspace prefix like "geonode:layer").
+
+    Returns:
+        WMS GetLegendGraphic URL.
+    """
+    parsed = urlparse(wfs_url)
+    _, path = _wfs_url_to_wms_path(wfs_url)
+
+    # Build GetLegendGraphic parameters
+    params = {
+        "service": "WMS",
+        "version": "1.1.1",
+        "request": "GetLegendGraphic",
+        "layer": layer_name,
+        "format": "image/png",
     }
 
     new_parsed = parsed._replace(path=path, query=urlencode(params))
@@ -205,7 +278,7 @@ def extract_wms_style(
     collection_path: Path,
     *,
     source_layer: str | None = None,
-    style_name: str = "source",
+    style_name: str = "default",
     timeout: float = 30.0,
 ) -> ExtractedStyle | None:
     """Extract style from WMS GetStyles and write as Mapbox GL JSON.
@@ -218,7 +291,7 @@ def extract_wms_style(
         layer_name: Layer name (may include workspace prefix).
         collection_path: Path to collection directory.
         source_layer: Source layer name for Mapbox GL (defaults to layer_name stem).
-        style_name: Output filename (default "source").
+        style_name: Output filename (default "default").
         timeout: Request timeout in seconds.
 
     Returns:
@@ -266,7 +339,7 @@ def extract_esri_style(
     collection_path: Path,
     *,
     source_layer: str | None = None,
-    style_name: str = "source",
+    style_name: str = "default",
     timeout: float = 30.0,
 ) -> ExtractedStyle | None:
     """Extract style from ESRI REST layer and write as Mapbox GL JSON.
@@ -278,7 +351,7 @@ def extract_esri_style(
         layer_url: ESRI layer URL (e.g., .../FeatureServer/0).
         collection_path: Path to collection directory.
         source_layer: Source layer name for Mapbox GL (defaults to layer name).
-        style_name: Output filename (default "source").
+        style_name: Output filename (default "default").
         timeout: Request timeout in seconds.
 
     Returns:
@@ -321,4 +394,114 @@ def extract_esri_style(
         name=style_name,
         source_format="esri",
         warnings=warnings,
+    )
+
+
+# =============================================================================
+# Legend Extraction (Issue #498)
+# =============================================================================
+
+
+def _fetch_wms_legend(url: str, timeout: float = 30.0) -> bytes | None:
+    """Fetch legend image bytes from WMS GetLegendGraphic request.
+
+    Args:
+        url: WMS GetLegendGraphic URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        PNG image bytes if successful, None on errors.
+    """
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.get(url)
+            response.raise_for_status()
+
+            content_type = response.headers.get("content-type", "")
+
+            # Check for image/png response
+            if "image/png" in content_type:
+                return response.content
+
+            # Some servers return image without proper content-type
+            # Check for PNG magic bytes
+            if response.content.startswith(b"\x89PNG"):
+                return response.content
+
+            logger.warning("Unexpected content type from WMS GetLegendGraphic: %s", content_type)
+            return None
+
+    except httpx.HTTPStatusError as e:
+        logger.warning("WMS GetLegendGraphic request failed: HTTP %s", e.response.status_code)
+        return None
+    except httpx.RequestError as e:
+        logger.warning("WMS GetLegendGraphic request failed: %s", e)
+        return None
+
+
+def _write_legend_file(
+    legend_bytes: bytes,
+    collection_path: Path,
+    name: str,
+) -> Path:
+    """Write legend PNG to collection's legends directory.
+
+    Args:
+        legend_bytes: PNG image bytes.
+        collection_path: Path to collection directory.
+        name: Legend filename (without .png extension).
+
+    Returns:
+        Path to written file.
+    """
+    legends_dir = collection_path / "legends"
+    legends_dir.mkdir(parents=True, exist_ok=True)
+
+    legend_path = legends_dir / f"{name}.png"
+    legend_path.write_bytes(legend_bytes)
+
+    return legend_path
+
+
+def extract_wms_legend(
+    wfs_url: str,
+    layer_name: str,
+    collection_path: Path,
+    *,
+    legend_name: str = "source",
+    timeout: float = 30.0,
+) -> ExtractedLegend | None:
+    """Extract legend from WMS GetLegendGraphic and save to legends/ directory.
+
+    Attempts to fetch legend image from companion WMS endpoint.
+    Returns None if legend cannot be extracted.
+
+    Args:
+        wfs_url: WFS service endpoint URL.
+        layer_name: Layer name (may include workspace prefix).
+        collection_path: Path to collection directory.
+        legend_name: Output filename (default "source").
+        timeout: Request timeout in seconds.
+
+    Returns:
+        ExtractedLegend if successful, None if legend unavailable.
+    """
+    # Build WMS GetLegendGraphic URL
+    legend_url = _build_wms_getlegendgraphic_url(wfs_url, layer_name)
+    logger.debug("Fetching WMS legend from: %s", legend_url)
+
+    # Fetch legend image
+    legend_bytes = _fetch_wms_legend(legend_url, timeout=timeout)
+    if legend_bytes is None:
+        logger.warning("Could not fetch WMS legend for %s", layer_name)
+        return None
+
+    # Write legend file
+    legend_path = _write_legend_file(legend_bytes, collection_path, legend_name)
+    logger.info("Wrote legend to %s", legend_path)
+
+    return ExtractedLegend(
+        path=legend_path,
+        name=legend_name,
+        media_type="image/png",
     )

--- a/portolan_cli/extract/common/styles.py
+++ b/portolan_cli/extract/common/styles.py
@@ -1,0 +1,360 @@
+"""Style extraction orchestration for remote services.
+
+This module provides the high-level API for extracting styles from
+WMS and ESRI REST endpoints and writing them as Mapbox GL JSON files.
+
+The flow is:
+1. Fetch style from source (WMS GetStyles or ESRI layer JSON)
+2. Convert to Mapbox GL using format-specific converter
+3. Write to {collection}/styles/{name}.json
+4. Return StyleInfo for STAC asset registration
+
+Usage:
+    # During WFS extraction
+    style_info = extract_wms_style(wms_url, layer_name, collection_path)
+
+    # During ArcGIS extraction
+    style_info = extract_esri_style(layer_url, collection_path)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import httpx
+
+from portolan_cli.extract.common.converters.esri import (
+    ESRIConverterError,
+    convert_esri_renderer,
+)
+from portolan_cli.extract.common.converters.sld import (
+    SLDConverterError,
+    convert_sld,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StyleExtractionError(Exception):
+    """Error during style extraction from remote service."""
+
+    pass
+
+
+@dataclass
+class ExtractedStyle:
+    """Result of style extraction.
+
+    Attributes:
+        path: Path to written style JSON file.
+        name: Style name (used as asset key).
+        source_format: Original format ("sld" or "esri").
+        warnings: Any conversion warnings.
+    """
+
+    path: Path
+    name: str
+    source_format: str
+    warnings: list[str]
+
+
+def _build_wms_getstyles_url(wfs_url: str, layer_name: str) -> str:
+    """Build WMS GetStyles URL from WFS endpoint.
+
+    GeoServer/GeoNode typically expose WMS at the same base URL as WFS.
+    We replace the service parameter and add GetStyles request.
+
+    Args:
+        wfs_url: WFS service endpoint URL.
+        layer_name: Layer name (may include workspace prefix like "geonode:layer").
+
+    Returns:
+        WMS GetStyles URL.
+    """
+    parsed = urlparse(wfs_url)
+
+    # Try to detect if this is a GeoServer URL and adjust path
+    # GeoServer pattern: .../geoserver/wfs -> .../geoserver/wms
+    path = parsed.path
+    if "/wfs" in path.lower():
+        path = path.replace("/wfs", "/wms").replace("/WFS", "/wms")
+    elif "/ows" in path.lower():
+        path = path.replace("/ows", "/wms").replace("/OWS", "/wms")
+
+    # Build GetStyles parameters
+    params = {
+        "service": "WMS",
+        "version": "1.1.1",
+        "request": "GetStyles",
+        "layers": layer_name,
+    }
+
+    new_parsed = parsed._replace(path=path, query=urlencode(params))
+    return urlunparse(new_parsed)
+
+
+def _fetch_wms_style(url: str, timeout: float = 30.0) -> str:
+    """Fetch SLD XML from WMS GetStyles request.
+
+    Args:
+        url: WMS GetStyles URL.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        SLD XML string.
+
+    Raises:
+        StyleExtractionError: On HTTP or response errors.
+    """
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.get(url)
+            response.raise_for_status()
+
+            content_type = response.headers.get("content-type", "")
+
+            # Check for XML response (SLD)
+            if "xml" in content_type or response.text.strip().startswith("<?xml"):
+                return response.text
+
+            # Check for error response
+            if "ServiceException" in response.text:
+                raise StyleExtractionError(f"WMS GetStyles returned error: {response.text[:200]}")
+
+            raise StyleExtractionError(
+                f"Unexpected content type from WMS GetStyles: {content_type}"
+            )
+
+    except httpx.HTTPStatusError as e:
+        raise StyleExtractionError(
+            f"WMS GetStyles request failed: HTTP {e.response.status_code}"
+        ) from e
+    except httpx.RequestError as e:
+        raise StyleExtractionError(f"WMS GetStyles request failed: {e}") from e
+
+
+def _fetch_esri_layer_json(layer_url: str, timeout: float = 30.0) -> dict[str, Any]:
+    """Fetch layer JSON from ESRI REST endpoint.
+
+    Args:
+        layer_url: ESRI layer URL (e.g., .../FeatureServer/0).
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Layer JSON dict.
+
+    Raises:
+        StyleExtractionError: On HTTP or response errors.
+    """
+    # Ensure f=json parameter
+    parsed = urlparse(layer_url)
+    params = parse_qs(parsed.query)
+    params["f"] = ["json"]
+    new_parsed = parsed._replace(query=urlencode(params, doseq=True))
+    url = urlunparse(new_parsed)
+
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.get(url)
+            response.raise_for_status()
+            result: dict[str, Any] = response.json()
+            return result
+
+    except httpx.HTTPStatusError as e:
+        raise StyleExtractionError(
+            f"ESRI layer request failed: HTTP {e.response.status_code}"
+        ) from e
+    except httpx.RequestError as e:
+        raise StyleExtractionError(f"ESRI layer request failed: {e}") from e
+    except json.JSONDecodeError as e:
+        raise StyleExtractionError(f"Invalid JSON from ESRI endpoint: {e}") from e
+
+
+def _write_style_file(
+    style_dict: dict[str, Any],
+    collection_path: Path,
+    name: str,
+) -> Path:
+    """Write Mapbox GL style to collection's styles directory.
+
+    Args:
+        style_dict: Mapbox GL style dict.
+        collection_path: Path to collection directory.
+        name: Style filename (without .json extension).
+
+    Returns:
+        Path to written file.
+    """
+    styles_dir = collection_path / "styles"
+    styles_dir.mkdir(parents=True, exist_ok=True)
+
+    style_path = styles_dir / f"{name}.json"
+    style_path.write_text(json.dumps(style_dict, indent=2))
+
+    return style_path
+
+
+def extract_wms_style(
+    wfs_url: str,
+    layer_name: str,
+    collection_path: Path,
+    *,
+    source_layer: str | None = None,
+    style_name: str = "source",
+    timeout: float = 30.0,
+) -> ExtractedStyle | None:
+    """Extract style from WMS GetStyles and write as Mapbox GL JSON.
+
+    Attempts to fetch SLD from companion WMS endpoint and convert to
+    Mapbox GL format. Returns None if style cannot be extracted.
+
+    Args:
+        wfs_url: WFS service endpoint URL.
+        layer_name: Layer name (may include workspace prefix).
+        collection_path: Path to collection directory.
+        source_layer: Source layer name for Mapbox GL (defaults to layer_name stem).
+        style_name: Output filename (default "source").
+        timeout: Request timeout in seconds.
+
+    Returns:
+        ExtractedStyle if successful, None if style unavailable.
+    """
+    # Build source layer name
+    if source_layer is None:
+        # Strip workspace prefix like "geonode:"
+        source_layer = layer_name.split(":")[-1] if ":" in layer_name else layer_name
+
+    # Build WMS URL
+    wms_url = _build_wms_getstyles_url(wfs_url, layer_name)
+    logger.debug("Fetching WMS style from: %s", wms_url)
+
+    try:
+        sld_xml = _fetch_wms_style(wms_url, timeout=timeout)
+    except StyleExtractionError as e:
+        logger.warning("Could not fetch WMS style for %s: %s", layer_name, e)
+        return None
+
+    # Convert SLD to Mapbox GL
+    try:
+        style, warnings = convert_sld(sld_xml, source_layer, return_warnings=True)
+    except SLDConverterError as e:
+        logger.warning("Could not convert SLD for %s: %s", layer_name, e)
+        return None
+
+    for warning in warnings:
+        logger.warning("SLD conversion warning for %s: %s", layer_name, warning)
+
+    # Write style file
+    style_path = _write_style_file(style, collection_path, style_name)
+    logger.info("Wrote style to %s", style_path)
+
+    return ExtractedStyle(
+        path=style_path,
+        name=style_name,
+        source_format="sld",
+        warnings=warnings,
+    )
+
+
+def extract_esri_style(
+    layer_url: str,
+    collection_path: Path,
+    *,
+    source_layer: str | None = None,
+    style_name: str = "source",
+    timeout: float = 30.0,
+) -> ExtractedStyle | None:
+    """Extract style from ESRI REST layer and write as Mapbox GL JSON.
+
+    Fetches drawingInfo.renderer from layer JSON and converts to
+    Mapbox GL format. Returns None if style cannot be extracted.
+
+    Args:
+        layer_url: ESRI layer URL (e.g., .../FeatureServer/0).
+        collection_path: Path to collection directory.
+        source_layer: Source layer name for Mapbox GL (defaults to layer name).
+        style_name: Output filename (default "source").
+        timeout: Request timeout in seconds.
+
+    Returns:
+        ExtractedStyle if successful, None if style unavailable.
+    """
+    try:
+        layer_json = _fetch_esri_layer_json(layer_url, timeout=timeout)
+    except StyleExtractionError as e:
+        logger.warning("Could not fetch ESRI layer JSON: %s", e)
+        return None
+
+    # Extract renderer from drawingInfo
+    drawing_info = layer_json.get("drawingInfo", {})
+    renderer = drawing_info.get("renderer")
+
+    if not renderer:
+        logger.debug("No renderer found in ESRI layer JSON")
+        return None
+
+    # Get source layer name
+    if source_layer is None:
+        source_layer = layer_json.get("name", "data")
+
+    # Convert to Mapbox GL
+    try:
+        style, warnings = convert_esri_renderer(renderer, source_layer, return_warnings=True)
+    except ESRIConverterError as e:
+        logger.warning("Could not convert ESRI renderer: %s", e)
+        return None
+
+    for warning in warnings:
+        logger.warning("ESRI conversion warning: %s", warning)
+
+    # Write style file
+    style_path = _write_style_file(style, collection_path, style_name)
+    logger.info("Wrote style to %s", style_path)
+
+    return ExtractedStyle(
+        path=style_path,
+        name=style_name,
+        source_format="esri",
+        warnings=warnings,
+    )
+
+
+def download_icon(
+    url: str,
+    collection_path: Path,
+    filename: str,
+    *,
+    timeout: float = 30.0,
+) -> Path | None:
+    """Download icon image for ESRI picture marker symbols.
+
+    Args:
+        url: Icon URL.
+        collection_path: Path to collection directory.
+        filename: Output filename (with extension).
+        timeout: Request timeout in seconds.
+
+    Returns:
+        Path to downloaded file, or None on failure.
+    """
+    icons_dir = collection_path / "styles" / "icons"
+    icons_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
+            response = client.get(url)
+            response.raise_for_status()
+
+            icon_path = icons_dir / filename
+            icon_path.write_bytes(response.content)
+            logger.debug("Downloaded icon to %s", icon_path)
+            return icon_path
+
+    except (httpx.HTTPStatusError, httpx.RequestError) as e:
+        logger.warning("Could not download icon from %s: %s", url, e)
+        return None

--- a/portolan_cli/extract/common/styles.py
+++ b/portolan_cli/extract/common/styles.py
@@ -322,39 +322,3 @@ def extract_esri_style(
         source_format="esri",
         warnings=warnings,
     )
-
-
-def download_icon(
-    url: str,
-    collection_path: Path,
-    filename: str,
-    *,
-    timeout: float = 30.0,
-) -> Path | None:
-    """Download icon image for ESRI picture marker symbols.
-
-    Args:
-        url: Icon URL.
-        collection_path: Path to collection directory.
-        filename: Output filename (with extension).
-        timeout: Request timeout in seconds.
-
-    Returns:
-        Path to downloaded file, or None on failure.
-    """
-    icons_dir = collection_path / "styles" / "icons"
-    icons_dir.mkdir(parents=True, exist_ok=True)
-
-    try:
-        with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-            response = client.get(url)
-            response.raise_for_status()
-
-            icon_path = icons_dir / filename
-            icon_path.write_bytes(response.content)
-            logger.debug("Downloaded icon to %s", icon_path)
-            return icon_path
-
-    except (httpx.HTTPStatusError, httpx.RequestError) as e:
-        logger.warning("Could not download icon from %s: %s", url, e)
-        return None

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -776,6 +776,17 @@ def _auto_init_catalog(
         catalog_root=output_dir,
     )
 
+    # Register extracted styles as STAC assets (Issue #490)
+    from portolan_cli.style import discover_styles, register_style_assets
+
+    for result in report.layers:
+        if result.status == "success" and result.output_path:
+            collection_dir = output_dir / Path(result.output_path).parent
+            styles = discover_styles(collection_dir)
+            if styles:
+                register_style_assets(collection_dir, styles)
+                logger.debug("Registered %d style(s) for %s", len(styles), result.name)
+
     # Add via links for provenance tracking
     _add_via_links_to_collections(output_dir, report)
 

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -39,7 +39,7 @@ from portolan_cli.extract.common.report import (
 )
 from portolan_cli.extract.common.resume import ResumeState, get_resume_state, should_process_layer
 from portolan_cli.extract.common.retry import RetryConfig, retry_with_backoff
-from portolan_cli.extract.common.styles import extract_wms_style
+from portolan_cli.extract.common.styles import extract_wms_legend, extract_wms_style
 from portolan_cli.extract.wfs.discovery import LayerInfo, WFSDiscoveryResult, discover_layers
 
 if TYPE_CHECKING:
@@ -542,6 +542,15 @@ def _extract_layer_task(
             if style_result:
                 logger.debug("Extracted style for %s: %s", layer.name, style_result.path)
 
+            # Extract legend from WMS GetLegendGraphic (Issue #498)
+            legend_result = extract_wms_legend(
+                wfs_url=url,
+                layer_name=layer.name,
+                collection_path=collection_dir,
+            )
+            if legend_result:
+                logger.debug("Extracted legend for %s: %s", layer.name, legend_result.path)
+
         return LayerResult(
             id=layer.id,
             name=layer.name,
@@ -776,8 +785,13 @@ def _auto_init_catalog(
         catalog_root=output_dir,
     )
 
-    # Register extracted styles as STAC assets (Issue #490)
-    from portolan_cli.style import discover_styles, register_style_assets
+    # Register extracted styles and legends as STAC assets (Issue #490, #498)
+    from portolan_cli.style import (
+        discover_legends,
+        discover_styles,
+        register_legend_assets,
+        register_style_assets,
+    )
 
     for result in report.layers:
         if result.status == "success" and result.output_path:
@@ -786,6 +800,11 @@ def _auto_init_catalog(
             if styles:
                 register_style_assets(collection_dir, styles)
                 logger.debug("Registered %d style(s) for %s", len(styles), result.name)
+
+            legends = discover_legends(collection_dir)
+            if legends:
+                register_legend_assets(collection_dir, legends)
+                logger.debug("Registered %d legend(s) for %s", len(legends), result.name)
 
     # Add via links for provenance tracking
     _add_via_links_to_collections(output_dir, report)

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -39,6 +39,7 @@ from portolan_cli.extract.common.report import (
 )
 from portolan_cli.extract.common.resume import ResumeState, get_resume_state, should_process_layer
 from portolan_cli.extract.common.retry import RetryConfig, retry_with_backoff
+from portolan_cli.extract.common.styles import extract_wms_style
 from portolan_cli.extract.wfs.discovery import LayerInfo, WFSDiscoveryResult, discover_layers
 
 if TYPE_CHECKING:
@@ -527,6 +528,18 @@ def _extract_layer_task(
 
     if result.success:
         features, size_bytes, duration = result.value  # type: ignore[misc]
+
+        # Extract style from WMS GetStyles (Issue #490)
+        try:
+            extract_wms_style(
+                wfs_url=url,
+                layer_name=layer.name,
+                collection_path=collection_dir,
+                source_layer=layer_slug,
+            )
+        except Exception as e:
+            logger.debug("Style extraction failed for %s: %s", layer.name, e)
+
         return LayerResult(
             id=layer.id,
             name=layer.name,

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -66,6 +66,7 @@ class ExtractionOptions:
         resume: Whether to resume from existing extraction report.
         raw: If True, skip auto-init (only create extraction files, no STAC catalog).
         dry_run: If True, list layers without extracting.
+        no_styles: If True, skip style extraction from WMS GetStyles.
         wfs_version: WFS version ("1.0.0", "1.1.0", "2.0.0", or "auto").
             When "auto", the version is negotiated with the server once and
             used consistently for both discovery and extraction.
@@ -82,6 +83,7 @@ class ExtractionOptions:
     resume: bool = False
     raw: bool = False
     dry_run: bool = False
+    no_styles: bool = False
     wfs_version: str = "auto"
     output_crs: str | None = None
     bbox: tuple[float, float, float, float] | None = None
@@ -530,15 +532,15 @@ def _extract_layer_task(
         features, size_bytes, duration = result.value  # type: ignore[misc]
 
         # Extract style from WMS GetStyles (Issue #490)
-        try:
-            extract_wms_style(
+        if not options.no_styles:
+            style_result = extract_wms_style(
                 wfs_url=url,
                 layer_name=layer.name,
                 collection_path=collection_dir,
                 source_layer=layer_slug,
             )
-        except Exception as e:
-            logger.debug("Style extraction failed for %s: %s", layer.name, e)
+            if style_result:
+                logger.debug("Extracted style for %s: %s", layer.name, style_result.path)
 
         return LayerResult(
             id=layer.id,

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -210,6 +210,31 @@ def _should_generate(parquet_path: Path, pmtiles_path: Path, force: bool) -> boo
     return parquet_path.stat().st_mtime > pmtiles_path.stat().st_mtime
 
 
+def _discover_style_for_thumbnail(collection_dir: Path) -> Path | None:
+    """Find a style file for thumbnail generation.
+
+    Searches for styles/default.json or styles/source.json in the collection
+    directory, preferring default.json (the extracted style, per Issue #497).
+
+    Args:
+        collection_dir: Path to collection directory.
+
+    Returns:
+        Path to style file if found, None otherwise.
+    """
+    styles_dir = collection_dir / "styles"
+    if not styles_dir.exists():
+        return None
+
+    # Prefer default.json (extracted style), then source.json
+    for name in ("default.json", "source.json"):
+        style_path = styles_dir / name
+        if style_path.exists():
+            return style_path
+
+    return None
+
+
 def generate_pmtiles(
     parquet_path: Path,
     pmtiles_path: Path,
@@ -650,10 +675,13 @@ def generate_pmtiles_for_collection(
                     get_thumbnail_config(catalog_root) if catalog_root else ThumbnailConfig()
                 )
                 if thumb_config.enabled:
+                    # Discover style for thumbnail (Issue #495)
+                    style_path = _discover_style_for_thumbnail(collection_path)
                     thumb_path = generate_vector_thumbnail(
                         pmtiles_path=pmtiles_path,
                         geoparquet_path=parquet_path,  # fallback
                         config=thumb_config,
+                        style_path=style_path,
                     )
                     # Register thumbnail as asset so it's tracked in STAC
                     if thumb_path:

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -462,7 +462,7 @@ def register_style_assets(
     for style_info in styles:
         asset_dict: dict[str, Any] = {
             "href": style_info.href,
-            "type": "application/json",
+            "type": "application/vnd.mapbox.style+json",
             "title": style_info.title,
             "roles": ["style"],
         }

--- a/portolan_cli/style.py
+++ b/portolan_cli/style.py
@@ -1,11 +1,13 @@
-"""Style generation for vector and raster assets (Issue #13).
+"""Style and legend generation for vector and raster assets (Issue #13, #498).
 
 Generates Mapbox GL style specs for PMTiles and render extension properties for COGs.
+Also provides legend discovery and registration for WMS-extracted legend images.
 
 Public API:
 - VectorStyleConfig: Configuration for vector styling
 - RasterStyleConfig: Configuration for raster styling
 - StyleInfo: Discovered style file metadata
+- LegendInfo: Discovered legend file metadata
 - build_full_style: Generate complete Mapbox GL style with sources
 - write_style_file: Write style dict to JSON file
 - write_default_style: Convenience function to write default.json
@@ -15,6 +17,9 @@ Public API:
 - discover_styles: Discover style JSON files in styles/ directory
 - build_styles_manifest: Build portolan:styles manifest array
 - register_style_assets: Register styles as STAC assets in collection.json
+- discover_legends: Discover legend PNG files in legends/ directory
+- build_legends_manifest: Build portolan:legends manifest array
+- register_legend_assets: Register legends as STAC assets in collection.json
 """
 
 from __future__ import annotations
@@ -87,6 +92,25 @@ class StyleInfo:
     href: str
     title: str
     description: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class LegendInfo:
+    """Metadata for a discovered legend file.
+
+    Attributes:
+        key: STAC asset key (e.g., "legends/source").
+        href: Relative href for STAC asset (e.g., "./legends/source.png").
+        title: Human-readable title derived from filename.
+        media_type: MIME type (always "image/png").
+        path: Absolute path to the legend file on disk.
+    """
+
+    key: str
+    href: str
+    title: str
+    media_type: str
     path: Path
 
 
@@ -477,6 +501,113 @@ def register_style_assets(
         data["portolan:styles"] = build_styles_manifest(styles)
     else:
         data.pop("portolan:styles", None)
+
+    collection_json_path.write_text(json.dumps(data, indent=2))
+
+
+# =============================================================================
+# Legend Discovery (Issue #498)
+# =============================================================================
+
+
+def discover_legends(collection_path: Path) -> list[LegendInfo]:
+    """Discover legend PNG files in {collection_path}/legends/ directory.
+
+    Args:
+        collection_path: Path to the collection directory.
+
+    Returns:
+        List of LegendInfo objects. Empty list if no legends/ directory exists.
+    """
+    legends_dir = collection_path / "legends"
+
+    if not legends_dir.exists():
+        return []
+
+    legends: list[LegendInfo] = []
+
+    for path in sorted(legends_dir.glob("*.png")):
+        name = path.stem
+        title = f"{name} Legend"
+
+        legends.append(
+            LegendInfo(
+                key=f"legends/{name}",
+                href=f"./legends/{path.name}",
+                title=title,
+                media_type="image/png",
+                path=path,
+            )
+        )
+
+    return legends
+
+
+def build_legends_manifest(legends: list[LegendInfo]) -> list[str]:
+    """Build the portolan:legends manifest array.
+
+    Returns ordered list of asset keys with legends/source first if present,
+    then remaining legends sorted alphabetically.
+
+    Args:
+        legends: List of LegendInfo objects (from discover_legends).
+
+    Returns:
+        List of legend asset keys.
+    """
+    keys = [lg.key for lg in legends]
+
+    if "legends/source" in keys:
+        # Put source first, sort the rest
+        remaining = [k for k in keys if k != "legends/source"]
+        return ["legends/source"] + sorted(remaining)
+
+    # No source, just sort all
+    return sorted(keys)
+
+
+def register_legend_assets(
+    collection_path: Path,
+    legends: list[LegendInfo],
+) -> None:
+    """Register discovered legends as STAC assets and set portolan:legends manifest.
+
+    Updates collection.json to add/update legend assets and remove stale ones.
+
+    Args:
+        collection_path: Path to the collection directory.
+        legends: List of LegendInfo objects from discover_legends().
+    """
+    collection_json_path = collection_path / "collection.json"
+    if not collection_json_path.exists():
+        return
+
+    data = json.loads(collection_json_path.read_text())
+    assets = data.get("assets", {})
+
+    # Remove stale legend assets (assets with "legends/" prefix that no longer have files)
+    current_keys = {lg.key for lg in legends}
+    stale_keys = [k for k in assets if k.startswith("legends/") and k not in current_keys]
+    for key in stale_keys:
+        del assets[key]
+
+    # Add/update legend assets
+    for legend_info in legends:
+        asset_dict: dict[str, Any] = {
+            "href": legend_info.href,
+            "type": legend_info.media_type,
+            "title": legend_info.title,
+            "roles": ["legend"],
+        }
+        assets[legend_info.key] = asset_dict
+
+    data["assets"] = assets
+
+    # Set or remove portolan:legends manifest
+    if legends:
+        data["portolan:legends"] = build_legends_manifest(legends)
+    else:
+        data.pop("portolan:legends", None)
 
     collection_json_path.write_text(json.dumps(data, indent=2))
 

--- a/portolan_cli/thumbnail.py
+++ b/portolan_cli/thumbnail.py
@@ -356,7 +356,14 @@ def _process_tile_data(
             geom = feature.get("geometry", {})
             if geom.get("type") and geom.get("coordinates"):
                 transformed = _transform_coords(geom["coordinates"], tile_bounds)
-                geometries.append({"type": geom["type"], "coordinates": transformed})
+                props = feature.get("properties", {})
+                geometries.append(
+                    {
+                        "type": geom["type"],
+                        "coordinates": transformed,
+                        "properties": props,
+                    }
+                )
                 # Extract actual geometry bounds (not tile bounds) for accurate basemap extent
                 _extract_coord_bounds(transformed, all_lons, all_lats)
 
@@ -464,24 +471,24 @@ def _add_multipolygon_patches(coords: list[Any], patches: list[Any], mpl_polygon
             patches.append(mpl_polygon_cls(polygon[0], closed=True))
 
 
-def _plot_points(ax: Any, coords: list[Any], geom_type: str) -> None:
+def _plot_points(ax: Any, coords: list[Any], geom_type: str, color: str = "#3388ff") -> None:
     """Plot point or multipoint geometries."""
     if geom_type == "Point":
-        ax.plot(coords[0], coords[1], "o", markersize=2, color="#3388ff")
+        ax.plot(coords[0], coords[1], "o", markersize=2, color=color)
     else:
         for pt in coords:
-            ax.plot(pt[0], pt[1], "o", markersize=2, color="#3388ff")
+            ax.plot(pt[0], pt[1], "o", markersize=2, color=color)
 
 
-def _plot_lines(ax: Any, coords: list[Any], geom_type: str) -> None:
+def _plot_lines(ax: Any, coords: list[Any], geom_type: str, color: str = "#3388ff") -> None:
     """Plot linestring or multilinestring geometries."""
     if geom_type == "LineString":
         xs, ys = [c[0] for c in coords], [c[1] for c in coords]
-        ax.plot(xs, ys, linewidth=1, color="#3388ff")
+        ax.plot(xs, ys, linewidth=1, color=color)
     else:
         for line in coords:
             xs, ys = [c[0] for c in line], [c[1] for c in line]
-            ax.plot(xs, ys, linewidth=1, color="#3388ff")
+            ax.plot(xs, ys, linewidth=1, color=color)
 
 
 def _render_geometries(
@@ -489,14 +496,16 @@ def _render_geometries(
     output_path: Path,
     config: ThumbnailConfig,
     bounds: tuple[float, float, float, float] | None = None,
+    style_path: Path | None = None,
 ) -> bool:
     """Render geometries to JPEG thumbnail with optional basemap.
 
     Args:
-        geometries: List of geometry dicts with 'type' and 'coordinates'.
+        geometries: List of geometry dicts with 'type', 'coordinates', and 'properties'.
         output_path: Where to write the JPEG.
         config: Thumbnail configuration.
         bounds: Geographic bounds (minx, miny, maxx, maxy) for basemap.
+        style_path: Optional path to Mapbox GL style for categorical coloring.
 
     Returns:
         True if successful, False otherwise.
@@ -509,27 +518,64 @@ def _render_geometries(
         logger.debug("matplotlib not available")
         return False
 
+    # Load style if provided
+    style = None
+    if style_path:
+        from portolan_cli.thumbnail_style import load_thumbnail_style
+
+        style = load_thumbnail_style(style_path)
+
+    # Default colors
+    default_fill = "#3388ff"
+    default_edge = "#2266cc"
+    default_opacity = 0.6
+
+    if style:
+        default_fill = style.fill_color
+        default_edge = style.edge_color or default_edge
+        default_opacity = style.fill_opacity
+
     fig, ax = plt.subplots(figsize=(config.max_size / 100, config.max_size / 100), dpi=100)
     ax.set_aspect("equal")
     ax.axis("off")
 
     # Plot data FIRST (establishes axes extent for basemap zoom calculation)
     patches: list[Any] = []
+    patch_colors: list[str] = []
+
     for geom in geometries:
         geom_type, coords = geom["type"], geom["coordinates"]
+        props = geom.get("properties", {})
+
+        # Resolve color for this geometry
+        if style and style.color_map and style.color_field:
+            from portolan_cli.thumbnail_style import resolve_color_for_properties
+
+            fill_color = resolve_color_for_properties(props, style)
+        else:
+            fill_color = default_fill
+
         if geom_type == "Polygon":
+            n_before = len(patches)
             _add_polygon_patches(coords, patches, MplPolygon)
+            patch_colors.extend([fill_color] * (len(patches) - n_before))
         elif geom_type == "MultiPolygon":
+            n_before = len(patches)
             _add_multipolygon_patches(coords, patches, MplPolygon)
+            patch_colors.extend([fill_color] * (len(patches) - n_before))
         elif geom_type in ("Point", "MultiPoint"):
-            _plot_points(ax, coords, geom_type)
+            _plot_points(ax, coords, geom_type, color=fill_color)
         elif geom_type in ("LineString", "MultiLineString"):
-            _plot_lines(ax, coords, geom_type)
+            _plot_lines(ax, coords, geom_type, color=fill_color)
 
     if patches:
-        pc = PatchCollection(
-            patches, facecolor="#3388ff", edgecolor="#2266cc", alpha=0.6, linewidth=0.5
-        )
+        # Apply individual colors to patches
+        for patch, color in zip(patches, patch_colors, strict=True):
+            patch.set_facecolor(color)
+            patch.set_edgecolor(default_edge)
+            patch.set_alpha(default_opacity)
+            patch.set_linewidth(0.5)
+        pc = PatchCollection(patches, match_original=True)
         ax.add_collection(pc)
 
     # Set axis limits from bounds (required before adding basemap)
@@ -679,6 +725,7 @@ def _render_geoparquet(
     gpq_path: Path,
     output_path: Path,
     config: ThumbnailConfig,
+    style_path: Path | None = None,
 ) -> bool:
     """Render GeoParquet to JPEG thumbnail.
 
@@ -690,6 +737,7 @@ def _render_geoparquet(
         gpq_path: Path to GeoParquet file.
         output_path: Where to write the JPEG.
         config: Thumbnail configuration.
+        style_path: Optional path to Mapbox GL style for categorical coloring.
 
     Returns:
         True if successful, False otherwise.
@@ -706,6 +754,23 @@ def _render_geoparquet(
         if gdf is None or full_bounds is None:
             return False
 
+        # Load style if provided
+        fill_color: str | Any = "#3388ff"  # Any allows pd.Series
+        edge_color = "#2266cc"
+        fill_opacity = 0.6
+
+        if style_path:
+            from portolan_cli.thumbnail_style import (
+                load_thumbnail_style,
+                resolve_colors_for_gdf,
+            )
+
+            style = load_thumbnail_style(style_path)
+            if style:
+                fill_color = resolve_colors_for_gdf(gdf, style)
+                edge_color = style.edge_color or edge_color
+                fill_opacity = style.fill_opacity
+
         fig, ax = plt.subplots(figsize=(config.max_size / 100, config.max_size / 100), dpi=100)
         ax.set_aspect("equal")
         ax.axis("off")
@@ -713,9 +778,9 @@ def _render_geoparquet(
         # Plot data first (establishes axes extent for basemap zoom calculation)
         gdf.plot(
             ax=ax,
-            facecolor="#3388ff",
-            edgecolor="#2266cc",
-            alpha=0.6,
+            facecolor=fill_color,
+            edgecolor=edge_color,
+            alpha=fill_opacity,
             linewidth=0.5,
         )
 
@@ -810,6 +875,7 @@ def add_basemap(
 def generate_thumbnail_from_pmtiles(
     pmtiles_path: Path,
     config: ThumbnailConfig,
+    style_path: Path | None = None,
 ) -> Path | None:
     """Generate JPEG thumbnail from PMTiles file.
 
@@ -818,6 +884,7 @@ def generate_thumbnail_from_pmtiles(
     Args:
         pmtiles_path: Path to source PMTiles file.
         config: Thumbnail configuration.
+        style_path: Optional path to Mapbox GL style for categorical coloring.
 
     Returns:
         Path to generated thumbnail, or None if generation failed.
@@ -830,7 +897,7 @@ def generate_thumbnail_from_pmtiles(
             logger.debug("No geometries found in PMTiles: %s", pmtiles_path)
             return None
 
-        if _render_geometries(geometries, thumb_path, config, bounds=bounds):
+        if _render_geometries(geometries, thumb_path, config, bounds=bounds, style_path=style_path):
             logger.debug("Generated PMTiles thumbnail: %s", thumb_path)
             return thumb_path
         return None
@@ -842,6 +909,7 @@ def generate_thumbnail_from_pmtiles(
 def generate_thumbnail_from_geoparquet(
     gpq_path: Path,
     config: ThumbnailConfig,
+    style_path: Path | None = None,
 ) -> Path | None:
     """Generate JPEG thumbnail from GeoParquet file.
 
@@ -850,6 +918,7 @@ def generate_thumbnail_from_geoparquet(
     Args:
         gpq_path: Path to source GeoParquet file.
         config: Thumbnail configuration.
+        style_path: Optional path to Mapbox GL style for categorical coloring.
 
     Returns:
         Path to generated thumbnail, or None if generation failed.
@@ -861,7 +930,7 @@ def generate_thumbnail_from_geoparquet(
         logger.debug("No bounds found in GeoParquet: %s", gpq_path)
         return None
 
-    if _render_geoparquet(gpq_path, thumb_path, config):
+    if _render_geoparquet(gpq_path, thumb_path, config, style_path=style_path):
         logger.debug("Generated GeoParquet thumbnail: %s", thumb_path)
         return thumb_path
     return None
@@ -872,6 +941,7 @@ def generate_vector_thumbnail(
     pmtiles_path: Path | None,
     geoparquet_path: Path | None,
     config: ThumbnailConfig,
+    style_path: Path | None = None,
 ) -> Path | None:
     """Generate thumbnail for vector data, preferring PMTiles.
 
@@ -882,6 +952,7 @@ def generate_vector_thumbnail(
         pmtiles_path: Path to PMTiles file (optional).
         geoparquet_path: Path to GeoParquet file (optional, used as fallback).
         config: Thumbnail configuration.
+        style_path: Optional path to Mapbox GL style for categorical coloring.
 
     Returns:
         Path to generated thumbnail, or None if generation failed or disabled.
@@ -896,13 +967,13 @@ def generate_vector_thumbnail(
 
     # Try PMTiles first
     if pmtiles_path is not None:
-        result = generate_thumbnail_from_pmtiles(pmtiles_path, config)
+        result = generate_thumbnail_from_pmtiles(pmtiles_path, config, style_path)
         if result is not None:
             return result
         logger.debug("PMTiles thumbnail failed, falling back to GeoParquet")
 
     # Fall back to GeoParquet
     if geoparquet_path is not None:
-        return generate_thumbnail_from_geoparquet(geoparquet_path, config)
+        return generate_thumbnail_from_geoparquet(geoparquet_path, config, style_path)
 
     return None

--- a/portolan_cli/thumbnail_style.py
+++ b/portolan_cli/thumbnail_style.py
@@ -1,0 +1,275 @@
+"""Mapbox GL style parsing for thumbnail rendering.
+
+This module extracts rendering parameters from Mapbox GL styles to apply
+consistent colors when generating thumbnails. Supports:
+- Simple fill colors (hex strings)
+- Match expressions for categorical styling
+- Case-insensitive field matching
+
+For full Mapbox GL rendering, use a proper map renderer. This module provides
+a minimal subset for matplotlib-based thumbnail generation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ThumbnailStyle:
+    """Parsed style for thumbnail rendering.
+
+    Attributes:
+        fill_color: Default fill color (hex). Used for all features if no
+            categorical mapping, or as fallback for unmapped values.
+        fill_opacity: Fill opacity (0.0-1.0).
+        edge_color: Optional outline color (hex).
+        color_field: Field name for categorical coloring (from match expression).
+        color_map: Mapping of field values to colors (from match expression).
+    """
+
+    fill_color: str
+    fill_opacity: float
+    edge_color: str | None
+    color_field: str | None = None
+    color_map: dict[Any, str] | None = None
+
+
+def parse_match_expression(
+    expr: Any,
+) -> tuple[str, dict[Any, str], str] | None:
+    """Parse a Mapbox GL match expression.
+
+    Expected format: ["match", ["get", "field"], value1, color1, value2, color2, ..., default]
+
+    Args:
+        expr: The expression to parse (typically from paint["fill-color"]).
+
+    Returns:
+        Tuple of (field_name, {value: color}, default_color), or None if not
+        a valid match expression.
+    """
+    if not isinstance(expr, list) or len(expr) < 4:
+        return None
+
+    if expr[0] != "match":
+        return None
+
+    # expr[1] should be ["get", "field_name"]
+    get_expr = expr[1]
+    if not isinstance(get_expr, list) or len(get_expr) != 2 or get_expr[0] != "get":
+        return None
+
+    field_name = get_expr[1]
+
+    # Remaining items are value/color pairs followed by default
+    # ["match", ["get", "x"], val1, c1, val2, c2, default]
+    #                         ^--- expr[2:]
+    pairs_and_default = expr[2:]
+    if len(pairs_and_default) < 2:
+        return None
+
+    default_color = pairs_and_default[-1]
+    pairs = pairs_and_default[:-1]
+
+    # pairs should have even length (value, color, value, color, ...)
+    if len(pairs) % 2 != 0:
+        return None
+
+    color_map: dict[Any, str] = {}
+    for i in range(0, len(pairs), 2):
+        value = pairs[i]
+        color = pairs[i + 1]
+        color_map[value] = color
+
+    return field_name, color_map, default_color
+
+
+def load_thumbnail_style(style_path: Path) -> ThumbnailStyle | None:
+    """Load Mapbox GL style and extract thumbnail rendering parameters.
+
+    Finds the first fill layer and extracts its paint properties. Supports
+    both simple fill colors and match expressions for categorical styling.
+
+    Args:
+        style_path: Path to Mapbox GL style JSON file.
+
+    Returns:
+        ThumbnailStyle if a fill layer was found and parsed, None otherwise.
+    """
+    try:
+        with open(style_path) as f:
+            style = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug("Failed to load style %s: %s", style_path, e)
+        return None
+
+    # Find first fill layer
+    layers = style.get("layers", [])
+    fill_layer = None
+    for layer in layers:
+        if layer.get("type") == "fill":
+            fill_layer = layer
+            break
+
+    if fill_layer is None:
+        logger.debug("No fill layer found in style %s", style_path)
+        return None
+
+    paint = fill_layer.get("paint", {})
+    fill_color_expr = paint.get("fill-color", "#3388ff")
+    fill_opacity = paint.get("fill-opacity", 1.0)
+    edge_color = paint.get("fill-outline-color")
+
+    # Parse fill-color: either simple string or match expression
+    color_field: str | None = None
+    color_map: dict[Any, str] | None = None
+    fill_color: str
+
+    if isinstance(fill_color_expr, str):
+        fill_color = fill_color_expr
+    elif isinstance(fill_color_expr, list):
+        match_result = parse_match_expression(fill_color_expr)
+        if match_result:
+            color_field, color_map, fill_color = match_result
+        else:
+            # Not a match expression we understand (e.g., interpolate)
+            # Try to extract a reasonable default
+            if len(fill_color_expr) > 0 and fill_color_expr[0] == "interpolate":
+                # For interpolate, use the first color as default
+                # Format: ["interpolate", ["linear"], ["get", "x"], stop1, color1, ...]
+                fill_color = _extract_first_color_from_interpolate(fill_color_expr)
+            else:
+                fill_color = "#3388ff"
+    else:
+        fill_color = "#3388ff"
+
+    return ThumbnailStyle(
+        fill_color=fill_color,
+        fill_opacity=fill_opacity,
+        edge_color=edge_color,
+        color_field=color_field,
+        color_map=color_map,
+    )
+
+
+def _extract_first_color_from_interpolate(expr: list[Any]) -> str:
+    """Extract first color from interpolate expression as fallback.
+
+    Format: ["interpolate", ["linear"], ["get", "x"], stop1, color1, stop2, color2, ...]
+    """
+    # Skip "interpolate", interpolation method, and input expression
+    if len(expr) >= 5:
+        # expr[4] should be first color (after stop1)
+        first_color = expr[4]
+        if isinstance(first_color, str) and first_color.startswith("#"):
+            return first_color
+    return "#3388ff"
+
+
+def resolve_colors_for_gdf(
+    gdf: Any,
+    style: ThumbnailStyle,
+) -> Any:
+    """Resolve per-feature colors from style and GeoDataFrame attributes.
+
+    For categorical styles (with color_map), maps each feature's field value
+    to its corresponding color. Handles case-insensitive field matching.
+
+    For simple styles (no color_map), returns the uniform fill_color.
+
+    Args:
+        gdf: GeoDataFrame with feature attributes.
+        style: Parsed thumbnail style.
+
+    Returns:
+        Either a pandas Series of hex colors (categorical) or a single hex
+        string (uniform color).
+    """
+    if style.color_map is None or style.color_field is None:
+        return style.fill_color
+
+    # Case-insensitive field lookup
+    field = style.color_field
+    actual_field = _find_column_case_insensitive(gdf.columns, field)
+
+    if actual_field is None:
+        logger.debug("Field %s not found in GDF columns: %s", field, list(gdf.columns))
+        return style.fill_color
+
+    # Map field values to colors, using fill_color as default
+    values = gdf[actual_field]
+
+    # Convert color_map keys to strings for consistent matching
+    # (GDF values might be strings, color_map keys might be from JSON)
+    str_color_map = {str(k): v for k, v in style.color_map.items()}
+
+    colors = values.astype(str).map(str_color_map).fillna(style.fill_color)
+
+    return colors
+
+
+def _find_column_case_insensitive(
+    columns: Any,
+    target: str,
+) -> str | None:
+    """Find column name matching target case-insensitively.
+
+    Args:
+        columns: DataFrame column index.
+        target: Target column name (any case).
+
+    Returns:
+        Actual column name if found, None otherwise.
+    """
+    target_lower = target.lower()
+    for col in columns:
+        if str(col).lower() == target_lower:
+            return str(col)
+    return None
+
+
+def resolve_color_for_properties(
+    properties: dict[str, Any],
+    style: ThumbnailStyle,
+) -> str:
+    """Resolve color for a single feature from its properties.
+
+    Used for PMTiles path where features are dicts, not GeoDataFrame rows.
+
+    Args:
+        properties: Feature properties dict.
+        style: Parsed thumbnail style.
+
+    Returns:
+        Hex color string.
+    """
+    if style.color_map is None or style.color_field is None:
+        return style.fill_color
+
+    # Case-insensitive property lookup
+    field = style.color_field
+    value = None
+    field_lower = field.lower()
+    for key, val in properties.items():
+        if key.lower() == field_lower:
+            value = val
+            break
+
+    if value is None:
+        return style.fill_color
+
+    # Look up in color_map (try both original and string representation)
+    color = style.color_map.get(value)
+    if color is None:
+        color = style.color_map.get(str(value))
+    if color is None:
+        color = style.fill_color
+
+    return color

--- a/tests/fixtures/styles/esri_classbreaks.json
+++ b/tests/fixtures/styles/esri_classbreaks.json
@@ -1,0 +1,155 @@
+{
+  "renderer": {
+    "type": "classBreaks",
+    "authoringInfo": {
+      "type": "classedSize",
+      "classificationMethod": "esriClassifyNaturalBreaks"
+    },
+    "field": "POP2000",
+    "classificationMethod": "esriClassifyNaturalBreaks",
+    "minValue": 0,
+    "classBreakInfos": [
+      {
+        "symbol": {
+          "type": "esriSMS",
+          "style": "esriSMSCircle",
+          "color": [
+            115,
+            178,
+            255,
+            255
+          ],
+          "size": 4,
+          "angle": 0,
+          "xoffset": 0,
+          "yoffset": 0,
+          "outline": {
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "width": 1
+          }
+        },
+        "classMaxValue": 61,
+        "label": "0 - 61"
+      },
+      {
+        "symbol": {
+          "type": "esriSMS",
+          "style": "esriSMSCircle",
+          "color": [
+            115,
+            178,
+            255,
+            255
+          ],
+          "size": 7.5,
+          "angle": 0,
+          "xoffset": 0,
+          "yoffset": 0,
+          "outline": {
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "width": 1
+          }
+        },
+        "classMaxValue": 264,
+        "label": "62 - 264"
+      },
+      {
+        "symbol": {
+          "type": "esriSMS",
+          "style": "esriSMSCircle",
+          "color": [
+            115,
+            178,
+            255,
+            255
+          ],
+          "size": 11,
+          "angle": 0,
+          "xoffset": 0,
+          "yoffset": 0,
+          "outline": {
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "width": 1
+          }
+        },
+        "classMaxValue": 759,
+        "label": "265 - 759"
+      },
+      {
+        "symbol": {
+          "type": "esriSMS",
+          "style": "esriSMSCircle",
+          "color": [
+            115,
+            178,
+            255,
+            255
+          ],
+          "size": 14.5,
+          "angle": 0,
+          "xoffset": 0,
+          "yoffset": 0,
+          "outline": {
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "width": 1
+          }
+        },
+        "classMaxValue": 1900,
+        "label": "760 - 1900"
+      },
+      {
+        "symbol": {
+          "type": "esriSMS",
+          "style": "esriSMSCircle",
+          "color": [
+            115,
+            178,
+            255,
+            255
+          ],
+          "size": 18,
+          "angle": 0,
+          "xoffset": 0,
+          "yoffset": 0,
+          "outline": {
+            "color": [
+              0,
+              0,
+              0,
+              255
+            ],
+            "width": 1
+          }
+        },
+        "classMaxValue": 9409,
+        "label": "1901 - 9409"
+      }
+    ],
+    "legendOptions": {
+      "order": "ascendingValues"
+    }
+  },
+  "scaleSymbols": false,
+  "transparency": 0,
+  "labelingInfo": null
+}

--- a/tests/fixtures/styles/esri_uniquevalue.json
+++ b/tests/fixtures/styles/esri_uniquevalue.json
@@ -1,0 +1,399 @@
+{
+  "renderer": {
+    "type": "uniqueValue",
+    "field1": "Pub_Access",
+    "uniqueValueGroups": [
+      {
+        "heading": "Public Access",
+        "classes": [
+          {
+            "label": "Restricted Access",
+            "description": "Restricted Access",
+            "symbol": {
+              "type": "esriSFS",
+              "style": "esriSFSSolid",
+              "color": [
+                100,
+                179,
+                131,
+                255
+              ],
+              "outline": {
+                "type": "esriSLS",
+                "style": "esriSLSNull",
+                "color": [
+                  110,
+                  110,
+                  110,
+                  0
+                ],
+                "width": 0
+              }
+            },
+            "values": [
+              [
+                "RA"
+              ]
+            ]
+          },
+          {
+            "label": "Open Access",
+            "description": "Open Access",
+            "symbol": {
+              "type": "esriSFS",
+              "style": "esriSFSSolid",
+              "color": [
+                129,
+                196,
+                53,
+                255
+              ],
+              "outline": {
+                "type": "esriSLS",
+                "style": "esriSLSNull",
+                "color": [
+                  110,
+                  110,
+                  110,
+                  0
+                ],
+                "width": 0
+              }
+            },
+            "values": [
+              [
+                "OA"
+              ]
+            ]
+          },
+          {
+            "label": "Closed Access",
+            "description": "Closed Access",
+            "symbol": {
+              "type": "esriSFS",
+              "style": "esriSFSSolid",
+              "color": [
+                255,
+                240,
+                201,
+                255
+              ],
+              "outline": {
+                "type": "esriSLS",
+                "style": "esriSLSNull",
+                "color": [
+                  110,
+                  110,
+                  110,
+                  0
+                ],
+                "width": 0
+              }
+            },
+            "values": [
+              [
+                "XA"
+              ]
+            ]
+          }
+        ]
+      }
+    ],
+    "uniqueValueInfos": [
+      {
+        "symbol": {
+          "type": "esriSFS",
+          "style": "esriSFSSolid",
+          "color": [
+            100,
+            179,
+            131,
+            255
+          ],
+          "outline": {
+            "type": "esriSLS",
+            "style": "esriSLSNull",
+            "color": [
+              110,
+              110,
+              110,
+              0
+            ],
+            "width": 0
+          }
+        },
+        "value": "RA",
+        "label": "Restricted Access"
+      },
+      {
+        "symbol": {
+          "type": "esriSFS",
+          "style": "esriSFSSolid",
+          "color": [
+            129,
+            196,
+            53,
+            255
+          ],
+          "outline": {
+            "type": "esriSLS",
+            "style": "esriSLSNull",
+            "color": [
+              110,
+              110,
+              110,
+              0
+            ],
+            "width": 0
+          }
+        },
+        "value": "OA",
+        "label": "Open Access"
+      },
+      {
+        "symbol": {
+          "type": "esriSFS",
+          "style": "esriSFSSolid",
+          "color": [
+            255,
+            240,
+            201,
+            255
+          ],
+          "outline": {
+            "type": "esriSLS",
+            "style": "esriSLSNull",
+            "color": [
+              110,
+              110,
+              110,
+              0
+            ],
+            "width": 0
+          }
+        },
+        "value": "XA",
+        "label": "Closed Access"
+      }
+    ],
+    "fieldDelimiter": ",",
+    "authoringInfo": {
+      "colorRamp": {
+        "type": "multipart",
+        "colorRamps": [
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              191,
+              40,
+              45,
+              255
+            ],
+            "toColor": [
+              191,
+              40,
+              45,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              57,
+              50,
+              199,
+              255
+            ],
+            "toColor": [
+              57,
+              50,
+              199,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              56,
+              199,
+              84,
+              255
+            ],
+            "toColor": [
+              56,
+              199,
+              84,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              56,
+              144,
+              181,
+              255
+            ],
+            "toColor": [
+              56,
+              144,
+              181,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              191,
+              69,
+              155,
+              255
+            ],
+            "toColor": [
+              191,
+              69,
+              155,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              184,
+              156,
+              48,
+              255
+            ],
+            "toColor": [
+              184,
+              156,
+              48,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              64,
+              199,
+              172,
+              255
+            ],
+            "toColor": [
+              64,
+              199,
+              172,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              72,
+              99,
+              189,
+              255
+            ],
+            "toColor": [
+              72,
+              99,
+              189,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              153,
+              44,
+              72,
+              255
+            ],
+            "toColor": [
+              153,
+              44,
+              72,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              140,
+              39,
+              168,
+              255
+            ],
+            "toColor": [
+              140,
+              39,
+              168,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              171,
+              99,
+              41,
+              255
+            ],
+            "toColor": [
+              171,
+              99,
+              41,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              117,
+              158,
+              35,
+              255
+            ],
+            "toColor": [
+              117,
+              158,
+              35,
+              255
+            ]
+          },
+          {
+            "type": "algorithmic",
+            "algorithm": "esriCIELabAlgorithm",
+            "fromColor": [
+              63,
+              161,
+              102,
+              255
+            ],
+            "toColor": [
+              63,
+              161,
+              102,
+              255
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "scaleSymbols": true,
+  "transparency": 0,
+  "labelingInfo": null
+}

--- a/tests/fixtures/styles/sld_categorical.xml
+++ b/tests/fixtures/styles/sld_categorical.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld" xmlns="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0">
+    <sld:NamedLayer>
+        <sld:Name>geonode:barrios_y_pueblos</sld:Name>
+        <sld:UserStyle>
+            <sld:Name>barrios_y_pueblos</sld:Name>
+            <sld:IsDefault>1</sld:IsDefault>
+            <sld:FeatureTypeStyle>
+                <sld:Name>name</sld:Name>
+                <sld:Rule>
+                    <sld:Name>1</sld:Name>
+                    <sld:Title>1</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>1</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#c4db69</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>2</sld:Name>
+                    <sld:Title>2</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>2</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#4bdf5c</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>3</sld:Name>
+                    <sld:Title>3</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>3</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#4b4eee</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>4</sld:Name>
+                    <sld:Title>4</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>4</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#6ed0d5</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>5</sld:Name>
+                    <sld:Title>5</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>5</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#e87749</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>6</sld:Name>
+                    <sld:Title>6</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>6</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#83e0b9</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>7</sld:Name>
+                    <sld:Title>7</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>7</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#8c4cda</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>8</sld:Name>
+                    <sld:Title>8</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>8</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#156fc9</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>9</sld:Name>
+                    <sld:Title>9</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>9</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#e56a81</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>10</sld:Name>
+                    <sld:Title>10</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>10</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#5dda1e</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>11</sld:Name>
+                    <sld:Title>11</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>11</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#cf7fd7</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:Name>12</sld:Name>
+                    <sld:Title>12</sld:Title>
+                    <ogc:Filter>
+                        <ogc:PropertyIsEqualTo>
+                            <ogc:PropertyName>color_id</ogc:PropertyName>
+                            <ogc:Literal>12</ogc:Literal>
+                        </ogc:PropertyIsEqualTo>
+                    </ogc:Filter>
+                    <sld:PolygonSymbolizer>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#da2a9a</sld:CssParameter>
+                            <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:Stroke>
+                            <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                            <sld:CssParameter name="stroke-linejoin">bevel</sld:CssParameter>
+                            <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+                        </sld:Stroke>
+                    </sld:PolygonSymbolizer>
+                </sld:Rule>
+                <sld:Rule>
+                    <sld:MaxScaleDenominator>50000.0</sld:MaxScaleDenominator>
+                    <sld:TextSymbolizer>
+                        <sld:Label>
+                            <ogc:PropertyName>nombre</ogc:PropertyName>
+                        </sld:Label>
+                        <sld:Font>
+                            <sld:CssParameter name="font-family">DejaVu Sans</sld:CssParameter>
+                            <sld:CssParameter name="font-size">10</sld:CssParameter>
+                            <sld:CssParameter name="font-style">normal</sld:CssParameter>
+                            <sld:CssParameter name="font-weight">normal</sld:CssParameter>
+                        </sld:Font>
+                        <sld:LabelPlacement>
+                            <sld:PointPlacement>
+                                <sld:AnchorPoint>
+                                    <sld:AnchorPointX>0</sld:AnchorPointX>
+                                    <sld:AnchorPointY>0.5</sld:AnchorPointY>
+                                </sld:AnchorPoint>
+                            </sld:PointPlacement>
+                        </sld:LabelPlacement>
+                        <sld:Halo>
+                            <sld:Radius>2</sld:Radius>
+                            <sld:Fill>
+                                <sld:CssParameter name="fill">#ffffff</sld:CssParameter>
+                                <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+                            </sld:Fill>
+                        </sld:Halo>
+                        <sld:Fill>
+                            <sld:CssParameter name="fill">#000000</sld:CssParameter>
+                        </sld:Fill>
+                        <sld:VendorOption name="group">yes</sld:VendorOption>
+                    </sld:TextSymbolizer>
+                </sld:Rule>
+            </sld:FeatureTypeStyle>
+        </sld:UserStyle>
+    </sld:NamedLayer>
+</sld:StyledLayerDescriptor>

--- a/tests/fixtures/styles/sld_simple_point.xml
+++ b/tests/fixtures/styles/sld_simple_point.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?><sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld" xmlns="http://www.opengis.net/sld" xmlns:gml="http://www.opengis.net/gml" xmlns:ogc="http://www.opengis.net/ogc" version="1.0.0">
+    <sld:NamedLayer>
+        <sld:Name>geonode:aeropuertos</sld:Name>
+        <sld:UserStyle>
+            <sld:Name>aeropuertos</sld:Name>
+            <sld:IsDefault>1</sld:IsDefault>
+            <sld:FeatureTypeStyle>
+                <sld:Name>name</sld:Name>
+                <sld:Rule>
+                    <sld:PointSymbolizer>
+                        <sld:Graphic>
+                            <sld:Mark>
+                                <sld:WellKnownName>circle</sld:WellKnownName>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#232323</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:Mark>
+                            <sld:Size>24</sld:Size>
+                        </sld:Graphic>
+                    </sld:PointSymbolizer>
+                    <sld:PointSymbolizer>
+                        <sld:Graphic>
+                            <sld:Mark>
+                                <sld:WellKnownName>circle</sld:WellKnownName>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#ffffff</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:Mark>
+                            <sld:Size>18</sld:Size>
+                        </sld:Graphic>
+                    </sld:PointSymbolizer>
+                    <sld:PointSymbolizer>
+                        <sld:Graphic>
+                            <sld:Mark>
+                                <sld:WellKnownName>ttf://DejaVu Sans#0x2708</sld:WellKnownName>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#000000</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:Mark>
+                            <sld:Size>14</sld:Size>
+                        </sld:Graphic>
+                    </sld:PointSymbolizer>
+                </sld:Rule>
+            </sld:FeatureTypeStyle>
+        </sld:UserStyle>
+    </sld:NamedLayer>
+</sld:StyledLayerDescriptor>

--- a/tests/unit/extract/common/converters/__init__.py
+++ b/tests/unit/extract/common/converters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for style converters."""

--- a/tests/unit/extract/common/converters/test_base.py
+++ b/tests/unit/extract/common/converters/test_base.py
@@ -16,6 +16,7 @@ from portolan_cli.extract.common.converters.base import (
     make_mapbox_style,
     make_match_expression,
     make_step_expression,
+    make_symbol_layer,
 )
 
 pytestmark = pytest.mark.unit
@@ -223,6 +224,82 @@ class TestLayerBuilders:
         assert layer["type"] == "line"
         assert layer["paint"]["line-color"] == "#333333"
         assert layer["paint"]["line-width"] == 2
+
+    def test_make_symbol_layer_basic(self) -> None:
+        """Symbol layer for text labels."""
+        layer = make_symbol_layer(
+            layer_id="labels",
+            source_layer="data",
+            text_field=["get", "name"],
+        )
+        assert layer["id"] == "labels"
+        assert layer["type"] == "symbol"
+        assert layer["source"] == "data"
+        assert layer["source-layer"] == "data"
+        assert layer["layout"]["text-field"] == ["get", "name"]
+        assert layer["paint"]["text-color"] == "#000000"  # default
+
+    def test_make_symbol_layer_with_font(self) -> None:
+        """Symbol layer with custom font."""
+        layer = make_symbol_layer(
+            layer_id="labels",
+            source_layer="data",
+            text_field=["get", "name"],
+            text_font=["Open Sans Regular", "Noto Sans Regular"],
+        )
+        assert layer["layout"]["text-font"] == [
+            "Open Sans Regular",
+            "Noto Sans Regular",
+        ]
+
+    def test_make_symbol_layer_with_halo(self) -> None:
+        """Symbol layer with text halo (outline)."""
+        layer = make_symbol_layer(
+            layer_id="labels",
+            source_layer="data",
+            text_field=["get", "name"],
+            text_halo_color="#ffffff",
+            text_halo_width=2.0,
+        )
+        assert layer["paint"]["text-halo-color"] == "#ffffff"
+        assert layer["paint"]["text-halo-width"] == 2.0
+
+    def test_make_symbol_layer_with_anchor_and_offset(self) -> None:
+        """Symbol layer with anchor and offset."""
+        layer = make_symbol_layer(
+            layer_id="labels",
+            source_layer="data",
+            text_field=["get", "name"],
+            text_anchor="left",
+            text_offset=(1.0, 0.0),
+        )
+        assert layer["layout"]["text-anchor"] == "left"
+        assert layer["layout"]["text-offset"] == [1.0, 0.0]
+
+    def test_make_symbol_layer_full(self) -> None:
+        """Symbol layer with all properties."""
+        layer = make_symbol_layer(
+            layer_id="categorical-fill-labels",
+            source_layer="barrios",
+            text_field=["get", "nombre"],
+            text_color="#333333",
+            text_size=14,
+            text_font=["Noto Sans Regular"],
+            text_halo_color="#ffffff",
+            text_halo_width=1.5,
+            text_anchor="bottom-left",
+            text_offset=(0.5, -0.5),
+        )
+        assert layer["id"] == "categorical-fill-labels"
+        assert layer["type"] == "symbol"
+        assert layer["layout"]["text-field"] == ["get", "nombre"]
+        assert layer["layout"]["text-size"] == 14
+        assert layer["layout"]["text-font"] == ["Noto Sans Regular"]
+        assert layer["layout"]["text-anchor"] == "bottom-left"
+        assert layer["layout"]["text-offset"] == [0.5, -0.5]
+        assert layer["paint"]["text-color"] == "#333333"
+        assert layer["paint"]["text-halo-color"] == "#ffffff"
+        assert layer["paint"]["text-halo-width"] == 1.5
 
 
 class TestMapboxStyleBuilder:

--- a/tests/unit/extract/common/converters/test_base.py
+++ b/tests/unit/extract/common/converters/test_base.py
@@ -1,0 +1,256 @@
+"""Tests for base Mapbox GL style builders.
+
+These are the DRY building blocks used by all style converters.
+"""
+
+from __future__ import annotations
+
+from portolan_cli.extract.common.converters.base import (
+    esri_color_to_hex,
+    hex_to_rgba,
+    make_circle_layer,
+    make_fill_layer,
+    make_line_layer,
+    make_mapbox_style,
+    make_match_expression,
+    make_step_expression,
+)
+
+
+class TestColorConversion:
+    """Tests for color format conversion utilities."""
+
+    def test_esri_color_to_hex_rgb(self) -> None:
+        """ESRI [r, g, b, a] array converts to #rrggbb hex."""
+        assert esri_color_to_hex([255, 0, 0, 255]) == "#ff0000"
+        assert esri_color_to_hex([0, 255, 0, 255]) == "#00ff00"
+        assert esri_color_to_hex([0, 0, 255, 255]) == "#0000ff"
+
+    def test_esri_color_to_hex_with_alpha(self) -> None:
+        """Alpha channel is ignored in hex output (handled separately)."""
+        assert esri_color_to_hex([255, 0, 0, 128]) == "#ff0000"
+        assert esri_color_to_hex([255, 0, 0, 0]) == "#ff0000"
+
+    def test_esri_color_to_hex_real_values(self) -> None:
+        """Real values from ESRI Census fixture."""
+        assert esri_color_to_hex([115, 178, 255, 255]) == "#73b2ff"
+        assert esri_color_to_hex([100, 179, 131, 255]) == "#64b383"
+
+    def test_hex_to_rgba_basic(self) -> None:
+        """Hex color converts to rgba() string with opacity."""
+        assert hex_to_rgba("#ff0000", 1.0) == "rgba(255, 0, 0, 1.0)"
+        assert hex_to_rgba("#00ff00", 0.5) == "rgba(0, 255, 0, 0.5)"
+
+    def test_hex_to_rgba_with_hash(self) -> None:
+        """Works with or without leading #."""
+        assert hex_to_rgba("ff0000", 1.0) == "rgba(255, 0, 0, 1.0)"
+        assert hex_to_rgba("#ff0000", 1.0) == "rgba(255, 0, 0, 1.0)"
+
+
+class TestMatchExpression:
+    """Tests for Mapbox GL match expression builder."""
+
+    def test_match_expression_simple(self) -> None:
+        """Basic match expression with string field."""
+        expr = make_match_expression(
+            field="type",
+            cases=[("A", "#ff0000"), ("B", "#00ff00")],
+            default="#cccccc",
+        )
+        assert expr == [
+            "match",
+            ["get", "type"],
+            "A",
+            "#ff0000",
+            "B",
+            "#00ff00",
+            "#cccccc",
+        ]
+
+    def test_match_expression_numeric_values(self) -> None:
+        """Match expression with numeric field values."""
+        expr = make_match_expression(
+            field="color_id",
+            cases=[(1, "#c4db69"), (2, "#4bdf5c"), (3, "#4b4eee")],
+            default="#888888",
+        )
+        assert expr == [
+            "match",
+            ["get", "color_id"],
+            1,
+            "#c4db69",
+            2,
+            "#4bdf5c",
+            3,
+            "#4b4eee",
+            "#888888",
+        ]
+
+    def test_match_expression_empty_cases(self) -> None:
+        """Empty cases returns just default."""
+        expr = make_match_expression(field="x", cases=[], default="#000000")
+        assert expr == ["match", ["get", "x"], "#000000"]
+
+
+class TestStepExpression:
+    """Tests for Mapbox GL step expression builder (class breaks)."""
+
+    def test_step_expression_basic(self) -> None:
+        """Step expression for graduated values."""
+        expr = make_step_expression(
+            field="POP2000",
+            breaks=[
+                (0, 4),  # min value, initial size
+                (61, 7.5),  # break at 61, size becomes 7.5
+                (264, 11),  # break at 264, size becomes 11
+            ],
+        )
+        assert expr == [
+            "step",
+            ["get", "POP2000"],
+            4,  # initial value
+            61,
+            7.5,  # first break
+            264,
+            11,  # second break
+        ]
+
+    def test_step_expression_single_break(self) -> None:
+        """Single break point."""
+        expr = make_step_expression(
+            field="value",
+            breaks=[(0, 10), (100, 20)],
+        )
+        assert expr == ["step", ["get", "value"], 10, 100, 20]
+
+
+class TestLayerBuilders:
+    """Tests for Mapbox GL layer type builders."""
+
+    def test_make_fill_layer_basic(self) -> None:
+        """Fill layer with solid color."""
+        layer = make_fill_layer(
+            layer_id="fill-layer",
+            source_layer="my-layer",
+            fill_color="#ff0000",
+            fill_opacity=0.6,
+        )
+        assert layer["id"] == "fill-layer"
+        assert layer["type"] == "fill"
+        assert layer["source-layer"] == "my-layer"
+        assert layer["paint"]["fill-color"] == "#ff0000"
+        assert layer["paint"]["fill-opacity"] == 0.6
+
+    def test_make_fill_layer_with_outline(self) -> None:
+        """Fill layer with outline color."""
+        layer = make_fill_layer(
+            layer_id="fill-layer",
+            source_layer="my-layer",
+            fill_color="#ff0000",
+            fill_opacity=0.6,
+            outline_color="#000000",
+        )
+        assert layer["paint"]["fill-outline-color"] == "#000000"
+
+    def test_make_fill_layer_with_expression(self) -> None:
+        """Fill layer with match expression for color."""
+        expr = ["match", ["get", "type"], "A", "#ff0000", "#cccccc"]
+        layer = make_fill_layer(
+            layer_id="categorical-fill",
+            source_layer="data",
+            fill_color=expr,
+            fill_opacity=0.4,
+        )
+        assert layer["paint"]["fill-color"] == expr
+
+    def test_make_circle_layer_basic(self) -> None:
+        """Circle layer for point data."""
+        layer = make_circle_layer(
+            layer_id="points",
+            source_layer="data",
+            circle_color="#73b2ff",
+            circle_radius=8,
+            circle_opacity=1.0,
+        )
+        assert layer["type"] == "circle"
+        assert layer["paint"]["circle-color"] == "#73b2ff"
+        assert layer["paint"]["circle-radius"] == 8
+        assert layer["paint"]["circle-opacity"] == 1.0
+
+    def test_make_circle_layer_with_stroke(self) -> None:
+        """Circle layer with stroke."""
+        layer = make_circle_layer(
+            layer_id="points",
+            source_layer="data",
+            circle_color="#73b2ff",
+            circle_radius=8,
+            stroke_color="#000000",
+            stroke_width=1,
+        )
+        assert layer["paint"]["circle-stroke-color"] == "#000000"
+        assert layer["paint"]["circle-stroke-width"] == 1
+
+    def test_make_circle_layer_with_expression(self) -> None:
+        """Circle layer with step expression for radius."""
+        expr = ["step", ["get", "POP2000"], 4, 61, 7.5, 264, 11]
+        layer = make_circle_layer(
+            layer_id="graduated-points",
+            source_layer="data",
+            circle_color="#73b2ff",
+            circle_radius=expr,
+        )
+        assert layer["paint"]["circle-radius"] == expr
+
+    def test_make_line_layer_basic(self) -> None:
+        """Line layer for linestring data."""
+        layer = make_line_layer(
+            layer_id="roads",
+            source_layer="data",
+            line_color="#333333",
+            line_width=2,
+        )
+        assert layer["type"] == "line"
+        assert layer["paint"]["line-color"] == "#333333"
+        assert layer["paint"]["line-width"] == 2
+
+
+class TestMapboxStyleBuilder:
+    """Tests for complete Mapbox GL style document builder."""
+
+    def test_make_mapbox_style_minimal(self) -> None:
+        """Minimal style with one layer."""
+        layer = make_fill_layer("fill", "data", "#ff0000", 0.5)
+        style = make_mapbox_style(
+            name="Test Style",
+            source_layer="data",
+            layers=[layer],
+        )
+        assert style["version"] == 8
+        assert style["name"] == "Test Style"
+        assert "data" in style["sources"]
+        assert style["sources"]["data"]["type"] == "vector"
+        assert len(style["layers"]) == 1
+
+    def test_make_mapbox_style_with_pmtiles_url(self) -> None:
+        """Style with PMTiles source URL."""
+        layer = make_fill_layer("fill", "data", "#ff0000", 0.5)
+        style = make_mapbox_style(
+            name="Test",
+            source_layer="data",
+            layers=[layer],
+            pmtiles_url="../data.pmtiles",
+        )
+        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+
+    def test_make_mapbox_style_multiple_layers(self) -> None:
+        """Style with multiple layers (e.g., fill + outline)."""
+        fill = make_fill_layer("fill", "data", "#ff0000", 0.5)
+        outline = make_line_layer("outline", "data", "#000000", 1)
+        style = make_mapbox_style(
+            name="Multi-layer",
+            source_layer="data",
+            layers=[fill, outline],
+        )
+        assert len(style["layers"]) == 2
+        assert style["layers"][0]["id"] == "fill"
+        assert style["layers"][1]["id"] == "outline"

--- a/tests/unit/extract/common/converters/test_base.py
+++ b/tests/unit/extract/common/converters/test_base.py
@@ -123,6 +123,13 @@ class TestStepExpression:
         )
         assert expr == ["step", ["get", "value"], 10, 100, 20]
 
+    def test_step_expression_empty_raises(self) -> None:
+        """Empty breaks raises ValueError."""
+        import pytest
+
+        with pytest.raises(ValueError, match="at least one break point"):
+            make_step_expression(field="value", breaks=[])
+
 
 class TestLayerBuilders:
     """Tests for Mapbox GL layer type builders."""

--- a/tests/unit/extract/common/converters/test_base.py
+++ b/tests/unit/extract/common/converters/test_base.py
@@ -5,6 +5,8 @@ These are the DRY building blocks used by all style converters.
 
 from __future__ import annotations
 
+import pytest
+
 from portolan_cli.extract.common.converters.base import (
     esri_color_to_hex,
     hex_to_rgba,
@@ -15,6 +17,8 @@ from portolan_cli.extract.common.converters.base import (
     make_match_expression,
     make_step_expression,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestColorConversion:

--- a/tests/unit/extract/common/converters/test_esri.py
+++ b/tests/unit/extract/common/converters/test_esri.py
@@ -1,0 +1,243 @@
+"""Tests for ESRI renderer to Mapbox GL converter.
+
+Uses real fixture data from ESRI REST endpoints:
+- esri_classbreaks.json: Census MapServer graduated symbol sizes
+- esri_uniquevalue.json: PAD-US categorical fill colors
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.extract.common.converters.esri import (
+    ESRIConverterError,
+    convert_esri_renderer,
+    parse_classbreaks_renderer,
+    parse_simple_renderer,
+    parse_uniquevalue_renderer,
+)
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent.parent.parent / "fixtures" / "styles"
+
+
+@pytest.fixture
+def classbreaks_renderer() -> dict:
+    """Load Census ClassBreaks renderer fixture."""
+    data = json.loads((FIXTURES_DIR / "esri_classbreaks.json").read_text())
+    return data["renderer"]
+
+
+@pytest.fixture
+def uniquevalue_renderer() -> dict:
+    """Load PAD-US UniqueValue renderer fixture."""
+    data = json.loads((FIXTURES_DIR / "esri_uniquevalue.json").read_text())
+    return data["renderer"]
+
+
+class TestSimpleRenderer:
+    """Tests for simple (single symbol) renderer conversion."""
+
+    def test_simple_fill_renderer(self) -> None:
+        """Simple fill symbol converts to static fill layer."""
+        renderer = {
+            "type": "simple",
+            "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [255, 0, 0, 255],
+                "outline": {
+                    "type": "esriSLS",
+                    "style": "esriSLSSolid",
+                    "color": [0, 0, 0, 255],
+                    "width": 1,
+                },
+            },
+        }
+        style = parse_simple_renderer(renderer, source_layer="data")
+
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+        fill_layer = style["layers"][0]
+        assert fill_layer["type"] == "fill"
+        assert fill_layer["paint"]["fill-color"] == "#ff0000"
+
+    def test_simple_circle_renderer(self) -> None:
+        """Simple marker symbol converts to circle layer."""
+        renderer = {
+            "type": "simple",
+            "symbol": {
+                "type": "esriSMS",
+                "style": "esriSMSCircle",
+                "color": [0, 128, 255, 255],
+                "size": 10,
+                "outline": {
+                    "color": [0, 0, 0, 255],
+                    "width": 1,
+                },
+            },
+        }
+        style = parse_simple_renderer(renderer, source_layer="data")
+
+        circle_layer = style["layers"][0]
+        assert circle_layer["type"] == "circle"
+        assert circle_layer["paint"]["circle-color"] == "#0080ff"
+        assert circle_layer["paint"]["circle-radius"] == 5  # ESRI size / 2
+
+
+class TestUniqueValueRenderer:
+    """Tests for unique value (categorical) renderer conversion."""
+
+    def test_uniquevalue_fill_renderer(self, uniquevalue_renderer: dict) -> None:
+        """PAD-US categorical fill converts to match expression."""
+        style = parse_uniquevalue_renderer(uniquevalue_renderer, source_layer="padus")
+
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+
+        fill_layer = style["layers"][0]
+        assert fill_layer["type"] == "fill"
+
+        # Color should be a match expression
+        fill_color = fill_layer["paint"]["fill-color"]
+        assert isinstance(fill_color, list)
+        assert fill_color[0] == "match"
+        assert fill_color[1] == ["get", "Pub_Access"]
+
+        # Check that values are present
+        # Format: ["match", ["get", "field"], val1, color1, val2, color2, ..., default]
+        assert "RA" in fill_color  # Restricted Access
+        assert "OA" in fill_color  # Open Access
+        assert "XA" in fill_color  # Closed Access
+
+    def test_uniquevalue_extracts_correct_colors(self, uniquevalue_renderer: dict) -> None:
+        """Verify exact color values from PAD-US fixture."""
+        style = parse_uniquevalue_renderer(uniquevalue_renderer, source_layer="data")
+        fill_color = style["layers"][0]["paint"]["fill-color"]
+
+        # Find the color for "OA" (Open Access) - should be #81c435 (green)
+        # The match expression is: ["match", ["get", "field"], v1, c1, v2, c2, ..., default]
+        oa_idx = fill_color.index("OA")
+        oa_color = fill_color[oa_idx + 1]
+        assert oa_color == "#81c435"
+
+        # "RA" (Restricted Access) should be #64b383
+        ra_idx = fill_color.index("RA")
+        ra_color = fill_color[ra_idx + 1]
+        assert ra_color == "#64b383"
+
+
+class TestClassBreaksRenderer:
+    """Tests for class breaks (graduated) renderer conversion."""
+
+    def test_classbreaks_circle_renderer(self, classbreaks_renderer: dict) -> None:
+        """Census graduated circles convert to step expression."""
+        style = parse_classbreaks_renderer(classbreaks_renderer, source_layer="census")
+
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+
+        circle_layer = style["layers"][0]
+        assert circle_layer["type"] == "circle"
+
+        # Radius should be a step expression
+        radius = circle_layer["paint"]["circle-radius"]
+        assert isinstance(radius, list)
+        assert radius[0] == "step"
+        assert radius[1] == ["get", "POP2000"]
+
+    def test_classbreaks_extracts_break_values(self, classbreaks_renderer: dict) -> None:
+        """Verify break values from Census fixture."""
+        style = parse_classbreaks_renderer(classbreaks_renderer, source_layer="data")
+        radius = style["layers"][0]["paint"]["circle-radius"]
+
+        # Step expression: ["step", ["get", "field"], initial, break1, val1, break2, val2, ...]
+        # From fixture: breaks at 61, 264, 759, 1900
+        # Sizes: 4, 7.5, 11, 14.5, 18 (divided by 2 for Mapbox radius)
+        assert 61 in radius
+        assert 264 in radius
+        assert 759 in radius
+
+    def test_classbreaks_preserves_color(self, classbreaks_renderer: dict) -> None:
+        """All break classes have same fill color in this fixture."""
+        style = parse_classbreaks_renderer(classbreaks_renderer, source_layer="data")
+        circle_layer = style["layers"][0]
+
+        # Census fixture uses same blue for all classes
+        assert circle_layer["paint"]["circle-color"] == "#73b2ff"
+
+
+class TestConvertESRIRenderer:
+    """Tests for the main conversion entry point."""
+
+    def test_convert_detects_simple_type(self) -> None:
+        """Dispatcher routes simple renderer correctly."""
+        renderer = {
+            "type": "simple",
+            "symbol": {
+                "type": "esriSFS",
+                "style": "esriSFSSolid",
+                "color": [255, 0, 0, 255],
+            },
+        }
+        style = convert_esri_renderer(renderer, source_layer="data")
+        assert style["version"] == 8
+
+    def test_convert_detects_uniquevalue_type(self, uniquevalue_renderer: dict) -> None:
+        """Dispatcher routes uniqueValue renderer correctly."""
+        style = convert_esri_renderer(uniquevalue_renderer, source_layer="data")
+        fill_color = style["layers"][0]["paint"]["fill-color"]
+        assert fill_color[0] == "match"
+
+    def test_convert_detects_classbreaks_type(self, classbreaks_renderer: dict) -> None:
+        """Dispatcher routes classBreaks renderer correctly."""
+        style = convert_esri_renderer(classbreaks_renderer, source_layer="data")
+        radius = style["layers"][0]["paint"]["circle-radius"]
+        assert radius[0] == "step"
+
+    def test_convert_unknown_type_raises(self) -> None:
+        """Unknown renderer type raises ESRIConverterError."""
+        renderer = {"type": "unknownRenderer"}
+        with pytest.raises(ESRIConverterError, match="Unsupported.*unknownRenderer"):
+            convert_esri_renderer(renderer, source_layer="data")
+
+
+class TestWarningsAndPartialConversion:
+    """Tests for warn-and-continue behavior on unsupported features."""
+
+    def test_picture_marker_warns_but_continues(self) -> None:
+        """esriPMS (picture marker) emits warning but still produces style."""
+        renderer = {
+            "type": "simple",
+            "symbol": {
+                "type": "esriPMS",
+                "url": "https://example.com/icon.png",
+                "width": 24,
+                "height": 24,
+            },
+        }
+        style, warnings = convert_esri_renderer(renderer, source_layer="data", return_warnings=True)
+
+        # Should still return a style (fallback to circle)
+        assert style["version"] == 8
+        assert len(warnings) > 0
+        assert any("picture marker" in w.lower() for w in warnings)
+
+    def test_unsupported_symbol_style_warns(self) -> None:
+        """Unsupported esriSMS style (e.g., cross) warns but continues."""
+        renderer = {
+            "type": "simple",
+            "symbol": {
+                "type": "esriSMS",
+                "style": "esriSMSCross",  # Not directly supported in Mapbox GL
+                "color": [255, 0, 0, 255],
+                "size": 10,
+            },
+        }
+        style, warnings = convert_esri_renderer(renderer, source_layer="data", return_warnings=True)
+
+        # Falls back to circle
+        assert style["layers"][0]["type"] == "circle"
+        assert len(warnings) > 0

--- a/tests/unit/extract/common/converters/test_esri.py
+++ b/tests/unit/extract/common/converters/test_esri.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -20,21 +21,25 @@ from portolan_cli.extract.common.converters.esri import (
     parse_uniquevalue_renderer,
 )
 
+pytestmark = pytest.mark.unit
+
 FIXTURES_DIR = Path(__file__).parent.parent.parent.parent.parent / "fixtures" / "styles"
 
 
 @pytest.fixture
-def classbreaks_renderer() -> dict:
+def classbreaks_renderer() -> dict[str, Any]:
     """Load Census ClassBreaks renderer fixture."""
     data = json.loads((FIXTURES_DIR / "esri_classbreaks.json").read_text())
-    return data["renderer"]
+    renderer: dict[str, Any] = data["renderer"]
+    return renderer
 
 
 @pytest.fixture
-def uniquevalue_renderer() -> dict:
+def uniquevalue_renderer() -> dict[str, Any]:
     """Load PAD-US UniqueValue renderer fixture."""
     data = json.loads((FIXTURES_DIR / "esri_uniquevalue.json").read_text())
-    return data["renderer"]
+    renderer: dict[str, Any] = data["renderer"]
+    return renderer
 
 
 class TestSimpleRenderer:
@@ -90,7 +95,7 @@ class TestSimpleRenderer:
 class TestUniqueValueRenderer:
     """Tests for unique value (categorical) renderer conversion."""
 
-    def test_uniquevalue_fill_renderer(self, uniquevalue_renderer: dict) -> None:
+    def test_uniquevalue_fill_renderer(self, uniquevalue_renderer: dict[str, Any]) -> None:
         """PAD-US categorical fill converts to match expression."""
         style = parse_uniquevalue_renderer(uniquevalue_renderer, source_layer="padus")
 
@@ -112,7 +117,9 @@ class TestUniqueValueRenderer:
         assert "OA" in fill_color  # Open Access
         assert "XA" in fill_color  # Closed Access
 
-    def test_uniquevalue_extracts_correct_colors(self, uniquevalue_renderer: dict) -> None:
+    def test_uniquevalue_extracts_correct_colors(
+        self, uniquevalue_renderer: dict[str, Any]
+    ) -> None:
         """Verify exact color values from PAD-US fixture."""
         style = parse_uniquevalue_renderer(uniquevalue_renderer, source_layer="data")
         fill_color = style["layers"][0]["paint"]["fill-color"]
@@ -132,7 +139,7 @@ class TestUniqueValueRenderer:
 class TestClassBreaksRenderer:
     """Tests for class breaks (graduated) renderer conversion."""
 
-    def test_classbreaks_circle_renderer(self, classbreaks_renderer: dict) -> None:
+    def test_classbreaks_circle_renderer(self, classbreaks_renderer: dict[str, Any]) -> None:
         """Census graduated circles convert to step expression."""
         style = parse_classbreaks_renderer(classbreaks_renderer, source_layer="census")
 
@@ -148,7 +155,7 @@ class TestClassBreaksRenderer:
         assert radius[0] == "step"
         assert radius[1] == ["get", "POP2000"]
 
-    def test_classbreaks_extracts_break_values(self, classbreaks_renderer: dict) -> None:
+    def test_classbreaks_extracts_break_values(self, classbreaks_renderer: dict[str, Any]) -> None:
         """Verify break values from Census fixture."""
         style = parse_classbreaks_renderer(classbreaks_renderer, source_layer="data")
         radius = style["layers"][0]["paint"]["circle-radius"]
@@ -160,7 +167,7 @@ class TestClassBreaksRenderer:
         assert 264 in radius
         assert 759 in radius
 
-    def test_classbreaks_preserves_color(self, classbreaks_renderer: dict) -> None:
+    def test_classbreaks_preserves_color(self, classbreaks_renderer: dict[str, Any]) -> None:
         """All break classes have same fill color in this fixture."""
         style = parse_classbreaks_renderer(classbreaks_renderer, source_layer="data")
         circle_layer = style["layers"][0]
@@ -185,13 +192,13 @@ class TestConvertESRIRenderer:
         style = convert_esri_renderer(renderer, source_layer="data")
         assert style["version"] == 8
 
-    def test_convert_detects_uniquevalue_type(self, uniquevalue_renderer: dict) -> None:
+    def test_convert_detects_uniquevalue_type(self, uniquevalue_renderer: dict[str, Any]) -> None:
         """Dispatcher routes uniqueValue renderer correctly."""
         style = convert_esri_renderer(uniquevalue_renderer, source_layer="data")
         fill_color = style["layers"][0]["paint"]["fill-color"]
         assert fill_color[0] == "match"
 
-    def test_convert_detects_classbreaks_type(self, classbreaks_renderer: dict) -> None:
+    def test_convert_detects_classbreaks_type(self, classbreaks_renderer: dict[str, Any]) -> None:
         """Dispatcher routes classBreaks renderer correctly."""
         style = convert_esri_renderer(classbreaks_renderer, source_layer="data")
         radius = style["layers"][0]["paint"]["circle-radius"]

--- a/tests/unit/extract/common/converters/test_sld.py
+++ b/tests/unit/extract/common/converters/test_sld.py
@@ -17,6 +17,7 @@ from portolan_cli.extract.common.converters.sld import (
     parse_filter_to_value,
     parse_point_symbolizer,
     parse_polygon_symbolizer,
+    parse_text_symbolizer,
 )
 
 pytestmark = pytest.mark.unit
@@ -214,11 +215,171 @@ class TestConvertSLD:
         assert fill_layer["paint"]["fill-opacity"] == 0.4
 
 
+class TestParseTextSymbolizer:
+    """Tests for TextSymbolizer extraction."""
+
+    def test_basic_label_extraction(self) -> None:
+        """Extract text field from Label/PropertyName."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>name</ogc:PropertyName>
+            </sld:Label>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        assert result["text_field"] == ["get", "name"]
+
+    def test_font_extraction(self) -> None:
+        """Extract font family and size from Font element."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>label</ogc:PropertyName>
+            </sld:Label>
+            <sld:Font>
+                <sld:CssParameter name="font-family">DejaVu Sans</sld:CssParameter>
+                <sld:CssParameter name="font-size">14</sld:CssParameter>
+            </sld:Font>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        assert result["text_size"] == 14
+        # Font mapped to Noto Sans (fallback for unknown fonts)
+        assert result["text_font"] == ["Noto Sans Regular"]
+
+    def test_fill_color_extraction(self) -> None:
+        """Extract text color from Fill element."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>label</ogc:PropertyName>
+            </sld:Label>
+            <sld:Fill>
+                <sld:CssParameter name="fill">#333333</sld:CssParameter>
+            </sld:Fill>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        assert result["text_color"] == "#333333"
+
+    def test_halo_extraction(self) -> None:
+        """Extract halo (text outline) properties."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>label</ogc:PropertyName>
+            </sld:Label>
+            <sld:Halo>
+                <sld:Radius>2</sld:Radius>
+                <sld:Fill>
+                    <sld:CssParameter name="fill">#ffffff</sld:CssParameter>
+                </sld:Fill>
+            </sld:Halo>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        assert result["text_halo_color"] == "#ffffff"
+        assert result["text_halo_width"] == 2.0
+
+    def test_anchor_point_extraction(self) -> None:
+        """Extract anchor point from LabelPlacement."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>label</ogc:PropertyName>
+            </sld:Label>
+            <sld:LabelPlacement>
+                <sld:PointPlacement>
+                    <sld:AnchorPoint>
+                        <sld:AnchorPointX>0</sld:AnchorPointX>
+                        <sld:AnchorPointY>0.5</sld:AnchorPointY>
+                    </sld:AnchorPoint>
+                </sld:PointPlacement>
+            </sld:LabelPlacement>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        # SLD anchor (0, 0.5) maps to Mapbox "left" (left edge, vertical center)
+        assert result["text_anchor"] == "left"
+
+    def test_complete_text_symbolizer(self) -> None:
+        """Parse complete TextSymbolizer with all properties."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>nombre</ogc:PropertyName>
+            </sld:Label>
+            <sld:Font>
+                <sld:CssParameter name="font-family">DejaVu Sans</sld:CssParameter>
+                <sld:CssParameter name="font-size">10</sld:CssParameter>
+                <sld:CssParameter name="font-style">normal</sld:CssParameter>
+                <sld:CssParameter name="font-weight">normal</sld:CssParameter>
+            </sld:Font>
+            <sld:LabelPlacement>
+                <sld:PointPlacement>
+                    <sld:AnchorPoint>
+                        <sld:AnchorPointX>0</sld:AnchorPointX>
+                        <sld:AnchorPointY>0.5</sld:AnchorPointY>
+                    </sld:AnchorPoint>
+                </sld:PointPlacement>
+            </sld:LabelPlacement>
+            <sld:Halo>
+                <sld:Radius>2</sld:Radius>
+                <sld:Fill>
+                    <sld:CssParameter name="fill">#ffffff</sld:CssParameter>
+                </sld:Fill>
+            </sld:Halo>
+            <sld:Fill>
+                <sld:CssParameter name="fill">#000000</sld:CssParameter>
+            </sld:Fill>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        assert result["text_field"] == ["get", "nombre"]
+        assert result["text_color"] == "#000000"
+        assert result["text_size"] == 10
+        assert result["text_halo_color"] == "#ffffff"
+        assert result["text_halo_width"] == 2.0
+        assert result["text_anchor"] == "left"
+
+    def test_defaults_for_missing_properties(self) -> None:
+        """Missing optional properties get sensible defaults."""
+        symbolizer_xml = """
+        <sld:TextSymbolizer xmlns:sld="http://www.opengis.net/sld"
+                            xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:Label>
+                <ogc:PropertyName>name</ogc:PropertyName>
+            </sld:Label>
+        </sld:TextSymbolizer>
+        """
+        result = parse_text_symbolizer(symbolizer_xml)
+
+        assert result["text_field"] == ["get", "name"]
+        assert result["text_color"] == "#000000"  # Default black
+        assert result["text_size"] == 12  # Default size
+        assert result["text_anchor"] == "center"  # Default center
+        assert result.get("text_halo_color") is None
+        assert result.get("text_halo_width") is None
+
+
 class TestWarningsAndPartialConversion:
     """Tests for warn-and-continue behavior on unsupported SLD features."""
 
-    def test_text_symbolizer_warns_but_continues(self) -> None:
-        """TextSymbolizer emits warning but still produces style."""
+    def test_text_symbolizer_creates_label_layer(self) -> None:
+        """TextSymbolizer creates a symbol layer for labels."""
         sld = """<?xml version="1.0" encoding="UTF-8"?>
         <sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld"
                                    xmlns:ogc="http://www.opengis.net/ogc">
@@ -244,16 +405,83 @@ class TestWarningsAndPartialConversion:
             </sld:NamedLayer>
         </sld:StyledLayerDescriptor>
         """
-        style, warnings = convert_sld(sld, source_layer="data", return_warnings=True)
+        style = convert_sld(sld, source_layer="data")
 
-        # Should still produce the fill layer
+        # Should have fill layer AND symbol layer for labels
         assert style["version"] == 8
-        assert len(style["layers"]) >= 1
-        assert style["layers"][0]["type"] == "fill"
+        assert len(style["layers"]) == 2
 
-        # Should warn about TextSymbolizer
-        assert len(warnings) > 0
-        assert any("TextSymbolizer" in w for w in warnings)
+        fill_layer = style["layers"][0]
+        assert fill_layer["type"] == "fill"
+
+        label_layer = style["layers"][1]
+        assert label_layer["type"] == "symbol"
+        assert label_layer["id"] == "fill-0-labels"
+        assert label_layer["layout"]["text-field"] == ["get", "name"]
+
+    def test_text_symbolizer_with_halo(self) -> None:
+        """TextSymbolizer with halo extracts halo properties."""
+        sld = """<?xml version="1.0" encoding="UTF-8"?>
+        <sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld"
+                                   xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:NamedLayer>
+                <sld:Name>test</sld:Name>
+                <sld:UserStyle>
+                    <sld:Name>test</sld:Name>
+                    <sld:FeatureTypeStyle>
+                        <sld:Rule>
+                            <sld:PolygonSymbolizer>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#ff0000</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:PolygonSymbolizer>
+                            <sld:TextSymbolizer>
+                                <sld:Label>
+                                    <ogc:PropertyName>label</ogc:PropertyName>
+                                </sld:Label>
+                                <sld:Font>
+                                    <sld:CssParameter name="font-size">12</sld:CssParameter>
+                                </sld:Font>
+                                <sld:Halo>
+                                    <sld:Radius>2</sld:Radius>
+                                    <sld:Fill>
+                                        <sld:CssParameter name="fill">#ffffff</sld:CssParameter>
+                                    </sld:Fill>
+                                </sld:Halo>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#333333</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:TextSymbolizer>
+                        </sld:Rule>
+                    </sld:FeatureTypeStyle>
+                </sld:UserStyle>
+            </sld:NamedLayer>
+        </sld:StyledLayerDescriptor>
+        """
+        style = convert_sld(sld, source_layer="data")
+
+        label_layer = style["layers"][1]
+        assert label_layer["type"] == "symbol"
+        assert label_layer["paint"]["text-color"] == "#333333"
+        assert label_layer["paint"]["text-halo-color"] == "#ffffff"
+        assert label_layer["paint"]["text-halo-width"] == 2.0
+        assert label_layer["layout"]["text-size"] == 12
+
+    def test_categorical_sld_with_labels(self, categorical_sld: str) -> None:
+        """Categorical SLD with TextSymbolizer produces label layer."""
+        style = convert_sld(categorical_sld, source_layer="barrios")
+
+        # Should have fill layer + label layer
+        assert len(style["layers"]) == 2
+
+        fill_layer = style["layers"][0]
+        assert fill_layer["type"] == "fill"
+        assert fill_layer["id"] == "categorical-fill"
+
+        label_layer = style["layers"][1]
+        assert label_layer["type"] == "symbol"
+        assert label_layer["id"] == "categorical-fill-labels"
+        assert label_layer["layout"]["text-field"] == ["get", "nombre"]
 
     def test_invalid_sld_raises(self) -> None:
         """Invalid XML raises SLDConverterError."""

--- a/tests/unit/extract/common/converters/test_sld.py
+++ b/tests/unit/extract/common/converters/test_sld.py
@@ -266,3 +266,33 @@ class TestWarningsAndPartialConversion:
         """
         with pytest.raises(SLDConverterError, match="No.*rules"):
             convert_sld(sld, source_layer="data")
+
+    def test_sld_1_1_se_namespace(self) -> None:
+        """SLD 1.1 with SE namespace is parsed correctly."""
+        sld = """<?xml version="1.0" encoding="UTF-8"?>
+        <StyledLayerDescriptor xmlns="http://www.opengis.net/sld"
+                               xmlns:se="http://www.opengis.net/se"
+                               xmlns:ogc="http://www.opengis.net/ogc"
+                               version="1.1.0">
+            <NamedLayer>
+                <se:Name>test</se:Name>
+                <UserStyle>
+                    <se:Name>test</se:Name>
+                    <se:FeatureTypeStyle>
+                        <se:Rule>
+                            <se:PolygonSymbolizer>
+                                <se:Fill>
+                                    <se:SvgParameter name="fill">#00ff00</se:SvgParameter>
+                                </se:Fill>
+                            </se:PolygonSymbolizer>
+                        </se:Rule>
+                    </se:FeatureTypeStyle>
+                </UserStyle>
+            </NamedLayer>
+        </StyledLayerDescriptor>
+        """
+        style = convert_sld(sld, source_layer="data")
+
+        # Should produce a valid Mapbox GL style
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1

--- a/tests/unit/extract/common/converters/test_sld.py
+++ b/tests/unit/extract/common/converters/test_sld.py
@@ -1,0 +1,268 @@
+"""Tests for SLD to Mapbox GL converter.
+
+Uses real fixture data from WMS GetStyles requests:
+- sld_simple_point.xml: Pergamino aeropuertos (stacked circles with airplane glyph)
+- sld_categorical.xml: Pergamino barrios_y_pueblos (12-category polygon fills)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.extract.common.converters.sld import (
+    SLDConverterError,
+    convert_sld,
+    parse_filter_to_value,
+    parse_point_symbolizer,
+    parse_polygon_symbolizer,
+)
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent.parent.parent / "fixtures" / "styles"
+
+
+@pytest.fixture
+def simple_point_sld() -> str:
+    """Load aeropuertos simple point SLD fixture."""
+    return (FIXTURES_DIR / "sld_simple_point.xml").read_text()
+
+
+@pytest.fixture
+def categorical_sld() -> str:
+    """Load barrios_y_pueblos categorical SLD fixture."""
+    return (FIXTURES_DIR / "sld_categorical.xml").read_text()
+
+
+class TestParseFilter:
+    """Tests for OGC Filter to value extraction."""
+
+    def test_property_is_equal_to_string(self) -> None:
+        """PropertyIsEqualTo with string literal extracts value."""
+        filter_xml = """
+        <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>type</ogc:PropertyName>
+                <ogc:Literal>residential</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+        </ogc:Filter>
+        """
+        field, value = parse_filter_to_value(filter_xml)
+        assert field == "type"
+        assert value == "residential"
+
+    def test_property_is_equal_to_numeric(self) -> None:
+        """PropertyIsEqualTo attempts numeric coercion."""
+        filter_xml = """
+        <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+            <ogc:PropertyIsEqualTo>
+                <ogc:PropertyName>class</ogc:PropertyName>
+                <ogc:Literal>42</ogc:Literal>
+            </ogc:PropertyIsEqualTo>
+        </ogc:Filter>
+        """
+        field, value = parse_filter_to_value(filter_xml)
+        assert field == "class"
+        # Value should be coerced to int if it looks numeric
+        assert value == 42 or value == "42"  # Either is acceptable
+
+
+class TestParsePolygonSymbolizer:
+    """Tests for PolygonSymbolizer extraction."""
+
+    def test_solid_fill_with_stroke(self) -> None:
+        """Extract fill color, opacity, and stroke from PolygonSymbolizer."""
+        symbolizer_xml = """
+        <sld:PolygonSymbolizer xmlns:sld="http://www.opengis.net/sld">
+            <sld:Fill>
+                <sld:CssParameter name="fill">#c4db69</sld:CssParameter>
+                <sld:CssParameter name="fill-opacity">0.4</sld:CssParameter>
+            </sld:Fill>
+            <sld:Stroke>
+                <sld:CssParameter name="stroke">#ffffff</sld:CssParameter>
+                <sld:CssParameter name="stroke-width">2</sld:CssParameter>
+            </sld:Stroke>
+        </sld:PolygonSymbolizer>
+        """
+        result = parse_polygon_symbolizer(symbolizer_xml)
+
+        assert result["fill_color"] == "#c4db69"
+        assert result["fill_opacity"] == 0.4
+        assert result["stroke_color"] == "#ffffff"
+        assert result["stroke_width"] == 2
+
+    def test_fill_without_opacity(self) -> None:
+        """Fill without explicit opacity defaults to 1.0."""
+        symbolizer_xml = """
+        <sld:PolygonSymbolizer xmlns:sld="http://www.opengis.net/sld">
+            <sld:Fill>
+                <sld:CssParameter name="fill">#ff0000</sld:CssParameter>
+            </sld:Fill>
+        </sld:PolygonSymbolizer>
+        """
+        result = parse_polygon_symbolizer(symbolizer_xml)
+
+        assert result["fill_color"] == "#ff0000"
+        assert result["fill_opacity"] == 1.0
+
+
+class TestParsePointSymbolizer:
+    """Tests for PointSymbolizer extraction."""
+
+    def test_circle_mark(self) -> None:
+        """Circle WellKnownName extracts as circle layer."""
+        symbolizer_xml = """
+        <sld:PointSymbolizer xmlns:sld="http://www.opengis.net/sld">
+            <sld:Graphic>
+                <sld:Mark>
+                    <sld:WellKnownName>circle</sld:WellKnownName>
+                    <sld:Fill>
+                        <sld:CssParameter name="fill">#232323</sld:CssParameter>
+                    </sld:Fill>
+                </sld:Mark>
+                <sld:Size>24</sld:Size>
+            </sld:Graphic>
+        </sld:PointSymbolizer>
+        """
+        result = parse_point_symbolizer(symbolizer_xml)
+
+        assert result["type"] == "circle"
+        assert result["fill_color"] == "#232323"
+        assert result["size"] == 24
+
+    def test_ttf_glyph_warns(self) -> None:
+        """TTF glyph (like airplane) warns but extracts color."""
+        symbolizer_xml = """
+        <sld:PointSymbolizer xmlns:sld="http://www.opengis.net/sld">
+            <sld:Graphic>
+                <sld:Mark>
+                    <sld:WellKnownName>ttf://DejaVu Sans#0x2708</sld:WellKnownName>
+                    <sld:Fill>
+                        <sld:CssParameter name="fill">#000000</sld:CssParameter>
+                    </sld:Fill>
+                </sld:Mark>
+                <sld:Size>14</sld:Size>
+            </sld:Graphic>
+        </sld:PointSymbolizer>
+        """
+        result = parse_point_symbolizer(symbolizer_xml)
+
+        # Falls back to circle with warning
+        assert result["type"] == "circle"
+        assert result["fill_color"] == "#000000"
+        assert result.get("warning") is not None
+
+
+class TestConvertSLD:
+    """Tests for complete SLD document conversion."""
+
+    def test_simple_point_sld(self, simple_point_sld: str) -> None:
+        """Aeropuertos point SLD converts to circle layer."""
+        style = convert_sld(simple_point_sld, source_layer="aeropuertos")
+
+        assert style["version"] == 8
+        assert style["name"] == "aeropuertos"
+        assert len(style["layers"]) >= 1
+
+        # Should have circle layer(s) for the stacked symbols
+        circle_layers = [lyr for lyr in style["layers"] if lyr["type"] == "circle"]
+        assert len(circle_layers) >= 1
+
+    def test_categorical_sld(self, categorical_sld: str) -> None:
+        """Barrios categorical SLD converts to match expression."""
+        style = convert_sld(categorical_sld, source_layer="barrios")
+
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+
+        fill_layer = style["layers"][0]
+        assert fill_layer["type"] == "fill"
+
+        # Color should be a match expression for categorical
+        fill_color = fill_layer["paint"]["fill-color"]
+        assert isinstance(fill_color, list)
+        assert fill_color[0] == "match"
+
+    def test_categorical_extracts_field(self, categorical_sld: str) -> None:
+        """Categorical SLD extracts correct field name."""
+        style = convert_sld(categorical_sld, source_layer="barrios")
+        fill_color = style["layers"][0]["paint"]["fill-color"]
+
+        # Should be matching on color_id field
+        assert fill_color[1] == ["get", "color_id"]
+
+    def test_categorical_extracts_colors(self, categorical_sld: str) -> None:
+        """Categorical SLD extracts correct color values."""
+        style = convert_sld(categorical_sld, source_layer="barrios")
+        fill_color = style["layers"][0]["paint"]["fill-color"]
+
+        # First category color from fixture: #c4db69
+        assert "#c4db69" in fill_color
+        # Second category: #4bdf5c
+        assert "#4bdf5c" in fill_color
+        # Third category: #4b4eee
+        assert "#4b4eee" in fill_color
+
+    def test_preserves_opacity(self, categorical_sld: str) -> None:
+        """Fill opacity from SLD is preserved."""
+        style = convert_sld(categorical_sld, source_layer="barrios")
+        fill_layer = style["layers"][0]
+
+        # Fixture has 0.4 opacity
+        assert fill_layer["paint"]["fill-opacity"] == 0.4
+
+
+class TestWarningsAndPartialConversion:
+    """Tests for warn-and-continue behavior on unsupported SLD features."""
+
+    def test_text_symbolizer_warns_but_continues(self) -> None:
+        """TextSymbolizer emits warning but still produces style."""
+        sld = """<?xml version="1.0" encoding="UTF-8"?>
+        <sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld"
+                                   xmlns:ogc="http://www.opengis.net/ogc">
+            <sld:NamedLayer>
+                <sld:Name>test</sld:Name>
+                <sld:UserStyle>
+                    <sld:Name>test</sld:Name>
+                    <sld:FeatureTypeStyle>
+                        <sld:Rule>
+                            <sld:PolygonSymbolizer>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#ff0000</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:PolygonSymbolizer>
+                            <sld:TextSymbolizer>
+                                <sld:Label>
+                                    <ogc:PropertyName>name</ogc:PropertyName>
+                                </sld:Label>
+                            </sld:TextSymbolizer>
+                        </sld:Rule>
+                    </sld:FeatureTypeStyle>
+                </sld:UserStyle>
+            </sld:NamedLayer>
+        </sld:StyledLayerDescriptor>
+        """
+        style, warnings = convert_sld(sld, source_layer="data", return_warnings=True)
+
+        # Should still produce the fill layer
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+        assert style["layers"][0]["type"] == "fill"
+
+        # Should warn about TextSymbolizer
+        assert len(warnings) > 0
+        assert any("TextSymbolizer" in w for w in warnings)
+
+    def test_invalid_sld_raises(self) -> None:
+        """Invalid XML raises SLDConverterError."""
+        with pytest.raises(SLDConverterError):
+            convert_sld("not valid xml", source_layer="data")
+
+    def test_empty_sld_raises(self) -> None:
+        """Empty SLD (no rules) raises SLDConverterError."""
+        sld = """<?xml version="1.0" encoding="UTF-8"?>
+        <sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld">
+        </sld:StyledLayerDescriptor>
+        """
+        with pytest.raises(SLDConverterError, match="No.*rules"):
+            convert_sld(sld, source_layer="data")

--- a/tests/unit/extract/common/converters/test_sld.py
+++ b/tests/unit/extract/common/converters/test_sld.py
@@ -19,6 +19,8 @@ from portolan_cli.extract.common.converters.sld import (
     parse_polygon_symbolizer,
 )
 
+pytestmark = pytest.mark.unit
+
 FIXTURES_DIR = Path(__file__).parent.parent.parent.parent.parent / "fixtures" / "styles"
 
 

--- a/tests/unit/extract/common/test_styles.py
+++ b/tests/unit/extract/common/test_styles.py
@@ -1,0 +1,283 @@
+"""Tests for style extraction orchestration.
+
+Tests the high-level API for extracting styles from WMS and ESRI endpoints.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from portolan_cli.extract.common.styles import (
+    StyleExtractionError,
+    _build_wms_getstyles_url,
+    extract_esri_style,
+    extract_wms_style,
+)
+
+
+class TestBuildWMSGetStylesURL:
+    """Tests for WMS URL construction."""
+
+    def test_geoserver_wfs_to_wms(self) -> None:
+        """GeoServer WFS URL converts to WMS GetStyles."""
+        wfs_url = "https://geonode.example.com/geoserver/wfs"
+        result = _build_wms_getstyles_url(wfs_url, "geonode:layer")
+
+        assert "/wms?" in result
+        assert "service=WMS" in result
+        assert "request=GetStyles" in result
+        assert "layers=geonode%3Alayer" in result or "layers=geonode:layer" in result
+
+    def test_geoserver_ows_to_wms(self) -> None:
+        """GeoServer OWS URL converts to WMS."""
+        wfs_url = "https://example.com/geoserver/ows?service=WFS"
+        result = _build_wms_getstyles_url(wfs_url, "layer")
+
+        assert "/wms?" in result
+        assert "request=GetStyles" in result
+
+    def test_preserves_host_and_path(self) -> None:
+        """Host and base path are preserved."""
+        wfs_url = "https://geonode.pergamino.gob.ar/geoserver/wfs"
+        result = _build_wms_getstyles_url(wfs_url, "test")
+
+        assert "geonode.pergamino.gob.ar" in result
+        assert "/geoserver/wms" in result
+
+
+class TestExtractWMSStyle:
+    """Tests for WMS style extraction."""
+
+    @pytest.fixture
+    def sample_sld(self) -> str:
+        """Simple SLD for testing."""
+        return """<?xml version="1.0" encoding="UTF-8"?>
+        <sld:StyledLayerDescriptor xmlns:sld="http://www.opengis.net/sld">
+            <sld:NamedLayer>
+                <sld:Name>test</sld:Name>
+                <sld:UserStyle>
+                    <sld:Name>test</sld:Name>
+                    <sld:FeatureTypeStyle>
+                        <sld:Rule>
+                            <sld:PolygonSymbolizer>
+                                <sld:Fill>
+                                    <sld:CssParameter name="fill">#ff0000</sld:CssParameter>
+                                </sld:Fill>
+                            </sld:PolygonSymbolizer>
+                        </sld:Rule>
+                    </sld:FeatureTypeStyle>
+                </sld:UserStyle>
+            </sld:NamedLayer>
+        </sld:StyledLayerDescriptor>
+        """
+
+    def test_extracts_and_writes_style(self, tmp_path: Path, sample_sld: str) -> None:
+        """Successfully extracts SLD and writes Mapbox GL JSON."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_style") as mock_fetch:
+            mock_fetch.return_value = sample_sld
+
+            result = extract_wms_style(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="test",
+                collection_path=collection_path,
+            )
+
+        assert result is not None
+        assert result.path.exists()
+        assert result.source_format == "sld"
+
+        # Verify written JSON is valid Mapbox GL
+        style = json.loads(result.path.read_text())
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+
+    def test_returns_none_on_fetch_failure(self, tmp_path: Path) -> None:
+        """Returns None when WMS request fails."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_style") as mock_fetch:
+            mock_fetch.side_effect = StyleExtractionError("Connection failed")
+
+            result = extract_wms_style(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="test",
+                collection_path=collection_path,
+            )
+
+        assert result is None
+
+    def test_strips_workspace_prefix(self, tmp_path: Path, sample_sld: str) -> None:
+        """Workspace prefix like 'geonode:' is stripped for source-layer."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_style") as mock_fetch:
+            mock_fetch.return_value = sample_sld
+
+            result = extract_wms_style(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="geonode:mylayer",
+                collection_path=collection_path,
+            )
+
+        assert result is not None
+        style = json.loads(result.path.read_text())
+        # source-layer should be "mylayer" (stripped prefix), not "geonode:mylayer"
+        assert style["layers"][0]["source-layer"] == "mylayer"
+
+
+class TestExtractESRIStyle:
+    """Tests for ESRI style extraction."""
+
+    @pytest.fixture
+    def sample_layer_json(self) -> dict:
+        """Simple ESRI layer JSON with renderer."""
+        return {
+            "name": "TestLayer",
+            "drawingInfo": {
+                "renderer": {
+                    "type": "simple",
+                    "symbol": {
+                        "type": "esriSFS",
+                        "style": "esriSFSSolid",
+                        "color": [255, 0, 0, 255],
+                    },
+                }
+            },
+        }
+
+    def test_extracts_and_writes_style(self, tmp_path: Path, sample_layer_json: dict) -> None:
+        """Successfully extracts renderer and writes Mapbox GL JSON."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_esri_layer_json") as mock_fetch:
+            mock_fetch.return_value = sample_layer_json
+
+            result = extract_esri_style(
+                layer_url="https://example.com/FeatureServer/0",
+                collection_path=collection_path,
+            )
+
+        assert result is not None
+        assert result.path.exists()
+        assert result.source_format == "esri"
+
+        # Verify written JSON is valid Mapbox GL
+        style = json.loads(result.path.read_text())
+        assert style["version"] == 8
+        assert len(style["layers"]) >= 1
+        assert style["layers"][0]["type"] == "fill"
+
+    def test_returns_none_when_no_renderer(self, tmp_path: Path) -> None:
+        """Returns None when layer has no drawingInfo."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_esri_layer_json") as mock_fetch:
+            mock_fetch.return_value = {"name": "TestLayer"}
+
+            result = extract_esri_style(
+                layer_url="https://example.com/FeatureServer/0",
+                collection_path=collection_path,
+            )
+
+        assert result is None
+
+    def test_returns_none_on_fetch_failure(self, tmp_path: Path) -> None:
+        """Returns None when ESRI request fails."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_esri_layer_json") as mock_fetch:
+            mock_fetch.side_effect = StyleExtractionError("Connection failed")
+
+            result = extract_esri_style(
+                layer_url="https://example.com/FeatureServer/0",
+                collection_path=collection_path,
+            )
+
+        assert result is None
+
+    def test_uses_layer_name_as_source_layer(self, tmp_path: Path, sample_layer_json: dict) -> None:
+        """Layer name from JSON is used as source-layer."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_esri_layer_json") as mock_fetch:
+            mock_fetch.return_value = sample_layer_json
+
+            result = extract_esri_style(
+                layer_url="https://example.com/FeatureServer/0",
+                collection_path=collection_path,
+            )
+
+        assert result is not None
+        style = json.loads(result.path.read_text())
+        assert style["layers"][0]["source-layer"] == "TestLayer"
+
+
+class TestStyleFileOutput:
+    """Tests for style file writing."""
+
+    def test_creates_styles_directory(self, tmp_path: Path) -> None:
+        """styles/ directory is created if it doesn't exist."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        sample_json = {
+            "name": "Test",
+            "drawingInfo": {
+                "renderer": {
+                    "type": "simple",
+                    "symbol": {"type": "esriSFS", "color": [0, 0, 255, 255]},
+                }
+            },
+        }
+
+        with patch("portolan_cli.extract.common.styles._fetch_esri_layer_json") as mock_fetch:
+            mock_fetch.return_value = sample_json
+
+            result = extract_esri_style(
+                layer_url="https://example.com/FeatureServer/0",
+                collection_path=collection_path,
+            )
+
+        assert result is not None
+        assert (collection_path / "styles").is_dir()
+        assert result.path == collection_path / "styles" / "source.json"
+
+    def test_custom_style_name(self, tmp_path: Path) -> None:
+        """Custom style name is used for output file."""
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        sample_json = {
+            "name": "Test",
+            "drawingInfo": {
+                "renderer": {
+                    "type": "simple",
+                    "symbol": {"type": "esriSFS", "color": [0, 0, 255, 255]},
+                }
+            },
+        }
+
+        with patch("portolan_cli.extract.common.styles._fetch_esri_layer_json") as mock_fetch:
+            mock_fetch.return_value = sample_json
+
+            result = extract_esri_style(
+                layer_url="https://example.com/FeatureServer/0",
+                collection_path=collection_path,
+                style_name="original",
+            )
+
+        assert result is not None
+        assert result.path.name == "original.json"

--- a/tests/unit/extract/common/test_styles.py
+++ b/tests/unit/extract/common/test_styles.py
@@ -260,7 +260,7 @@ class TestStyleFileOutput:
 
         assert result is not None
         assert (collection_path / "styles").is_dir()
-        assert result.path == collection_path / "styles" / "source.json"
+        assert result.path == collection_path / "styles" / "default.json"
 
     def test_custom_style_name(self, tmp_path: Path) -> None:
         """Custom style name is used for output file."""
@@ -288,3 +288,208 @@ class TestStyleFileOutput:
 
         assert result is not None
         assert result.path.name == "original.json"
+
+
+# =============================================================================
+# Legend Extraction Tests (Issue #498)
+# =============================================================================
+
+
+class TestBuildWMSGetLegendGraphicURL:
+    """Tests for WMS GetLegendGraphic URL construction."""
+
+    def test_geoserver_wfs_to_wms_legend(self) -> None:
+        """GeoServer WFS URL converts to WMS GetLegendGraphic."""
+        from portolan_cli.extract.common.styles import _build_wms_getlegendgraphic_url
+
+        wfs_url = "https://geonode.example.com/geoserver/wfs"
+        result = _build_wms_getlegendgraphic_url(wfs_url, "geonode:layer")
+
+        assert "/wms?" in result
+        assert "service=WMS" in result
+        assert "request=GetLegendGraphic" in result
+        assert "layer=geonode%3Alayer" in result or "layer=geonode:layer" in result
+        assert "format=image%2Fpng" in result or "format=image/png" in result
+
+    def test_geoserver_ows_to_wms_legend(self) -> None:
+        """GeoServer OWS URL converts to WMS GetLegendGraphic."""
+        from portolan_cli.extract.common.styles import _build_wms_getlegendgraphic_url
+
+        wfs_url = "https://example.com/geoserver/ows?service=WFS"
+        result = _build_wms_getlegendgraphic_url(wfs_url, "layer")
+
+        assert "/wms?" in result
+        assert "request=GetLegendGraphic" in result
+
+    def test_preserves_host_and_path(self) -> None:
+        """Host and base path are preserved."""
+        from portolan_cli.extract.common.styles import _build_wms_getlegendgraphic_url
+
+        wfs_url = "https://geonode.pergamino.gob.ar/geoserver/wfs"
+        result = _build_wms_getlegendgraphic_url(wfs_url, "test")
+
+        assert "geonode.pergamino.gob.ar" in result
+        assert "/geoserver/wms" in result
+
+
+class TestFetchWMSLegend:
+    """Tests for WMS legend fetching."""
+
+    def test_returns_bytes_on_success(self) -> None:
+        """Returns PNG bytes when request succeeds."""
+        from unittest.mock import MagicMock, patch
+
+        from portolan_cli.extract.common.styles import _fetch_wms_legend
+
+        # Create a mock response with PNG content
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "image/png"}
+        mock_response.content = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        with patch("portolan_cli.extract.common.styles.httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            result = _fetch_wms_legend("https://example.com/wms?request=GetLegendGraphic")
+
+        assert result is not None
+        assert result.startswith(b"\x89PNG")
+
+    def test_returns_none_on_http_error(self) -> None:
+        """Returns None on HTTP errors."""
+        from unittest.mock import MagicMock, patch
+
+        import httpx
+
+        from portolan_cli.extract.common.styles import _fetch_wms_legend
+
+        # Create proper mock request and response for HTTPStatusError
+        mock_request = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("portolan_cli.extract.common.styles.httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.side_effect = httpx.HTTPStatusError(
+                "Not found", request=mock_request, response=mock_response
+            )
+
+            result = _fetch_wms_legend("https://example.com/wms")
+
+        assert result is None
+
+    def test_returns_none_on_non_image_content(self) -> None:
+        """Returns None when response is not an image."""
+        from unittest.mock import MagicMock, patch
+
+        from portolan_cli.extract.common.styles import _fetch_wms_legend
+
+        mock_response = MagicMock()
+        mock_response.headers = {"content-type": "text/xml"}
+        mock_response.content = b"<ServiceException>Error</ServiceException>"
+
+        with patch("portolan_cli.extract.common.styles.httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.get.return_value = mock_response
+
+            result = _fetch_wms_legend("https://example.com/wms")
+
+        assert result is None
+
+
+class TestExtractWMSLegend:
+    """Tests for WMS legend extraction."""
+
+    def test_extracts_and_writes_legend(self, tmp_path: Path) -> None:
+        """Successfully extracts legend PNG and writes to legends/ directory."""
+        from unittest.mock import patch
+
+        from portolan_cli.extract.common.styles import extract_wms_legend
+
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        # Valid PNG bytes (minimal valid PNG header)
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_legend") as mock_fetch:
+            mock_fetch.return_value = png_bytes
+
+            result = extract_wms_legend(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="test",
+                collection_path=collection_path,
+            )
+
+        assert result is not None
+        assert result.path.exists()
+        assert result.path.suffix == ".png"
+        assert result.media_type == "image/png"
+        assert result.name == "source"
+        assert (collection_path / "legends").is_dir()
+
+    def test_returns_none_on_fetch_failure(self, tmp_path: Path) -> None:
+        """Returns None when legend fetch fails."""
+        from unittest.mock import patch
+
+        from portolan_cli.extract.common.styles import extract_wms_legend
+
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_legend") as mock_fetch:
+            mock_fetch.return_value = None
+
+            result = extract_wms_legend(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="test",
+                collection_path=collection_path,
+            )
+
+        assert result is None
+
+    def test_custom_legend_name(self, tmp_path: Path) -> None:
+        """Custom legend name is used for output file."""
+        from unittest.mock import patch
+
+        from portolan_cli.extract.common.styles import extract_wms_legend
+
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_legend") as mock_fetch:
+            mock_fetch.return_value = png_bytes
+
+            result = extract_wms_legend(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="test",
+                collection_path=collection_path,
+                legend_name="original",
+            )
+
+        assert result is not None
+        assert result.path.name == "original.png"
+        assert result.name == "original"
+
+    def test_creates_legends_directory(self, tmp_path: Path) -> None:
+        """legends/ directory is created if it doesn't exist."""
+        from unittest.mock import patch
+
+        from portolan_cli.extract.common.styles import extract_wms_legend
+
+        collection_path = tmp_path / "test-collection"
+        collection_path.mkdir()
+
+        assert not (collection_path / "legends").exists()
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+
+        with patch("portolan_cli.extract.common.styles._fetch_wms_legend") as mock_fetch:
+            mock_fetch.return_value = png_bytes
+
+            extract_wms_legend(
+                wfs_url="https://example.com/geoserver/wfs",
+                layer_name="test",
+                collection_path=collection_path,
+            )
+
+        assert (collection_path / "legends").is_dir()

--- a/tests/unit/extract/common/test_styles.py
+++ b/tests/unit/extract/common/test_styles.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +18,8 @@ from portolan_cli.extract.common.styles import (
     extract_esri_style,
     extract_wms_style,
 )
+
+pytestmark = pytest.mark.unit
 
 
 class TestBuildWMSGetStylesURL:
@@ -138,7 +141,7 @@ class TestExtractESRIStyle:
     """Tests for ESRI style extraction."""
 
     @pytest.fixture
-    def sample_layer_json(self) -> dict:
+    def sample_layer_json(self) -> dict[str, Any]:
         """Simple ESRI layer JSON with renderer."""
         return {
             "name": "TestLayer",
@@ -154,7 +157,9 @@ class TestExtractESRIStyle:
             },
         }
 
-    def test_extracts_and_writes_style(self, tmp_path: Path, sample_layer_json: dict) -> None:
+    def test_extracts_and_writes_style(
+        self, tmp_path: Path, sample_layer_json: dict[str, Any]
+    ) -> None:
         """Successfully extracts renderer and writes Mapbox GL JSON."""
         collection_path = tmp_path / "test-collection"
         collection_path.mkdir()
@@ -207,7 +212,9 @@ class TestExtractESRIStyle:
 
         assert result is None
 
-    def test_uses_layer_name_as_source_layer(self, tmp_path: Path, sample_layer_json: dict) -> None:
+    def test_uses_layer_name_as_source_layer(
+        self, tmp_path: Path, sample_layer_json: dict[str, Any]
+    ) -> None:
         """Layer name from JSON is used as source-layer."""
         collection_path = tmp_path / "test-collection"
         collection_path.mkdir()

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
-    from portolan_cli.style import StyleInfo
+    from portolan_cli.style import LegendInfo, StyleInfo
 
 # =============================================================================
 # Phase 1: VectorStyleConfig Tests
@@ -959,3 +959,295 @@ class TestRegisterStyleAssets:
         updated = json.loads((tmp_path / "collection.json").read_text())
         assert "styles/old" not in updated["assets"]
         assert updated["portolan:styles"] == ["styles/default"]
+
+
+# =============================================================================
+# Phase 11: Legend Discovery Tests (Issue #498)
+# =============================================================================
+
+
+class TestLegendInfo:
+    """Tests for LegendInfo dataclass."""
+
+    @pytest.mark.unit
+    def test_legend_info_creation(self) -> None:
+        """LegendInfo can be created with all fields."""
+        from portolan_cli.style import LegendInfo
+
+        legend = LegendInfo(
+            key="legends/source",
+            href="./legends/source.png",
+            title="Source Legend",
+            media_type="image/png",
+            path=Path("/tmp/test/legends/source.png"),
+        )
+
+        assert legend.key == "legends/source"
+        assert legend.href == "./legends/source.png"
+        assert legend.title == "Source Legend"
+        assert legend.media_type == "image/png"
+        assert legend.path == Path("/tmp/test/legends/source.png")
+
+
+class TestDiscoverLegends:
+    """Tests for discover_legends function."""
+
+    @pytest.mark.unit
+    def test_discovers_legend_files(self, tmp_path: Path) -> None:
+        """Creates 2 legend files and verifies both found with correct keys."""
+        from portolan_cli.style import discover_legends
+
+        legends_dir = tmp_path / "legends"
+        legends_dir.mkdir()
+
+        # Create two PNG files (minimal valid PNG header)
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (legends_dir / "source.png").write_bytes(png_bytes)
+        (legends_dir / "custom.png").write_bytes(png_bytes)
+
+        legends = discover_legends(tmp_path)
+
+        assert len(legends) == 2
+        keys = {lg.key for lg in legends}
+        assert keys == {"legends/source", "legends/custom"}
+
+    @pytest.mark.unit
+    def test_returns_empty_when_no_legends_dir(self, tmp_path: Path) -> None:
+        """No legends/ directory returns empty list."""
+        from portolan_cli.style import discover_legends
+
+        legends = discover_legends(tmp_path)
+
+        assert legends == []
+
+    @pytest.mark.unit
+    def test_skips_non_png_files(self, tmp_path: Path) -> None:
+        """Non-PNG files in legends/ directory are ignored."""
+        from portolan_cli.style import discover_legends
+
+        legends_dir = tmp_path / "legends"
+        legends_dir.mkdir()
+
+        # Create a PNG file and a non-PNG file
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (legends_dir / "source.png").write_bytes(png_bytes)
+        (legends_dir / "README.md").write_text("# Legends\n")
+        (legends_dir / "data.json").write_text("{}")
+
+        legends = discover_legends(tmp_path)
+
+        assert len(legends) == 1
+        assert legends[0].key == "legends/source"
+
+    @pytest.mark.unit
+    def test_legend_title_from_filename(self, tmp_path: Path) -> None:
+        """Legend title is derived from filename."""
+        from portolan_cli.style import discover_legends
+
+        legends_dir = tmp_path / "legends"
+        legends_dir.mkdir()
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (legends_dir / "land-use.png").write_bytes(png_bytes)
+
+        legends = discover_legends(tmp_path)
+
+        assert len(legends) == 1
+        assert legends[0].title == "land-use Legend"
+
+    @pytest.mark.unit
+    def test_legend_media_type_is_png(self, tmp_path: Path) -> None:
+        """Legend media type is always image/png."""
+        from portolan_cli.style import discover_legends
+
+        legends_dir = tmp_path / "legends"
+        legends_dir.mkdir()
+
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (legends_dir / "source.png").write_bytes(png_bytes)
+
+        legends = discover_legends(tmp_path)
+
+        assert len(legends) == 1
+        assert legends[0].media_type == "image/png"
+
+
+class TestBuildLegendsManifest:
+    """Tests for build_legends_manifest function."""
+
+    @staticmethod
+    def _legend_info(key: str) -> LegendInfo:
+        from portolan_cli.style import LegendInfo
+
+        return LegendInfo(key=key, href="", title="", media_type="image/png", path=Path())
+
+    @pytest.mark.unit
+    def test_source_first(self) -> None:
+        """Source legend always first regardless of input order."""
+        from portolan_cli.style import build_legends_manifest
+
+        legends = [
+            self._legend_info("legends/zebra"),
+            self._legend_info("legends/source"),
+            self._legend_info("legends/alpha"),
+        ]
+
+        manifest = build_legends_manifest(legends)
+
+        assert manifest[0] == "legends/source"
+        assert len(manifest) == 3
+
+    @pytest.mark.unit
+    def test_alphabetical_after_source(self) -> None:
+        """Non-source legends sorted alphabetically."""
+        from portolan_cli.style import build_legends_manifest
+
+        legends = [
+            self._legend_info("legends/zebra"),
+            self._legend_info("legends/source"),
+            self._legend_info("legends/alpha"),
+            self._legend_info("legends/beta"),
+        ]
+
+        manifest = build_legends_manifest(legends)
+
+        assert manifest == ["legends/source", "legends/alpha", "legends/beta", "legends/zebra"]
+
+    @pytest.mark.unit
+    def test_no_source(self) -> None:
+        """Works without a legend named 'source'."""
+        from portolan_cli.style import build_legends_manifest
+
+        legends = [
+            self._legend_info("legends/zebra"),
+            self._legend_info("legends/alpha"),
+        ]
+
+        manifest = build_legends_manifest(legends)
+
+        assert manifest == ["legends/alpha", "legends/zebra"]
+
+    @pytest.mark.unit
+    def test_empty_list(self) -> None:
+        """Empty input returns empty output."""
+        from portolan_cli.style import build_legends_manifest
+
+        manifest = build_legends_manifest([])
+
+        assert manifest == []
+
+
+class TestRegisterLegendAssets:
+    """Tests for registering discovered legends as STAC assets."""
+
+    @pytest.mark.unit
+    def test_registers_legend_assets_in_collection(self, tmp_path: Path) -> None:
+        """Discovered legends are added as assets in collection.json."""
+        import json
+
+        from portolan_cli.style import discover_legends, register_legend_assets
+
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "assets": {
+                "data": {"href": "./data.parquet", "type": "application/vnd.apache.parquet"}
+            },
+        }
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        legends_dir = tmp_path / "legends"
+        legends_dir.mkdir()
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        (legends_dir / "source.png").write_bytes(png_bytes)
+        (legends_dir / "alternate.png").write_bytes(png_bytes)
+
+        legends = discover_legends(tmp_path)
+        register_legend_assets(tmp_path, legends)
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+
+        assert "legends/source" in updated["assets"]
+        assert "legends/alternate" in updated["assets"]
+
+        source_asset = updated["assets"]["legends/source"]
+        assert source_asset["type"] == "image/png"
+        assert source_asset["roles"] == ["legend"]
+        assert source_asset["title"] == "source Legend"
+        assert source_asset["href"] == "./legends/source.png"
+
+        assert updated["portolan:legends"] == ["legends/source", "legends/alternate"]
+
+    @pytest.mark.unit
+    def test_no_legends_no_manifest(self, tmp_path: Path) -> None:
+        """No portolan:legends property when no legends exist."""
+        import json
+
+        from portolan_cli.style import register_legend_assets
+
+        collection_data = {"type": "Collection", "id": "test", "assets": {}}
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        register_legend_assets(tmp_path, [])
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "portolan:legends" not in updated
+
+    @pytest.mark.unit
+    def test_no_op_without_collection_json(self, tmp_path: Path) -> None:
+        """Does nothing when collection.json doesn't exist."""
+        from portolan_cli.style import LegendInfo, register_legend_assets
+
+        legends = [
+            LegendInfo(
+                key="legends/source",
+                href="./legends/source.png",
+                title="Source Legend",
+                media_type="image/png",
+                path=tmp_path / "legends" / "source.png",
+            )
+        ]
+        register_legend_assets(tmp_path, legends)
+
+        assert not (tmp_path / "collection.json").exists()
+
+    @pytest.mark.unit
+    def test_removes_stale_legend_assets(self, tmp_path: Path) -> None:
+        """Removes legend assets that no longer have files on disk."""
+        import json
+
+        from portolan_cli.style import LegendInfo, register_legend_assets
+
+        collection_data = {
+            "type": "Collection",
+            "id": "test",
+            "portolan:legends": ["legends/source", "legends/old"],
+            "assets": {
+                "legends/source": {
+                    "href": "./legends/source.png",
+                    "type": "image/png",
+                    "roles": ["legend"],
+                },
+                "legends/old": {
+                    "href": "./legends/old.png",
+                    "type": "image/png",
+                    "roles": ["legend"],
+                },
+            },
+        }
+        (tmp_path / "collection.json").write_text(json.dumps(collection_data))
+
+        current_legends = [
+            LegendInfo(
+                key="legends/source",
+                href="./legends/source.png",
+                title="Source Legend",
+                media_type="image/png",
+                path=tmp_path / "legends" / "source.png",
+            )
+        ]
+        register_legend_assets(tmp_path, current_legends)
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "legends/old" not in updated["assets"]
+        assert updated["portolan:legends"] == ["legends/source"]

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -874,7 +874,7 @@ class TestRegisterStyleAssets:
         assert "styles/by-age" in updated["assets"]
 
         default_asset = updated["assets"]["styles/default"]
-        assert default_asset["type"] == "application/json"
+        assert default_asset["type"] == "application/vnd.mapbox.style+json"
         assert default_asset["roles"] == ["style"]
         assert default_asset["title"] == "Default"
 
@@ -931,12 +931,12 @@ class TestRegisterStyleAssets:
             "assets": {
                 "styles/default": {
                     "href": "./styles/default.json",
-                    "type": "application/json",
+                    "type": "application/vnd.mapbox.style+json",
                     "roles": ["style"],
                 },
                 "styles/old": {
                     "href": "./styles/old.json",
-                    "type": "application/json",
+                    "type": "application/vnd.mapbox.style+json",
                     "roles": ["style"],
                 },
             },

--- a/tests/unit/test_thumbnail_style.py
+++ b/tests/unit/test_thumbnail_style.py
@@ -1,0 +1,391 @@
+"""Unit tests for thumbnail_style module.
+
+Tests parsing of Mapbox GL styles for thumbnail rendering, including:
+- Simple color extraction
+- Match expression parsing (categorical styles)
+- Case-insensitive field matching
+- Edge cases (missing fields, no fill layer, etc.)
+"""
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.thumbnail_style import (
+    ThumbnailStyle,
+    load_thumbnail_style,
+    parse_match_expression,
+    resolve_colors_for_gdf,
+)
+
+# =============================================================================
+# parse_match_expression tests
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_parse_match_expression_simple():
+    """Parse a simple match expression with one category."""
+    expr = ["match", ["get", "land_use"], "residential", "#ff6b6b", "#95afc0"]
+    field, color_map, default = parse_match_expression(expr)
+
+    assert field == "land_use"
+    assert color_map == {"residential": "#ff6b6b"}
+    assert default == "#95afc0"
+
+
+@pytest.mark.unit
+def test_parse_match_expression_multiple_categories():
+    """Parse a match expression with multiple categories."""
+    expr = [
+        "match",
+        ["get", "land_use"],
+        "residential",
+        "#ff6b6b",
+        "commercial",
+        "#4ecdc4",
+        "industrial",
+        "#45b7d1",
+        "#95afc0",
+    ]
+    field, color_map, default = parse_match_expression(expr)
+
+    assert field == "land_use"
+    assert color_map == {
+        "residential": "#ff6b6b",
+        "commercial": "#4ecdc4",
+        "industrial": "#45b7d1",
+    }
+    assert default == "#95afc0"
+
+
+@pytest.mark.unit
+def test_parse_match_expression_numeric_values():
+    """Parse a match expression with numeric category values."""
+    expr = ["match", ["get", "zone_code"], 1, "#ff0000", 2, "#00ff00", "#0000ff"]
+    field, color_map, default = parse_match_expression(expr)
+
+    assert field == "zone_code"
+    assert color_map == {1: "#ff0000", 2: "#00ff00"}
+    assert default == "#0000ff"
+
+
+@pytest.mark.unit
+def test_parse_match_expression_invalid_format():
+    """Return None for invalid match expression format."""
+    # Not a list
+    assert parse_match_expression("invalid") is None
+
+    # Too short
+    assert parse_match_expression(["match"]) is None
+
+    # Not a match expression
+    assert parse_match_expression(["interpolate", ["linear"], ["get", "x"]]) is None
+
+    # Invalid get expression
+    assert parse_match_expression(["match", "not_a_get", "val", "#000", "#fff"]) is None
+
+
+# =============================================================================
+# load_thumbnail_style tests
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_simple_color(tmp_path: Path):
+    """Load a style with simple fill color."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text(
+        """{
+        "version": 8,
+        "layers": [{
+            "type": "fill",
+            "paint": {
+                "fill-color": "#ff0000",
+                "fill-opacity": 0.8
+            }
+        }]
+    }"""
+    )
+
+    style = load_thumbnail_style(style_file)
+
+    assert style is not None
+    assert style.fill_color == "#ff0000"
+    assert style.fill_opacity == 0.8
+    assert style.color_field is None
+    assert style.color_map is None
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_categorical(tmp_path: Path):
+    """Load a style with categorical match expression."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text(
+        """{
+        "version": 8,
+        "layers": [{
+            "type": "fill",
+            "paint": {
+                "fill-color": ["match", ["get", "land_use"],
+                    "residential", "#ff6b6b",
+                    "commercial", "#4ecdc4",
+                    "#95afc0"
+                ],
+                "fill-opacity": 0.7
+            }
+        }]
+    }"""
+    )
+
+    style = load_thumbnail_style(style_file)
+
+    assert style is not None
+    assert style.fill_color == "#95afc0"  # default from match
+    assert style.fill_opacity == 0.7
+    assert style.color_field == "land_use"
+    assert style.color_map == {"residential": "#ff6b6b", "commercial": "#4ecdc4"}
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_with_outline(tmp_path: Path):
+    """Load a style with fill-outline-color."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text(
+        """{
+        "version": 8,
+        "layers": [{
+            "type": "fill",
+            "paint": {
+                "fill-color": "#3388ff",
+                "fill-opacity": 0.6,
+                "fill-outline-color": "#2266cc"
+            }
+        }]
+    }"""
+    )
+
+    style = load_thumbnail_style(style_file)
+
+    assert style is not None
+    assert style.fill_color == "#3388ff"
+    assert style.edge_color == "#2266cc"
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_no_fill_layer(tmp_path: Path):
+    """Return None when style has no fill layer."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text(
+        """{
+        "version": 8,
+        "layers": [{
+            "type": "line",
+            "paint": {"line-color": "#ff0000"}
+        }]
+    }"""
+    )
+
+    style = load_thumbnail_style(style_file)
+    assert style is None
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_missing_file():
+    """Return None for missing style file."""
+    style = load_thumbnail_style(Path("/nonexistent/style.json"))
+    assert style is None
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_invalid_json(tmp_path: Path):
+    """Return None for invalid JSON."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text("not valid json")
+
+    style = load_thumbnail_style(style_file)
+    assert style is None
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_default_opacity(tmp_path: Path):
+    """Use default opacity when not specified."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text(
+        """{
+        "version": 8,
+        "layers": [{"type": "fill", "paint": {"fill-color": "#ff0000"}}]
+    }"""
+    )
+
+    style = load_thumbnail_style(style_file)
+
+    assert style is not None
+    assert style.fill_opacity == 1.0  # Mapbox GL default
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_uses_first_fill_layer(tmp_path: Path):
+    """Use the first fill layer when multiple exist."""
+    style_file = tmp_path / "style.json"
+    style_file.write_text(
+        """{
+        "version": 8,
+        "layers": [
+            {"type": "line", "paint": {"line-color": "#000000"}},
+            {"type": "fill", "paint": {"fill-color": "#ff0000"}},
+            {"type": "fill", "paint": {"fill-color": "#00ff00"}}
+        ]
+    }"""
+    )
+
+    style = load_thumbnail_style(style_file)
+
+    assert style is not None
+    assert style.fill_color == "#ff0000"  # First fill layer
+
+
+@pytest.mark.unit
+def test_load_thumbnail_style_from_fixture():
+    """Load from existing test fixture."""
+    fixture_path = (
+        Path(__file__).parent.parent
+        / "fixtures"
+        / "metadata"
+        / "style"
+        / "valid"
+        / "style_categorical.json"
+    )
+
+    if not fixture_path.exists():
+        pytest.skip("Fixture not found")
+
+    style = load_thumbnail_style(fixture_path)
+
+    assert style is not None
+    assert style.color_field == "land_use"
+    assert "residential" in style.color_map
+
+
+# =============================================================================
+# resolve_colors_for_gdf tests
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_resolve_colors_uniform():
+    """Return uniform color when no color_map."""
+    pytest.importorskip("geopandas")
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame({"a": [1, 2, 3]}, geometry=[Point(0, 0)] * 3)
+    style = ThumbnailStyle(
+        fill_color="#ff0000",
+        fill_opacity=0.5,
+        edge_color=None,
+        color_field=None,
+        color_map=None,
+    )
+
+    colors = resolve_colors_for_gdf(gdf, style)
+
+    assert colors == "#ff0000"
+
+
+@pytest.mark.unit
+def test_resolve_colors_categorical():
+    """Resolve categorical colors from field values."""
+    pytest.importorskip("geopandas")
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame(
+        {"land_use": ["residential", "commercial", "residential"]},
+        geometry=[Point(0, 0)] * 3,
+    )
+    style = ThumbnailStyle(
+        fill_color="#000000",
+        fill_opacity=0.7,
+        edge_color=None,
+        color_field="land_use",
+        color_map={"residential": "#ff6b6b", "commercial": "#4ecdc4"},
+    )
+
+    colors = resolve_colors_for_gdf(gdf, style)
+
+    assert list(colors) == ["#ff6b6b", "#4ecdc4", "#ff6b6b"]
+
+
+@pytest.mark.unit
+def test_resolve_colors_case_insensitive():
+    """Match field names case-insensitively."""
+    pytest.importorskip("geopandas")
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    # GDF has uppercase column, style expects lowercase
+    gdf = gpd.GeoDataFrame(
+        {"LAND_USE": ["residential", "commercial"]},
+        geometry=[Point(0, 0)] * 2,
+    )
+    style = ThumbnailStyle(
+        fill_color="#000000",
+        fill_opacity=0.7,
+        edge_color=None,
+        color_field="land_use",  # lowercase
+        color_map={"residential": "#ff6b6b", "commercial": "#4ecdc4"},
+    )
+
+    colors = resolve_colors_for_gdf(gdf, style)
+
+    assert list(colors) == ["#ff6b6b", "#4ecdc4"]
+
+
+@pytest.mark.unit
+def test_resolve_colors_missing_field():
+    """Use default color when field not in GDF."""
+    pytest.importorskip("geopandas")
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame(
+        {"other_field": ["a", "b"]},
+        geometry=[Point(0, 0)] * 2,
+    )
+    style = ThumbnailStyle(
+        fill_color="#default",
+        fill_opacity=0.7,
+        edge_color=None,
+        color_field="land_use",  # not in GDF
+        color_map={"residential": "#ff6b6b"},
+    )
+
+    colors = resolve_colors_for_gdf(gdf, style)
+
+    # Should fall back to default fill_color
+    assert colors == "#default"
+
+
+@pytest.mark.unit
+def test_resolve_colors_unmapped_values():
+    """Use default color for values not in color_map."""
+    pytest.importorskip("geopandas")
+    import geopandas as gpd
+    from shapely.geometry import Point
+
+    gdf = gpd.GeoDataFrame(
+        {"land_use": ["residential", "unknown_type"]},
+        geometry=[Point(0, 0)] * 2,
+    )
+    style = ThumbnailStyle(
+        fill_color="#default",
+        fill_opacity=0.7,
+        edge_color=None,
+        color_field="land_use",
+        color_map={"residential": "#ff6b6b"},  # no mapping for unknown_type
+    )
+
+    colors = resolve_colors_for_gdf(gdf, style)
+
+    assert list(colors) == ["#ff6b6b", "#default"]


### PR DESCRIPTION
## Summary

Implements automatic style extraction during WFS and ArcGIS extraction (#490):

- **WMS GetStyles**: Fetches SLD XML from companion WMS endpoint, converts to Mapbox GL JSON
- **ESRI REST**: Extracts `drawingInfo.renderer` from layer JSON, converts to Mapbox GL JSON

## Architecture

DRY design for future format support (QGIS QML, etc.):

| Module | Purpose |
|--------|---------|
| `converters/base.py` | Shared Mapbox GL building blocks (match/step expressions, layer builders) |
| `converters/sld.py` | SLD XML parser (PolygonSymbolizer, PointSymbolizer, LineSymbolizer, categorical filters) |
| `converters/esri.py` | ESRI renderer parser (simple, uniqueValue, classBreaks) |
| `common/styles.py` | Orchestration layer for fetching and writing styles |

## Behavior

- Styles written to `{collection}/styles/source.json` during extraction
- Existing `scan` flow registers styles as STAC assets via `discover_styles()`
- Unsupported features (TextSymbolizer, TTF glyphs, esriPMS) warn and continue
- Style extraction failures logged but don't block data extraction

## Test Fixtures

Real data from production endpoints:
- **Pergamino GeoNode (WMS)**: `aeropuertos` (simple point), `barrios_y_pueblos` (12-category polygon)
- **ESRI SampleServer6**: Census (classBreaks), PAD-US (uniqueValue)

## Test Plan

- [x] 59 new unit tests for converters and orchestration
- [x] All 599 existing tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Complexity check passes (xenon)
- [ ] Manual test against real WFS endpoint
- [ ] Manual test against real ESRI endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic extraction of remote map styles (ArcGIS/WMS) and legends, conversion to Mapbox GL JSON/PNG, and registration as STAC assets
  * CLI flag to skip style/legend extraction
  * Style assets published with Mapbox Style media type

* **Documentation**
  * Guides updated to document style & legend extraction workflow and the skip-style flag

* **Tests**
  * New fixtures and unit tests covering style/legend conversion, extraction, and asset registration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->