### PR TITLE
feat(extract): ArcGIS folder recursion, folder URLs, token auth (#493)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0051](context/shared/adr/0051-self-contained-catalog-type.md) | SELF_CONTAINED catalog type (relative links, portable) |
 | [0052](context/shared/adr/0052-llms-txt-requirement.md) | Require llms.txt for AI/LLM integration at catalog and collection levels |
 | [0053](context/shared/adr/0053-mandatory-human-readable-titles.md) | Mandatory human-readable titles/descriptions; auto-humanize slugs; title on child/item links |
+| [0054](context/shared/adr/0054-arcgis-folder-recursion-and-structure.md) | ArcGIS folder recursion (default-on), folder URLs, token auth pass-through, nested-folder subcatalogs |
 
 ## Common Commands
 

--- a/context/shared/adr/0054-arcgis-folder-recursion-and-structure.md
+++ b/context/shared/adr/0054-arcgis-folder-recursion-and-structure.md
@@ -1,0 +1,41 @@
+# ADR-0054: ArcGIS folder recursion and nested-folder catalog structure
+
+## Status
+Adopted
+
+## Context
+`portolan extract arcgis` against a services root only discovered top-level
+services, silently skipping every service nested in an ArcGIS Server folder, and
+rejected folder URLs. ArcGIS Enterprise and federated servers organize services
+into folders (some put ALL services in folders), so services-root extraction was
+unusable against them. See issue #493.
+
+## Decision
+1. Services-root extraction recurses into folders by default. ArcGIS returns
+   folder-qualified service names (e.g. `NationalDatasets/Property`), so URL
+   construction and glob filters work unchanged. `--no-recurse` opts out.
+2. Folders that error or require a token are logged as warnings and skipped; the
+   run never aborts. Coverage (folders traversed/skipped, services found) is
+   recorded on the extraction report and printed.
+3. Folder URLs (`.../rest/services/<folder>`) parse as a new `SERVICES_FOLDER`
+   type, scoped to that folder, with the base URL normalized to the true
+   services root.
+4. Token-secured folders/services are reachable when the user supplies a token
+   (`--token`/`ARCGIS_TOKEN`) or username/password (minted via `generateToken`).
+   This is a contained pass-through; the full auth design remains issue #311.
+5. Folders map to nested subcatalogs; each folder segment becomes a slugified
+   subcatalog directory and the service becomes a collection (single layer) or
+   subcatalog (multi layer), consistent with ADR-0032 (nested catalogs for
+   hierarchy). `--services`/`--exclude-services` match folder-qualified names.
+
+## Consequences
+- Enterprise/federated catalogs extract completely by default.
+- Catalog trees gain a folder tier; deeper nesting for multi-layer services.
+- Slug collisions are possible for names differing only by stripped characters
+  (e.g. `turkiye` vs `turkiye-alt`), accepted for now, not mitigated.
+- ImageServer-in-folder extraction and the full auth module are out of scope
+  (issue #311).
+
+## Related
+Issues #493, #6, #492, #358, #311. Supersedes nothing. Builds on ADR-0032,
+ADR-0048, ADR-0007.

--- a/context/shared/plans/2026-06-09-arcgis-folder-recursion-design.md
+++ b/context/shared/plans/2026-06-09-arcgis-folder-recursion-design.md
@@ -1,0 +1,226 @@
+# Design, folder-aware ArcGIS services-root extraction
+
+**Issue:** [portolan-sdi/portolan-cli#493](https://github.com/portolan-sdi/portolan-cli/issues/493)
+**Branch:** `feature/arcgis-folder-recursion`
+**Date:** 2026-06-09
+**Status:** Approved, ready for implementation plan
+
+## Problem
+
+`portolan extract arcgis <URL>` against a services root (`.../rest/services`) only
+discovers and extracts services at the **top level**. It reads the `folders` array
+but never traverses it, so every service nested in a folder is silently skipped, with
+no error or warning. Folder URLs (`.../rest/services/<folder>`) are also rejected by
+the URL parser. This makes the services-root mode unusable against ArcGIS Enterprise
+and federated servers, where organizing services into folders is the norm.
+
+Verified against `main` (`1.0.0a0`):
+
+- `portolan_cli/extract/arcgis/discovery.py`, `discover_services()` (lines ~235-279)
+  reads `data.get("folders", [])` but never fetches `<root>/<folder>?f=json`.
+- `portolan_cli/extract/arcgis/orchestrator.py`, both `list_services()` (~131) and
+  `_discover_and_filter_services()` (~783) call `discover_services(..., return_folders=True)`
+  then **discard** the folders.
+- `portolan_cli/extract/arcgis/url_parser.py`, `_SERVICES_ROOT_PATTERN = r"/rest/services/?$"`
+  matches only the bare root, so a folder URL raises `InvalidArcGISURLError [PRTLN-EXT001]`.
+
+## Investigation findings (live servers)
+
+Two live, anonymously readable servers were probed with `curl`.
+
+1. South Africa NSPDR, `https://nspdr.dlrrd.gov.za/server/rest/services`
+   - 13 top-level services (mostly GPServer export tools, 2 MapServers).
+   - 7 folders. `NationalDatasets` alone holds 8 MapServers, 100+ feature layers.
+   - Querying a folder returns names **already root-qualified**, e.g.
+     `NationalDatasets/Property`. Nested `folders` is empty.
+2. JRC federated server, `https://arcgis-maps.jrc.ec.europa.eu/federated_server/rest/services`
+   - **Zero top-level services.** All data lives in 14 folders.
+   - Folder JSON returns root-qualified names, e.g. `ecml/active_faults`, and
+     `folders: []` (no nesting).
+   - Non-ASCII names exist, e.g. `ecml/eq_türkiye_20230206_m78_mmi`.
+
+Consequences for the design:
+
+- Recursion must be **on by default** for services-root extraction, or the JRC server
+  (and any folder-organized Enterprise server) yields nothing.
+- The API returns root-qualified names, so `ServiceInfo.get_url(root_base)` already
+  builds correct URLs, and `fnmatch`-based filters already match `Folder/Service`.
+- Folders are single level per the ArcGIS REST spec, but traversal is written
+  defensively (queue based, depth guarded) per the issue request.
+- `_slugify` already collapses non-ASCII and `/` into `_`, so names are filesystem safe,
+  with a small collision risk (`türkiye` vs `turkiye`) noted, not addressed in v1.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Recursion trigger | Default-on for services-root extraction | Folder-organized servers are common, silent partial results are the bug |
+| Token-secured folders | Use auth if provided, else skip with warning | User can reach secured data, runs never abort |
+| Auth scope | `--token` plus `--username`/`--password` to token via `generateToken`, plus `ARCGIS_TOKEN` env | Matches operator workflows, contained pass-through, full design stays in #311 |
+| Catalog structure | Nested by folder, folder becomes a subcatalog tier | ADR-0032 favors nested catalogs for hierarchy |
+| Structure governance | New ADR in this repo, no portolan-spec issue | ADR-0048, CLI repo is spec source of truth |
+| Scope | All 5 issue points plus auth refinement | Cohesive single spec |
+
+## Architecture
+
+The change is contained to the arcgis extract subsystem
+(`portolan_cli/extract/arcgis/`) plus CLI wiring in `cli.py`, one new ADR, and tests.
+The library-wraps-CLI boundary (ADR-0007) is preserved, all logic stays in the
+extract modules and the CLI only parses flags and delegates.
+
+### Unit 1, discovery recursion (`discovery.py`)
+
+- Add `recurse: bool = False` and `auth: ArcGISCredentials | None = None` to
+  `discover_services()`. Default stays non-recursive so existing direct callers and
+  unit tests keep their contract. The **orchestrator** opts into `recurse=True`.
+- New `FolderTraversal` dataclass capturing `visited: list[str]`,
+  `skipped: list[tuple[str, str]]` (folder, reason), `service_count: int`.
+- New internal `_discover_services_recursive(root_url, service_types, auth, timeout,
+  max_depth=2)` doing a queue-based BFS, seeded with the root, enqueuing each
+  `folders` entry, fetching `<root>/<folder>?f=json`, merging `services`. Depth guard
+  prevents pathological loops on misbehaving servers.
+- `discover_services(..., recurse=True, return_folders=True)` returns
+  `(services, FolderTraversal)`. Keep the existing non-recursive return shapes via
+  overloads so type checking stays precise.
+- `_fetch_json()` is extended to raise a typed discovery error when the body is a
+  JSON `{"error": {"code": ..., "message": ...}}` object, since ArcGIS returns HTTP
+  200 with an embedded error for token-required cases.
+
+### Unit 2, auth (`extract/arcgis/auth.py`, new)
+
+- `@dataclass ArcGISCredentials` with `token: str | None`, `username: str | None`,
+  `password: str | None`.
+- `resolve_token(creds, base_url, timeout) -> str | None`. If `token` is set, return
+  it. If username/password are set, discover the token endpoint from
+  `<server>/rest/info?f=json` (`authInfo.tokenServicesUrl`, fallback to
+  `<root>/../tokens/generateToken`) and POST credentials to mint a token. Errors raise
+  a typed `ArcGISAuthError` (added to `errors.py`).
+- `apply_auth(url, token) -> str` appends `token=<token>` to a request URL.
+- Token threads into every discovery request and into `gpio.extract_arcgis` via its
+  auth/token parameter, feature-detected with `inspect.signature` exactly like the
+  existing `max_workers` detection in `_extract_single_layer`.
+- Credential sources resolved in CLI, precedence `--token` > `--username`/`--password`
+  > `ARCGIS_TOKEN` env. Cross-reference #311 in code comments, this is the minimal
+  contained version, not the full module.
+
+### Unit 3, graceful skip
+
+- During recursion, a folder fetch that raises (non-2xx or embedded error) is caught,
+  logged via `output.warn`, appended to `FolderTraversal.skipped`, and traversal
+  continues. Never aborts.
+- The existing per-service layer-discovery skip in `_collect_layers_from_services`
+  (already a try/except continue) is retained and its failures fold into the coverage
+  report.
+
+### Unit 4, URL parser accepts folder URLs (`url_parser.py`)
+
+- Add `ArcGISURLType.SERVICES_FOLDER`.
+- After the FeatureServer/MapServer/ImageServer patterns fail and before the bare-root
+  pattern, match `/rest/services/(.+?)/?$` where the captured remainder contains **no**
+  known server-type segment. That remainder is the folder path.
+- Return `ParsedArcGISURL` with `url_type=SERVICES_FOLDER`, `base_url` normalized to the
+  true `.../rest/services` root (strip the folder), and the folder captured in a new
+  `folder: str | None` field. This keeps `ServiceInfo.get_url(base_url)` correct because
+  names stay root-qualified.
+- `is_single_service` stays `False` for `SERVICES_FOLDER` so it routes through the
+  services-root extraction path, scoped to the one folder.
+- Document the ambiguity rule, a trailing path after `rest/services` with no server-type
+  segment is treated as a folder.
+
+### Unit 5, nested-by-folder structure (`orchestrator.py`)
+
+- In `_extract_services_root`, replace `service_slug = _slugify(service.name)` with a
+  split on `/`. Each leading segment (the folder path) becomes a slugified subcatalog
+  directory, the final segment is the service. Resulting layout:
+  - single-layer service, `output/<folder...>/<service>/<service>.parquet`
+  - multi-layer service, `output/<folder...>/<service>/<layer>/<layer>.parquet`
+- `_auto_init_catalog` already calls `init_catalog` then `add_files`, which infers the
+  catalog tree from the on-disk directory layout and creates subcatalog `catalog.json`
+  files (the existing multi-layer path proves this). The plan must **verify** that a
+  folder tier with multiple services produces a valid intermediate `catalog.json`, and
+  add coverage if not.
+- For a `SERVICES_FOLDER` URL, the same code path runs scoped to the single folder, so
+  the output is rooted at that folder's subcatalog naturally.
+
+### Unit 6, filters and coverage reporting
+
+- Filters already operate on `s.name` and use `fnmatch`, so `--services "ecml/*"`
+  matches `ecml/active_faults`. Add tests and document, no behavior change needed.
+- `ServicesRootDiscoveryResult` and the extraction report/summary gain coverage fields
+  fed from `FolderTraversal`, folders traversed, folders skipped with reasons, services
+  found.
+- `--list-services` output and the post-extraction summary print coverage so a partial
+  result is never mistaken for complete. `report.py` carries the fields, CLI renders
+  them (text and `--json`).
+
+### Unit 7, ADR
+
+- New `context/shared/adr/0053-arcgis-folder-recursion-and-structure.md` recording, the
+  folder to subcatalog mapping, recursion-by-default for services-root extraction, the
+  graceful-skip-unless-auth behavior, and the minimal token pass-through with a pointer
+  to #311.
+- Register `0053` in the root `CLAUDE.md` ADR index (the validator reads it).
+
+## CLI surface (new options on `extract arcgis`)
+
+- `--token TEXT`, ArcGIS token, also `ARCGIS_TOKEN` env.
+- `--username TEXT` and `--password TEXT`, mint a token via `generateToken`.
+- `--no-recurse`, opt out of folder recursion for services-root URLs (default recurses).
+- No change to `--services`/`--exclude-services`/`--filter` semantics, they already match
+  folder-qualified names.
+
+## Error handling
+
+- `ArcGISAuthError` (new, `errors.py`), token minting or invalid credentials.
+- Embedded ArcGIS error bodies raise the existing `ArcGISDiscoveryError` for the failing
+  endpoint, caught and converted to a skip during folder traversal.
+- Folder URL parsing failures keep raising `InvalidArcGISURLError [PRTLN-EXT001]`.
+- All user-facing messages go through `output.py` (`warn`/`info`/`error`), diagnostics
+  through `logging`, per the python rules.
+
+## Testing strategy (TDD, network mocked)
+
+Unit, mocked `httpx`:
+
+- recursion merges folder services and preserves root-qualified names
+- depth guard stops at `max_depth`, nested folders beyond it are not fetched
+- embedded `{"error": {...}}` body triggers skip, traversal continues, recorded in
+  `FolderTraversal.skipped`
+- auth, `--token` appended to requests, username/password resolves via mocked
+  `generateToken`, `ArcGISAuthError` on failure
+- url_parser, folder URL parses to `SERVICES_FOLDER` with normalized root base and
+  captured folder, ambiguous and Unicode folder names, plus regression that real
+  service URLs still parse as before
+- nested path construction for single and multi layer services, folder tier produces a
+  subcatalog
+- filter matches `ecml/*` against qualified names
+- coverage record populated and rendered (text and JSON)
+
+Integration, `@pytest.mark.network` (or `realdata`, mocked locally, real in nightly):
+
+- against the SA NSPDR and JRC roots, assert folders are traversed, qualified names are
+  returned, and the JRC root (zero top-level services) yields a non-empty service list.
+
+Existing tests to update:
+
+- any test asserting `discover_services` returns top-level only stays valid for the
+  non-recursive default, add new tests for `recurse=True`.
+- orchestrator tests that assumed top-level-only services-root extraction get folder
+  fixtures.
+
+## Out of scope
+
+- GPServer and Utilities services, still filtered to FeatureServer/MapServer.
+- ImageServer-in-folder extraction (raster path), the recursion is wired for the vector
+  path, ImageServer folder support can follow.
+- The full unified auth module, owned by #311. This spec ships only a contained token
+  pass-through.
+
+## Related issues
+
+- #493, this bug.
+- #6, parent feature, full ArcGIS Server to Portolan conversion, the folder-filtering
+  comment depends on qualified names delivered here.
+- #492, upstream sync, depends on folder traversal and qualified names.
+- #358, flatten single-layer services, structure precedent.
+- #311, unified auth, this spec is the minimal contained precursor.

--- a/context/shared/plans/2026-06-09-arcgis-folder-recursion-plan.md
+++ b/context/shared/plans/2026-06-09-arcgis-folder-recursion-plan.md
@@ -1,0 +1,1854 @@
+# Folder-aware ArcGIS services-root extraction, Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `portolan extract arcgis` against a services root recurse into ArcGIS Server folders by default, accept folder URLs, reach token-secured folders when credentials are given (skip otherwise), map folders to nested subcatalogs, and report coverage.
+
+**Architecture:** All changes are contained to `portolan_cli/extract/arcgis/` (discovery, url_parser, orchestrator, new auth module), one shared model addition in `extract/common/report.py`, CLI flag wiring in `cli.py`, one error class in `errors.py`, plus a new ADR. The CLI stays a thin Click layer (ADR-0007); all logic lives in the extract modules. Network is mocked in unit tests.
+
+**Tech Stack:** Python 3.10+, `httpx` (sync client, already used in discovery), `click`, `pytest`, `mypy --strict`, `ruff`. Design doc: `context/shared/plans/2026-06-09-arcgis-folder-recursion-design.md`. Issue: [#493](https://github.com/portolan-sdi/portolan-cli/issues/493).
+
+**Conventions to follow (from `.claude/rules/python.md`):** `from __future__ import annotations` at top of every module; modern typing (`X | None`, `list[str]`); raise typed errors from `errors.py`; user-facing messages via `portolan_cli.output`, diagnostics via `logging`; `pathlib.Path` only.
+
+**Run tests with:** `uv run pytest <path> -v`. Lint with `uv run ruff check .`, types with `uv run mypy portolan_cli`.
+
+---
+
+## File map
+
+- Create `portolan_cli/extract/arcgis/auth.py` — credentials + token resolution.
+- Create `tests/unit/extract/arcgis/test_auth.py`.
+- Create `context/shared/adr/0053-arcgis-folder-recursion-and-structure.md`.
+- Modify `portolan_cli/errors.py` — add `ArcGISAuthError`.
+- Modify `portolan_cli/extract/arcgis/discovery.py` — auth + embedded-error in `_fetch_json`, `FolderTraversal`, `discover_services_recursive`.
+- Modify `portolan_cli/extract/arcgis/url_parser.py` — `SERVICES_FOLDER`, `folder` field, folder-URL parsing.
+- Modify `portolan_cli/extract/common/report.py` — `FolderCoverage`, `ExtractionReport.folder_coverage`.
+- Modify `portolan_cli/extract/arcgis/orchestrator.py` — recursive discovery, folder scoping, nested paths, token threading, coverage on report, `ExtractionOptions` fields.
+- Modify `portolan_cli/cli.py` — `--token`/`--username`/`--password`/`--no-recurse`, credential build, `SERVICES_FOLDER` handling, coverage rendering.
+- Modify `CLAUDE.md` — register ADR-0053.
+- Tests touched: `tests/unit/extract/arcgis/test_discovery.py`, `test_url_parser.py`, `test_orchestrator.py`, `tests/integration/extract/arcgis/test_orchestrator_live.py`.
+
+---
+
+## Task 1: Add `ArcGISAuthError`
+
+**Files:**
+- Modify: `portolan_cli/errors.py`
+- Test: `tests/unit/test_errors.py` (create if absent, else append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_errors.py
+import pytest
+from portolan_cli.errors import ArcGISAuthError, PortolanError
+
+
+@pytest.mark.unit
+def test_arcgis_auth_error_code_and_message() -> None:
+    err = ArcGISAuthError("token request failed", url="https://x/generateToken")
+    assert isinstance(err, PortolanError)
+    assert err.code == "PRTLN-EXT002"
+    assert "token request failed" in str(err)
+    assert err.to_dict()["context"]["url"] == "https://x/generateToken"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/test_errors.py::test_arcgis_auth_error_code_and_message -v`
+Expected: FAIL with `ImportError: cannot import name 'ArcGISAuthError'`.
+
+- [ ] **Step 3: Implement**
+
+Find the extract error section. `InvalidArcGISURLError` (code `PRTLN-EXT001`) currently lives in `portolan_cli/extract/arcgis/url_parser.py`. Add a sibling in `errors.py` near the bottom of the error hierarchy:
+
+```python
+# Extract Errors (PRTLN-EXT*)
+class ArcGISAuthError(PortolanError):
+    """Raised when ArcGIS token resolution or authentication fails.
+
+    Error code: PRTLN-EXT002
+    """
+
+    code = "PRTLN-EXT002"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/test_errors.py::test_arcgis_auth_error_code_and_message -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/errors.py tests/unit/test_errors.py
+git commit -m "feat(extract): add ArcGISAuthError (PRTLN-EXT002) (#493)"
+```
+
+---
+
+## Task 2: `_fetch_json` accepts a token and detects embedded ArcGIS errors
+
+ArcGIS returns HTTP 200 with a body like `{"error": {"code": 499, "message": "Token Required"}}` for secured endpoints. `_fetch_json` must raise `ArcGISDiscoveryError` for that, and append `token=` when a token is supplied.
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/discovery.py` (`_fetch_json`, ~122-150)
+- Test: `tests/unit/extract/arcgis/test_discovery.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/extract/arcgis/test_discovery.py  (append)
+import httpx
+import pytest
+from portolan_cli.extract.arcgis.discovery import ArcGISDiscoveryError, _fetch_json
+
+
+@pytest.mark.unit
+def test_fetch_json_raises_on_embedded_error(monkeypatch) -> None:
+    def fake_get(self, url):  # noqa: ANN001
+        return httpx.Response(200, json={"error": {"code": 499, "message": "Token Required"}})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    with pytest.raises(ArcGISDiscoveryError, match="499"):
+        _fetch_json("https://x/rest/services/Secret")
+
+
+@pytest.mark.unit
+def test_fetch_json_appends_token(monkeypatch) -> None:
+    seen: dict[str, str] = {}
+
+    def fake_get(self, url):  # noqa: ANN001
+        seen["url"] = url
+        return httpx.Response(200, json={"services": [], "folders": []})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    _fetch_json("https://x/rest/services", token="ABC123")
+    assert "token=ABC123" in seen["url"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_discovery.py -k "embedded_error or appends_token" -v`
+Expected: FAIL (`_fetch_json` has no `token` param; no embedded-error check).
+
+- [ ] **Step 3: Implement**
+
+Replace the `_fetch_json` signature and body in `discovery.py`:
+
+```python
+def _fetch_json(url: str, timeout: float = 60.0, token: str | None = None) -> dict[str, Any]:
+    """Fetch JSON from URL with standard error handling.
+
+    Appends f=json and, when provided, token=<token>. ArcGIS returns HTTP 200
+    with an embedded {"error": {...}} body for secured or invalid endpoints;
+    that case is raised as ArcGISDiscoveryError.
+    """
+    request_url = _ensure_json_format(url)
+    if token:
+        request_url = _append_query_param(request_url, "token", token)
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.get(request_url)
+            response.raise_for_status()
+            data = cast("dict[str, Any]", response.json())
+    except httpx.HTTPStatusError as e:
+        msg = f"Failed to fetch from {url}: HTTP {e.response.status_code}"
+        raise ArcGISDiscoveryError(msg) from e
+    except httpx.RequestError as e:
+        msg = f"Failed to fetch from {url}: {e}"
+        raise ArcGISDiscoveryError(msg) from e
+    except ValueError as e:
+        msg = f"Invalid JSON response from {url}: {e}"
+        raise ArcGISDiscoveryError(msg) from e
+
+    error = data.get("error")
+    if isinstance(error, dict):
+        code = error.get("code", "unknown")
+        message = error.get("message", "ArcGIS error")
+        raise ArcGISDiscoveryError(f"ArcGIS error from {url}: {code} {message}")
+
+    return data
+```
+
+Add the helper near `_ensure_json_format`:
+
+```python
+def _append_query_param(url: str, key: str, value: str) -> str:
+    """Append a single query parameter to a URL."""
+    parsed = urlparse(url)
+    query_params = parse_qs(parsed.query)
+    query_params[key] = [value]
+    new_query = urlencode(query_params, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_discovery.py -k "embedded_error or appends_token" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/discovery.py tests/unit/extract/arcgis/test_discovery.py
+git commit -m "feat(extract): _fetch_json token support + embedded-error detection (#493)"
+```
+
+---
+
+## Task 3: `FolderTraversal` + `discover_services_recursive`
+
+Queue-based BFS over folders. Names returned by ArcGIS are already root-qualified, so no renaming. Default `max_depth=2` (folders are single-level per spec; the guard protects against misbehaving servers). Folder fetch failures are recorded and skipped, never raised.
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/discovery.py`
+- Test: `tests/unit/extract/arcgis/test_discovery.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/extract/arcgis/test_discovery.py  (append)
+from portolan_cli.extract.arcgis.discovery import (
+    FolderTraversal,
+    discover_services_recursive,
+)
+
+
+def _mock_endpoints(monkeypatch, responses: dict[str, dict]) -> None:
+    """Map base URL (without query) -> JSON body."""
+    def fake_fetch(url, timeout=60.0, token=None):  # noqa: ANN001
+        base = url.split("?")[0]
+        if base not in responses:
+            raise ArcGISDiscoveryError(f"ArcGIS error from {url}: 499 Token Required")
+        return responses[base]
+
+    monkeypatch.setattr("portolan_cli.extract.arcgis.discovery._fetch_json", fake_fetch)
+
+
+@pytest.mark.unit
+def test_recursive_merges_folder_services(monkeypatch) -> None:
+    root = "https://x/rest/services"
+    _mock_endpoints(monkeypatch, {
+        root: {"services": [{"name": "Top", "type": "MapServer"}],
+               "folders": ["NationalDatasets"]},
+        f"{root}/NationalDatasets": {
+            "services": [
+                {"name": "NationalDatasets/Property", "type": "MapServer"},
+                {"name": "NationalDatasets/Agriculture", "type": "MapServer"},
+            ],
+            "folders": [],
+        },
+    })
+    services, traversal = discover_services_recursive(root)
+    names = sorted(s.name for s in services)
+    assert names == ["NationalDatasets/Agriculture", "NationalDatasets/Property", "Top"]
+    assert traversal.visited == ["NationalDatasets"]
+    assert traversal.skipped == []
+    assert traversal.service_count == 3
+
+
+@pytest.mark.unit
+def test_recursive_skips_secured_folder(monkeypatch) -> None:
+    root = "https://x/rest/services"
+    _mock_endpoints(monkeypatch, {
+        root: {"services": [], "folders": ["Open", "Locked"]},
+        f"{root}/Open": {"services": [{"name": "Open/A", "type": "MapServer"}], "folders": []},
+        # Locked intentionally absent -> fake_fetch raises -> skipped
+    })
+    services, traversal = discover_services_recursive(root)
+    assert [s.name for s in services] == ["Open/A"]
+    assert traversal.visited == ["Open"]
+    assert [f for f, _ in traversal.skipped] == ["Locked"]
+
+
+@pytest.mark.unit
+def test_recursive_respects_max_depth(monkeypatch) -> None:
+    root = "https://x/rest/services"
+    _mock_endpoints(monkeypatch, {
+        root: {"services": [], "folders": ["L1"]},
+        f"{root}/L1": {"services": [{"name": "L1/A", "type": "MapServer"}], "folders": ["L2"]},
+        f"{root}/L2": {"services": [{"name": "L2/B", "type": "MapServer"}], "folders": []},
+    })
+    services, _ = discover_services_recursive(root, max_depth=1)
+    # depth 1 fetches root (depth 0) + L1 (depth 1), not L2
+    assert [s.name for s in services] == ["L1/A"]
+
+
+@pytest.mark.unit
+def test_recursive_filters_by_service_type(monkeypatch) -> None:
+    root = "https://x/rest/services"
+    _mock_endpoints(monkeypatch, {
+        root: {"services": [{"name": "Tool", "type": "GPServer"},
+                            {"name": "Map", "type": "MapServer"}], "folders": []},
+    })
+    services, _ = discover_services_recursive(root, service_types=["FeatureServer", "MapServer"])
+    assert [s.name for s in services] == ["Map"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_discovery.py -k recursive -v`
+Expected: FAIL (`FolderTraversal`/`discover_services_recursive` not defined).
+
+- [ ] **Step 3: Implement**
+
+Add to `discovery.py` (after `discover_services`):
+
+```python
+@dataclass
+class FolderTraversal:
+    """Record of a recursive services-root traversal.
+
+    Attributes:
+        visited: Folder names successfully fetched.
+        skipped: (folder_name, reason) pairs for folders that errored.
+        service_count: Total services discovered (root plus all folders).
+    """
+
+    visited: list[str]
+    skipped: list[tuple[str, str]]
+    service_count: int
+
+
+def _build_service_list(
+    data: dict[str, Any],
+    service_types: Sequence[str] | None,
+) -> list[ServiceInfo]:
+    """Build a filtered ServiceInfo list from a services-root JSON payload."""
+    services: list[ServiceInfo] = []
+    for service_data in data.get("services", []):
+        service = ServiceInfo(name=service_data["name"], service_type=service_data["type"])
+        if service_types is None or service.service_type in service_types:
+            services.append(service)
+    return services
+
+
+def discover_services_recursive(
+    url: str,
+    *,
+    service_types: Sequence[str] | None = None,
+    token: str | None = None,
+    timeout: float = 60.0,
+    max_depth: int = 2,
+) -> tuple[list[ServiceInfo], FolderTraversal]:
+    """Discover services from a services root, recursing into folders.
+
+    ArcGIS returns service names already qualified by folder (e.g.
+    "NationalDatasets/Property"), so ServiceInfo.get_url(root) stays correct.
+    Folders that error (secured, non-200, embedded error) are recorded and
+    skipped, never raised. max_depth guards against pathological nesting;
+    standard ArcGIS folders are single-level.
+
+    Returns:
+        (services, traversal) where traversal records visited/skipped folders.
+    """
+    root_base = url.split("?")[0].rstrip("/")
+    root_data = _fetch_json(root_base, timeout=timeout, token=token)
+
+    services = _build_service_list(root_data, service_types)
+    visited: list[str] = []
+    skipped: list[tuple[str, str]] = []
+
+    # Queue of (folder_name, depth). Folder names are paths relative to root.
+    queue: list[tuple[str, int]] = [(f, 1) for f in root_data.get("folders", [])]
+    while queue:
+        folder, depth = queue.pop(0)
+        if depth > max_depth:
+            continue
+        folder_url = f"{root_base}/{folder}"
+        try:
+            folder_data = _fetch_json(folder_url, timeout=timeout, token=token)
+        except ArcGISDiscoveryError as e:
+            skipped.append((folder, str(e)))
+            logger.warning("Skipping folder '%s': %s", folder, e)
+            continue
+        visited.append(folder)
+        services.extend(_build_service_list(folder_data, service_types))
+        for sub in folder_data.get("folders", []):
+            queue.append((sub, depth + 1))
+
+    traversal = FolderTraversal(
+        visited=visited, skipped=skipped, service_count=len(services)
+    )
+    return services, traversal
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_discovery.py -k recursive -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/discovery.py tests/unit/extract/arcgis/test_discovery.py
+git commit -m "feat(extract): recursive folder discovery with traversal record (#493)"
+```
+
+---
+
+## Task 4: Auth module (`auth.py`)
+
+Token directly, or username/password minted via ArcGIS `generateToken`. Token-services URL discovered from `<server>/rest/info?f=json`.
+
+**Files:**
+- Create: `portolan_cli/extract/arcgis/auth.py`
+- Test: `tests/unit/extract/arcgis/test_auth.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/extract/arcgis/test_auth.py
+import httpx
+import pytest
+from portolan_cli.errors import ArcGISAuthError
+from portolan_cli.extract.arcgis.auth import (
+    ArcGISCredentials,
+    apply_token,
+    resolve_token,
+)
+
+
+@pytest.mark.unit
+def test_apply_token_appends_param() -> None:
+    assert "token=T" in apply_token("https://x/rest/services?f=json", "T")
+
+
+@pytest.mark.unit
+def test_resolve_token_returns_explicit_token() -> None:
+    creds = ArcGISCredentials(token="EXPLICIT")
+    assert resolve_token(creds, "https://x/rest/services") == "EXPLICIT"
+
+
+@pytest.mark.unit
+def test_resolve_token_none_when_no_credentials() -> None:
+    assert resolve_token(ArcGISCredentials(), "https://x/rest/services") is None
+
+
+@pytest.mark.unit
+def test_resolve_token_mints_from_username_password(monkeypatch) -> None:
+    def fake_get(self, url):  # noqa: ANN001
+        # /rest/info returns the token services URL
+        return httpx.Response(200, json={
+            "authInfo": {"tokenServicesUrl": "https://x/portal/sharing/rest/generateToken"}
+        })
+
+    def fake_post(self, url, data=None):  # noqa: ANN001
+        assert data["username"] == "u" and data["password"] == "p"
+        return httpx.Response(200, json={"token": "MINTED", "expires": 1})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    creds = ArcGISCredentials(username="u", password="p")
+    assert resolve_token(creds, "https://x/server/rest/services") == "MINTED"
+
+
+@pytest.mark.unit
+def test_resolve_token_raises_on_mint_error(monkeypatch) -> None:
+    def fake_get(self, url):  # noqa: ANN001
+        return httpx.Response(200, json={"authInfo": {"tokenServicesUrl": "https://x/generateToken"}})
+
+    def fake_post(self, url, data=None):  # noqa: ANN001
+        return httpx.Response(200, json={"error": {"code": 400, "message": "Invalid credentials"}})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    with pytest.raises(ArcGISAuthError, match="Invalid credentials"):
+        resolve_token(ArcGISCredentials(username="u", password="p"), "https://x/server/rest/services")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_auth.py -v`
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Implement**
+
+```python
+# portolan_cli/extract/arcgis/auth.py
+"""ArcGIS authentication, minimal token pass-through.
+
+Supports a pre-generated token or username/password minted via the ArcGIS
+generateToken endpoint. The token is appended to discovery requests and passed
+to gpio.extract_arcgis. This is a contained subset; the full unified auth design
+lives in issue #311.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import httpx
+
+from portolan_cli.errors import ArcGISAuthError
+
+
+@dataclass
+class ArcGISCredentials:
+    """ArcGIS credentials. token takes precedence over username/password."""
+
+    token: str | None = None
+    username: str | None = None
+    password: str | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no usable credentials are present."""
+        return not self.token and not (self.username and self.password)
+
+
+def apply_token(url: str, token: str) -> str:
+    """Append token=<token> to a URL."""
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    params["token"] = [token]
+    return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
+
+
+def _token_services_url(base_url: str, timeout: float) -> str:
+    """Discover the generateToken endpoint from <server>/rest/info."""
+    # base_url is e.g. https://host/server/rest/services[/folder]; derive /rest/info
+    root = base_url.split("/rest/")[0] + "/rest/info"
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(_with_json(root))
+            resp.raise_for_status()
+            data = cast("dict[str, Any]", resp.json())
+    except (httpx.HTTPError, ValueError) as e:
+        raise ArcGISAuthError(f"Failed to read token services URL from {root}: {e}", url=root) from e
+    token_url = data.get("authInfo", {}).get("tokenServicesUrl")
+    if not token_url:
+        raise ArcGISAuthError(f"Server does not advertise a token endpoint at {root}", url=root)
+    return cast("str", token_url)
+
+
+def _with_json(url: str) -> str:
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    params.setdefault("f", ["json"])
+    return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
+
+
+def resolve_token(creds: ArcGISCredentials, base_url: str, timeout: float = 60.0) -> str | None:
+    """Resolve a usable token from credentials.
+
+    Returns the explicit token, mints one from username/password, or None when
+    no credentials are present. Raises ArcGISAuthError when minting fails.
+    """
+    if creds.token:
+        return creds.token
+    if not (creds.username and creds.password):
+        return None
+
+    token_url = _token_services_url(base_url, timeout)
+    referer = base_url.split("/rest/")[0]
+    payload = {
+        "username": creds.username,
+        "password": creds.password,
+        "client": "referer",
+        "referer": referer,
+        "expiration": "60",
+        "f": "json",
+    }
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(token_url, data=payload)
+            resp.raise_for_status()
+            data = cast("dict[str, Any]", resp.json())
+    except (httpx.HTTPError, ValueError) as e:
+        raise ArcGISAuthError(f"Token request failed at {token_url}: {e}", url=token_url) from e
+
+    error = data.get("error")
+    if isinstance(error, dict):
+        raise ArcGISAuthError(
+            f"Token request rejected: {error.get('message', 'unknown')}", url=token_url
+        )
+    token = data.get("token")
+    if not token:
+        raise ArcGISAuthError(f"No token in response from {token_url}", url=token_url)
+    return cast("str", token)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_auth.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/auth.py tests/unit/extract/arcgis/test_auth.py
+git commit -m "feat(extract): ArcGIS token/username-password auth module (#493, refs #311)"
+```
+
+---
+
+## Task 5: URL parser accepts folder URLs (`SERVICES_FOLDER`)
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/url_parser.py`
+- Test: `tests/unit/extract/arcgis/test_url_parser.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/extract/arcgis/test_url_parser.py  (append)
+import pytest
+from portolan_cli.extract.arcgis.url_parser import (
+    ArcGISURLType,
+    parse_arcgis_url,
+)
+
+
+@pytest.mark.unit
+def test_parse_folder_url() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services/NationalDatasets")
+    assert r.url_type == ArcGISURLType.SERVICES_FOLDER
+    assert r.folder == "NationalDatasets"
+    assert r.base_url == "https://x/server/rest/services"
+    assert r.is_single_service is False
+
+
+@pytest.mark.unit
+def test_parse_folder_url_unicode() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services/ecml")
+    assert r.url_type == ArcGISURLType.SERVICES_FOLDER
+    assert r.folder == "ecml"
+
+
+@pytest.mark.unit
+def test_service_in_folder_still_parses_as_service() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services/NationalDatasets/Property/MapServer")
+    assert r.url_type == ArcGISURLType.MAP_SERVER
+    assert r.service_name == "NationalDatasets/Property"
+
+
+@pytest.mark.unit
+def test_bare_services_root_still_parses() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services")
+    assert r.url_type == ArcGISURLType.SERVICES_ROOT
+    assert r.folder is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_url_parser.py -k "folder or bare_services" -v`
+Expected: FAIL (`SERVICES_FOLDER`/`folder` attribute missing).
+
+- [ ] **Step 3: Implement**
+
+In `url_parser.py`:
+
+1. Add the enum member:
+
+```python
+class ArcGISURLType(Enum):
+    """Type of ArcGIS REST endpoint."""
+
+    FEATURE_SERVER = "FeatureServer"
+    MAP_SERVER = "MapServer"
+    IMAGE_SERVER = "ImageServer"
+    SERVICES_ROOT = "services"
+    SERVICES_FOLDER = "services_folder"
+```
+
+2. Add the `folder` field and update `is_single_service`:
+
+```python
+@dataclass(frozen=True)
+class ParsedArcGISURL:
+    url_type: ArcGISURLType
+    base_url: str
+    service_name: str | None
+    layer_id: int | None
+    folder: str | None = None
+
+    @property
+    def is_single_service(self) -> bool:
+        """Whether this URL targets a single service (vs a services root/folder)."""
+        return self.url_type not in (
+            ArcGISURLType.SERVICES_ROOT,
+            ArcGISURLType.SERVICES_FOLDER,
+        )
+```
+
+3. Add a folder pattern next to the others:
+
+```python
+# Match: /rest/services/<folder-path> (no server-type segment) -> folder-scoped root
+_SERVICES_FOLDER_PATTERN = re.compile(
+    r"/rest/services/(.+?)/?$",
+    re.IGNORECASE,
+)
+```
+
+4. In `parse_arcgis_url`, insert a branch AFTER the services-root check and BEFORE the final raise:
+
+```python
+    # Try to match services root
+    if _SERVICES_ROOT_PATTERN.search(url_path):
+        base_url = url_path.rstrip("/")
+        return ParsedArcGISURL(
+            url_type=ArcGISURLType.SERVICES_ROOT,
+            base_url=base_url,
+            service_name=None,
+            layer_id=None,
+        )
+
+    # Try to match a folder-scoped services root: /rest/services/<folder>
+    # (reached only when no FeatureServer/MapServer/ImageServer matched)
+    folder_match = _SERVICES_FOLDER_PATTERN.search(url_path)
+    if folder_match:
+        folder = folder_match.group(1).strip("/")
+        # base_url is the true services root (folder stripped) so qualified
+        # service names from discovery resolve correctly via ServiceInfo.get_url.
+        services_idx = url_path.lower().find("/rest/services") + len("/rest/services")
+        base_url = url_path[:services_idx].rstrip("/")
+        return ParsedArcGISURL(
+            url_type=ArcGISURLType.SERVICES_FOLDER,
+            base_url=base_url,
+            service_name=None,
+            layer_id=None,
+            folder=folder,
+        )
+
+    # No match - not a recognized ArcGIS URL
+    raise InvalidArcGISURLError(
+        url,
+        "not a recognized ArcGIS REST URL; expected FeatureServer, MapServer, ImageServer, or rest/services",
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_url_parser.py -v`
+Expected: PASS (new tests plus all existing url_parser tests still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/url_parser.py tests/unit/extract/arcgis/test_url_parser.py
+git commit -m "feat(extract): parse folder URLs as SERVICES_FOLDER (#493)"
+```
+
+---
+
+## Task 6: `FolderCoverage` on the extraction report
+
+Coverage lives in the shared report model so it serializes into `extraction-report.json` and `--json`. Keep it arcgis-agnostic (no import from `extract.arcgis`).
+
+**Files:**
+- Modify: `portolan_cli/extract/common/report.py`
+- Test: `tests/unit/extract/common/test_report.py` (create if absent, else append)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/extract/common/test_report.py  (append)
+import pytest
+from portolan_cli.extract.common.report import FolderCoverage
+
+
+@pytest.mark.unit
+def test_folder_coverage_roundtrip() -> None:
+    cov = FolderCoverage(
+        folders_visited=["A", "B"],
+        folders_skipped=[("Locked", "499 Token Required")],
+        services_found=5,
+    )
+    d = cov.to_dict()
+    assert d["folders_visited"] == ["A", "B"]
+    assert d["folders_skipped"] == [{"folder": "Locked", "reason": "499 Token Required"}]
+    assert d["services_found"] == 5
+    back = FolderCoverage.from_dict(d)
+    assert back == cov
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/common/test_report.py -k folder_coverage -v`
+Expected: FAIL (`FolderCoverage` missing).
+
+- [ ] **Step 3: Implement**
+
+Add to `common/report.py` (before `ExtractionReport`):
+
+```python
+@dataclass
+class FolderCoverage:
+    """Coverage of a recursive services-root traversal.
+
+    Attributes:
+        folders_visited: Folder names successfully traversed.
+        folders_skipped: (folder, reason) pairs for folders that errored.
+        services_found: Total services discovered.
+    """
+
+    folders_visited: list[str]
+    folders_skipped: list[tuple[str, str]]
+    services_found: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "folders_visited": self.folders_visited,
+            "folders_skipped": [{"folder": f, "reason": r} for f, r in self.folders_skipped],
+            "services_found": self.services_found,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FolderCoverage:
+        return cls(
+            folders_visited=data.get("folders_visited", []),
+            folders_skipped=[
+                (s["folder"], s["reason"]) for s in data.get("folders_skipped", [])
+            ],
+            services_found=data.get("services_found", 0),
+        )
+```
+
+Then add an optional field to `ExtractionReport` and wire it through its `to_dict`/`from_dict`. Locate the `ExtractionReport` dataclass and add:
+
+```python
+    folder_coverage: FolderCoverage | None = None
+```
+
+In `ExtractionReport.to_dict`, before `return result` (or equivalent), add:
+
+```python
+        if self.folder_coverage is not None:
+            result["folder_coverage"] = self.folder_coverage.to_dict()
+```
+
+In `ExtractionReport.from_dict`, add to the constructor kwargs:
+
+```python
+            folder_coverage=(
+                FolderCoverage.from_dict(data["folder_coverage"])
+                if data.get("folder_coverage")
+                else None
+            ),
+```
+
+NOTE: read the existing `ExtractionReport.to_dict`/`from_dict` first and match their exact construction style. `folder_coverage` must default to `None` so all existing `ExtractionReport(...)` call sites stay valid.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/common/test_report.py -k folder_coverage -v`
+Then full report suite: `uv run pytest tests/unit/extract/common/test_report.py -v`
+Expected: PASS, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/common/report.py tests/unit/extract/common/test_report.py
+git commit -m "feat(extract): FolderCoverage on extraction report (#493)"
+```
+
+---
+
+## Task 7: `list_services` recurses and reports coverage
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/orchestrator.py` (`ServicesRootDiscoveryResult`, `list_services`)
+- Test: `tests/unit/extract/arcgis/test_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/extract/arcgis/test_orchestrator.py  (append)
+import pytest
+from portolan_cli.extract.arcgis.discovery import FolderTraversal, ServiceInfo
+from portolan_cli.extract.arcgis.orchestrator import list_services
+
+
+@pytest.mark.unit
+def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:
+    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # noqa: ANN001
+        services = [
+            ServiceInfo("Top", "MapServer"),
+            ServiceInfo("NationalDatasets/Property", "MapServer"),
+        ]
+        traversal = FolderTraversal(
+            visited=["NationalDatasets"], skipped=[("Locked", "499")], service_count=2
+        )
+        return services, traversal
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
+    )
+    result = list_services("https://x/rest/services")
+    names = [s.name for s in result.services]
+    assert "NationalDatasets/Property" in names
+    assert result.coverage is not None
+    assert result.coverage.folders_visited == ["NationalDatasets"]
+    assert result.coverage.folders_skipped == [("Locked", "499")]
+    d = result.to_dict()
+    assert d["folder_coverage"]["folders_skipped"] == [{"folder": "Locked", "reason": "499"}]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k list_services_recurses -v`
+Expected: FAIL (no `coverage` attribute; `list_services` still uses old discovery).
+
+- [ ] **Step 3: Implement**
+
+In `orchestrator.py` imports, add `discover_services_recursive`, `FolderTraversal`, and `FolderCoverage`:
+
+```python
+from portolan_cli.extract.arcgis.discovery import (
+    FolderTraversal,
+    LayerInfo,
+    ServiceDiscoveryResult,
+    ServiceInfo,
+    discover_layers,
+    discover_services,
+    discover_services_recursive,
+)
+...
+from portolan_cli.extract.common.report import (
+    ExtractionReport,
+    ExtractionSummary,
+    FolderCoverage,
+    LayerResult,
+    MetadataExtracted,
+    load_report,
+    save_report,
+)
+```
+
+Add a converter helper near the top of the module:
+
+```python
+def _coverage_from_traversal(traversal: FolderTraversal) -> FolderCoverage:
+    """Map a discovery FolderTraversal to a serializable FolderCoverage."""
+    return FolderCoverage(
+        folders_visited=traversal.visited,
+        folders_skipped=traversal.skipped,
+        services_found=traversal.service_count,
+    )
+```
+
+Extend `ServicesRootDiscoveryResult`:
+
+```python
+@dataclass
+class ServicesRootDiscoveryResult:
+    services: list[ServiceInfo]
+    folders: list[str]
+    base_url: str
+    coverage: FolderCoverage | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = {
+            "base_url": self.base_url,
+            "services": [
+                {"name": s.name, "type": s.service_type, "url": s.get_url(self.base_url)}
+                for s in self.services
+            ],
+            "folders": self.folders,
+            "total_services": len(self.services),
+        }
+        if self.coverage is not None:
+            result["folder_coverage"] = self.coverage.to_dict()
+        return result
+```
+
+Rewrite `list_services` to recurse (add `token` and `recurse` params):
+
+```python
+def list_services(
+    url: str,
+    *,
+    service_types: Sequence[str] | None = None,
+    service_filter: list[str] | None = None,
+    token: str | None = None,
+    recurse: bool = True,
+    timeout: float = 60.0,
+) -> ServicesRootDiscoveryResult:
+    """List services from an ArcGIS services root or folder URL.
+
+    Recurses into folders by default. Folders that error are skipped and
+    recorded in the returned coverage.
+    """
+    from portolan_cli.extract.arcgis.filters import filter_services
+
+    parsed = parse_arcgis_url(url)
+    if parsed.url_type not in (ArcGISURLType.SERVICES_ROOT, ArcGISURLType.SERVICES_FOLDER):
+        msg = f"URL is not a services root or folder URL: {url}"
+        raise ValueError(msg)
+
+    if recurse:
+        services, traversal = discover_services_recursive(
+            url,
+            service_types=list(service_types) if service_types else None,
+            token=token,
+            timeout=timeout,
+        )
+        coverage: FolderCoverage | None = _coverage_from_traversal(traversal)
+        folders = traversal.visited
+    else:
+        services, folders = discover_services(
+            url, service_types=list(service_types) if service_types else None,
+            return_folders=True, timeout=timeout,
+        )
+        coverage = None
+
+    if service_filter:
+        service_names = [s.name for s in services]
+        filtered_names = filter_services(service_names, include=service_filter, case_sensitive=False)
+        services = [s for s in services if s.name in filtered_names]
+
+    return ServicesRootDiscoveryResult(
+        services=services,
+        folders=folders,
+        base_url=parsed.base_url,
+        coverage=coverage,
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k list_services -v`
+Expected: PASS. Re-run existing orchestrator tests, fix any that asserted the old `list_services` discovery path (update their mocks to patch `discover_services_recursive`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/orchestrator.py tests/unit/extract/arcgis/test_orchestrator.py
+git commit -m "feat(extract): list_services recurses folders and reports coverage (#493)"
+```
+
+---
+
+## Task 8: `_discover_and_filter_services` recurses, supports folder scoping and token
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/orchestrator.py` (`_discover_and_filter_services`)
+- Test: `tests/unit/extract/arcgis/test_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/extract/arcgis/test_orchestrator.py  (append)
+from portolan_cli.extract.arcgis.orchestrator import _discover_and_filter_services
+
+
+@pytest.mark.unit
+def test_discover_and_filter_scopes_to_folder(monkeypatch) -> None:
+    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # noqa: ANN001
+        services = [
+            ServiceInfo("ecml/active_faults", "MapServer"),
+            ServiceInfo("water/rivers", "MapServer"),
+        ]
+        return services, FolderTraversal(visited=["ecml", "water"], skipped=[], service_count=2)
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
+    )
+    services, coverage = _discover_and_filter_services(
+        "https://x/rest/services", None, None, 60.0, token=None, folder="ecml"
+    )
+    assert [s.name for s in services] == ["ecml/active_faults"]
+    assert coverage is not None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k scopes_to_folder -v`
+Expected: FAIL (signature mismatch, returns a list not a tuple, no folder scoping).
+
+- [ ] **Step 3: Implement**
+
+Replace `_discover_and_filter_services`:
+
+```python
+def _discover_and_filter_services(
+    url: str,
+    service_filter: list[str] | None,
+    service_exclude: list[str] | None,
+    timeout: float,
+    *,
+    token: str | None = None,
+    folder: str | None = None,
+) -> tuple[list[ServiceInfo], FolderCoverage]:
+    """Discover services recursively, scope to a folder, and apply filters.
+
+    Returns (services, coverage). When folder is set (SERVICES_FOLDER URL), only
+    services under that folder prefix are kept.
+    """
+    from portolan_cli.extract.arcgis.filters import filter_services
+
+    services, traversal = discover_services_recursive(
+        url,
+        service_types=["FeatureServer", "MapServer"],
+        token=token,
+        timeout=timeout,
+    )
+
+    if folder:
+        prefix = f"{folder.rstrip('/')}/"
+        services = [s for s in services if s.name.startswith(prefix)]
+
+    if service_filter or service_exclude:
+        service_names = [s.name for s in services]
+        filtered_names = filter_services(
+            service_names, include=service_filter, exclude=service_exclude, case_sensitive=False
+        )
+        services = [s for s in services if s.name in filtered_names]
+
+    return services, _coverage_from_traversal(traversal)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k scopes_to_folder -v`
+Expected: PASS. (Callers are updated in Task 10; the suite may show `_extract_services_root` call-site type errors until then, which is expected.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/orchestrator.py tests/unit/extract/arcgis/test_orchestrator.py
+git commit -m "feat(extract): recursive service discovery with folder scoping (#493)"
+```
+
+---
+
+## Task 9: Nested-by-folder output paths
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/orchestrator.py` (`_extract_services_root`, path building ~966-986)
+- Test: `tests/unit/extract/arcgis/test_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/extract/arcgis/test_orchestrator.py  (append)
+from portolan_cli.extract.arcgis.orchestrator import _service_output_dir
+
+
+@pytest.mark.unit
+def test_service_output_dir_nests_folders(tmp_path) -> None:
+    # qualified single/multi-segment names -> nested slugified dirs
+    assert _service_output_dir(tmp_path, "ecml/active_faults") == tmp_path / "ecml" / "active_faults"
+    assert _service_output_dir(tmp_path, "Top") == tmp_path / "top"
+    assert (
+        _service_output_dir(tmp_path, "RDH_hazard/Flood Risk")
+        == tmp_path / "rdh_hazard" / "flood_risk"
+    )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k service_output_dir -v`
+Expected: FAIL (`_service_output_dir` not defined).
+
+- [ ] **Step 3: Implement**
+
+Add the helper near `_slugify`:
+
+```python
+def _service_output_dir(output_dir: Path, service_name: str) -> Path:
+    """Map a (possibly folder-qualified) service name to a nested directory.
+
+    "ecml/active_faults" -> output_dir/ecml/active_faults
+    "Top"                -> output_dir/top
+    Each path segment is slugified independently so the folder hierarchy is
+    preserved as nested subcatalogs (ADR-0032, ADR-0053).
+    """
+    parts = [_slugify(p) for p in service_name.split("/") if p]
+    result = output_dir
+    for part in parts:
+        result = result / part
+    return result
+```
+
+Then in `_extract_services_root`, replace the slug/path block (currently):
+
+```python
+        service_slug = _slugify(service.name)
+        layer_slug = _slugify(layer.name)
+        ...
+        is_single_layer = layer_count_per_service.get(service.name, 0) == 1
+        service_dir = output_dir / service_slug
+
+        if is_single_layer:
+            output_path = service_dir / f"{service_slug}.parquet"
+        else:
+            collection_dir = service_dir / layer_slug
+            output_path = collection_dir / f"{layer_slug}.parquet"
+```
+
+with:
+
+```python
+        layer_slug = _slugify(layer.name)
+        service_dir = _service_output_dir(output_dir, service.name)
+        service_leaf_slug = service_dir.name
+
+        is_single_layer = layer_count_per_service.get(service.name, 0) == 1
+
+        if is_single_layer:
+            output_path = service_dir / f"{service_leaf_slug}.parquet"
+        else:
+            collection_dir = service_dir / layer_slug
+            output_path = collection_dir / f"{layer_slug}.parquet"
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k service_output_dir -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/orchestrator.py tests/unit/extract/arcgis/test_orchestrator.py
+git commit -m "feat(extract): nest folder-qualified services as subcatalogs (#493)"
+```
+
+---
+
+## Task 10: Route folder URLs, thread auth/coverage through `_extract_services_root` and `extract_arcgis_catalog`
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/orchestrator.py` (`ExtractionOptions`, `_extract_services_root`, `extract_arcgis_catalog`)
+- Test: `tests/unit/extract/arcgis/test_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/extract/arcgis/test_orchestrator.py  (append)
+from pathlib import Path
+from portolan_cli.extract.arcgis.orchestrator import (
+    ExtractionOptions,
+    extract_arcgis_catalog,
+)
+
+
+@pytest.mark.unit
+def test_extract_routes_folder_url_and_attaches_coverage(monkeypatch, tmp_path) -> None:
+    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # noqa: ANN001
+        return (
+            [ServiceInfo("ecml/active_faults", "MapServer")],
+            FolderTraversal(visited=["ecml"], skipped=[], service_count=1),
+        )
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
+    )
+    # No layers discovered -> dry_run avoids real extraction
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator._collect_layers_from_services",
+        lambda services, base_url, timeout: ([], {}, {}, []),
+    )
+    report = extract_arcgis_catalog(
+        url="https://x/server/rest/services/ecml",
+        output_dir=tmp_path / "out",
+        options=ExtractionOptions(dry_run=True),
+    )
+    assert report.folder_coverage is not None
+    assert report.folder_coverage.folders_visited == ["ecml"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k routes_folder_url -v`
+Expected: FAIL (SERVICES_FOLDER not routed; report has no coverage).
+
+- [ ] **Step 3: Implement**
+
+1. Add auth/recurse fields to `ExtractionOptions`:
+
+```python
+@dataclass
+class ExtractionOptions:
+    workers: int = 3
+    retries: int = 3
+    timeout: float = 60.0
+    resume: bool = False
+    raw: bool = False
+    dry_run: bool = False
+    sort_hilbert: bool = True
+    token: str | None = None
+    recurse: bool = True
+```
+
+2. In `extract_arcgis_catalog`, route folder URLs to the services-root path:
+
+```python
+    # Handle services root and folder-scoped URLs
+    if parsed.url_type in (ArcGISURLType.SERVICES_ROOT, ArcGISURLType.SERVICES_FOLDER):
+        return _extract_services_root(
+            url=url,
+            parsed=parsed,
+            output_dir=output_dir,
+            layer_filter=layer_filter,
+            layer_exclude=layer_exclude,
+            service_filter=service_filter,
+            service_exclude=service_exclude,
+            options=options,
+            on_progress=on_progress,
+        )
+```
+
+3. In `_extract_services_root`, capture coverage, pass token/folder, and attach coverage to BOTH the dry-run and final reports. Update the discovery call:
+
+```python
+    # Discover and filter services (recursive, folder-scoped, auth-aware)
+    services, coverage = _discover_and_filter_services(
+        url,
+        service_filter,
+        service_exclude,
+        options.timeout,
+        token=options.token,
+        folder=parsed.folder,
+    )
+```
+
+Then where the dry-run report is built, set coverage before returning:
+
+```python
+        dry_report = _build_report(
+            url=url, discovery_result=combined_discovery, layer_results=dry_run_results
+        )
+        dry_report.folder_coverage = coverage
+        return dry_report
+```
+
+And for the final report, before `save_report`:
+
+```python
+    report = _build_report(
+        url=url, discovery_result=combined_discovery, layer_results=layer_results
+    )
+    report.folder_coverage = coverage
+    report_path = output_dir / ".portolan" / "extraction-report.json"
+    save_report(report, report_path)
+```
+
+(Replace the existing un-attributed `report = _build_report(...)` block with the version above.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k routes_folder_url -v`
+Then the full orchestrator suite: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -v`
+Expected: PASS. Fix any older tests still asserting the previous (non-recursive, list-returning) `_discover_and_filter_services` shape.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/orchestrator.py tests/unit/extract/arcgis/test_orchestrator.py
+git commit -m "feat(extract): route folder URLs, thread auth + coverage through extraction (#493)"
+```
+
+---
+
+## Task 11: Pass token into `gpio.extract_arcgis` (feature-detected)
+
+**Files:**
+- Modify: `portolan_cli/extract/arcgis/orchestrator.py` (`_extract_single_layer`, ~234-264)
+- Test: `tests/unit/extract/arcgis/test_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/extract/arcgis/test_orchestrator.py  (append)
+import sys
+import types
+from portolan_cli.extract.arcgis.discovery import LayerInfo
+from portolan_cli.extract.arcgis.orchestrator import ExtractionOptions, _extract_single_layer
+
+
+@pytest.mark.unit
+def test_extract_single_layer_passes_token(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_extract_arcgis(url, max_workers=None, token=None):  # noqa: ANN001
+        captured["token"] = token
+
+        class _T:
+            def to_parquet(self, path, **kwargs):  # noqa: ANN001, ANN002
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_bytes(b"PAR1")
+
+            num_rows = 1
+
+        return _T()
+
+    fake_gpio = types.ModuleType("geoparquet_io")
+    fake_gpio.extract_arcgis = fake_extract_arcgis  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "geoparquet_io", fake_gpio)
+
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        tmp_path / "out.parquet",
+        ExtractionOptions(token="TKN", sort_hilbert=False),
+    )
+    assert captured["token"] == "TKN"
+```
+
+NOTE: align the fake's `to_parquet`/`num_rows`/return-shape with the real `_extract_single_layer` body. Read lines ~254-300 first and mirror exactly what it calls on the returned table; adjust the fake accordingly so the test exercises only the token-passing branch.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k passes_token -v`
+Expected: FAIL (token never forwarded).
+
+- [ ] **Step 3: Implement**
+
+In `_extract_single_layer`, extend the existing `inspect.signature` feature-detection to include `token`:
+
+```python
+    sig = inspect.signature(gpio.extract_arcgis)
+    kwargs: dict[str, object] = {}
+    if "max_workers" in sig.parameters:
+        kwargs["max_workers"] = options.workers
+    if options.token and "token" in sig.parameters:
+        kwargs["token"] = options.token
+    table = gpio.extract_arcgis(layer_url, **kwargs)
+```
+
+(Replace the current `if "max_workers" in sig.parameters: ... else: table = gpio.extract_arcgis(layer_url)` block with the kwargs form above, preserving the rest of the function.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/extract/arcgis/test_orchestrator.py -k passes_token -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/extract/arcgis/orchestrator.py tests/unit/extract/arcgis/test_orchestrator.py
+git commit -m "feat(extract): forward ArcGIS token to gpio.extract_arcgis (#493)"
+```
+
+---
+
+## Task 12: CLI flags, credentials, folder URLs, coverage rendering
+
+**Files:**
+- Modify: `portolan_cli/cli.py` (`extract arcgis` options + `extract_arcgis_cmd` + `_handle_list_services_mode`)
+- Test: `tests/unit/test_cli_extract_arcgis.py` (create if absent, else the existing CLI extract test module)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_cli_extract_arcgis.py  (append/create)
+import pytest
+from click.testing import CliRunner
+from portolan_cli.cli import cli
+
+
+@pytest.mark.unit
+def test_extract_arcgis_has_auth_and_recurse_flags() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "arcgis", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--token", "--username", "--password", "--no-recurse"):
+        assert flag in result.output
+
+
+@pytest.mark.unit
+def test_list_services_accepts_folder_url(monkeypatch) -> None:
+    from portolan_cli.extract.arcgis.discovery import ServiceInfo
+    from portolan_cli.extract.common.report import FolderCoverage
+    from portolan_cli.extract.arcgis.orchestrator import ServicesRootDiscoveryResult
+
+    def fake_list_services(url, *, service_filter=None, token=None, recurse=True, timeout=60.0):  # noqa: ANN001
+        return ServicesRootDiscoveryResult(
+            services=[ServiceInfo("ecml/active_faults", "MapServer")],
+            folders=["ecml"],
+            base_url="https://x/server/rest/services",
+            coverage=FolderCoverage(folders_visited=["ecml"], folders_skipped=[("Locked", "499")], services_found=1),
+        )
+
+    monkeypatch.setattr("portolan_cli.extract.arcgis.orchestrator.list_services", fake_list_services)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["extract", "arcgis", "https://x/server/rest/services/ecml", "--list-services"]
+    )
+    assert result.exit_code == 0
+    assert "ecml/active_faults" in result.output
+    assert "skipped" in result.output.lower()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `uv run pytest tests/unit/test_cli_extract_arcgis.py -v`
+Expected: FAIL (flags absent; `--list-services` rejects folder URL).
+
+- [ ] **Step 3: Implement**
+
+1. Add options to the `extract arcgis` command (next to `--exclude-services`/`--list-services`):
+
+```python
+@click.option("--token", default=None, help="ArcGIS token (or set ARCGIS_TOKEN). For secured services/folders.")
+@click.option("--username", default=None, help="ArcGIS username (mints a token via generateToken).")
+@click.option("--password", default=None, help="ArcGIS password (used with --username).")
+@click.option(
+    "--no-recurse",
+    "no_recurse",
+    is_flag=True,
+    help="Do not traverse folders for services-root URLs (default: recurse).",
+)
+```
+
+2. Add the matching params to `extract_arcgis_cmd` signature: `token: str | None`, `username: str | None`, `password: str | None`, `no_recurse: bool`.
+
+3. Near the top of the function body, build credentials (precedence: `--token` > `--username/--password` > `ARCGIS_TOKEN` env):
+
+```python
+    import os
+    from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
+
+    creds = ArcGISCredentials(
+        token=token or os.environ.get("ARCGIS_TOKEN"),
+        username=username,
+        password=password,
+    )
+    try:
+        resolved_token = resolve_token(creds, url, timeout=timeout) if not creds.is_empty else None
+    except Exception as e:  # ArcGISAuthError and transport errors
+        _output_extract_error(use_json, type(e).__name__, str(e), url)
+        raise SystemExit(1) from None
+```
+
+4. Update the `--list-services` guard to allow folder URLs and pass token/recurse:
+
+```python
+    if list_services:
+        if parsed.url_type not in (ArcGISURLType.SERVICES_ROOT, ArcGISURLType.SERVICES_FOLDER):
+            _output_extract_error(
+                use_json,
+                "InvalidURLError",
+                "--list-services requires a services root or folder URL",
+                url,
+            )
+            raise SystemExit(1)
+        service_filter = _parse_filter_patterns(services)
+        _handle_list_services_mode(
+            url, service_filter, timeout, use_json, token=resolved_token, recurse=not no_recurse
+        )
+        return
+```
+
+5. Update default output dir to also cover `SERVICES_FOLDER`:
+
+```python
+    if output_dir is None:
+        if parsed.url_type == ArcGISURLType.SERVICES_ROOT:
+            output_dir = Path("services_extract")
+        elif parsed.url_type == ArcGISURLType.SERVICES_FOLDER:
+            output_dir = Path((parsed.folder or "services_extract").replace("/", "_").lower())
+        else:
+            service_name = parsed.service_name or "arcgis_extract"
+            output_dir = Path(service_name.replace("/", "_").lower())
+```
+
+6. Set token/recurse on the options object:
+
+```python
+    options = ExtractionOptions(
+        workers=workers,
+        retries=retries,
+        timeout=timeout,
+        resume=resume,
+        dry_run=dry_run,
+        raw=raw,
+        token=resolved_token,
+        recurse=not no_recurse,
+    )
+```
+
+7. Update `_handle_list_services_mode` to accept and forward token/recurse, and render coverage:
+
+```python
+def _handle_list_services_mode(
+    url: str,
+    service_filter: list[str] | None,
+    timeout: float,
+    use_json: bool,
+    *,
+    token: str | None = None,
+    recurse: bool = True,
+) -> None:
+    """Handle --list-services mode: list available services and exit."""
+    from portolan_cli.extract.arcgis.orchestrator import list_services as list_services_func
+
+    try:
+        result = list_services_func(
+            url, service_filter=service_filter, token=token, recurse=recurse, timeout=timeout
+        )
+    except Exception as e:
+        _output_extract_error(use_json, type(e).__name__, str(e), url)
+        raise SystemExit(1) from None
+
+    if use_json:
+        click.echo(json.dumps(result.to_dict(), indent=2))
+        return
+
+    click.echo(f"Services at {url}:")
+    click.echo()
+    for svc in result.services:
+        click.echo(f"  • {svc.name} ({svc.service_type})")
+    click.echo()
+    click.echo(f"Total: {len(result.services)} services")
+    if result.coverage is not None:
+        cov = result.coverage
+        click.echo(
+            f"Folders traversed: {len(cov.folders_visited)}, skipped: {len(cov.folders_skipped)}"
+        )
+        for folder, reason in cov.folders_skipped:
+            click.echo(f"  ⚠ skipped {folder}: {reason}")
+    elif result.folders:
+        click.echo(f"Folders: {', '.join(result.folders)}")
+```
+
+8. Render coverage in the extraction summary. In `_output_extract_result` (find it in cli.py), after the existing summary lines and only for text output, add:
+
+```python
+    coverage = getattr(report, "folder_coverage", None)
+    if coverage is not None and not use_json:
+        from portolan_cli.output import info, warn
+
+        info(
+            f"Folders traversed: {len(coverage.folders_visited)}, "
+            f"skipped: {len(coverage.folders_skipped)}, "
+            f"services found: {coverage.services_found}"
+        )
+        for folder, reason in coverage.folders_skipped:
+            warn(f"Skipped folder {folder}: {reason}")
+```
+
+(Read `_output_extract_result`'s exact signature first; it already receives `report` and a json flag, reuse those names.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/test_cli_extract_arcgis.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portolan_cli/cli.py tests/unit/test_cli_extract_arcgis.py
+git commit -m "feat(cli): arcgis auth flags, folder URLs in --list-services, coverage output (#493)"
+```
+
+---
+
+## Task 13: Filter behavior on folder-qualified names (tests + docs)
+
+Filters already match qualified names via `fnmatch`; lock it with a test and document it.
+
+**Files:**
+- Test: `tests/unit/extract/common/test_filters.py` (append) or `tests/unit/extract/arcgis/test_filters.py`
+- Modify: `docs/` ArcGIS extract reference if present (grep first), else skip the doc edit and note it in the ADR.
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/unit/extract/common/test_filters.py  (append)
+import pytest
+from portolan_cli.extract.common.filters import filter_services
+
+
+@pytest.mark.unit
+def test_filter_matches_folder_qualified_names() -> None:
+    names = ["ecml/active_faults", "ecml/airports_v2", "water/rivers", "Top"]
+    assert filter_services(names, include=["ecml/*"]) == ["ecml/active_faults", "ecml/airports_v2"]
+    assert filter_services(names, exclude=["water/*"]) == [
+        "ecml/active_faults", "ecml/airports_v2", "Top",
+    ]
+```
+
+- [ ] **Step 2: Run to verify it passes immediately (documents existing behavior)**
+
+Run: `uv run pytest tests/unit/extract/common/test_filters.py -k folder_qualified -v`
+Expected: PASS (no code change needed). If it FAILS, fnmatch handling differs from assumption, investigate before proceeding.
+
+- [ ] **Step 3: Docs**
+
+Run `grep -ril "extract arcgis" docs/` to find the reference page. If found, add a short note that `--services`/`--exclude-services` patterns match folder-qualified names (e.g. `--services "ecml/*"`). If no page exists, record the behavior in ADR-0053 (Task 14) instead.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/extract/common/test_filters.py docs/ 2>/dev/null
+git commit -m "test(extract): filters match folder-qualified service names; document (#493)"
+```
+
+---
+
+## Task 14: ADR-0053 and CLAUDE.md index
+
+**Files:**
+- Create: `context/shared/adr/0053-arcgis-folder-recursion-and-structure.md`
+- Modify: `CLAUDE.md` (ADR Index table)
+
+- [ ] **Step 1: Write the ADR**
+
+```markdown
+# ADR-0053: ArcGIS folder recursion and nested-folder catalog structure
+
+## Status
+Adopted
+
+## Context
+`portolan extract arcgis` against a services root only discovered top-level
+services, silently skipping every service nested in an ArcGIS Server folder, and
+rejected folder URLs. ArcGIS Enterprise and federated servers organize services
+into folders (some put ALL services in folders), so services-root extraction was
+unusable against them. See issue #493.
+
+## Decision
+1. Services-root extraction recurses into folders by default. ArcGIS returns
+   folder-qualified service names (e.g. `NationalDatasets/Property`), so URL
+   construction and glob filters work unchanged. `--no-recurse` opts out.
+2. Folders that error or require a token are logged as warnings and skipped, the
+   run never aborts. Coverage (folders traversed/skipped, services found) is
+   recorded on the extraction report and printed.
+3. Folder URLs (`.../rest/services/<folder>`) parse as a new `SERVICES_FOLDER`
+   type, scoped to that folder, with the base URL normalized to the true
+   services root.
+4. Token-secured folders/services are reachable when the user supplies a token
+   (`--token`/`ARCGIS_TOKEN`) or username/password (minted via `generateToken`).
+   This is a contained pass-through; the full auth design remains issue #311.
+5. Folders map to nested subcatalogs, each folder segment becomes a slugified
+   subcatalog directory and the service becomes a collection (single layer) or
+   subcatalog (multi layer), consistent with ADR-0032 (nested catalogs for
+   hierarchy). `--services`/`--exclude-services` match folder-qualified names.
+
+## Consequences
+- Enterprise/federated catalogs extract completely by default.
+- Catalog trees gain a folder tier; deeper nesting for multi-layer services.
+- Slug collisions are possible for names differing only by stripped characters
+  (e.g. `türkiye` vs `turkiye`), accepted for now, not mitigated.
+- ImageServer-in-folder extraction and the full auth module are out of scope
+  (issue #311).
+
+## Related
+Issues #493, #6, #492, #358, #311. Supersedes nothing. Builds on ADR-0032,
+ADR-0048, ADR-0007.
+```
+
+- [ ] **Step 2: Register in CLAUDE.md**
+
+Add this row to the ADR Index table in `CLAUDE.md`, after the ADR-0052 row:
+
+```markdown
+| [0053](context/shared/adr/0053-arcgis-folder-recursion-and-structure.md) | ArcGIS folder recursion (default-on), folder URLs, token auth pass-through, nested-folder subcatalogs |
+```
+
+- [ ] **Step 3: Validate CLAUDE.md if a validator exists**
+
+Run: `uv run python scripts/validate_claude_md.py` (if present)
+Expected: PASS. If the script does not exist, skip.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add context/shared/adr/0053-arcgis-folder-recursion-and-structure.md CLAUDE.md
+git commit -m "docs(adr): ADR-0053 ArcGIS folder recursion and structure (#493)"
+```
+
+---
+
+## Task 15: Integration tests against real servers (network-marked)
+
+**Files:**
+- Modify: `tests/integration/extract/arcgis/test_orchestrator_live.py`
+
+- [ ] **Step 1: Write the tests**
+
+```python
+# tests/integration/extract/arcgis/test_orchestrator_live.py  (append)
+import pytest
+from portolan_cli.extract.arcgis.orchestrator import list_services
+
+SA_ROOT = "https://nspdr.dlrrd.gov.za/server/rest/services"
+JRC_ROOT = "https://arcgis-maps.jrc.ec.europa.eu/federated_server/rest/services"
+
+
+@pytest.mark.network
+@pytest.mark.slow
+def test_sa_root_traverses_folders() -> None:
+    result = list_services(SA_ROOT, timeout=60.0)
+    names = [s.name for s in result.services]
+    # NationalDatasets services live in a folder; recursion must surface them
+    assert any(n.startswith("NationalDatasets/") for n in names)
+    assert result.coverage is not None
+    assert "NationalDatasets" in result.coverage.folders_visited
+
+
+@pytest.mark.network
+@pytest.mark.slow
+def test_jrc_root_has_only_folder_services() -> None:
+    # JRC root has ZERO top-level services; everything is in folders.
+    result = list_services(JRC_ROOT, timeout=60.0)
+    assert len(result.services) > 0
+    assert all("/" in s.name for s in result.services)
+```
+
+- [ ] **Step 2: Run (network)**
+
+Run: `uv run pytest tests/integration/extract/arcgis/test_orchestrator_live.py -k "sa_root or jrc_root" -m network -v`
+Expected: PASS when online. These are `network`-marked, so they are excluded from the default unit run and gated to nightly CI.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/extract/arcgis/test_orchestrator_live.py
+git commit -m "test(extract): live folder-recursion tests for SA and JRC roots (#493)"
+```
+
+---
+
+## Task 16: Full verification gate
+
+- [ ] **Step 1: Run the arcgis unit + integration (non-network) suites**
+
+Run: `uv run pytest tests/unit/extract/arcgis tests/unit/extract/common tests/integration/extract/arcgis -m "not network and not slow" -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Lint, format, types, imports**
+
+Run:
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy portolan_cli
+uv run lint-imports
+```
+Expected: clean. Fix any issues (the new `auth.py` and `discovery.py` changes must satisfy `mypy --strict`).
+
+- [ ] **Step 3: Quick manual smoke (network, optional)**
+
+Run:
+```bash
+uv run portolan extract arcgis "https://arcgis-maps.jrc.ec.europa.eu/federated_server/rest/services" --list-services
+```
+Expected: non-empty list of folder-qualified services, plus a "Folders traversed/skipped" line.
+
+- [ ] **Step 4: Final commit if any fixups were needed**
+
+```bash
+git add -A
+git commit -m "chore(extract): lint/type fixups for folder recursion (#493)"
+```
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** Task 3 = recursion; Task 4 + 11 + 12 = auth (token + username/password, threaded to discovery and gpio); Task 2 + 3 = graceful skip; Task 5 = folder URLs; Task 9 = nested structure; Task 6 + 7 + 10 + 12 = coverage reporting; Task 13 = filter on qualified names; Task 14 = ADR. All five issue points plus the auth refinement are covered.
+- **Type consistency:** `FolderTraversal` (discovery) is converted to `FolderCoverage` (report) only via `_coverage_from_traversal`. `discover_services_recursive` always returns `(list[ServiceInfo], FolderTraversal)`. `_discover_and_filter_services` returns `(list[ServiceInfo], FolderCoverage)`. `ExtractionOptions.token`/`.recurse` are the single source of auth/recurse state inside the orchestrator.
+- **Order dependency:** Tasks 7, 8, 10 touch overlapping orchestrator regions, run them in order. Task 8 leaves callers temporarily mismatched until Task 10, this is called out in Task 8 Step 4.
+- **Existing tests:** Tasks 7 and 10 explicitly require updating older orchestrator tests that assumed the non-recursive discovery shape. Patch their mocks to `discover_services_recursive`.
+```

--- a/context/shared/plans/2026-06-09-arcgis-folder-recursion-plan.md
+++ b/context/shared/plans/2026-06-09-arcgis-folder-recursion-plan.md
@@ -367,7 +367,9 @@ def discover_services_recursive(
         visited.append(folder)
         services.extend(_build_service_list(folder_data, service_types))
         for sub in folder_data.get("folders", []):
-            queue.append((sub, depth + 1))
+            # Enqueue the full folder path so nested fetch URLs stay correct
+            # (<root>/<parent>/<sub>, not <root>/<sub>).
+            queue.append((f"{folder}/{sub}", depth + 1))
 
     traversal = FolderTraversal(
         visited=visited, skipped=skipped, service_count=len(services)

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -371,6 +371,8 @@ portolan extract arcgis URL --services "Census*,Transport*"
 portolan extract arcgis URL --exclude-services "*_Archive,*_Test"
 ```
 
+Patterns use fnmatch, and `*` spans `/`, so they work naturally with folder-qualified service names produced when extracting from a services root that contains ArcGIS folders. For example, `--services "ecml/*"` selects every service inside the `ecml` folder, and `--services "*faults*"` matches `ecml/active_faults` too.
+
 ### Output Structure
 
 Services root extraction creates a nested catalog structure. **Single-layer services are flattened** to avoid redundant nesting:

--- a/docs/guides/extract-arcgis.md
+++ b/docs/guides/extract-arcgis.md
@@ -361,6 +361,70 @@ portolan extract arcgis \
   ./output --services "Census*,Demographics*"
 ```
 
+### Folder Recursion
+
+By default, Portolan **recursively traverses ArcGIS Server folders** when you point it at a services root. Services inside folders are discovered automatically and appear with folder-qualified names such as `NationalDatasets/Property`.
+
+```bash
+# Default: recurse into all folders (services root URL)
+portolan extract arcgis https://gis.example.com/arcgis/rest/services ./output
+
+# Disable folder traversal (only top-level services)
+portolan extract arcgis https://gis.example.com/arcgis/rest/services ./output --no-recurse
+```
+
+To extract only a single folder, point at the folder URL directly:
+
+```bash
+portolan extract arcgis \
+  https://gis.example.com/arcgis/rest/services/NationalDatasets \
+  ./output
+```
+
+Folders map to nested subcatalogs in the output: each folder segment becomes a subcatalog directory containing the services discovered inside it.
+
+### Authentication
+
+For secured services or folders, supply credentials with one of these options (listed in precedence order, highest first):
+
+- `--token <TOKEN>`: pass an ArcGIS token directly
+- `--username <U> --password <P>`: Portolan mints a token via the server's `generateToken` endpoint
+- `ARCGIS_TOKEN` environment variable: token read from the environment
+
+```bash
+# Token flag
+portolan extract arcgis URL ./output --token "eyJ..."
+
+# Username and password (token is minted automatically)
+portolan extract arcgis URL ./output --username myuser --password mypass
+
+# Environment variable
+ARCGIS_TOKEN="eyJ..." portolan extract arcgis URL ./output
+```
+
+Secured folders that cannot be accessed (for example, a 499 Token Required response) are **skipped with a warning**, not a fatal error. The extraction continues with any accessible services.
+
+### Coverage Report
+
+After a services-root extraction (or when using `--list-services`), Portolan reports folder traversal statistics: how many folders were visited, how many were skipped, and how many services were found.
+
+```bash
+portolan extract arcgis https://gis.example.com/arcgis/rest/services ./output --list-services
+# Output includes: folders visited, folders skipped (with reason), total services found
+```
+
+With `--json`, the coverage appears as a `folder_coverage` key in the JSON output:
+
+```json
+{
+  "folder_coverage": {
+    "folders_visited": ["NationalDatasets", "Boundaries"],
+    "folders_skipped": [{"folder": "Restricted", "reason": "499 Token Required"}],
+    "services_found": 14
+  }
+}
+```
+
 ### Filtering Services
 
 ```bash

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -6079,27 +6079,40 @@ def _handle_list_services_mode(
     service_filter: list[str] | None,
     timeout: float,
     use_json: bool,
+    *,
+    token: str | None = None,
+    recurse: bool = True,
 ) -> None:
     """Handle --list-services mode: list available services and exit."""
     from portolan_cli.extract.arcgis.orchestrator import list_services as list_services_func
 
     try:
-        result = list_services_func(url, service_filter=service_filter, timeout=timeout)
+        result = list_services_func(
+            url, service_filter=service_filter, token=token, recurse=recurse, timeout=timeout
+        )
     except Exception as e:
         _output_extract_error(use_json, type(e).__name__, str(e), url)
         raise SystemExit(1) from None
 
     if use_json:
         click.echo(json.dumps(result.to_dict(), indent=2))
-    else:
-        click.echo(f"Services at {url}:")
-        click.echo()
-        for svc in result.services:
-            click.echo(f"  • {svc.name} ({svc.service_type})")
-        click.echo()
-        click.echo(f"Total: {len(result.services)} services")
-        if result.folders:
-            click.echo(f"Folders: {', '.join(result.folders)}")
+        return
+
+    click.echo(f"Services at {url}:")
+    click.echo()
+    for svc in result.services:
+        click.echo(f"  • {svc.name} ({svc.service_type})")
+    click.echo()
+    click.echo(f"Total: {len(result.services)} services")
+    if result.coverage is not None:
+        cov = result.coverage
+        click.echo(
+            f"Folders traversed: {len(cov.folders_visited)}, skipped: {len(cov.folders_skipped)}"
+        )
+        for folder, reason in cov.folders_skipped:
+            click.echo(f"  ⚠ skipped {folder}: {reason}")
+    elif result.folders:
+        click.echo(f"Folders: {', '.join(result.folders)}")
 
 
 def _validate_collection_name_cli(
@@ -6315,6 +6328,10 @@ def _output_extract_result(
             ],
         }
 
+        coverage = getattr(report, "folder_coverage", None)
+        if coverage is not None:
+            data["folder_coverage"] = coverage.to_dict()
+
         if report.summary.failed > 0:
             # Emit error envelope for partial failures
             failed_layers = [
@@ -6373,6 +6390,16 @@ def _output_extract_result(
     info_output(f"Output: {output_dir}")
     info_output(f"Report: {output_dir}/.portolan/extraction-report.json")
 
+    coverage = getattr(report, "folder_coverage", None)
+    if coverage is not None:
+        info_output(
+            f"Folders traversed: {len(coverage.folders_visited)}, "
+            f"skipped: {len(coverage.folders_skipped)}, "
+            f"services found: {coverage.services_found}"
+        )
+        for folder, reason in coverage.folders_skipped:
+            warn(f"Skipped folder {folder}: {reason}")
+
 
 @cli.group()
 def extract() -> None:
@@ -6427,6 +6454,27 @@ def extract() -> None:
     "--list-services",
     is_flag=True,
     help="List available services without extracting (for services root URLs).",
+)
+@click.option(
+    "--token",
+    default=None,
+    help="ArcGIS token (or set ARCGIS_TOKEN). For secured services/folders.",
+)
+@click.option(
+    "--username",
+    default=None,
+    help="ArcGIS username (mints a token via generateToken).",
+)
+@click.option(
+    "--password",
+    default=None,
+    help="ArcGIS password (used with --username).",
+)
+@click.option(
+    "--no-recurse",
+    "no_recurse",
+    is_flag=True,
+    help="Do not traverse folders for services-root URLs (default: recurse).",
 )
 @click.option(
     "--workers",
@@ -6520,6 +6568,10 @@ def extract_arcgis_cmd(
     services: str | None,
     exclude_services: str | None,
     list_services: bool,
+    token: str | None,
+    username: str | None,
+    password: str | None,
+    no_recurse: bool,
     workers: int,
     retries: int,
     timeout: float,
@@ -6598,24 +6650,47 @@ def extract_arcgis_cmd(
         _output_extract_error(use_json, "InvalidURLError", str(e), url)
         raise SystemExit(1) from None
 
+    # Resolve credentials and token (token > username/password > ARCGIS_TOKEN env).
+    import os
+
+    from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
+
+    creds = ArcGISCredentials(
+        token=token or os.environ.get("ARCGIS_TOKEN"),
+        username=username,
+        password=password,
+    )
+    try:
+        resolved_token = resolve_token(creds, url, timeout=timeout) if not creds.is_empty else None
+    except Exception as e:  # ArcGISAuthError and transport errors
+        _output_extract_error(use_json, type(e).__name__, str(e), url)
+        raise SystemExit(1) from None
+
     # Handle --list-services mode
     if list_services:
-        if parsed.url_type != ArcGISURLType.SERVICES_ROOT:
+        if parsed.url_type not in (
+            ArcGISURLType.SERVICES_ROOT,
+            ArcGISURLType.SERVICES_FOLDER,
+        ):
             _output_extract_error(
                 use_json,
                 "InvalidURLError",
-                "--list-services requires a services root URL (ending with /rest/services)",
+                "--list-services requires a services root or folder URL",
                 url,
             )
             raise SystemExit(1)
         service_filter = _parse_filter_patterns(services)
-        _handle_list_services_mode(url, service_filter, timeout, use_json)
+        _handle_list_services_mode(
+            url, service_filter, timeout, use_json, token=resolved_token, recurse=not no_recurse
+        )
         return
 
     # Default output directory from service name (or "services_extract" for services root)
     if output_dir is None:
         if parsed.url_type == ArcGISURLType.SERVICES_ROOT:
             output_dir = Path("services_extract")
+        elif parsed.url_type == ArcGISURLType.SERVICES_FOLDER:
+            output_dir = Path((parsed.folder or "services_extract").replace("/", "_").lower())
         else:
             service_name = parsed.service_name or "arcgis_extract"
             output_dir = Path(service_name.replace("/", "_").lower())
@@ -6656,6 +6731,8 @@ def extract_arcgis_cmd(
         resume=resume,
         dry_run=dry_run,
         raw=raw,
+        token=resolved_token,
+        recurse=not no_recurse,
     )
 
     # Progress callback for text output

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -6469,7 +6469,8 @@ def extract() -> None:
 @click.option(
     "--password",
     default=None,
-    help="ArcGIS password (used with --username).",
+    help="ArcGIS password (used with --username, or set ARCGIS_PASSWORD). "
+    "Prompted interactively when omitted.",
 )
 @click.option(
     "--no-recurse",
@@ -6651,13 +6652,19 @@ def extract_arcgis_cmd(
         _output_extract_error(use_json, "InvalidURLError", str(e), url)
         raise SystemExit(1) from None
 
-    # Resolve credentials and token (token > username/password > ARCGIS_TOKEN env).
+    # Resolve credentials and token (token > username/password > env).
+    # Never require the password on argv (it leaks via shell history and process
+    # listings). Take it from ARCGIS_PASSWORD, or prompt when running interactively.
     from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
+
+    resolved_password = password or os.environ.get("ARCGIS_PASSWORD")
+    if username and not resolved_password and not auto and not use_json:
+        resolved_password = click.prompt("ArcGIS password", hide_input=True)
 
     creds = ArcGISCredentials(
         token=token or os.environ.get("ARCGIS_TOKEN"),
         username=username,
-        password=password,
+        password=resolved_password,
     )
     try:
         resolved_token = resolve_token(creds, url, timeout=timeout) if not creds.is_empty else None

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, NoReturn
 if TYPE_CHECKING:
     from portolan_cli.backends.protocol import VersioningBackend
     from portolan_cli.extract.arcgis.report import ExtractionReport
+    from portolan_cli.extract.arcgis.url_parser import ParsedArcGISURL
     from portolan_cli.pull import PullResult
 
 import click
@@ -6293,6 +6294,55 @@ def _output_extract_error(
         error(message)
 
 
+def _resolve_arcgis_token(
+    *,
+    url: str,
+    token: str | None,
+    username: str | None,
+    password: str | None,
+    timeout: float,
+    auto: bool,
+    use_json: bool,
+) -> str | None:
+    """Resolve an ArcGIS token from flags, env, or username/password.
+
+    Precedence: explicit token > ARCGIS_TOKEN > username/password (minted).
+    The password is never required on argv (it leaks via shell history and
+    process listings): it comes from ARCGIS_PASSWORD, or an interactive prompt.
+    Outputs an error envelope and raises SystemExit on auth failure.
+    """
+    from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
+
+    resolved_password = password or os.environ.get("ARCGIS_PASSWORD")
+    if username and not resolved_password and not auto and not use_json:
+        resolved_password = click.prompt("ArcGIS password", hide_input=True)
+
+    creds = ArcGISCredentials(
+        token=token or os.environ.get("ARCGIS_TOKEN"),
+        username=username,
+        password=resolved_password,
+    )
+    if creds.is_empty:
+        return None
+    try:
+        return resolve_token(creds, url, timeout=timeout)
+    except Exception as e:  # ArcGISAuthError and transport errors
+        _output_extract_error(use_json, type(e).__name__, str(e), url)
+        raise SystemExit(1) from None
+
+
+def _default_arcgis_output_dir(parsed: ParsedArcGISURL) -> Path:
+    """Infer the default output directory from a parsed ArcGIS URL."""
+    from portolan_cli.extract.arcgis.url_parser import ArcGISURLType
+
+    if parsed.url_type == ArcGISURLType.SERVICES_ROOT:
+        return Path("services_extract")
+    if parsed.url_type == ArcGISURLType.SERVICES_FOLDER:
+        return Path((parsed.folder or "services_extract").replace("/", "_").lower())
+    service_name = parsed.service_name or "arcgis_extract"
+    return Path(service_name.replace("/", "_").lower())
+
+
 def _output_extract_result(
     report: ExtractionReport,
     output_dir: Path,
@@ -6652,25 +6702,15 @@ def extract_arcgis_cmd(
         _output_extract_error(use_json, "InvalidURLError", str(e), url)
         raise SystemExit(1) from None
 
-    # Resolve credentials and token (token > username/password > env).
-    # Never require the password on argv (it leaks via shell history and process
-    # listings). Take it from ARCGIS_PASSWORD, or prompt when running interactively.
-    from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
-
-    resolved_password = password or os.environ.get("ARCGIS_PASSWORD")
-    if username and not resolved_password and not auto and not use_json:
-        resolved_password = click.prompt("ArcGIS password", hide_input=True)
-
-    creds = ArcGISCredentials(
-        token=token or os.environ.get("ARCGIS_TOKEN"),
+    resolved_token = _resolve_arcgis_token(
+        url=url,
+        token=token,
         username=username,
-        password=resolved_password,
+        password=password,
+        timeout=timeout,
+        auto=auto,
+        use_json=use_json,
     )
-    try:
-        resolved_token = resolve_token(creds, url, timeout=timeout) if not creds.is_empty else None
-    except Exception as e:  # ArcGISAuthError and transport errors
-        _output_extract_error(use_json, type(e).__name__, str(e), url)
-        raise SystemExit(1) from None
 
     # Handle --list-services mode
     if list_services:
@@ -6693,13 +6733,7 @@ def extract_arcgis_cmd(
 
     # Default output directory from service name (or "services_extract" for services root)
     if output_dir is None:
-        if parsed.url_type == ArcGISURLType.SERVICES_ROOT:
-            output_dir = Path("services_extract")
-        elif parsed.url_type == ArcGISURLType.SERVICES_FOLDER:
-            output_dir = Path((parsed.folder or "services_extract").replace("/", "_").lower())
-        else:
-            service_name = parsed.service_name or "arcgis_extract"
-            output_dir = Path(service_name.replace("/", "_").lower())
+        output_dir = _default_arcgis_output_dir(parsed)
 
     # Handle ImageServer URLs (raster extraction)
     if parsed.url_type == ArcGISURLType.IMAGE_SERVER:

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -7,6 +7,7 @@ All business logic lives in the library; the CLI handles user interaction.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -6110,7 +6111,7 @@ def _handle_list_services_mode(
             f"Folders traversed: {len(cov.folders_visited)}, skipped: {len(cov.folders_skipped)}"
         )
         for folder, reason in cov.folders_skipped:
-            click.echo(f"  ⚠ skipped {folder}: {reason}")
+            warn(f"Skipped folder {folder}: {reason}")
     elif result.folders:
         click.echo(f"Folders: {', '.join(result.folders)}")
 
@@ -6328,7 +6329,7 @@ def _output_extract_result(
             ],
         }
 
-        coverage = getattr(report, "folder_coverage", None)
+        coverage = report.folder_coverage
         if coverage is not None:
             data["folder_coverage"] = coverage.to_dict()
 
@@ -6390,7 +6391,7 @@ def _output_extract_result(
     info_output(f"Output: {output_dir}")
     info_output(f"Report: {output_dir}/.portolan/extraction-report.json")
 
-    coverage = getattr(report, "folder_coverage", None)
+    coverage = report.folder_coverage
     if coverage is not None:
         info_output(
             f"Folders traversed: {len(coverage.folders_visited)}, "
@@ -6651,8 +6652,6 @@ def extract_arcgis_cmd(
         raise SystemExit(1) from None
 
     # Resolve credentials and token (token > username/password > ARCGIS_TOKEN env).
-    import os
-
     from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
 
     creds = ArcGISCredentials(

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -6313,12 +6313,25 @@ def _resolve_arcgis_token(
     """
     from portolan_cli.extract.arcgis.auth import ArcGISCredentials, resolve_token
 
+    resolved_token = token or os.environ.get("ARCGIS_TOKEN")
     resolved_password = password or os.environ.get("ARCGIS_PASSWORD")
     if username and not resolved_password and not auto and not use_json:
         resolved_password = click.prompt("ArcGIS password", hide_input=True)
 
+    # Explicit username with no resolvable password must fail fast, not silently
+    # run unauthenticated (resolve_token returns None for incomplete credentials).
+    if username and not resolved_password and not resolved_token:
+        _output_extract_error(
+            use_json,
+            "ArcGISAuthError",
+            "ArcGIS --username requires a password (set ARCGIS_PASSWORD, "
+            "or omit --auto/--json to be prompted)",
+            url,
+        )
+        raise SystemExit(1)
+
     creds = ArcGISCredentials(
-        token=token or os.environ.get("ARCGIS_TOKEN"),
+        token=resolved_token,
         username=username,
         password=resolved_password,
     )
@@ -6737,6 +6750,16 @@ def extract_arcgis_cmd(
 
     # Handle ImageServer URLs (raster extraction)
     if parsed.url_type == ArcGISURLType.IMAGE_SERVER:
+        if resolved_token is not None:
+            # Raster extraction does not thread the token yet (issue #311); reject
+            # rather than silently running unauthenticated against a secured service.
+            _output_extract_error(
+                use_json,
+                "ArcGISAuthError",
+                "ArcGIS authentication is not yet supported for ImageServer URLs (issue #311)",
+                url,
+            )
+            raise SystemExit(1)
         _handle_imageserver_extraction(
             ctx=ctx,
             url=url,

--- a/portolan_cli/errors.py
+++ b/portolan_cli/errors.py
@@ -9,6 +9,7 @@ All errors follow the format PRTLN-{category}{number}:
 - PRTLN-VAL*: Validation errors
 - PRTLN-CNV*: Conversion errors
 - PRTLN-CFG*: Configuration errors
+- PRTLN-EXT*: Extract / harvest errors
 """
 
 from __future__ import annotations
@@ -439,3 +440,13 @@ class ConfigInvalidStructureError(ConfigError):
             path=path,
             detail=detail,
         )
+
+
+# Extract Errors (PRTLN-EXT*)
+class ArcGISAuthError(PortolanError):
+    """Raised when ArcGIS token resolution or authentication fails.
+
+    Error code: PRTLN-EXT002
+    """
+
+    code = "PRTLN-EXT002"

--- a/portolan_cli/extract/arcgis/auth.py
+++ b/portolan_cli/extract/arcgis/auth.py
@@ -1,0 +1,135 @@
+"""ArcGIS authentication, minimal token pass-through.
+
+Supports a pre-generated token or username/password minted via the ArcGIS
+generateToken endpoint. The token is appended to discovery requests and passed
+to gpio.extract_arcgis. This is a contained subset; the full unified auth design
+lives in issue #311.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import httpx
+
+from portolan_cli.errors import ArcGISAuthError
+
+
+@dataclass
+class ArcGISCredentials:
+    """ArcGIS credentials. token takes precedence over username/password."""
+
+    token: str | None = None
+    username: str | None = None
+    password: str | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """True when no usable credentials are present."""
+        return not self.token and not (self.username and self.password)
+
+
+def apply_token(url: str, token: str) -> str:
+    """Append token=<token> to a URL."""
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    params["token"] = [token]
+    return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
+
+
+def _with_json(url: str) -> str:
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    params.setdefault("f", ["json"])
+    return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
+
+
+def _token_services_url(base_url: str, timeout: float) -> str:
+    """Discover the generateToken endpoint from <server>/rest/info."""
+    # base_url is e.g. https://host/server/rest/services[/folder]; derive /rest/info
+    root = base_url.split("/rest/")[0] + "/rest/info"
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(_with_json(root))
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ArcGISAuthError(
+            f"Failed to read token services URL from {root}: {exc}", url=root
+        ) from exc
+
+    if resp.status_code >= 400:
+        raise ArcGISAuthError(
+            f"Failed to read token services URL from {root}: HTTP {resp.status_code}", url=root
+        )
+
+    try:
+        data = cast("dict[str, Any]", resp.json())
+    except ValueError as exc:
+        raise ArcGISAuthError(
+            f"Failed to read token services URL from {root}: {exc}", url=root
+        ) from exc
+
+    token_url = data.get("authInfo", {}).get("tokenServicesUrl")
+    if not token_url:
+        raise ArcGISAuthError(
+            f"Server does not advertise a token endpoint at {root}", url=root
+        )
+    return cast("str", token_url)
+
+
+def resolve_token(
+    creds: ArcGISCredentials,
+    base_url: str,
+    timeout: float = 60.0,
+) -> str | None:
+    """Resolve a usable token from credentials.
+
+    Returns the explicit token, mints one from username/password, or None when
+    no credentials are present. Raises ArcGISAuthError when minting fails.
+    """
+    if creds.token:
+        return creds.token
+    if not (creds.username and creds.password):
+        return None
+
+    token_url = _token_services_url(base_url, timeout)
+    referer = base_url.split("/rest/")[0]
+    payload: dict[str, str] = {
+        "username": creds.username,
+        "password": creds.password,
+        "client": "referer",
+        "referer": referer,
+        "expiration": "60",
+        "f": "json",
+    }
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(token_url, data=payload)
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ArcGISAuthError(
+            f"Token request failed at {token_url}: {exc}", url=token_url
+        ) from exc
+
+    if resp.status_code >= 400:
+        raise ArcGISAuthError(
+            f"Token request failed at {token_url}: HTTP {resp.status_code}", url=token_url
+        )
+
+    try:
+        data = cast("dict[str, Any]", resp.json())
+    except ValueError as exc:
+        raise ArcGISAuthError(
+            f"Token request failed at {token_url}: {exc}", url=token_url
+        ) from exc
+
+    error = data.get("error")
+    if isinstance(error, dict):
+        raise ArcGISAuthError(
+            f"Token request rejected: {error.get('message', 'unknown')}", url=token_url
+        )
+    token = data.get("token")
+    if not token:
+        raise ArcGISAuthError(f"No token in response from {token_url}", url=token_url)
+    return cast("str", token)

--- a/portolan_cli/extract/arcgis/auth.py
+++ b/portolan_cli/extract/arcgis/auth.py
@@ -32,7 +32,11 @@ class ArcGISCredentials:
 
 
 def apply_token(url: str, token: str) -> str:
-    """Append token=<token> to a URL."""
+    """Append token=<token> to a URL.
+
+    Note: discovery._append_query_param does the same thing generically;
+    consolidate both into a shared url util when #311 reworks auth.
+    """
     parsed = urlparse(url)
     params = parse_qs(parsed.query)
     params["token"] = [token]
@@ -40,6 +44,7 @@ def apply_token(url: str, token: str) -> str:
 
 
 def _with_json(url: str) -> str:
+    """Add f=json to url if not already set (setdefault semantics)."""
     parsed = urlparse(url)
     params = parse_qs(parsed.query)
     params.setdefault("f", ["json"])
@@ -100,7 +105,7 @@ def resolve_token(
         "password": creds.password,
         "client": "referer",
         "referer": referer,
-        "expiration": "60",
+        "expiration": "60",  # TODO(#311): make configurable, long runs can exceed 60 min
         "f": "json",
     }
 

--- a/portolan_cli/extract/arcgis/auth.py
+++ b/portolan_cli/extract/arcgis/auth.py
@@ -77,9 +77,7 @@ def _token_services_url(base_url: str, timeout: float) -> str:
 
     token_url = data.get("authInfo", {}).get("tokenServicesUrl")
     if not token_url:
-        raise ArcGISAuthError(
-            f"Server does not advertise a token endpoint at {root}", url=root
-        )
+        raise ArcGISAuthError(f"Server does not advertise a token endpoint at {root}", url=root)
     return cast("str", token_url)
 
 
@@ -113,9 +111,7 @@ def resolve_token(
         with httpx.Client(timeout=timeout) as client:
             resp = client.post(token_url, data=payload)
     except (httpx.HTTPError, ValueError) as exc:
-        raise ArcGISAuthError(
-            f"Token request failed at {token_url}: {exc}", url=token_url
-        ) from exc
+        raise ArcGISAuthError(f"Token request failed at {token_url}: {exc}", url=token_url) from exc
 
     if resp.status_code >= 400:
         raise ArcGISAuthError(
@@ -125,9 +121,7 @@ def resolve_token(
     try:
         data = cast("dict[str, Any]", resp.json())
     except ValueError as exc:
-        raise ArcGISAuthError(
-            f"Token request failed at {token_url}: {exc}", url=token_url
-        ) from exc
+        raise ArcGISAuthError(f"Token request failed at {token_url}: {exc}", url=token_url) from exc
 
     error = data.get("error")
     if isinstance(error, dict):

--- a/portolan_cli/extract/arcgis/auth.py
+++ b/portolan_cli/extract/arcgis/auth.py
@@ -51,10 +51,21 @@ def _with_json(url: str) -> str:
     return urlunparse(parsed._replace(query=urlencode(params, doseq=True)))
 
 
+def _server_root(base_url: str) -> str:
+    """Return the ArcGIS server root (everything before /rest/), case-insensitively.
+
+    base_url is e.g. https://host/server/rest/services[/folder]. ArcGIS treats the
+    /rest/ segment case-insensitively, and url_parser accepts /REST/ too, so match
+    it the same way here. Falls back to the full URL when /rest/ is absent.
+    """
+    idx = base_url.lower().find("/rest/")
+    root = base_url if idx < 0 else base_url[:idx]
+    return root.rstrip("/")
+
+
 def _token_services_url(base_url: str, timeout: float) -> str:
     """Discover the generateToken endpoint from <server>/rest/info."""
-    # base_url is e.g. https://host/server/rest/services[/folder]; derive /rest/info
-    root = base_url.split("/rest/")[0] + "/rest/info"
+    root = _server_root(base_url) + "/rest/info"
     try:
         with httpx.Client(timeout=timeout) as client:
             resp = client.get(_with_json(root))
@@ -69,16 +80,20 @@ def _token_services_url(base_url: str, timeout: float) -> str:
         )
 
     try:
-        data = cast("dict[str, Any]", resp.json())
+        raw = resp.json()
     except ValueError as exc:
         raise ArcGISAuthError(
             f"Failed to read token services URL from {root}: {exc}", url=root
         ) from exc
+    if not isinstance(raw, dict):
+        raise ArcGISAuthError(f"Invalid JSON object from {root}", url=root)
+    data = cast("dict[str, Any]", raw)
 
-    token_url = data.get("authInfo", {}).get("tokenServicesUrl")
-    if not token_url:
+    auth_info = data.get("authInfo")
+    token_url = auth_info.get("tokenServicesUrl") if isinstance(auth_info, dict) else None
+    if not isinstance(token_url, str) or not token_url:
         raise ArcGISAuthError(f"Server does not advertise a token endpoint at {root}", url=root)
-    return cast("str", token_url)
+    return token_url
 
 
 def resolve_token(
@@ -97,7 +112,7 @@ def resolve_token(
         return None
 
     token_url = _token_services_url(base_url, timeout)
-    referer = base_url.split("/rest/")[0]
+    referer = _server_root(base_url)
     payload: dict[str, str] = {
         "username": creds.username,
         "password": creds.password,
@@ -119,9 +134,12 @@ def resolve_token(
         )
 
     try:
-        data = cast("dict[str, Any]", resp.json())
+        raw = resp.json()
     except ValueError as exc:
         raise ArcGISAuthError(f"Token request failed at {token_url}: {exc}", url=token_url) from exc
+    if not isinstance(raw, dict):
+        raise ArcGISAuthError(f"Invalid JSON object from {token_url}", url=token_url)
+    data = cast("dict[str, Any]", raw)
 
     error = data.get("error")
     if isinstance(error, dict):
@@ -129,6 +147,6 @@ def resolve_token(
             f"Token request rejected: {error.get('message', 'unknown')}", url=token_url
         )
     token = data.get("token")
-    if not token:
+    if not isinstance(token, str) or not token:
         raise ArcGISAuthError(f"No token in response from {token_url}", url=token_url)
-    return cast("str", token)
+    return token

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -159,9 +159,6 @@ def _fetch_json(url: str, timeout: float = 60.0, token: str | None = None) -> di
             data = cast("dict[str, Any]", response.json())
     except ArcGISDiscoveryError:
         raise
-    except httpx.HTTPStatusError as e:
-        msg = f"Failed to fetch from {url}: HTTP {e.response.status_code}"
-        raise ArcGISDiscoveryError(msg) from e
     except httpx.RequestError as e:
         msg = f"Failed to fetch from {url}: {e}"
         raise ArcGISDiscoveryError(msg) from e

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -21,6 +21,7 @@ Typical usage:
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -29,6 +30,8 @@ import httpx
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+logger = logging.getLogger(__name__)
 
 
 class ArcGISDiscoveryError(Exception):
@@ -302,6 +305,84 @@ def discover_services(
         return services, folders
 
     return services
+
+
+@dataclass
+class FolderTraversal:
+    """Record of a recursive services-root traversal.
+
+    Attributes:
+        visited: Folder names successfully fetched.
+        skipped: (folder_name, reason) pairs for folders that errored.
+        service_count: Total services discovered (root plus all folders).
+    """
+
+    visited: list[str]
+    skipped: list[tuple[str, str]]
+    service_count: int
+
+
+def _build_service_list(
+    data: dict[str, Any],
+    service_types: Sequence[str] | None,
+) -> list[ServiceInfo]:
+    """Build a filtered ServiceInfo list from a services-root JSON payload."""
+    services: list[ServiceInfo] = []
+    for service_data in data.get("services", []):
+        service = ServiceInfo(name=service_data["name"], service_type=service_data["type"])
+        if service_types is None or service.service_type in service_types:
+            services.append(service)
+    return services
+
+
+def discover_services_recursive(
+    url: str,
+    *,
+    service_types: Sequence[str] | None = None,
+    token: str | None = None,
+    timeout: float = 60.0,
+    max_depth: int = 2,
+) -> tuple[list[ServiceInfo], FolderTraversal]:
+    """Discover services from a services root, recursing into folders.
+
+    ArcGIS returns service names already qualified by folder (e.g.
+    "NationalDatasets/Property"), so ServiceInfo.get_url(root) stays correct.
+    Folders that error (secured, non-200, embedded error) are recorded and
+    skipped, never raised. max_depth guards against pathological nesting;
+    standard ArcGIS folders are single-level.
+
+    Returns:
+        (services, traversal) where traversal records visited/skipped folders.
+    """
+    root_base = url.split("?")[0].rstrip("/")
+    root_data = _fetch_json(root_base, timeout=timeout, token=token)
+
+    services = _build_service_list(root_data, service_types)
+    visited: list[str] = []
+    skipped: list[tuple[str, str]] = []
+
+    # Queue of (folder_name, depth). Folder names are paths relative to root.
+    queue: list[tuple[str, int]] = [(f, 1) for f in root_data.get("folders", [])]
+    while queue:
+        folder, depth = queue.pop(0)
+        if depth > max_depth:
+            continue
+        folder_url = f"{root_base}/{folder}"
+        try:
+            folder_data = _fetch_json(folder_url, timeout=timeout, token=token)
+        except ArcGISDiscoveryError as e:
+            skipped.append((folder, str(e)))
+            logger.warning("Skipping folder '%s': %s", folder, e)
+            continue
+        visited.append(folder)
+        services.extend(_build_service_list(folder_data, service_types))
+        for sub in folder_data.get("folders", []):
+            queue.append((sub, depth + 1))
+
+    traversal = FolderTraversal(
+        visited=visited, skipped=skipped, service_count=len(services)
+    )
+    return services, traversal
 
 
 def fetch_layer_details(

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -159,7 +159,12 @@ def _fetch_json(url: str, timeout: float = 60.0, token: str | None = None) -> di
             if response.status_code >= 400:
                 msg = f"Failed to fetch from {url}: HTTP {response.status_code}"
                 raise ArcGISDiscoveryError(msg)
-            data = cast("dict[str, Any]", response.json())
+            raw = response.json()
+            if not isinstance(raw, dict):
+                raise ArcGISDiscoveryError(
+                    f"Expected JSON object from {url}, got {type(raw).__name__}"
+                )
+            data = cast("dict[str, Any]", raw)
     except ArcGISDiscoveryError:
         raise
     except httpx.RequestError as e:

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -96,6 +96,15 @@ class ServiceDiscoveryResult:
     access_information: str | None = None
 
 
+def _append_query_param(url: str, key: str, value: str) -> str:
+    """Append a single query parameter to a URL."""
+    parsed = urlparse(url)
+    query_params = parse_qs(parsed.query)
+    query_params[key] = [value]
+    new_query = urlencode(query_params, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+
+
 def _ensure_json_format(url: str) -> str:
     """Ensure URL has f=json parameter for ArcGIS REST API.
 
@@ -119,26 +128,37 @@ def _ensure_json_format(url: str) -> str:
     return urlunparse(new_parsed)
 
 
-def _fetch_json(url: str, timeout: float = 60.0) -> dict[str, Any]:
+def _fetch_json(url: str, timeout: float = 60.0, token: str | None = None) -> dict[str, Any]:
     """Fetch JSON from URL with standard error handling.
+
+    Appends f=json and, when provided, token=<token>. ArcGIS returns HTTP 200
+    with an embedded {"error": {...}} body for secured or invalid endpoints;
+    that case is raised as ArcGISDiscoveryError.
 
     Args:
         url: URL to fetch (will have f=json added if needed)
         timeout: Request timeout in seconds
+        token: Optional ArcGIS token appended as token=<token> query param
 
     Returns:
         Parsed JSON response
 
     Raises:
-        ArcGISDiscoveryError: On HTTP or parsing errors
+        ArcGISDiscoveryError: On HTTP errors, parsing errors, or embedded ArcGIS errors
     """
     request_url = _ensure_json_format(url)
+    if token:
+        request_url = _append_query_param(request_url, "token", token)
 
     try:
         with httpx.Client(timeout=timeout) as client:
             response = client.get(request_url)
-            response.raise_for_status()
-            return cast(dict[str, Any], response.json())
+            if response.status_code >= 400:
+                msg = f"Failed to fetch from {url}: HTTP {response.status_code}"
+                raise ArcGISDiscoveryError(msg)
+            data = cast("dict[str, Any]", response.json())
+    except ArcGISDiscoveryError:
+        raise
     except httpx.HTTPStatusError as e:
         msg = f"Failed to fetch from {url}: HTTP {e.response.status_code}"
         raise ArcGISDiscoveryError(msg) from e
@@ -148,6 +168,14 @@ def _fetch_json(url: str, timeout: float = 60.0) -> dict[str, Any]:
     except ValueError as e:
         msg = f"Invalid JSON response from {url}: {e}"
         raise ArcGISDiscoveryError(msg) from e
+
+    error = data.get("error")
+    if isinstance(error, dict):
+        code = error.get("code", "unknown")
+        message = error.get("message", "ArcGIS error")
+        raise ArcGISDiscoveryError(f"ArcGIS error from {url}: {code} {message}")
+
+    return data
 
 
 def discover_layers(

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -287,18 +287,7 @@ def discover_services(
     """
     data = _fetch_json(url, timeout=timeout)
 
-    # Extract services
-    services: list[ServiceInfo] = []
-
-    for service_data in data.get("services", []):
-        service = ServiceInfo(
-            name=service_data["name"],
-            service_type=service_data["type"],
-        )
-
-        # Filter by type if specified
-        if service_types is None or service.service_type in service_types:
-            services.append(service)
+    services = _build_service_list(data, service_types)
 
     if return_folders:
         folders = data.get("folders", [])
@@ -307,7 +296,7 @@ def discover_services(
     return services
 
 
-@dataclass
+@dataclass(frozen=True)
 class FolderTraversal:
     """Record of a recursive services-root traversal.
 
@@ -349,7 +338,9 @@ def discover_services_recursive(
     "NationalDatasets/Property"), so ServiceInfo.get_url(root) stays correct.
     Folders that error (secured, non-200, embedded error) are recorded and
     skipped, never raised. max_depth guards against pathological nesting;
-    standard ArcGIS folders are single-level.
+    standard ArcGIS folders are single-level. Defaults to 2 because standard
+    ArcGIS servers nest folders at most one level; the extra level guards against
+    non-standard but valid configurations.
 
     Returns:
         (services, traversal) where traversal records visited/skipped folders.
@@ -377,7 +368,7 @@ def discover_services_recursive(
         visited.append(folder)
         services.extend(_build_service_list(folder_data, service_types))
         for sub in folder_data.get("folders", []):
-            queue.append((sub, depth + 1))
+            queue.append((f"{folder}/{sub}", depth + 1))
 
     traversal = FolderTraversal(
         visited=visited, skipped=skipped, service_count=len(services)

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -370,9 +370,7 @@ def discover_services_recursive(
         for sub in folder_data.get("folders", []):
             queue.append((f"{folder}/{sub}", depth + 1))
 
-    traversal = FolderTraversal(
-        visited=visited, skipped=skipped, service_count=len(services)
-    )
+    traversal = FolderTraversal(visited=visited, skipped=skipped, service_count=len(services))
     return services, traversal
 
 

--- a/portolan_cli/extract/arcgis/discovery.py
+++ b/portolan_cli/extract/arcgis/discovery.py
@@ -247,6 +247,7 @@ def discover_services(
     service_types: Sequence[str] | None = ...,
     return_folders: Literal[False] = ...,
     timeout: float = ...,
+    token: str | None = ...,
 ) -> list[ServiceInfo]: ...
 
 
@@ -257,6 +258,7 @@ def discover_services(
     service_types: Sequence[str] | None = ...,
     return_folders: Literal[True],
     timeout: float = ...,
+    token: str | None = ...,
 ) -> tuple[list[ServiceInfo], list[str]]: ...
 
 
@@ -266,6 +268,7 @@ def discover_services(
     service_types: Sequence[str] | None = None,
     return_folders: bool = False,
     timeout: float = 60.0,
+    token: str | None = None,
 ) -> list[ServiceInfo] | tuple[list[ServiceInfo], list[str]]:
     """Discover services from an ArcGIS REST services root.
 
@@ -278,6 +281,7 @@ def discover_services(
             (e.g., ["FeatureServer", "MapServer"])
         return_folders: If True, also return list of folder names
         timeout: Request timeout in seconds
+        token: Optional ArcGIS token for authenticated discovery
 
     Returns:
         List of ServiceInfo objects (or tuple with folders if return_folders=True)
@@ -285,7 +289,7 @@ def discover_services(
     Raises:
         ArcGISDiscoveryError: If the request fails or response is invalid
     """
-    data = _fetch_json(url, timeout=timeout)
+    data = _fetch_json(url, timeout=timeout, token=token)
 
     services = _build_service_list(data, service_types)
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -30,11 +30,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from portolan_cli.extract.arcgis.discovery import (
+    FolderTraversal,
     LayerInfo,
     ServiceDiscoveryResult,
     ServiceInfo,
     discover_layers,
     discover_services,
+    discover_services_recursive,
 )
 from portolan_cli.extract.arcgis.metadata import extract_arcgis_metadata
 from portolan_cli.extract.arcgis.url_parser import (
@@ -46,6 +48,7 @@ from portolan_cli.extract.common.filters import filter_layers
 from portolan_cli.extract.common.report import (
     ExtractionReport,
     ExtractionSummary,
+    FolderCoverage,
     LayerResult,
     MetadataExtracted,
     load_report,
@@ -63,6 +66,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _coverage_from_traversal(traversal: FolderTraversal) -> FolderCoverage:
+    """Map a discovery FolderTraversal to a serializable FolderCoverage."""
+    return FolderCoverage(
+        folders_visited=traversal.visited,
+        folders_skipped=traversal.skipped,
+        services_found=traversal.service_count,
+    )
+
+
 @dataclass
 class ServicesRootDiscoveryResult:
     """Result of listing services from a services root URL.
@@ -73,15 +85,17 @@ class ServicesRootDiscoveryResult:
         services: List of discovered services.
         folders: List of folder names in the services root.
         base_url: The services root URL that was queried.
+        coverage: Optional folder traversal coverage when recursion was used.
     """
 
     services: list[ServiceInfo]
     folders: list[str]
     base_url: str
+    coverage: FolderCoverage | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Convert to JSON-serializable dict."""
-        return {
+        result: dict[str, object] = {
             "base_url": self.base_url,
             "services": [
                 {
@@ -94,6 +108,9 @@ class ServicesRootDiscoveryResult:
             "folders": self.folders,
             "total_services": len(self.services),
         }
+        if self.coverage is not None:
+            result["folder_coverage"] = self.coverage.to_dict()
+        return result
 
 
 def list_services(
@@ -101,42 +118,54 @@ def list_services(
     *,
     service_types: Sequence[str] | None = None,
     service_filter: list[str] | None = None,
+    token: str | None = None,
+    recurse: bool = True,
     timeout: float = 60.0,
 ) -> ServicesRootDiscoveryResult:
-    """List services from an ArcGIS services root URL.
+    """List services from an ArcGIS services root or folder URL.
 
-    This is a lightweight discovery operation that does NOT probe each service
-    for layers. Use this for --list-services mode.
+    Recurses into folders by default. Folders that error are skipped and
+    recorded in the returned coverage.
 
     Args:
-        url: ArcGIS services root URL (must end with /rest/services).
+        url: ArcGIS services root or folder URL.
         service_types: Filter by service types (e.g., ["FeatureServer"]).
         service_filter: Glob patterns to filter service names.
+        token: Optional ArcGIS token for authenticated endpoints.
+        recurse: Whether to recurse into sub-folders (default True).
         timeout: Request timeout in seconds.
 
     Returns:
-        ServicesRootDiscoveryResult with services and folders.
+        ServicesRootDiscoveryResult with services, folders, and optional coverage.
 
     Raises:
-        ValueError: If URL is not a services root URL.
+        ValueError: If URL is not a services root or folder URL.
     """
     from portolan_cli.extract.arcgis.filters import filter_services
 
-    # Parse URL to verify it's a services root
     parsed = parse_arcgis_url(url)
-    if parsed.url_type != ArcGISURLType.SERVICES_ROOT:
-        msg = f"URL is not a services root URL: {url}"
+    if parsed.url_type not in (ArcGISURLType.SERVICES_ROOT, ArcGISURLType.SERVICES_FOLDER):
+        msg = f"URL is not a services root or folder URL: {url}"
         raise ValueError(msg)
 
-    # Discover services
-    services, folders = discover_services(
-        url,
-        service_types=list(service_types) if service_types else None,
-        return_folders=True,
-        timeout=timeout,
-    )
+    if recurse:
+        services, traversal = discover_services_recursive(
+            url,
+            service_types=list(service_types) if service_types else None,
+            token=token,
+            timeout=timeout,
+        )
+        coverage: FolderCoverage | None = _coverage_from_traversal(traversal)
+        folders = traversal.visited
+    else:
+        services, folders = discover_services(
+            url,
+            service_types=list(service_types) if service_types else None,
+            return_folders=True,
+            timeout=timeout,
+        )
+        coverage = None
 
-    # Apply service filter if provided
     if service_filter:
         service_names = [s.name for s in services]
         filtered_names = filter_services(
@@ -150,6 +179,7 @@ def list_services(
         services=services,
         folders=folders,
         base_url=parsed.base_url,
+        coverage=coverage,
     )
 
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -229,7 +229,7 @@ def _service_output_dir(output_dir: Path, service_name: str) -> Path:
     "ecml/active_faults" -> output_dir/ecml/active_faults
     "Top"                -> output_dir/top
     Each path segment is slugified independently so the folder hierarchy is
-    preserved as nested subcatalogs (ADR-0032, ADR-0053).
+    preserved as nested subcatalogs (ADR-0032, ADR-0054).
     """
     parts = [_slugify(p) for p in service_name.split("/") if p]
     result = output_dir

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -856,20 +856,33 @@ def _discover_and_filter_services(
     *,
     token: str | None = None,
     folder: str | None = None,
-) -> tuple[list[ServiceInfo], FolderCoverage]:
-    """Discover services recursively, scope to a folder, and apply filters.
+    recurse: bool = True,
+) -> tuple[list[ServiceInfo], FolderCoverage | None]:
+    """Discover services (recursively by default), scope to a folder, and apply filters.
 
-    Returns (services, coverage). When folder is set (SERVICES_FOLDER URL), only
-    services under that folder prefix are kept.
+    Returns (services, coverage). When recurse is False the flat (non-recursive)
+    discovery is used and coverage is None. When folder is set (SERVICES_FOLDER
+    URL) only services under that folder prefix are kept.
     """
     from portolan_cli.extract.arcgis.filters import filter_services
 
-    services, traversal = discover_services_recursive(
-        url,
-        service_types=["FeatureServer", "MapServer"],
-        token=token,
-        timeout=timeout,
-    )
+    coverage: FolderCoverage | None
+    if recurse:
+        services, traversal = discover_services_recursive(
+            url,
+            service_types=["FeatureServer", "MapServer"],
+            token=token,
+            timeout=timeout,
+        )
+        coverage = _coverage_from_traversal(traversal)
+    else:
+        services, _folders = discover_services(
+            url,
+            service_types=["FeatureServer", "MapServer"],
+            return_folders=True,
+            timeout=timeout,
+        )
+        coverage = None
 
     if folder:
         prefix = f"{folder.rstrip('/')}/"
@@ -885,7 +898,7 @@ def _discover_and_filter_services(
         )
         services = [s for s in services if s.name in filtered_names]
 
-    return services, _coverage_from_traversal(traversal)
+    return services, coverage
 
 
 def _collect_layers_from_services(
@@ -1008,6 +1021,7 @@ def _extract_services_root(
         options.timeout,
         token=options.token,
         folder=parsed.folder,
+        recurse=options.recurse,
     )
 
     # Collect layers from all services

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -250,6 +250,8 @@ class ExtractionOptions:
         sort_hilbert: Whether to apply Hilbert spatial sorting
         raw: If True, skip auto-init (only create extraction files, no STAC catalog)
         no_styles: If True, skip style extraction from ESRI drawingInfo
+        token: Optional ArcGIS token for authenticated endpoints
+        recurse: Whether to recurse into sub-folders during discovery (default True)
     """
 
     workers: int = 3
@@ -260,6 +262,8 @@ class ExtractionOptions:
     dry_run: bool = False
     sort_hilbert: bool = True
     no_styles: bool = False
+    token: str | None = None
+    recurse: bool = True
 
 
 @dataclass
@@ -558,8 +562,8 @@ def extract_arcgis_catalog(
     # Parse URL
     parsed = parse_arcgis_url(url)
 
-    # Handle services root URLs differently
-    if parsed.url_type == ArcGISURLType.SERVICES_ROOT:
+    # Handle services root and folder URLs differently
+    if parsed.url_type in (ArcGISURLType.SERVICES_ROOT, ArcGISURLType.SERVICES_FOLDER):
         return _extract_services_root(
             url=url,
             parsed=parsed,
@@ -849,16 +853,27 @@ def _discover_and_filter_services(
     service_filter: list[str] | None,
     service_exclude: list[str] | None,
     timeout: float,
-) -> list[ServiceInfo]:
-    """Discover services and apply filters."""
+    *,
+    token: str | None = None,
+    folder: str | None = None,
+) -> tuple[list[ServiceInfo], FolderCoverage]:
+    """Discover services recursively, scope to a folder, and apply filters.
+
+    Returns (services, coverage). When folder is set (SERVICES_FOLDER URL), only
+    services under that folder prefix are kept.
+    """
     from portolan_cli.extract.arcgis.filters import filter_services
 
-    services, _folders = discover_services(
+    services, traversal = discover_services_recursive(
         url,
         service_types=["FeatureServer", "MapServer"],
-        return_folders=True,
+        token=token,
         timeout=timeout,
     )
+
+    if folder:
+        prefix = f"{folder.rstrip('/')}/"
+        services = [s for s in services if s.name.startswith(prefix)]
 
     if service_filter or service_exclude:
         service_names = [s.name for s in services]
@@ -870,7 +885,7 @@ def _discover_and_filter_services(
         )
         services = [s for s in services if s.name in filtered_names]
 
-    return services
+    return services, _coverage_from_traversal(traversal)
 
 
 def _collect_layers_from_services(
@@ -986,7 +1001,14 @@ def _extract_services_root(
         options = ExtractionOptions()
 
     # Discover and filter services
-    services = _discover_and_filter_services(url, service_filter, service_exclude, options.timeout)
+    services, coverage = _discover_and_filter_services(
+        url,
+        service_filter,
+        service_exclude,
+        options.timeout,
+        token=options.token,
+        folder=parsed.folder,
+    )
 
     # Collect layers from all services
     all_layers, service_for_layer, layer_count_per_service, _discovery_errors = (
@@ -1017,11 +1039,13 @@ def _extract_services_root(
         combined_discovery = ServiceDiscoveryResult(
             layers=[layer for _, layer in filtered_layers],
         )
-        return _build_report(
+        dry_report = _build_report(
             url=url,
             discovery_result=combined_discovery,
             layer_results=dry_run_results,
         )
+        dry_report.folder_coverage = coverage
+        return dry_report
 
     # Create output directory structure
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1142,6 +1166,7 @@ def _extract_services_root(
         discovery_result=combined_discovery,
         layer_results=layer_results,
     )
+    report.folder_coverage = coverage
     report_path = output_dir / ".portolan" / "extraction-report.json"
     save_report(report, report_path)
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -312,13 +312,15 @@ def _extract_single_layer(
     layer_url = f"{service_url.rstrip('/')}/{layer.id}"
     start_time = time.monotonic()
 
-    # Check if gpio.extract_arcgis supports max_workers (added in gpio 0.10.0+)
+    # Check which optional parameters gpio.extract_arcgis supports (feature-detected
+    # so older gpio versions continue to work without modification).
     sig = inspect.signature(gpio.extract_arcgis)
+    kwargs: dict[str, object] = {}
     if "max_workers" in sig.parameters:
-        table = gpio.extract_arcgis(layer_url, max_workers=options.workers)
-    else:
-        # Fallback for gpio < 0.10.0
-        table = gpio.extract_arcgis(layer_url)
+        kwargs["max_workers"] = options.workers
+    if options.token and "token" in sig.parameters:
+        kwargs["token"] = options.token
+    table = gpio.extract_arcgis(layer_url, **kwargs)
 
     # Apply Hilbert sorting if requested
     if options.sort_hilbert:

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -222,6 +222,21 @@ def _slugify(name: str) -> str:
     return slug or "unnamed"
 
 
+def _service_output_dir(output_dir: Path, service_name: str) -> Path:
+    """Map a (possibly folder-qualified) service name to a nested directory.
+
+    "ecml/active_faults" -> output_dir/ecml/active_faults
+    "Top"                -> output_dir/top
+    Each path segment is slugified independently so the folder hierarchy is
+    preserved as nested subcatalogs (ADR-0032, ADR-0053).
+    """
+    parts = [_slugify(p) for p in service_name.split("/") if p]
+    result = output_dir
+    for part in parts:
+        result = result / part
+    return result
+
+
 @dataclass
 class ExtractionOptions:
     """Options for the extraction process.
@@ -1024,18 +1039,18 @@ def _extract_services_root(
     for progress_idx, (layer_idx, layer) in enumerate(filtered_layers):
         service = service_for_layer[layer_idx]
         service_url = service.get_url(parsed.base_url)
-        service_slug = _slugify(service.name)
         layer_slug = _slugify(layer.name)
+        service_dir = _service_output_dir(output_dir, service.name)
+        service_leaf_slug = service_dir.name
 
         # Determine output path based on layer count:
         # - Single-layer service: service_name/service_name.parquet (flattened - no subcatalog)
         # - Multi-layer service: service_name/layer_name/layer_name.parquet (nested)
         is_single_layer = layer_count_per_service.get(service.name, 0) == 1
-        service_dir = output_dir / service_slug
 
         if is_single_layer:
             # Flatten: service becomes collection directly
-            output_path = service_dir / f"{service_slug}.parquet"
+            output_path = service_dir / f"{service_leaf_slug}.parquet"
         else:
             # Nested: service is subcatalog, layer is collection
             collection_dir = service_dir / layer_slug

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -163,6 +163,7 @@ def list_services(
             service_types=list(service_types) if service_types else None,
             return_folders=True,
             timeout=timeout,
+            token=token,
         )
         coverage = None
 
@@ -883,6 +884,7 @@ def _discover_and_filter_services(
             service_types=["FeatureServer", "MapServer"],
             return_folders=True,
             timeout=timeout,
+            token=token,
         )
         coverage = None
 

--- a/portolan_cli/extract/arcgis/url_parser.py
+++ b/portolan_cli/extract/arcgis/url_parser.py
@@ -28,6 +28,7 @@ class ArcGISURLType(Enum):
     MAP_SERVER = "MapServer"
     IMAGE_SERVER = "ImageServer"
     SERVICES_ROOT = "services"
+    SERVICES_FOLDER = "services_folder"
 
 
 class InvalidArcGISURLError(PortolanError):
@@ -51,21 +52,26 @@ class ParsedArcGISURL:
     """Result of parsing an ArcGIS REST URL.
 
     Attributes:
-        url_type: Type of endpoint (FeatureServer, MapServer, or services root)
-        base_url: URL without layer ID or query parameters
-        service_name: Extracted service name (None for services root)
+        url_type: Type of endpoint (FeatureServer, MapServer, ImageServer, services root, or services folder)
+        base_url: URL without layer ID or query parameters; for SERVICES_FOLDER this is the true services root
+        service_name: Extracted service name (None for services root or folder)
         layer_id: Layer ID if specified in URL (None otherwise)
+        folder: Folder name for SERVICES_FOLDER URLs (None for all other types)
     """
 
     url_type: ArcGISURLType
     base_url: str
     service_name: str | None
     layer_id: int | None
+    folder: str | None = None
 
     @property
     def is_single_service(self) -> bool:
-        """Whether this URL targets a single service (vs services root)."""
-        return self.url_type != ArcGISURLType.SERVICES_ROOT
+        """Whether this URL targets a single service (vs a services root/folder)."""
+        return self.url_type not in (
+            ArcGISURLType.SERVICES_ROOT,
+            ArcGISURLType.SERVICES_FOLDER,
+        )
 
     @property
     def service_endpoint_name(self) -> str | None:
@@ -97,6 +103,12 @@ _IMAGE_SERVER_PATTERN = re.compile(
 # Match: /rest/services at the end (services root)
 _SERVICES_ROOT_PATTERN = re.compile(
     r"/rest/services/?$",
+    re.IGNORECASE,
+)
+
+# Match: /rest/services/<folder-path> (no server-type segment) -> folder-scoped root
+_SERVICES_FOLDER_PATTERN = re.compile(
+    r"/rest/services/(.+?)/?$",
     re.IGNORECASE,
 )
 
@@ -204,6 +216,23 @@ def parse_arcgis_url(url: str) -> ParsedArcGISURL:
             base_url=base_url,
             service_name=None,
             layer_id=None,
+        )
+
+    # Try to match a folder-scoped services root: /rest/services/<folder>
+    # (reached only when no FeatureServer/MapServer/ImageServer matched)
+    folder_match = _SERVICES_FOLDER_PATTERN.search(url_path)
+    if folder_match:
+        folder = folder_match.group(1).strip("/")
+        # base_url is the true services root (folder stripped) so qualified
+        # service names from discovery resolve correctly via ServiceInfo.get_url.
+        services_idx = url_path.lower().find("/rest/services") + len("/rest/services")
+        base_url = url_path[:services_idx].rstrip("/")
+        return ParsedArcGISURL(
+            url_type=ArcGISURLType.SERVICES_FOLDER,
+            base_url=base_url,
+            service_name=None,
+            layer_id=None,
+            folder=folder,
         )
 
     # No match - not a recognized ArcGIS URL

--- a/portolan_cli/extract/arcgis/url_parser.py
+++ b/portolan_cli/extract/arcgis/url_parser.py
@@ -1,7 +1,7 @@
 """ArcGIS REST URL parser.
 
 Parses ArcGIS REST URLs to determine:
-- URL type (FeatureServer, MapServer, ImageServer, or services root)
+- URL type (FeatureServer, MapServer, ImageServer, services root, or services folder)
 - Service name (for default output directory naming)
 - Layer ID (if a specific layer is targeted)
 
@@ -9,6 +9,7 @@ Per design doc (context/shared/plans/extract-arcgis-design.md):
 - `*/FeatureServer` or `*/MapServer` -> single service extraction (vector)
 - `*/ImageServer` -> single service extraction (raster)
 - `*/rest/services` -> multi-service discovery and extraction
+- `*/rest/services/<folder>` -> folder-scoped multi-service discovery
 """
 
 from __future__ import annotations
@@ -117,10 +118,10 @@ def parse_arcgis_url(url: str) -> ParsedArcGISURL:
     """Parse an ArcGIS REST URL to determine type and extract metadata.
 
     Args:
-        url: ArcGIS REST URL (FeatureServer, MapServer, ImageServer, or services root)
+        url: ArcGIS REST URL (FeatureServer, MapServer, ImageServer, services root, or services folder)
 
     Returns:
-        ParsedArcGISURL with type, base URL, service name, and optional layer ID
+        ParsedArcGISURL with type, base URL, service name, optional layer ID, and optional folder
 
     Raises:
         InvalidArcGISURLError: If URL is not a recognized ArcGIS REST endpoint

--- a/portolan_cli/extract/common/report.py
+++ b/portolan_cli/extract/common/report.py
@@ -197,6 +197,40 @@ class MetadataExtracted:
 
 
 @dataclass
+class FolderCoverage:
+    """Coverage of a recursive services-root traversal.
+
+    Attributes:
+        folders_visited: Folder names successfully traversed.
+        folders_skipped: (folder, reason) pairs for folders that errored.
+        services_found: Total services discovered.
+    """
+
+    folders_visited: list[str]
+    folders_skipped: list[tuple[str, str]]
+    services_found: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict."""
+        return {
+            "folders_visited": self.folders_visited,
+            "folders_skipped": [{"folder": f, "reason": r} for f, r in self.folders_skipped],
+            "services_found": self.services_found,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FolderCoverage:
+        """Create FolderCoverage from dict."""
+        return cls(
+            folders_visited=data.get("folders_visited", []),
+            folders_skipped=[
+                (s["folder"], s["reason"]) for s in data.get("folders_skipped", [])
+            ],
+            services_found=data.get("services_found", 0),
+        )
+
+
+@dataclass
 class ExtractionReport:
     """Complete extraction report for a service.
 
@@ -211,6 +245,7 @@ class ExtractionReport:
         metadata_extracted: Harvested service metadata.
         layers: Results for each layer extraction attempt.
         summary: Aggregate statistics.
+        folder_coverage: Optional coverage data from recursive folder traversal.
     """
 
     extraction_date: str
@@ -220,10 +255,11 @@ class ExtractionReport:
     metadata_extracted: MetadataExtracted
     layers: list[LayerResult]
     summary: ExtractionSummary
+    folder_coverage: FolderCoverage | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON-serializable dict."""
-        return {
+        result: dict[str, Any] = {
             "extraction_date": self.extraction_date,
             "source_url": self.source_url,
             "portolan_version": self.portolan_version,
@@ -232,6 +268,9 @@ class ExtractionReport:
             "layers": [layer.to_dict() for layer in self.layers],
             "summary": self.summary.to_dict(),
         }
+        if self.folder_coverage is not None:
+            result["folder_coverage"] = self.folder_coverage.to_dict()
+        return result
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ExtractionReport:
@@ -244,6 +283,11 @@ class ExtractionReport:
             metadata_extracted=MetadataExtracted.from_dict(data["metadata_extracted"]),
             layers=[LayerResult.from_dict(layer) for layer in data["layers"]],
             summary=ExtractionSummary.from_dict(data["summary"]),
+            folder_coverage=(
+                FolderCoverage.from_dict(data["folder_coverage"])
+                if data.get("folder_coverage")
+                else None
+            ),
         )
 
 

--- a/portolan_cli/extract/common/report.py
+++ b/portolan_cli/extract/common/report.py
@@ -223,9 +223,7 @@ class FolderCoverage:
         """Create FolderCoverage from dict."""
         return cls(
             folders_visited=data.get("folders_visited", []),
-            folders_skipped=[
-                (s["folder"], s["reason"]) for s in data.get("folders_skipped", [])
-            ],
+            folders_skipped=[(s["folder"], s["reason"]) for s in data.get("folders_skipped", [])],
             services_found=data.get("services_found", 0),
         )
 

--- a/tests/integration/extract/arcgis/test_orchestrator_live.py
+++ b/tests/integration/extract/arcgis/test_orchestrator_live.py
@@ -16,6 +16,7 @@ from portolan_cli.extract.arcgis.orchestrator import (
     ExtractionOptions,
     ExtractionProgress,
     extract_arcgis_catalog,
+    list_services,
 )
 
 # Philadelphia's public ArcGIS services (stable, open data)
@@ -141,3 +142,29 @@ class TestLiveMetadataExtraction:
             "keywords": result.metadata_extracted.keywords,
         }
         assert report_dict["source_url"] is not None
+
+
+# South African national data portal — services live in a NationalDatasets folder.
+SA_ROOT = "https://nspdr.dlrrd.gov.za/server/rest/services"
+# JRC federated server — ALL services are in folders, zero top-level services.
+JRC_ROOT = "https://arcgis-maps.jrc.ec.europa.eu/federated_server/rest/services"
+
+
+@pytest.mark.network
+@pytest.mark.slow
+def test_sa_root_traverses_folders() -> None:
+    result = list_services(SA_ROOT, timeout=60.0)
+    names = [s.name for s in result.services]
+    # NationalDatasets services live in a folder; recursion must surface them
+    assert any(n.startswith("NationalDatasets/") for n in names)
+    assert result.coverage is not None
+    assert "NationalDatasets" in result.coverage.folders_visited
+
+
+@pytest.mark.network
+@pytest.mark.slow
+def test_jrc_root_has_only_folder_services() -> None:
+    # JRC root has ZERO top-level services; everything is in folders.
+    result = list_services(JRC_ROOT, timeout=60.0)
+    assert len(result.services) > 0
+    assert all("/" in s.name for s in result.services)

--- a/tests/unit/extract/arcgis/test_auth.py
+++ b/tests/unit/extract/arcgis/test_auth.py
@@ -1,0 +1,72 @@
+"""Tests for ArcGIS authentication module.
+
+Covers token pass-through, username/password token minting via generateToken,
+and error paths when minting fails.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from portolan_cli.errors import ArcGISAuthError
+from portolan_cli.extract.arcgis.auth import (
+    ArcGISCredentials,
+    apply_token,
+    resolve_token,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.unit
+def test_apply_token_appends_param() -> None:
+    assert "token=T" in apply_token("https://x/rest/services?f=json", "T")
+
+
+@pytest.mark.unit
+def test_resolve_token_returns_explicit_token() -> None:
+    creds = ArcGISCredentials(token="EXPLICIT")
+    assert resolve_token(creds, "https://x/rest/services") == "EXPLICIT"
+
+
+@pytest.mark.unit
+def test_resolve_token_none_when_no_credentials() -> None:
+    assert resolve_token(ArcGISCredentials(), "https://x/rest/services") is None
+
+
+@pytest.mark.unit
+def test_resolve_token_mints_from_username_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(self: object, url: str) -> httpx.Response:
+        # /rest/info returns the token services URL
+        return httpx.Response(
+            200,
+            json={"authInfo": {"tokenServicesUrl": "https://x/portal/sharing/rest/generateToken"}},
+        )
+
+    def fake_post(self: object, url: str, data: dict[str, str] | None = None) -> httpx.Response:
+        assert data is not None
+        assert data["username"] == "u" and data["password"] == "p"
+        return httpx.Response(200, json={"token": "MINTED", "expires": 1})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    creds = ArcGISCredentials(username="u", password="p")
+    assert resolve_token(creds, "https://x/server/rest/services") == "MINTED"
+
+
+@pytest.mark.unit
+def test_resolve_token_raises_on_mint_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(self: object, url: str) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"authInfo": {"tokenServicesUrl": "https://x/generateToken"}},
+        )
+
+    def fake_post(self: object, url: str, data: dict[str, str] | None = None) -> httpx.Response:
+        return httpx.Response(200, json={"error": {"code": 400, "message": "Invalid credentials"}})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    with pytest.raises(ArcGISAuthError, match="Invalid credentials"):
+        resolve_token(ArcGISCredentials(username="u", password="p"), "https://x/server/rest/services")

--- a/tests/unit/extract/arcgis/test_auth.py
+++ b/tests/unit/extract/arcgis/test_auth.py
@@ -72,3 +72,61 @@ def test_resolve_token_raises_on_mint_error(monkeypatch: pytest.MonkeyPatch) -> 
         resolve_token(
             ArcGISCredentials(username="u", password="p"), "https://x/server/rest/services"
         )
+
+
+@pytest.mark.unit
+def test_resolve_token_handles_uppercase_rest_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A /REST/ URL must derive the same server root as /rest/ for token minting."""
+    seen: dict[str, str] = {}
+
+    def fake_get(self: object, url: str) -> httpx.Response:
+        seen["info_url"] = url
+        return httpx.Response(
+            200,
+            json={"authInfo": {"tokenServicesUrl": "https://x/generateToken"}},
+        )
+
+    def fake_post(self: object, url: str, data: dict[str, str] | None = None) -> httpx.Response:
+        assert data is not None
+        seen["referer"] = data["referer"]
+        return httpx.Response(200, json={"token": "MINTED"})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    creds = ArcGISCredentials(username="u", password="p")
+    assert resolve_token(creds, "https://x/server/REST/services") == "MINTED"
+    assert seen["info_url"].startswith("https://x/server/rest/info")
+    assert seen["referer"] == "https://x/server"
+
+
+@pytest.mark.unit
+def test_resolve_token_raises_on_non_object_info_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-object JSON body from /rest/info must raise ArcGISAuthError, not AttributeError."""
+
+    def fake_get(self: object, url: str) -> httpx.Response:
+        return httpx.Response(200, json=["not", "an", "object"])
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    creds = ArcGISCredentials(username="u", password="p")
+    with pytest.raises(ArcGISAuthError):
+        resolve_token(creds, "https://x/server/rest/services")
+
+
+@pytest.mark.unit
+def test_resolve_token_raises_on_non_object_token_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-object JSON body from generateToken must raise ArcGISAuthError."""
+
+    def fake_get(self: object, url: str) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"authInfo": {"tokenServicesUrl": "https://x/generateToken"}},
+        )
+
+    def fake_post(self: object, url: str, data: dict[str, str] | None = None) -> httpx.Response:
+        return httpx.Response(200, json="just a string")
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    monkeypatch.setattr(httpx.Client, "post", fake_post)
+    creds = ArcGISCredentials(username="u", password="p")
+    with pytest.raises(ArcGISAuthError):
+        resolve_token(creds, "https://x/server/rest/services")

--- a/tests/unit/extract/arcgis/test_auth.py
+++ b/tests/unit/extract/arcgis/test_auth.py
@@ -69,4 +69,6 @@ def test_resolve_token_raises_on_mint_error(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(httpx.Client, "get", fake_get)
     monkeypatch.setattr(httpx.Client, "post", fake_post)
     with pytest.raises(ArcGISAuthError, match="Invalid credentials"):
-        resolve_token(ArcGISCredentials(username="u", password="p"), "https://x/server/rest/services")
+        resolve_token(
+            ArcGISCredentials(username="u", password="p"), "https://x/server/rest/services"
+        )

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -178,18 +178,6 @@ class TestDiscoverLayers:
             assert result.service_description is None
             assert result.copyright_text is None
 
-    def test_raises_on_http_error(self) -> None:
-        """Should raise ArcGISDiscoveryError on HTTP errors."""
-        with patch("portolan_cli.extract.arcgis.discovery.httpx.Client") as mock_client:
-            mock_client.return_value.__enter__.return_value.get.side_effect = httpx.HTTPStatusError(
-                "Not Found",
-                request=httpx.Request("GET", "https://example.com"),
-                response=httpx.Response(404),
-            )
-
-            with pytest.raises(ArcGISDiscoveryError, match="Failed to fetch"):
-                discover_layers("https://services.arcgis.com/test/FeatureServer")
-
     def test_raises_on_invalid_json(self) -> None:
         """Should raise ArcGISDiscoveryError on invalid JSON response."""
         with patch("portolan_cli.extract.arcgis.discovery.httpx.Client") as mock_client:
@@ -359,7 +347,7 @@ from portolan_cli.extract.arcgis.discovery import _fetch_json  # noqa: E402
 def test_fetch_json_raises_on_embedded_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Should raise ArcGISDiscoveryError when ArcGIS returns an embedded error body."""
 
-    def fake_get(self: object, url: str) -> httpx.Response:  # noqa: ANN001
+    def fake_get(self: object, url: str) -> httpx.Response:
         return httpx.Response(200, json={"error": {"code": 499, "message": "Token Required"}})
 
     monkeypatch.setattr(httpx.Client, "get", fake_get)
@@ -372,10 +360,22 @@ def test_fetch_json_appends_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Should append token=<token> to the request URL when token is provided."""
     seen: dict[str, str] = {}
 
-    def fake_get(self: object, url: str) -> httpx.Response:  # noqa: ANN001
+    def fake_get(self: object, url: str) -> httpx.Response:
         seen["url"] = url
         return httpx.Response(200, json={"services": [], "folders": []})
 
     monkeypatch.setattr(httpx.Client, "get", fake_get)
     _fetch_json("https://x/rest/services", token="ABC123")
     assert "token=ABC123" in seen["url"]
+
+
+@pytest.mark.unit
+def test_fetch_json_raises_on_http_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should raise ArcGISDiscoveryError when the server returns a 4xx/5xx status."""
+
+    def fake_get(self: object, url: str) -> httpx.Response:
+        return httpx.Response(404, json={})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    with pytest.raises(ArcGISDiscoveryError, match="HTTP 404"):
+        _fetch_json("https://x/rest/services/Missing")

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -379,3 +379,118 @@ def test_fetch_json_raises_on_http_error_status(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(httpx.Client, "get", fake_get)
     with pytest.raises(ArcGISDiscoveryError, match="HTTP 404"):
         _fetch_json("https://x/rest/services/Missing")
+
+
+# =============================================================================
+# discover_services_recursive tests
+# =============================================================================
+
+
+from portolan_cli.extract.arcgis.discovery import (  # noqa: E402
+    FolderTraversal,  # noqa: F401 — used in isinstance assertion below
+    discover_services_recursive,
+)
+
+
+def _mock_endpoints(monkeypatch: pytest.MonkeyPatch, responses: dict[str, dict]) -> None:  # type: ignore[type-arg]
+    """Map base URL (without query) -> JSON body."""
+
+    def fake_fetch(url: str, timeout: float = 60.0, token: str | None = None) -> dict[str, Any]:
+        base = url.split("?")[0]
+        if base not in responses:
+            raise ArcGISDiscoveryError(f"ArcGIS error from {url}: 499 Token Required")
+        return responses[base]
+
+    monkeypatch.setattr("portolan_cli.extract.arcgis.discovery._fetch_json", fake_fetch)
+
+
+@pytest.mark.unit
+def test_recursive_merges_folder_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should merge root services with services from all folders."""
+    root = "https://x/rest/services"
+    _mock_endpoints(
+        monkeypatch,
+        {
+            root: {
+                "services": [{"name": "Top", "type": "MapServer"}],
+                "folders": ["NationalDatasets"],
+            },
+            f"{root}/NationalDatasets": {
+                "services": [
+                    {"name": "NationalDatasets/Property", "type": "MapServer"},
+                    {"name": "NationalDatasets/Agriculture", "type": "MapServer"},
+                ],
+                "folders": [],
+            },
+        },
+    )
+    services, traversal = discover_services_recursive(root)
+    names = sorted(s.name for s in services)
+    assert names == ["NationalDatasets/Agriculture", "NationalDatasets/Property", "Top"]
+    assert traversal.visited == ["NationalDatasets"]
+    assert traversal.skipped == []
+    assert traversal.service_count == 3
+
+
+@pytest.mark.unit
+def test_recursive_skips_secured_folder(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should skip secured (erroring) folders and record them in skipped."""
+    root = "https://x/rest/services"
+    _mock_endpoints(
+        monkeypatch,
+        {
+            root: {"services": [], "folders": ["Open", "Locked"]},
+            f"{root}/Open": {
+                "services": [{"name": "Open/A", "type": "MapServer"}],
+                "folders": [],
+            },
+            # Locked intentionally absent -> fake_fetch raises -> skipped
+        },
+    )
+    services, traversal = discover_services_recursive(root)
+    assert [s.name for s in services] == ["Open/A"]
+    assert traversal.visited == ["Open"]
+    assert [f for f, _ in traversal.skipped] == ["Locked"]
+
+
+@pytest.mark.unit
+def test_recursive_respects_max_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should not fetch folders beyond max_depth."""
+    root = "https://x/rest/services"
+    _mock_endpoints(
+        monkeypatch,
+        {
+            root: {"services": [], "folders": ["L1"]},
+            f"{root}/L1": {
+                "services": [{"name": "L1/A", "type": "MapServer"}],
+                "folders": ["L2"],
+            },
+            f"{root}/L2": {
+                "services": [{"name": "L2/B", "type": "MapServer"}],
+                "folders": [],
+            },
+        },
+    )
+    services, _ = discover_services_recursive(root, max_depth=1)
+    # depth 1 fetches root (depth 0) + L1 (depth 1), not L2
+    assert [s.name for s in services] == ["L1/A"]
+
+
+@pytest.mark.unit
+def test_recursive_filters_by_service_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should only return services matching the given service_types."""
+    root = "https://x/rest/services"
+    _mock_endpoints(
+        monkeypatch,
+        {
+            root: {
+                "services": [
+                    {"name": "Tool", "type": "GPServer"},
+                    {"name": "Map", "type": "MapServer"},
+                ],
+                "folders": [],
+            },
+        },
+    )
+    services, _ = discover_services_recursive(root, service_types=["FeatureServer", "MapServer"])
+    assert [s.name for s in services] == ["Map"]

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -382,6 +382,18 @@ def test_fetch_json_raises_on_http_error_status(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.unit
+def test_fetch_json_raises_on_non_object_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-object JSON must raise ArcGISDiscoveryError, not AttributeError on .get()."""
+
+    def fake_get(self: object, url: str) -> httpx.Response:
+        return httpx.Response(200, json=["not", "an", "object"])
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    with pytest.raises(ArcGISDiscoveryError, match="Expected JSON object"):
+        _fetch_json("https://x/rest/services")
+
+
+@pytest.mark.unit
 def test_discover_services_forwards_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Should forward token to the request so --no-recurse discovery stays authenticated."""
     seen: dict[str, str] = {}

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -381,6 +381,20 @@ def test_fetch_json_raises_on_http_error_status(monkeypatch: pytest.MonkeyPatch)
         _fetch_json("https://x/rest/services/Missing")
 
 
+@pytest.mark.unit
+def test_discover_services_forwards_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should forward token to the request so --no-recurse discovery stays authenticated."""
+    seen: dict[str, str] = {}
+
+    def fake_get(self: object, url: str) -> httpx.Response:
+        seen["url"] = url
+        return httpx.Response(200, json={"services": [], "folders": []})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    discover_services("https://x/rest/services", token="TKN789")
+    assert "token=TKN789" in seen["url"]
+
+
 # =============================================================================
 # discover_services_recursive tests
 # =============================================================================

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -500,7 +500,10 @@ def test_recursive_builds_full_path_for_nested_folders(monkeypatch: pytest.Monke
         {
             root: {"services": [], "folders": ["L1"]},
             f"{root}/L1": {"services": [{"name": "L1/A", "type": "MapServer"}], "folders": ["L2"]},
-            f"{root}/L1/L2": {"services": [{"name": "L1/L2/B", "type": "MapServer"}], "folders": []},
+            f"{root}/L1/L2": {
+                "services": [{"name": "L1/L2/B", "type": "MapServer"}],
+                "folders": [],
+            },
         },
     )
     services, traversal = discover_services_recursive(root, max_depth=2)

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -72,6 +72,7 @@ def _mock_httpx_response(data: dict[str, Any]) -> MagicMock:
     mock_response = MagicMock()
     mock_response.json.return_value = data
     mock_response.raise_for_status = MagicMock()
+    mock_response.status_code = 200
     return mock_response
 
 
@@ -195,6 +196,7 @@ class TestDiscoverLayers:
             mock_response = MagicMock()
             mock_response.json.side_effect = ValueError("Invalid JSON")
             mock_response.raise_for_status = MagicMock()
+            mock_response.status_code = 200
             mock_client.return_value.__enter__.return_value.get.return_value = mock_response
 
             with pytest.raises(ArcGISDiscoveryError, match="Invalid JSON"):
@@ -259,7 +261,7 @@ class TestDiscoverServices:
 
     def test_handles_empty_services_list(self) -> None:
         """Should handle empty services list."""
-        empty_response = {"services": [], "folders": []}
+        empty_response: dict[str, Any] = {"services": [], "folders": []}
 
         with patch("portolan_cli.extract.arcgis.discovery.httpx.Client") as mock_client:
             mock_client.return_value.__enter__.return_value.get.return_value = _mock_httpx_response(
@@ -343,3 +345,37 @@ class TestServiceDiscoveryResult:
         assert len(result.layers) == 1
         assert result.service_description == "Test service"
         assert result.author == "Author"
+
+
+# =============================================================================
+# _fetch_json token and embedded-error tests
+# =============================================================================
+
+
+from portolan_cli.extract.arcgis.discovery import _fetch_json  # noqa: E402
+
+
+@pytest.mark.unit
+def test_fetch_json_raises_on_embedded_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should raise ArcGISDiscoveryError when ArcGIS returns an embedded error body."""
+
+    def fake_get(self: object, url: str) -> httpx.Response:  # noqa: ANN001
+        return httpx.Response(200, json={"error": {"code": 499, "message": "Token Required"}})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    with pytest.raises(ArcGISDiscoveryError, match="499"):
+        _fetch_json("https://x/rest/services/Secret")
+
+
+@pytest.mark.unit
+def test_fetch_json_appends_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should append token=<token> to the request URL when token is provided."""
+    seen: dict[str, str] = {}
+
+    def fake_get(self: object, url: str) -> httpx.Response:  # noqa: ANN001
+        seen["url"] = url
+        return httpx.Response(200, json={"services": [], "folders": []})
+
+    monkeypatch.setattr(httpx.Client, "get", fake_get)
+    _fetch_json("https://x/rest/services", token="ABC123")
+    assert "token=ABC123" in seen["url"]

--- a/tests/unit/extract/arcgis/test_discovery.py
+++ b/tests/unit/extract/arcgis/test_discovery.py
@@ -15,12 +15,15 @@ import pytest
 
 from portolan_cli.extract.arcgis.discovery import (
     ArcGISDiscoveryError,
+    FolderTraversal,
     LayerInfo,
     ServiceDiscoveryResult,
     ServiceInfo,
     _ensure_json_format,
+    _fetch_json,
     discover_layers,
     discover_services,
+    discover_services_recursive,
 )
 
 pytestmark = pytest.mark.unit
@@ -340,9 +343,6 @@ class TestServiceDiscoveryResult:
 # =============================================================================
 
 
-from portolan_cli.extract.arcgis.discovery import _fetch_json  # noqa: E402
-
-
 @pytest.mark.unit
 def test_fetch_json_raises_on_embedded_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Should raise ArcGISDiscoveryError when ArcGIS returns an embedded error body."""
@@ -386,12 +386,6 @@ def test_fetch_json_raises_on_http_error_status(monkeypatch: pytest.MonkeyPatch)
 # =============================================================================
 
 
-from portolan_cli.extract.arcgis.discovery import (  # noqa: E402
-    FolderTraversal,  # noqa: F401 — used in isinstance assertion below
-    discover_services_recursive,
-)
-
-
 def _mock_endpoints(monkeypatch: pytest.MonkeyPatch, responses: dict[str, dict]) -> None:  # type: ignore[type-arg]
     """Map base URL (without query) -> JSON body."""
 
@@ -430,6 +424,7 @@ def test_recursive_merges_folder_services(monkeypatch: pytest.MonkeyPatch) -> No
     assert traversal.visited == ["NationalDatasets"]
     assert traversal.skipped == []
     assert traversal.service_count == 3
+    assert isinstance(traversal, FolderTraversal)
 
 
 @pytest.mark.unit
@@ -494,3 +489,20 @@ def test_recursive_filters_by_service_type(monkeypatch: pytest.MonkeyPatch) -> N
     )
     services, _ = discover_services_recursive(root, service_types=["FeatureServer", "MapServer"])
     assert [s.name for s in services] == ["Map"]
+
+
+@pytest.mark.unit
+def test_recursive_builds_full_path_for_nested_folders(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Should build full root-relative paths for sub-folders, not bare names."""
+    root = "https://x/rest/services"
+    _mock_endpoints(
+        monkeypatch,
+        {
+            root: {"services": [], "folders": ["L1"]},
+            f"{root}/L1": {"services": [{"name": "L1/A", "type": "MapServer"}], "folders": ["L2"]},
+            f"{root}/L1/L2": {"services": [{"name": "L1/L2/B", "type": "MapServer"}], "folders": []},
+        },
+    )
+    services, traversal = discover_services_recursive(root, max_depth=2)
+    assert sorted(s.name for s in services) == ["L1/A", "L1/L2/B"]
+    assert traversal.visited == ["L1", "L1/L2"]

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -445,8 +445,6 @@ class TestListServices:
 
     def test_list_services_returns_services_only(self) -> None:
         """list_services should return services without probing for layers."""
-        from portolan_cli.extract.arcgis.discovery import FolderTraversal
-
         mock_services = [
             ServiceInfo(name="Census_2020", service_type="FeatureServer"),
             ServiceInfo(name="Transportation", service_type="MapServer"),
@@ -476,8 +474,6 @@ class TestListServices:
 
     def test_list_services_filters_by_type(self) -> None:
         """list_services should filter by service type."""
-        from portolan_cli.extract.arcgis.discovery import FolderTraversal
-
         mock_services = [
             ServiceInfo(name="Census_2020", service_type="FeatureServer"),
             ServiceInfo(name="Transportation", service_type="MapServer"),
@@ -504,8 +500,6 @@ class TestListServices:
 
     def test_list_services_applies_glob_filter(self) -> None:
         """list_services should apply glob pattern filters."""
-        from portolan_cli.extract.arcgis.discovery import FolderTraversal
-
         mock_services = [
             ServiceInfo(name="Census_2020", service_type="FeatureServer"),
             ServiceInfo(name="Census_2010", service_type="FeatureServer"),
@@ -1128,9 +1122,6 @@ class TestArcGISCollectionMetadataSeeding:
 
 @pytest.mark.unit
 def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    from portolan_cli.extract.arcgis.discovery import FolderTraversal, ServiceInfo
-    from portolan_cli.extract.arcgis.orchestrator import list_services
-
     captured: dict[str, object] = {}
 
     def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
@@ -1161,9 +1152,6 @@ def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # ty
 @pytest.mark.unit
 def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """recurse=False calls discover_services (not recursive), returns coverage=None."""
-    from portolan_cli.extract.arcgis.discovery import ServiceInfo
-    from portolan_cli.extract.arcgis.orchestrator import list_services
-
     def fake_discover(url, *, service_types=None, return_folders=False, timeout=60.0):  # type: ignore[no-untyped-def]  # noqa: ANN001
         assert return_folders is True
         return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
@@ -1238,3 +1226,19 @@ def test_extract_routes_folder_url_and_attaches_coverage(monkeypatch, tmp_path) 
     )
     assert report.folder_coverage is not None
     assert report.folder_coverage.folders_visited == ["ecml"]
+
+
+@pytest.mark.unit
+def test_discover_and_filter_no_recurse_uses_flat_discovery(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def fake_flat(url, *, service_types=None, return_folders=False, timeout=60.0):  # noqa: ANN001
+        assert return_folders is True
+        return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services", fake_flat
+    )
+    services, coverage = _discover_and_filter_services(
+        "https://x/rest/services", None, None, 60.0, recurse=False
+    )
+    assert [s.name for s in services] == ["Top"]
+    assert coverage is None

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from portolan_cli.extract.arcgis.discovery import (
+    FolderTraversal,
     LayerInfo,
     ServiceDiscoveryResult,
     ServiceInfo,
@@ -20,6 +21,7 @@ from portolan_cli.extract.arcgis.orchestrator import (
     ExtractionOptions,
     ExtractionProgress,
     ServicesRootDiscoveryResult,
+    _discover_and_filter_services,
     _service_output_dir,
     _slugify,
     extract_arcgis_catalog,
@@ -248,15 +250,17 @@ class TestExtractArcgisCatalog:
             ],
         )
 
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=2)
+
         with (
             patch(
-                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+                "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
             ) as mock_discover_services,
             patch(
                 "portolan_cli.extract.arcgis.orchestrator.discover_layers"
             ) as mock_discover_layers,
         ):
-            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_services.return_value = (mock_services, mock_traversal)
             # Return different layers for each service
             mock_discover_layers.side_effect = [mock_census_layers, mock_transport_layers]
 
@@ -584,16 +588,18 @@ class TestServicesRootExtraction:
             ],
         )
 
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=1)
+
         with (
             patch(
-                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+                "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
             ) as mock_discover_services,
             patch(
                 "portolan_cli.extract.arcgis.orchestrator.discover_layers"
             ) as mock_discover_layers,
             patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
         ):
-            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_services.return_value = (mock_services, mock_traversal)
             mock_discover_layers.return_value = mock_census_layers
             mock_extract.return_value = (100, 2048, 2.5)
 
@@ -633,16 +639,18 @@ class TestServicesRootExtraction:
             ],
         )
 
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=2)
+
         with (
             patch(
-                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+                "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
             ) as mock_discover_services,
             patch(
                 "portolan_cli.extract.arcgis.orchestrator.discover_layers"
             ) as mock_discover_layers,
             patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
         ):
-            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_services.return_value = (mock_services, mock_traversal)
             mock_discover_layers.return_value = mock_census_layers
             mock_extract.return_value = (100, 2048, 2.5)
 
@@ -684,16 +692,18 @@ class TestServicesRootExtraction:
             ],
         )
 
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=1)
+
         with (
             patch(
-                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+                "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
             ) as mock_discover_services,
             patch(
                 "portolan_cli.extract.arcgis.orchestrator.discover_layers"
             ) as mock_discover_layers,
             patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
         ):
-            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_services.return_value = (mock_services, mock_traversal)
             mock_discover_layers.return_value = mock_single_layer
             mock_extract.return_value = (100, 2048, 2.5)
 
@@ -744,16 +754,18 @@ class TestServicesRootExtraction:
             ],
         )
 
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=1)
+
         with (
             patch(
-                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+                "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
             ) as mock_discover_services,
             patch(
                 "portolan_cli.extract.arcgis.orchestrator.discover_layers"
             ) as mock_discover_layers,
             patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
         ):
-            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_services.return_value = (mock_services, mock_traversal)
             mock_discover_layers.return_value = mock_multi_layers
             mock_extract.return_value = (100, 2048, 2.5)
 
@@ -803,16 +815,18 @@ class TestServicesRootExtraction:
             ],
         )
 
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=2)
+
         with (
             patch(
-                "portolan_cli.extract.arcgis.orchestrator.discover_services"
+                "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
             ) as mock_discover_services,
             patch(
                 "portolan_cli.extract.arcgis.orchestrator.discover_layers"
             ) as mock_discover_layers,
             patch("portolan_cli.extract.arcgis.orchestrator._extract_single_layer") as mock_extract,
         ):
-            mock_discover_services.return_value = (mock_services, [])
+            mock_discover_services.return_value = (mock_services, mock_traversal)
             mock_discover_layers.side_effect = [mock_single, mock_multi]
             mock_extract.return_value = (100, 2048, 2.5)
 
@@ -1178,4 +1192,49 @@ def test_service_output_dir_nests_folders(tmp_path) -> None:  # type: ignore[no-
     )
 
 
-# TASKS_8_10_PLACEHOLDER
+# =============================================================================
+# Tasks 8 + 10: recursive folder discovery, scoping, routing, coverage
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_discover_and_filter_scopes_to_folder(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+        services = [
+            ServiceInfo("ecml/active_faults", "MapServer"),
+            ServiceInfo("water/rivers", "MapServer"),
+        ]
+        return services, FolderTraversal(visited=["ecml", "water"], skipped=[], service_count=2)
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
+    )
+    services, coverage = _discover_and_filter_services(
+        "https://x/rest/services", None, None, 60.0, token=None, folder="ecml"
+    )
+    assert [s.name for s in services] == ["ecml/active_faults"]
+    assert coverage is not None
+
+
+@pytest.mark.unit
+def test_extract_routes_folder_url_and_attaches_coverage(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
+    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+        return (
+            [ServiceInfo("ecml/active_faults", "MapServer")],
+            FolderTraversal(visited=["ecml"], skipped=[], service_count=1),
+        )
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
+    )
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator._collect_layers_from_services",
+        lambda services, base_url, timeout: ([], {}, {}, []),
+    )
+    report = extract_arcgis_catalog(
+        url="https://x/server/rest/services/ecml",
+        output_dir=tmp_path / "out",
+        options=ExtractionOptions(dry_run=True),
+    )
+    assert report.folder_coverage is not None
+    assert report.folder_coverage.folders_visited == ["ecml"]

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -440,46 +440,56 @@ class TestListServices:
 
     def test_list_services_returns_services_only(self) -> None:
         """list_services should return services without probing for layers."""
+        from portolan_cli.extract.arcgis.discovery import FolderTraversal
+
         mock_services = [
             ServiceInfo(name="Census_2020", service_type="FeatureServer"),
             ServiceInfo(name="Transportation", service_type="MapServer"),
             ServiceInfo(name="Basemap", service_type="MapServer"),
         ]
+        mock_traversal = FolderTraversal(
+            visited=["Archived", "Internal"], skipped=[], service_count=3
+        )
 
-        with patch("portolan_cli.extract.arcgis.orchestrator.discover_services") as mock_discover:
-            mock_discover.return_value = (mock_services, ["Archived", "Internal"])
+        with patch(
+            "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
+        ) as mock_discover:
+            mock_discover.return_value = (mock_services, mock_traversal)
 
             result = list_services(TEST_SERVICES_ROOT_URL)
 
-            # Should call discover_services with return_folders=True
+            # Should call discover_services_recursive
             mock_discover.assert_called_once()
-            call_kwargs = mock_discover.call_args.kwargs
-            assert call_kwargs.get("return_folders") is True
 
             # Should return all services
             assert len(result.services) == 3
             assert result.services[0].name == "Census_2020"
             assert result.services[1].name == "Transportation"
 
-            # Should include folders
+            # Should include folders from traversal
             assert result.folders == ["Archived", "Internal"]
 
     def test_list_services_filters_by_type(self) -> None:
         """list_services should filter by service type."""
+        from portolan_cli.extract.arcgis.discovery import FolderTraversal
+
         mock_services = [
             ServiceInfo(name="Census_2020", service_type="FeatureServer"),
             ServiceInfo(name="Transportation", service_type="MapServer"),
         ]
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=2)
 
-        with patch("portolan_cli.extract.arcgis.orchestrator.discover_services") as mock_discover:
-            mock_discover.return_value = (mock_services, [])
+        with patch(
+            "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
+        ) as mock_discover:
+            mock_discover.return_value = (mock_services, mock_traversal)
 
             result = list_services(
                 TEST_SERVICES_ROOT_URL,
                 service_types=["FeatureServer"],
             )
 
-            # discover_services should be called with service_types filter
+            # discover_services_recursive should be called with service_types filter
             mock_discover.assert_called_once()
             call_kwargs = mock_discover.call_args.kwargs
             assert call_kwargs.get("service_types") == ["FeatureServer"]
@@ -489,14 +499,19 @@ class TestListServices:
 
     def test_list_services_applies_glob_filter(self) -> None:
         """list_services should apply glob pattern filters."""
+        from portolan_cli.extract.arcgis.discovery import FolderTraversal
+
         mock_services = [
             ServiceInfo(name="Census_2020", service_type="FeatureServer"),
             ServiceInfo(name="Census_2010", service_type="FeatureServer"),
             ServiceInfo(name="Transportation", service_type="MapServer"),
         ]
+        mock_traversal = FolderTraversal(visited=[], skipped=[], service_count=3)
 
-        with patch("portolan_cli.extract.arcgis.orchestrator.discover_services") as mock_discover:
-            mock_discover.return_value = (mock_services, [])
+        with patch(
+            "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive"
+        ) as mock_discover:
+            mock_discover.return_value = (mock_services, mock_traversal)
 
             result = list_services(
                 TEST_SERVICES_ROOT_URL,
@@ -508,8 +523,8 @@ class TestListServices:
             assert all("Census" in s.name for s in result.services)
 
     def test_list_services_raises_for_non_services_root(self) -> None:
-        """list_services should raise error for non-services-root URLs."""
-        with pytest.raises(ValueError, match="not a services root URL"):
+        """list_services should raise error for non-services-root or folder URLs."""
+        with pytest.raises(ValueError, match="not a services root or folder URL"):
             list_services(TEST_FEATURE_SERVER_URL)
 
 
@@ -1021,6 +1036,7 @@ class TestArcGISCollectionMetadataSeeding:
             mock_fetch.assert_not_called()
 
     def test_seed_collection_metadata_arcgis_nested_output_path(self, tmp_path: Path) -> None:
+
         """Collection seeding handles nested output paths correctly."""
         from portolan_cli.extract.arcgis.orchestrator import _seed_collection_metadata_arcgis
         from portolan_cli.extract.common.report import (
@@ -1089,3 +1105,36 @@ class TestArcGISCollectionMetadataSeeding:
         assert metadata_path.exists()
         content = metadata_path.read_text()
         assert "Description from ArcGIS API" in content
+
+
+# =============================================================================
+# list_services folder recursion + coverage tests
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from portolan_cli.extract.arcgis.discovery import FolderTraversal, ServiceInfo
+    from portolan_cli.extract.arcgis.orchestrator import list_services
+
+    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+        services = [
+            ServiceInfo("Top", "MapServer"),
+            ServiceInfo("NationalDatasets/Property", "MapServer"),
+        ]
+        traversal = FolderTraversal(
+            visited=["NationalDatasets"], skipped=[("Locked", "499")], service_count=2
+        )
+        return services, traversal
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
+    )
+    result = list_services("https://x/rest/services")
+    names = [s.name for s in result.services]
+    assert "NationalDatasets/Property" in names
+    assert result.coverage is not None
+    assert result.coverage.folders_visited == ["NationalDatasets"]
+    assert result.coverage.folders_skipped == [("Locked", "499")]
+    d = result.to_dict()
+    assert d["folder_coverage"]["folders_skipped"] == [{"folder": "Locked", "reason": "499"}]

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -1036,7 +1036,6 @@ class TestArcGISCollectionMetadataSeeding:
             mock_fetch.assert_not_called()
 
     def test_seed_collection_metadata_arcgis_nested_output_path(self, tmp_path: Path) -> None:
-
         """Collection seeding handles nested output paths correctly."""
         from portolan_cli.extract.arcgis.orchestrator import _seed_collection_metadata_arcgis
         from portolan_cli.extract.common.report import (
@@ -1117,7 +1116,10 @@ def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # ty
     from portolan_cli.extract.arcgis.discovery import FolderTraversal, ServiceInfo
     from portolan_cli.extract.arcgis.orchestrator import list_services
 
+    captured: dict[str, object] = {}
+
     def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+        captured["token"] = token
         services = [
             ServiceInfo("Top", "MapServer"),
             ServiceInfo("NationalDatasets/Property", "MapServer"),
@@ -1130,7 +1132,8 @@ def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # ty
     monkeypatch.setattr(
         "portolan_cli.extract.arcgis.orchestrator.discover_services_recursive", fake_recursive
     )
-    result = list_services("https://x/rest/services")
+    result = list_services("https://x/rest/services", token="TKN")
+    assert captured["token"] == "TKN"
     names = [s.name for s in result.services]
     assert "NationalDatasets/Property" in names
     assert result.coverage is not None
@@ -1138,3 +1141,22 @@ def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # ty
     assert result.coverage.folders_skipped == [("Locked", "499")]
     d = result.to_dict()
     assert d["folder_coverage"]["folders_skipped"] == [{"folder": "Locked", "reason": "499"}]
+
+
+@pytest.mark.unit
+def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """recurse=False calls discover_services (not recursive), returns coverage=None."""
+    from portolan_cli.extract.arcgis.discovery import ServiceInfo
+    from portolan_cli.extract.arcgis.orchestrator import list_services
+
+    def fake_discover(url, *, service_types=None, return_folders=False, timeout=60.0):  # type: ignore[no-untyped-def]  # noqa: ANN001
+        assert return_folders is True
+        return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.discover_services", fake_discover
+    )
+    result = list_services("https://x/rest/services", recurse=False)
+    assert [s.name for s in result.services] == ["Top"]
+    assert result.coverage is None
+    assert "folder_coverage" not in result.to_dict()

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -20,6 +20,7 @@ from portolan_cli.extract.arcgis.orchestrator import (
     ExtractionOptions,
     ExtractionProgress,
     ServicesRootDiscoveryResult,
+    _service_output_dir,
     _slugify,
     extract_arcgis_catalog,
     list_services,
@@ -1160,3 +1161,21 @@ def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: 
     assert [s.name for s in result.services] == ["Top"]
     assert result.coverage is None
     assert "folder_coverage" not in result.to_dict()
+
+
+# =============================================================================
+# Task 9: nested-by-folder output paths
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_service_output_dir_nests_folders(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    assert _service_output_dir(tmp_path, "ecml/active_faults") == tmp_path / "ecml" / "active_faults"
+    assert _service_output_dir(tmp_path, "Top") == tmp_path / "top"
+    assert (
+        _service_output_dir(tmp_path, "RDH_hazard/Flood Risk")
+        == tmp_path / "rdh_hazard" / "flood_risk"
+    )
+
+
+# TASKS_8_10_PLACEHOLDER

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -6,6 +6,8 @@ URL parsing → Discovery → Filtering → Extraction → Report generation.
 
 from __future__ import annotations
 
+import sys
+import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +24,7 @@ from portolan_cli.extract.arcgis.orchestrator import (
     ExtractionProgress,
     ServicesRootDiscoveryResult,
     _discover_and_filter_services,
+    _extract_single_layer,
     _service_output_dir,
     _slugify,
     extract_arcgis_catalog,
@@ -1242,3 +1245,39 @@ def test_discover_and_filter_no_recurse_uses_flat_discovery(monkeypatch) -> None
     )
     assert [s.name for s in services] == ["Top"]
     assert coverage is None
+
+
+# =============================================================================
+# _extract_single_layer token-forwarding test
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_extract_single_layer_passes_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Token must be forwarded to gpio.extract_arcgis when the param is supported."""
+    captured: dict[str, object] = {}
+
+    def fake_extract_arcgis(url: str, max_workers: int | None = None, token: str | None = None) -> object:  # noqa: ANN001
+        captured["token"] = token
+
+        class _T:
+            num_rows = 1
+
+            def write(self, path: str) -> None:
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_bytes(b"PAR1")
+
+        return _T()
+
+    fake_gpio = types.ModuleType("geoparquet_io")
+    fake_gpio.extract_arcgis = fake_extract_arcgis  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "geoparquet_io", fake_gpio)
+
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        tmp_path / "out.parquet",
+        ExtractionOptions(token="TKN", sort_hilbert=False),
+    )
+    assert captured["token"] == "TKN"

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -1155,13 +1155,12 @@ def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # ty
 @pytest.mark.unit
 def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     """recurse=False calls discover_services (not recursive), returns coverage=None."""
+
     def fake_discover(url, *, service_types=None, return_folders=False, timeout=60.0):  # type: ignore[no-untyped-def]  # noqa: ANN001
         assert return_folders is True
         return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
 
-    monkeypatch.setattr(
-        "portolan_cli.extract.arcgis.orchestrator.discover_services", fake_discover
-    )
+    monkeypatch.setattr("portolan_cli.extract.arcgis.orchestrator.discover_services", fake_discover)
     result = list_services("https://x/rest/services", recurse=False)
     assert [s.name for s in result.services] == ["Top"]
     assert result.coverage is None
@@ -1175,7 +1174,9 @@ def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: 
 
 @pytest.mark.unit
 def test_service_output_dir_nests_folders(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    assert _service_output_dir(tmp_path, "ecml/active_faults") == tmp_path / "ecml" / "active_faults"
+    assert (
+        _service_output_dir(tmp_path, "ecml/active_faults") == tmp_path / "ecml" / "active_faults"
+    )
     assert _service_output_dir(tmp_path, "Top") == tmp_path / "top"
     assert (
         _service_output_dir(tmp_path, "RDH_hazard/Flood Risk")
@@ -1237,9 +1238,7 @@ def test_discover_and_filter_no_recurse_uses_flat_discovery(monkeypatch) -> None
         assert return_folders is True
         return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
 
-    monkeypatch.setattr(
-        "portolan_cli.extract.arcgis.orchestrator.discover_services", fake_flat
-    )
+    monkeypatch.setattr("portolan_cli.extract.arcgis.orchestrator.discover_services", fake_flat)
     services, coverage = _discover_and_filter_services(
         "https://x/rest/services", None, None, 60.0, recurse=False
     )
@@ -1257,7 +1256,9 @@ def test_extract_single_layer_passes_token(monkeypatch: pytest.MonkeyPatch, tmp_
     """Token must be forwarded to gpio.extract_arcgis when the param is supported."""
     captured: dict[str, object] = {}
 
-    def fake_extract_arcgis(url: str, max_workers: int | None = None, token: str | None = None) -> object:  # noqa: ANN001
+    def fake_extract_arcgis(
+        url: str, max_workers: int | None = None, token: str | None = None
+    ) -> object:  # noqa: ANN001
         captured["token"] = token
 
         class _T:

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -1124,10 +1124,17 @@ class TestArcGISCollectionMetadataSeeding:
 
 
 @pytest.mark.unit
-def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_list_services_recurses_and_reports_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
-    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+    def fake_recursive(
+        url: str,
+        *,
+        service_types: list[str] | None = None,
+        token: str | None = None,
+        timeout: float = 60.0,
+        max_depth: int = 2,
+    ) -> tuple[list[ServiceInfo], FolderTraversal]:
         captured["token"] = token
         services = [
             ServiceInfo("Top", "MapServer"),
@@ -1149,14 +1156,23 @@ def test_list_services_recurses_and_reports_coverage(monkeypatch) -> None:  # ty
     assert result.coverage.folders_visited == ["NationalDatasets"]
     assert result.coverage.folders_skipped == [("Locked", "499")]
     d = result.to_dict()
-    assert d["folder_coverage"]["folders_skipped"] == [{"folder": "Locked", "reason": "499"}]
+    folder_coverage = d["folder_coverage"]
+    assert isinstance(folder_coverage, dict)
+    assert folder_coverage["folders_skipped"] == [{"folder": "Locked", "reason": "499"}]
 
 
 @pytest.mark.unit
-def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+def test_list_services_no_recurse_skips_coverage(monkeypatch: pytest.MonkeyPatch) -> None:
     """recurse=False calls discover_services (not recursive), returns coverage=None."""
 
-    def fake_discover(url, *, service_types=None, return_folders=False, timeout=60.0):  # type: ignore[no-untyped-def]  # noqa: ANN001
+    def fake_discover(
+        url: str,
+        *,
+        service_types: list[str] | None = None,
+        return_folders: bool = False,
+        timeout: float = 60.0,
+        token: str | None = None,
+    ) -> tuple[list[ServiceInfo], list[str]]:
         assert return_folders is True
         return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
 
@@ -1173,7 +1189,7 @@ def test_list_services_no_recurse_skips_coverage(monkeypatch) -> None:  # type: 
 
 
 @pytest.mark.unit
-def test_service_output_dir_nests_folders(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_service_output_dir_nests_folders(tmp_path: Path) -> None:
     assert (
         _service_output_dir(tmp_path, "ecml/active_faults") == tmp_path / "ecml" / "active_faults"
     )
@@ -1190,8 +1206,15 @@ def test_service_output_dir_nests_folders(tmp_path) -> None:  # type: ignore[no-
 
 
 @pytest.mark.unit
-def test_discover_and_filter_scopes_to_folder(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+def test_discover_and_filter_scopes_to_folder(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_recursive(
+        url: str,
+        *,
+        service_types: list[str] | None = None,
+        token: str | None = None,
+        timeout: float = 60.0,
+        max_depth: int = 2,
+    ) -> tuple[list[ServiceInfo], FolderTraversal]:
         services = [
             ServiceInfo("ecml/active_faults", "MapServer"),
             ServiceInfo("water/rivers", "MapServer"),
@@ -1209,8 +1232,17 @@ def test_discover_and_filter_scopes_to_folder(monkeypatch) -> None:  # type: ign
 
 
 @pytest.mark.unit
-def test_extract_routes_folder_url_and_attaches_coverage(monkeypatch, tmp_path) -> None:  # type: ignore[no-untyped-def]
-    def fake_recursive(url, *, service_types=None, token=None, timeout=60.0, max_depth=2):  # type: ignore[no-untyped-def]  # noqa: ANN001
+def test_extract_routes_folder_url_and_attaches_coverage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_recursive(
+        url: str,
+        *,
+        service_types: list[str] | None = None,
+        token: str | None = None,
+        timeout: float = 60.0,
+        max_depth: int = 2,
+    ) -> tuple[list[ServiceInfo], FolderTraversal]:
         return (
             [ServiceInfo("ecml/active_faults", "MapServer")],
             FolderTraversal(visited=["ecml"], skipped=[], service_count=1),
@@ -1233,17 +1265,30 @@ def test_extract_routes_folder_url_and_attaches_coverage(monkeypatch, tmp_path) 
 
 
 @pytest.mark.unit
-def test_discover_and_filter_no_recurse_uses_flat_discovery(monkeypatch) -> None:  # type: ignore[no-untyped-def]
-    def fake_flat(url, *, service_types=None, return_folders=False, timeout=60.0):  # noqa: ANN001
+def test_discover_and_filter_no_recurse_uses_flat_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_flat(
+        url: str,
+        *,
+        service_types: list[str] | None = None,
+        return_folders: bool = False,
+        timeout: float = 60.0,
+        token: str | None = None,
+    ) -> tuple[list[ServiceInfo], list[str]]:
         assert return_folders is True
+        captured["token"] = token
         return [ServiceInfo("Top", "MapServer")], ["SomeFolder"]
 
     monkeypatch.setattr("portolan_cli.extract.arcgis.orchestrator.discover_services", fake_flat)
     services, coverage = _discover_and_filter_services(
-        "https://x/rest/services", None, None, 60.0, recurse=False
+        "https://x/rest/services", None, None, 60.0, token="TKN", recurse=False
     )
     assert [s.name for s in services] == ["Top"]
     assert coverage is None
+    assert captured["token"] == "TKN"
 
 
 # =============================================================================
@@ -1258,7 +1303,7 @@ def test_extract_single_layer_passes_token(monkeypatch: pytest.MonkeyPatch, tmp_
 
     def fake_extract_arcgis(
         url: str, max_workers: int | None = None, token: str | None = None
-    ) -> object:  # noqa: ANN001
+    ) -> object:
         captured["token"] = token
 
         class _T:

--- a/tests/unit/extract/arcgis/test_url_parser.py
+++ b/tests/unit/extract/arcgis/test_url_parser.py
@@ -199,10 +199,11 @@ class TestParseArcGISURLInvalid:
         with pytest.raises(InvalidArcGISURLError):
             parse_arcgis_url("not-a-url")
 
-    def test_invalid_partial_services_path(self) -> None:
-        """Partial services path without server type should raise error."""
-        with pytest.raises(InvalidArcGISURLError):
-            parse_arcgis_url("https://example.com/rest/services/Census")
+    def test_folder_scoped_path_is_now_valid(self) -> None:
+        """A services path with only a folder name is now a valid SERVICES_FOLDER URL."""
+        result = parse_arcgis_url("https://example.com/rest/services/Census")
+        assert result.url_type == ArcGISURLType.SERVICES_FOLDER
+        assert result.folder == "Census"
 
     def test_image_server_is_now_supported(self) -> None:
         """ImageServer is now supported (raster extraction added)."""
@@ -300,3 +301,33 @@ class TestRealWorldURLs:
         result = parse_arcgis_url(url)
 
         assert result.url_type == ArcGISURLType.SERVICES_ROOT
+
+
+@pytest.mark.unit
+def test_parse_folder_url() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services/NationalDatasets")
+    assert r.url_type == ArcGISURLType.SERVICES_FOLDER
+    assert r.folder == "NationalDatasets"
+    assert r.base_url == "https://x/server/rest/services"
+    assert r.is_single_service is False
+
+
+@pytest.mark.unit
+def test_parse_folder_url_unicode() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services/ecml")
+    assert r.url_type == ArcGISURLType.SERVICES_FOLDER
+    assert r.folder == "ecml"
+
+
+@pytest.mark.unit
+def test_service_in_folder_still_parses_as_service() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services/NationalDatasets/Property/MapServer")
+    assert r.url_type == ArcGISURLType.MAP_SERVER
+    assert r.service_name == "NationalDatasets/Property"
+
+
+@pytest.mark.unit
+def test_bare_services_root_still_parses() -> None:
+    r = parse_arcgis_url("https://x/server/rest/services")
+    assert r.url_type == ArcGISURLType.SERVICES_ROOT
+    assert r.folder is None

--- a/tests/unit/extract/arcgis/test_url_parser.py
+++ b/tests/unit/extract/arcgis/test_url_parser.py
@@ -4,6 +4,7 @@ The URL parser detects the type of ArcGIS REST endpoint:
 - FeatureServer: `*/FeatureServer` or `*/FeatureServer/0` (layer endpoint)
 - MapServer: `*/MapServer` or `*/MapServer/0`
 - Services Root: `*/rest/services` (lists all available services)
+- Services Folder: `*/rest/services/<folder>` (folder-scoped service discovery)
 
 It also extracts the service name for default output directory naming.
 """
@@ -314,9 +315,9 @@ def test_parse_folder_url() -> None:
 
 @pytest.mark.unit
 def test_parse_folder_url_unicode() -> None:
-    r = parse_arcgis_url("https://x/server/rest/services/ecml")
+    r = parse_arcgis_url("https://x/server/rest/services/Données")
     assert r.url_type == ArcGISURLType.SERVICES_FOLDER
-    assert r.folder == "ecml"
+    assert r.folder == "Données"
 
 
 @pytest.mark.unit

--- a/tests/unit/extract/common/test_filters.py
+++ b/tests/unit/extract/common/test_filters.py
@@ -226,3 +226,18 @@ class TestApplyUnifiedFilter:
 
         assert filtered_services is None
         assert len(filtered_layers) == 1
+
+
+# =============================================================================
+# Folder-Qualified Name Tests
+# =============================================================================
+
+
+@pytest.mark.unit
+def test_filter_matches_folder_qualified_names() -> None:
+    """fnmatch * spans / so folder-qualified names like ecml/active_faults are matched by ecml/*."""
+    names = ["ecml/active_faults", "ecml/airports_v2", "water/rivers", "Top"]
+    assert filter_services(names, include=["ecml/*"]) == ["ecml/active_faults", "ecml/airports_v2"]
+    assert filter_services(names, exclude=["water/*"]) == [
+        "ecml/active_faults", "ecml/airports_v2", "Top",
+    ]

--- a/tests/unit/extract/common/test_filters.py
+++ b/tests/unit/extract/common/test_filters.py
@@ -239,5 +239,7 @@ def test_filter_matches_folder_qualified_names() -> None:
     names = ["ecml/active_faults", "ecml/airports_v2", "water/rivers", "Top"]
     assert filter_services(names, include=["ecml/*"]) == ["ecml/active_faults", "ecml/airports_v2"]
     assert filter_services(names, exclude=["water/*"]) == [
-        "ecml/active_faults", "ecml/airports_v2", "Top",
+        "ecml/active_faults",
+        "ecml/airports_v2",
+        "Top",
     ]

--- a/tests/unit/extract/common/test_report.py
+++ b/tests/unit/extract/common/test_report.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from portolan_cli.extract.common.report import (
@@ -29,7 +31,7 @@ def test_folder_coverage_roundtrip() -> None:
 
 
 @pytest.mark.unit
-def test_extraction_report_folder_coverage_save_load_roundtrip(tmp_path) -> None:  # noqa: ANN001
+def test_extraction_report_folder_coverage_save_load_roundtrip(tmp_path: Path) -> None:
     """ExtractionReport with folder_coverage serialises and deserialises exactly."""
     coverage = FolderCoverage(
         folders_visited=["NationalDatasets", "Boundaries"],

--- a/tests/unit/extract/common/test_report.py
+++ b/tests/unit/extract/common/test_report.py
@@ -1,6 +1,16 @@
+from __future__ import annotations
+
 import pytest
 
-from portolan_cli.extract.common.report import FolderCoverage
+from portolan_cli.extract.common.report import (
+    ExtractionReport,
+    ExtractionSummary,
+    FolderCoverage,
+    LayerResult,
+    MetadataExtracted,
+    load_report,
+    save_report,
+)
 
 
 @pytest.mark.unit
@@ -16,3 +26,64 @@ def test_folder_coverage_roundtrip() -> None:
     assert d["services_found"] == 5
     back = FolderCoverage.from_dict(d)
     assert back == cov
+
+
+@pytest.mark.unit
+def test_extraction_report_folder_coverage_save_load_roundtrip(tmp_path) -> None:  # noqa: ANN001
+    """ExtractionReport with folder_coverage serialises and deserialises exactly."""
+    coverage = FolderCoverage(
+        folders_visited=["NationalDatasets", "Boundaries"],
+        folders_skipped=[("Restricted", "499 Token Required")],
+        services_found=7,
+    )
+    report = ExtractionReport(
+        extraction_date="2024-01-15T12:00:00Z",
+        source_url="https://gis.example.com/arcgis/rest/services",
+        portolan_version="1.0.0",
+        gpio_version="0.5.0",
+        metadata_extracted=MetadataExtracted(
+            source_url="https://gis.example.com/arcgis/rest/services",
+            description=None,
+            attribution=None,
+            keywords=None,
+            contact_name=None,
+            processing_notes=None,
+            known_issues=None,
+            license_info_raw=None,
+        ),
+        layers=[
+            LayerResult(
+                id=0,
+                name="parcels",
+                status="success",
+                features=100,
+                size_bytes=4096,
+                duration_seconds=1.5,
+                output_path="parcels/parcels.parquet",
+                warnings=[],
+                error=None,
+                attempts=1,
+            )
+        ],
+        summary=ExtractionSummary(
+            total_layers=1,
+            succeeded=1,
+            failed=0,
+            skipped=0,
+            empty=0,
+            total_features=100,
+            total_size_bytes=4096,
+            total_duration_seconds=1.5,
+        ),
+        folder_coverage=coverage,
+    )
+
+    report_path = tmp_path / ".portolan" / "extraction-report.json"
+    save_report(report, report_path)
+    loaded = load_report(report_path)
+
+    assert loaded.folder_coverage is not None
+    assert loaded.folder_coverage == coverage
+    assert loaded.folder_coverage.folders_visited == ["NationalDatasets", "Boundaries"]
+    assert loaded.folder_coverage.folders_skipped == [("Restricted", "499 Token Required")]
+    assert loaded.folder_coverage.services_found == 7

--- a/tests/unit/extract/common/test_report.py
+++ b/tests/unit/extract/common/test_report.py
@@ -1,0 +1,18 @@
+import pytest
+
+from portolan_cli.extract.common.report import FolderCoverage
+
+
+@pytest.mark.unit
+def test_folder_coverage_roundtrip() -> None:
+    cov = FolderCoverage(
+        folders_visited=["A", "B"],
+        folders_skipped=[("Locked", "499 Token Required")],
+        services_found=5,
+    )
+    d = cov.to_dict()
+    assert d["folders_visited"] == ["A", "B"]
+    assert d["folders_skipped"] == [{"folder": "Locked", "reason": "499 Token Required"}]
+    assert d["services_found"] == 5
+    back = FolderCoverage.from_dict(d)
+    assert back == cov

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -1,0 +1,47 @@
+"""CLI wiring tests for `extract arcgis` auth flags, folder URLs, and coverage."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.mark.unit
+def test_extract_arcgis_has_auth_and_recurse_flags() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "arcgis", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--token", "--username", "--password", "--no-recurse"):
+        assert flag in result.output
+
+
+@pytest.mark.unit
+def test_list_services_accepts_folder_url(monkeypatch) -> None:  # noqa: ANN001
+    from portolan_cli.extract.arcgis.discovery import ServiceInfo
+    from portolan_cli.extract.arcgis.orchestrator import ServicesRootDiscoveryResult
+    from portolan_cli.extract.common.report import FolderCoverage
+
+    def fake_list_services(url, *, service_filter=None, token=None, recurse=True, timeout=60.0):  # noqa: ANN001, ANN202
+        return ServicesRootDiscoveryResult(
+            services=[ServiceInfo("ecml/active_faults", "MapServer")],
+            folders=["ecml"],
+            base_url="https://x/server/rest/services",
+            coverage=FolderCoverage(
+                folders_visited=["ecml"],
+                folders_skipped=[("Locked", "499")],
+                services_found=1,
+            ),
+        )
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.list_services", fake_list_services
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["extract", "arcgis", "https://x/server/rest/services/ecml", "--list-services"]
+    )
+    assert result.exit_code == 0
+    assert "ecml/active_faults" in result.output
+    assert "skipped" in result.output.lower()

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -45,3 +45,28 @@ def test_list_services_accepts_folder_url(monkeypatch) -> None:  # noqa: ANN001
     assert result.exit_code == 0
     assert "ecml/active_faults" in result.output
     assert "skipped" in result.output.lower()
+
+
+@pytest.mark.unit
+def test_list_services_threads_no_recurse_and_token(monkeypatch) -> None:  # noqa: ANN001
+    from portolan_cli.extract.arcgis.discovery import ServiceInfo
+    from portolan_cli.extract.arcgis.orchestrator import ServicesRootDiscoveryResult
+
+    captured: dict[str, object] = {}
+
+    def fake_list_services(url, *, service_filter=None, token=None, recurse=True, timeout=60.0):  # noqa: ANN001, ANN202
+        captured["token"] = token
+        captured["recurse"] = recurse
+        return ServicesRootDiscoveryResult(
+            services=[ServiceInfo("Top", "MapServer")], folders=[], base_url=url, coverage=None
+        )
+
+    monkeypatch.setattr("portolan_cli.extract.arcgis.orchestrator.list_services", fake_list_services)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["extract", "arcgis", "https://x/server/rest/services", "--list-services", "--no-recurse", "--token", "TKN"],
+    )
+    assert result.exit_code == 0
+    assert captured["token"] == "TKN"
+    assert captured["recurse"] is False

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -140,3 +140,45 @@ def test_password_resolved_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert result.exit_code == 0
     assert captured["password"] == "envpass"
+
+
+@pytest.mark.unit
+def test_username_without_password_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--username with no resolvable password must error, not run unauthenticated."""
+    monkeypatch.delenv("ARCGIS_PASSWORD", raising=False)
+    monkeypatch.delenv("ARCGIS_TOKEN", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://x/server/rest/services",
+            "--list-services",
+            "--username",
+            "u",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "ArcGISAuthError" in result.output
+    assert "password" in result.output.lower()
+
+
+@pytest.mark.unit
+def test_imageserver_rejects_auth_flags() -> None:
+    """Auth flags must be rejected (not silently dropped) for ImageServer URLs."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://x/server/rest/services/Imagery/ImageServer",
+            "--token",
+            "TKN",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "ImageServer" in result.output

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -18,12 +18,19 @@ def test_extract_arcgis_has_auth_and_recurse_flags() -> None:
 
 
 @pytest.mark.unit
-def test_list_services_accepts_folder_url(monkeypatch) -> None:  # noqa: ANN001
+def test_list_services_accepts_folder_url(monkeypatch: pytest.MonkeyPatch) -> None:
     from portolan_cli.extract.arcgis.discovery import ServiceInfo
     from portolan_cli.extract.arcgis.orchestrator import ServicesRootDiscoveryResult
     from portolan_cli.extract.common.report import FolderCoverage
 
-    def fake_list_services(url, *, service_filter=None, token=None, recurse=True, timeout=60.0):  # noqa: ANN001, ANN202
+    def fake_list_services(
+        url: str,
+        *,
+        service_filter: list[str] | None = None,
+        token: str | None = None,
+        recurse: bool = True,
+        timeout: float = 60.0,
+    ) -> ServicesRootDiscoveryResult:
         return ServicesRootDiscoveryResult(
             services=[ServiceInfo("ecml/active_faults", "MapServer")],
             folders=["ecml"],
@@ -48,13 +55,20 @@ def test_list_services_accepts_folder_url(monkeypatch) -> None:  # noqa: ANN001
 
 
 @pytest.mark.unit
-def test_list_services_threads_no_recurse_and_token(monkeypatch) -> None:  # noqa: ANN001
+def test_list_services_threads_no_recurse_and_token(monkeypatch: pytest.MonkeyPatch) -> None:
     from portolan_cli.extract.arcgis.discovery import ServiceInfo
     from portolan_cli.extract.arcgis.orchestrator import ServicesRootDiscoveryResult
 
     captured: dict[str, object] = {}
 
-    def fake_list_services(url, *, service_filter=None, token=None, recurse=True, timeout=60.0):  # noqa: ANN001, ANN202
+    def fake_list_services(
+        url: str,
+        *,
+        service_filter: list[str] | None = None,
+        token: str | None = None,
+        recurse: bool = True,
+        timeout: float = 60.0,
+    ) -> ServicesRootDiscoveryResult:
         captured["token"] = token
         captured["recurse"] = recurse
         return ServicesRootDiscoveryResult(
@@ -80,3 +94,49 @@ def test_list_services_threads_no_recurse_and_token(monkeypatch) -> None:  # noq
     assert result.exit_code == 0
     assert captured["token"] == "TKN"
     assert captured["recurse"] is False
+
+
+@pytest.mark.unit
+def test_password_resolved_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--username with ARCGIS_PASSWORD env (no --password on argv) reaches resolve_token."""
+    from portolan_cli.extract.arcgis.auth import ArcGISCredentials
+    from portolan_cli.extract.arcgis.discovery import ServiceInfo
+    from portolan_cli.extract.arcgis.orchestrator import ServicesRootDiscoveryResult
+
+    captured: dict[str, object] = {}
+
+    def fake_resolve(creds: ArcGISCredentials, base_url: str, timeout: float = 60.0) -> str | None:
+        captured["password"] = creds.password
+        return None
+
+    def fake_list_services(
+        url: str,
+        *,
+        service_filter: list[str] | None = None,
+        token: str | None = None,
+        recurse: bool = True,
+        timeout: float = 60.0,
+    ) -> ServicesRootDiscoveryResult:
+        return ServicesRootDiscoveryResult(
+            services=[ServiceInfo("Top", "MapServer")], folders=[], base_url=url, coverage=None
+        )
+
+    monkeypatch.setattr("portolan_cli.extract.arcgis.auth.resolve_token", fake_resolve)
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.list_services", fake_list_services
+    )
+    monkeypatch.setenv("ARCGIS_PASSWORD", "envpass")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://x/server/rest/services",
+            "--list-services",
+            "--username",
+            "u",
+        ],
+    )
+    assert result.exit_code == 0
+    assert captured["password"] == "envpass"

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -61,11 +61,21 @@ def test_list_services_threads_no_recurse_and_token(monkeypatch) -> None:  # noq
             services=[ServiceInfo("Top", "MapServer")], folders=[], base_url=url, coverage=None
         )
 
-    monkeypatch.setattr("portolan_cli.extract.arcgis.orchestrator.list_services", fake_list_services)
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.list_services", fake_list_services
+    )
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["extract", "arcgis", "https://x/server/rest/services", "--list-services", "--no-recurse", "--token", "TKN"],
+        [
+            "extract",
+            "arcgis",
+            "https://x/server/rest/services",
+            "--list-services",
+            "--no-recurse",
+            "--token",
+            "TKN",
+        ],
     )
     assert result.exit_code == 0
     assert captured["token"] == "TKN"

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from portolan_cli.errors import (
+    ArcGISAuthError,
     CatalogAlreadyExistsError,
     # Catalog errors
     CatalogError,
@@ -468,3 +469,12 @@ class TestConversionErrors:
         assert "/path/to/output.parquet" in str(error)
         # Message should mention validation failure
         assert "validation" in str(error).lower() or "failed" in str(error).lower()
+
+
+@pytest.mark.unit
+def test_arcgis_auth_error_code_and_message() -> None:
+    err = ArcGISAuthError("token request failed", url="https://x/generateToken")
+    assert isinstance(err, PortolanError)
+    assert err.code == "PRTLN-EXT002"
+    assert "token request failed" in str(err)
+    assert err.to_dict()["context"]["url"] == "https://x/generateToken"


### PR DESCRIPTION
## Summary

Makes `portolan extract arcgis` work against ArcGIS Enterprise and federated services roots that organize services into folders. Closes #493.

Previously a services-root extraction only discovered top-level services and silently skipped everything nested in an ArcGIS Server folder, and folder URLs were rejected outright. Servers like the South African NSDI root (services under `NationalDatasets/`) and the JRC federated root (every service in a folder, zero top-level) were effectively unusable.

### What changed

- **Folder recursion (default on).** Services-root extraction now traverses ArcGIS Server folders via a queue-based, depth-guarded BFS. ArcGIS returns folder-qualified service names (e.g. `NationalDatasets/Property`), so URL construction and glob filters work unchanged. `--no-recurse` opts out, honored by both `--list-services` and the extraction path.
- **Authentication.** `--token` / `ARCGIS_TOKEN`, or `--username` / `--password` minted via the server generateToken endpoint. The token reaches both discovery fetches (including per-folder fetches) and `gpio.extract_arcgis` (feature-detected). Contained pass-through, the full auth design remains issue #311.
- **Graceful skip.** Secured or erroring folders are logged as warnings and skipped, the run never aborts. ArcGIS 200-with-embedded-error bodies are detected.
- **Folder URLs.** `.../rest/services/<folder>` parses as a new `SERVICES_FOLDER` type, scoped to that folder, with the base URL normalized to the true services root.
- **Nested structure and coverage.** Folders map to nested subcatalogs (each segment slugified). Coverage (folders traversed, skipped with reasons, services found) is attached to the extraction report and rendered in text and in the `--json` envelope as `folder_coverage`. `--services` / `--exclude-services` match folder-qualified names.
- **Docs and ADR.** New ADR-0053, plus an updated `docs/guides/extract-arcgis.md` covering the auth, recursion, folder-URL, and coverage surface.

### Architecture

Changes are contained to `portolan_cli/extract/arcgis/` (new `auth.py`, plus `discovery.py`, `url_parser.py`, `orchestrator.py`), one shared model addition in `extract/common/report.py` (`FolderCoverage`), CLI flag wiring in `cli.py`, and one error class `ArcGISAuthError` (PRTLN-EXT002) in `errors.py`. The CLI stays a thin Click layer (ADR-0007). Network is mocked in unit tests.

## Test Plan

- [x] `uv run pytest tests/unit/extract tests/unit/test_cli_extract_arcgis.py tests/unit/test_errors.py tests/integration/extract/arcgis -m "not network and not slow"` (611 passed)
- [x] Live network tests pass against the real South African and JRC roots (`tests/integration/extract/arcgis/test_orchestrator_live.py`, network-marked)
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean
- [x] `uv run mypy` clean on all touched files (4 remaining errors are pre-existing `defusedxml` / `gpio_pmtiles` stub issues in untouched modules)
- [x] `uv run lint-imports` 3 contracts kept
- [x] ADR index validator passes (53 ADRs)

Built with TDD across the implementation, every change has a failing-test-first commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recursive folder discovery for ArcGIS services now enabled by default, with `--no-recurse` to disable.
  * Authentication support: provide credentials via `--token`, `--username/--password`, or environment variables.
  * Folder traversal coverage reporting shows visited and skipped folders in extraction output.
  * Support for folder-scoped service URLs in discovery operations.

* **Documentation**
  * Updated extraction guides with authentication options and folder recursion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->