### PR TITLE
feat(stac): require human-readable titles and descriptions (#502)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0050](context/shared/adr/0050-pmtiles-visualization-requirement.md) | PMTiles required for vector datasets >100 MB |
 | [0051](context/shared/adr/0051-self-contained-catalog-type.md) | SELF_CONTAINED catalog type (relative links, portable) |
 | [0052](context/shared/adr/0052-llms-txt-requirement.md) | Require llms.txt for AI/LLM integration at catalog and collection levels |
+| [0053](context/shared/adr/0053-mandatory-human-readable-titles.md) | Mandatory human-readable titles/descriptions; auto-humanize slugs; title on child/item links |
 
 ## Common Commands
 

--- a/context/shared/adr/0038-metadata-yaml-enrichment.md
+++ b/context/shared/adr/0038-metadata-yaml-enrichment.md
@@ -46,7 +46,10 @@ The metadata.yaml template itself defines best practices:
 
 - **Required fields**: `contact` (name + email) and `license` (SPDX identifier)
 - **Optional fields**: citation, DOI, known_issues, etc.
-- Title and description come from STAC (set during `portolan init`)
+- Title and description are auto-derived (humanized from the collection id) and
+  are **mandatory** in the generated STAC ([ADR-0053](0053-mandatory-human-readable-titles.md)).
+  `metadata.yaml` may carry optional `title`/`description` keys to **override**
+  the auto-derived values — the human override has highest precedence.
 - No separate natural language specification document
 
 ### Separation from config.yaml
@@ -92,7 +95,7 @@ README includes a footer indicating it's generated—users know not to edit it.
 
 | Field | Location | Rationale |
 |-------|----------|-----------|
-| title, description | STAC catalog/collection | Set during `portolan init` |
+| title, description | STAC catalog/collection | Auto-derived (humanized from id), mandatory ([ADR-0053](0053-mandatory-human-readable-titles.md)); optionally overridden in metadata.yaml |
 | bbox, CRS, schema | STAC | Auto-extracted from data |
 | columns (table:columns) | STAC summaries | Auto-extracted by scan |
 | bands (eo:bands, raster:bands) | STAC summaries | Auto-extracted by scan |

--- a/context/shared/adr/0053-mandatory-human-readable-titles.md
+++ b/context/shared/adr/0053-mandatory-human-readable-titles.md
@@ -1,0 +1,99 @@
+# ADR-0053: Mandatory human-readable titles and descriptions
+
+## Status
+
+Accepted
+
+## Context
+
+STAC Browser renders the `title` of `child` and `item` links directly. When a
+link has no `title`, the browser must fetch every child's `collection.json`
+just to display its name — the pergamino catalog showed `data.source.coop`
+placeholders for several seconds while 100+ HTTP requests resolved.
+
+Portolan-cli previously left titles unset on auto-created collections
+(`description="Collection: <slug>"`, no title) and built `child`/`item` links
+with only `rel`/`href`/`type`. STAC *allows* `title` on links but PySTAC only
+emits it when the target object has a title, and several portolan code paths
+build links as raw JSON, bypassing PySTAC entirely.
+
+Feedback from Matthias Mohr (STAC Browser maintainer) and a portolan maintainer:
+
+> "provide titles for the child (and item) links. This should definitely be
+> part of the portolan spec."
+> "we should also require human readable ones … not allow
+> `publico_areas_programaticas_desarrollo_social` type — at least convert it to
+> `Publico Areas Programaticas Desarrollo Social`."
+
+Related: GitHub Issue [#502](https://github.com/portolan-sdi/portolan-cli/issues/502),
+STAC Browser issue radiantearth/stac-browser#899.
+
+## Decision
+
+`title` and `description` are **mandatory** on every catalog, collection, and
+item portolan generates, and every `child`/`item` link carries a `title`.
+Titles must be **human-readable**.
+
+1. **Auto-derive humanized titles.** When no human title is available, derive
+   one from the slug: underscores/hyphens → spaces, title-case each word,
+   preserving acronyms/CamelCase (`publico_arbolado` → `Publico Arbolado`,
+   `IGN_layers` → `IGN Layers`). Only the leaf segment of a nested id is used
+   ([ADR-0032](0032-nested-catalogs-with-flat-collections.md)). See
+   `portolan_cli/humanize.py` (`humanize_slug`, `derive_title`).
+2. **Default description = title** when no real description exists (never a
+   `Collection: <slug>` placeholder).
+3. **Human override.** `metadata.yaml` may set optional `title`/`description`
+   keys, which take highest precedence over the auto-derived values
+   ([ADR-0038](0038-metadata-yaml-enrichment.md)). Existing human-authored
+   titles are never overwritten (SMART merge).
+4. **Link propagation.** After catalog mutations, `ensure_link_titles()` walks
+   the catalog and backfills `title` (+ `type`) onto every `child`/`item` link
+   from its target.
+5. **Enforce + repair.** `MandatoryTitlesRule` (ERROR severity) fails `portolan
+   check` when a catalog/collection lacks a title/description, when a title is a
+   raw slug (contains `_` or a `ns:` namespace prefix), or when a `child`/`item`
+   link lacks a title. `portolan check --fix` repairs all of these.
+
+The rule's "raw slug" predicate is intentionally narrower than the general
+`is_technical_name` detector: it flags only the markers `humanize_slug`
+removes (underscores, namespace prefixes). This guarantees `check --fix`
+converges — a humanized title never re-triggers the rule, even for short ids
+(`t502` → `T502`) that cannot be humanized further.
+
+## Consequences
+
+### Benefits
+
+- STAC Browser renders child/item names instantly — no fan-out fetch.
+- Catalogs are self-describing; no `Collection: <slug>` placeholders.
+- Enforced by an automated rule, repairable in one command.
+
+### Trade-offs
+
+- Auto-derived titles are only as good as the slug; humans should override poor
+  ones via `metadata.yaml`.
+- Existing catalogs need a one-time `portolan check --fix` to become compliant.
+- The link-title backfill is O(catalog) per add batch (run once per batch, not
+  per collection, to stay linear).
+
+## Alternatives Considered
+
+### Leave titles optional, rely on PySTAC
+
+**Rejected**: PySTAC only emits link titles when targets have titles, and
+several portolan paths build links as raw JSON. Optional titles reproduce the
+exact browser-performance problem this ADR fixes.
+
+### Put title/description only in metadata.yaml
+
+**Rejected**: `metadata.yaml` is human enrichment; requiring it for every
+collection would block compliance on manual editing. Auto-derivation gives a
+compliant baseline with metadata.yaml as the override.
+
+## References
+
+- [GitHub Issue #502: Require title attribute on child and item links](https://github.com/portolan-sdi/portolan-cli/issues/502)
+- [ADR-0018: Metadata Generation Tiers](0018-metadata-generation-tiers.md)
+- [ADR-0032: Nested Catalogs with Flat Collections](0032-nested-catalogs-with-flat-collections.md)
+- [ADR-0038: Metadata YAML as Human Enrichment Layer](0038-metadata-yaml-enrichment.md)
+- [ADR-0045: Styles as STAC Assets](0045-styles-as-stac-assets.md)

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -653,7 +653,7 @@ def _ensure_root_links_to_child(catalog_root: Path, child_href: str) -> None:
     if not catalog_file.exists():
         return
 
-    content = json.loads(catalog_file.read_text())
+    content = json.loads(catalog_file.read_text(encoding="utf-8"))
     links = content.get("links", [])
 
     # Check if link already exists
@@ -664,7 +664,7 @@ def _ensure_root_links_to_child(catalog_root: Path, child_href: str) -> None:
     # Add the child link
     links.append({"rel": "child", "href": child_href, "type": "application/json"})
     content["links"] = links
-    catalog_file.write_text(json.dumps(content, indent=2))
+    catalog_file.write_text(json.dumps(content, indent=2), encoding="utf-8")
 
 
 def _ensure_catalog_links_to_child(catalog_file: Path, child_href: str) -> None:
@@ -672,7 +672,7 @@ def _ensure_catalog_links_to_child(catalog_file: Path, child_href: str) -> None:
     if not catalog_file.exists():
         return
 
-    content = json.loads(catalog_file.read_text())
+    content = json.loads(catalog_file.read_text(encoding="utf-8"))
     links = content.get("links", [])
 
     # Check if link already exists
@@ -683,7 +683,7 @@ def _ensure_catalog_links_to_child(catalog_file: Path, child_href: str) -> None:
     # Add the child link
     links.append({"rel": "child", "href": child_href, "type": "application/json"})
     content["links"] = links
-    catalog_file.write_text(json.dumps(content, indent=2))
+    catalog_file.write_text(json.dumps(content, indent=2), encoding="utf-8")
 
 
 def _link_title_from_target(
@@ -718,8 +718,8 @@ def _link_title_from_target(
         return None
 
     try:
-        data = json.loads(target.read_text())
-    except (OSError, json.JSONDecodeError):
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
     if link.get("rel") == "item":
@@ -757,8 +757,8 @@ def ensure_link_titles(catalog_root: Path) -> bool:
 
     for stac_file in stac_files:
         try:
-            content = json.loads(stac_file.read_text())
-        except (OSError, json.JSONDecodeError):
+            content = json.loads(stac_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
 
         links = content.get("links")
@@ -783,7 +783,7 @@ def ensure_link_titles(catalog_root: Path) -> bool:
                 file_changed = True
 
         if file_changed:
-            stac_file.write_text(json.dumps(content, indent=2))
+            stac_file.write_text(json.dumps(content, indent=2), encoding="utf-8")
             changed_any = True
 
     return changed_any

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -686,7 +686,9 @@ def _ensure_catalog_links_to_child(catalog_file: Path, child_href: str) -> None:
     catalog_file.write_text(json.dumps(content, indent=2))
 
 
-def _link_title_from_target(stac_file: Path, link: dict[str, object]) -> str | None:
+def _link_title_from_target(
+    stac_file: Path, link: dict[str, object], catalog_root: Path
+) -> str | None:
     """Read the human-readable title of a child/item link's target.
 
     Child links target a ``collection.json``/``catalog.json`` (title at the top
@@ -695,6 +697,7 @@ def _link_title_from_target(stac_file: Path, link: dict[str, object]) -> str | N
     Args:
         stac_file: The STAC file the link lives in (for relative resolution).
         link: The link mapping (must have an ``href``).
+        catalog_root: Root the resolved target must stay within.
 
     Returns:
         The target's title, or None if it can't be read.
@@ -704,6 +707,13 @@ def _link_title_from_target(stac_file: Path, link: dict[str, object]) -> str | N
         return None
 
     target = (stac_file.parent / href).resolve()
+
+    # ADR-0030 input hardening: ignore ``../`` hrefs that resolve outside the
+    # catalog so a crafted link can't read files elsewhere on disk.
+    root = catalog_root.resolve()
+    if target != root and root not in target.parents:
+        return None
+
     if not target.exists():
         return None
 
@@ -767,7 +777,7 @@ def ensure_link_titles(catalog_root: Path) -> bool:
                 )
                 file_changed = True
 
-            title = _link_title_from_target(stac_file, link)
+            title = _link_title_from_target(stac_file, link, catalog_root)
             if title and link.get("title") != title:
                 link["title"] = title
                 file_changed = True

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -390,12 +390,16 @@ def init_catalog(
     # Auto-extract id from directory name
     catalog_id = _sanitize_id(path.resolve().name)
 
-    # Set defaults
+    # Set defaults. Issue #502: title is mandatory and must be human-readable,
+    # so derive one from the directory name instead of leaving it empty.
+    if not title:
+        from portolan_cli.humanize import humanize_slug
+
+        title = humanize_slug(catalog_id)
+        warnings.append(f"Derived catalog title '{title}' from directory name")
+
     if description is None:
         description = "A Portolan-managed STAC catalog"
-
-    if title is None:
-        warnings.append("Missing title (recommended for discoverability)")
 
     # ─────────────────────────────────────────────────────────────────────────
     # WRITE ORDER: config.yaml LAST for atomicity (per issue #290)
@@ -680,6 +684,99 @@ def _ensure_catalog_links_to_child(catalog_file: Path, child_href: str) -> None:
     links.append({"rel": "child", "href": child_href, "type": "application/json"})
     content["links"] = links
     catalog_file.write_text(json.dumps(content, indent=2))
+
+
+def _link_title_from_target(stac_file: Path, link: dict[str, object]) -> str | None:
+    """Read the human-readable title of a child/item link's target.
+
+    Child links target a ``collection.json``/``catalog.json`` (title at the top
+    level); item links target an ``item.json`` (title under ``properties``).
+
+    Args:
+        stac_file: The STAC file the link lives in (for relative resolution).
+        link: The link mapping (must have an ``href``).
+
+    Returns:
+        The target's title, or None if it can't be read.
+    """
+    href = link.get("href")
+    if not isinstance(href, str) or not href:
+        return None
+
+    target = (stac_file.parent / href).resolve()
+    if not target.exists():
+        return None
+
+    try:
+        data = json.loads(target.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    if link.get("rel") == "item":
+        properties = data.get("properties", {})
+        title = properties.get("title") if isinstance(properties, dict) else None
+    else:
+        title = data.get("title")
+
+    return title if isinstance(title, str) and title.strip() else None
+
+
+def ensure_link_titles(catalog_root: Path) -> bool:
+    """Backfill ``title`` (and ``type``) on all child/item links (Issue #502).
+
+    Walks every ``catalog.json``/``collection.json`` under ``catalog_root`` and,
+    for each ``child``/``item`` link, copies the target's human-readable title
+    onto the link so STAC Browser can render names without fetching every child.
+    Also fills a missing ``type`` (``application/json`` for child links,
+    ``application/geo+json`` for item links).
+
+    Idempotent: only rewrites a file when a link actually changed. Reused by the
+    ``check --fix`` repair path.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+
+    Returns:
+        True if any file was modified.
+    """
+    changed_any = False
+
+    stac_files = sorted(catalog_root.rglob("catalog.json")) + sorted(
+        catalog_root.rglob("collection.json")
+    )
+
+    for stac_file in stac_files:
+        try:
+            content = json.loads(stac_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        links = content.get("links")
+        if not isinstance(links, list):
+            continue
+
+        file_changed = False
+        for link in links:
+            if not isinstance(link, dict) or link.get("rel") not in ("child", "item"):
+                continue
+
+            # Fill a missing media type (STAC best practice).
+            if not link.get("type"):
+                link["type"] = (
+                    "application/geo+json" if link.get("rel") == "item" else "application/json"
+                )
+                file_changed = True
+
+            title = _link_title_from_target(stac_file, link)
+            if title and link.get("title") != title:
+                link["title"] = title
+                file_changed = True
+
+        if file_changed:
+            stac_file.write_text(json.dumps(content, indent=2))
+            changed_any = True
+
+    return changed_any
 
 
 def update_catalog_versions(

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -1535,6 +1535,15 @@ def _run_fix_workflow(
         else:
             metadata_check_report = scan_catalog_metadata(catalog_root)
             metadata_fix_report = fix_metadata(catalog_root, metadata_check_report, dry_run=dry_run)
+
+            # Issue #502: populate human-readable titles/descriptions and
+            # backfill child/item link titles as part of the metadata fix.
+            from portolan_cli.metadata.fix import repair_titles_and_links
+
+            metadata_fix_report.results.extend(
+                repair_titles_and_links(catalog_root, dry_run=dry_run)
+            )
+
             if metadata_fix_report.failure_count > 0:
                 has_failures = True
 

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -177,7 +177,7 @@ def load_config(catalog_path: Path) -> dict[str, Any]:
     if not config_file.exists():
         return {}
 
-    content = config_file.read_text()
+    content = config_file.read_text(encoding="utf-8")
     if not content.strip():
         return {}
 
@@ -672,7 +672,7 @@ def _load_validated_mapping(file_path: Path) -> dict[str, Any] | None:
     """
     from portolan_cli.errors import ConfigInvalidStructureError
 
-    content = file_path.read_text()
+    content = file_path.read_text(encoding="utf-8")
     if not content.strip():
         return None
 

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -47,6 +47,7 @@ from portolan_cli.formats import (
     is_cloud_optimized_geotiff,
     is_multilayer,
 )
+from portolan_cli.humanize import humanize_slug
 from portolan_cli.metadata import (
     extract_band_statistics,
     extract_cog_metadata,
@@ -78,6 +79,7 @@ from portolan_cli.stac import (
     add_table_extension,
     add_vector_extension,
     aggregate_table_metadata,
+    apply_human_titles,
     create_collection,
     create_item,
     load_catalog,
@@ -1736,6 +1738,10 @@ def finalize_datasets(
             initial_bbox=first_item.bbox,
         )
 
+        # Issue #502: apply human title/description overrides from
+        # metadata.yaml (highest precedence over the auto-derived defaults).
+        apply_human_titles(collection, load_merged_metadata(collection_dir, catalog_root))
+
         # Add items or collection-level assets to collection (in memory)
         _add_prepared_items_to_collection(collection, items, merge_strategy)
 
@@ -1854,6 +1860,13 @@ def finalize_datasets(
                     asset_paths=[str(path) for _name, (path, _checksum) in p.asset_files.items()],
                 )
             )
+
+    # Issue #502: backfill human-readable titles onto child/item links so STAC
+    # Browser renders names without fetching every child. Done once per batch
+    # (O(catalog), not per-collection) after all collections are written.
+    from portolan_cli.catalog import ensure_link_titles
+
+    ensure_link_titles(catalog_root)
 
     return results
 
@@ -2298,10 +2311,14 @@ def _get_or_create_collection(
     if collection_path.exists():
         return pystac.Collection.from_file(str(collection_path))
 
-    # Create new collection
+    # Create new collection. Issue #502: derive a human-readable title from
+    # the collection id and default the description to it (no "Collection:
+    # <slug>" placeholder). create_collection fills both in when omitted.
+    title = humanize_slug(collection_id)
     return create_collection(
         collection_id=collection_id,
-        description=f"Collection: {collection_id}",
+        description=title,
+        title=title,
         bbox=initial_bbox,
     )
 
@@ -2489,9 +2506,12 @@ def _ensure_tabular_collection(
         sibling_count = len(sibling_bboxes)
         bbox_source = "sibling" if sibling_count > 0 else "global"
 
+    # Issue #502: human-readable title; description defaults to it.
+    tabular_title = humanize_slug(collection_id)
     collection = create_collection(
         collection_id=collection_id,
-        description=f"Tabular data collection: {collection_id}",
+        description=tabular_title,
+        title=tabular_title,
         bbox=final_bbox,
     )
 
@@ -2505,6 +2525,11 @@ def _ensure_tabular_collection(
 
     # Update catalog links to include this collection
     _update_catalog_links(catalog_root, collection_id)
+
+    # Issue #502: backfill the human-readable title onto the new child link.
+    from portolan_cli.catalog import ensure_link_titles
+
+    ensure_link_titles(catalog_root)
 
     # Log based on bbox source (ADR-0047 priority order)
     if bbox_source == "metadata.yaml":

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -736,7 +736,7 @@ def _fix_collection_links(
     if not collection_json_path.exists():
         return
 
-    collection_data = json.loads(collection_json_path.read_text())
+    collection_data = json.loads(collection_json_path.read_text(encoding="utf-8"))
     relative_root = os.path.relpath(catalog_root / "catalog.json", collection_dir)
 
     # Update root link to point to catalog
@@ -769,7 +769,7 @@ def _fix_collection_links(
         deduped_links.append(link)
     collection_data["links"] = deduped_links
 
-    collection_json_path.write_text(json.dumps(collection_data, indent=2))
+    collection_json_path.write_text(json.dumps(collection_data, indent=2), encoding="utf-8")
 
 
 def _derive_item_id_and_asset_level(
@@ -2698,7 +2698,7 @@ def list_datasets(
             continue
 
         # Load collection to get items
-        collection_data = json.loads(collection_path.read_text())
+        collection_data = json.loads(collection_path.read_text(encoding="utf-8"))
 
         for link in collection_data.get("links", []):
             if link.get("rel") != "item":
@@ -2714,7 +2714,7 @@ def list_datasets(
             if not item_path.exists():
                 continue
 
-            item_data = json.loads(item_path.read_text())
+            item_data = json.loads(item_path.read_text(encoding="utf-8"))
 
             # Determine format from assets
             format_type = FormatType.UNKNOWN
@@ -2769,7 +2769,7 @@ def get_dataset_info(
     if not item_path.exists():
         raise KeyError(f"Dataset not found: {dataset_id}")
 
-    item_data = json.loads(item_path.read_text())
+    item_data = json.loads(item_path.read_text(encoding="utf-8"))
 
     # Determine format from assets
     format_type = FormatType.UNKNOWN
@@ -2824,13 +2824,13 @@ def remove_dataset(
         # Update catalog links
         catalog_path = catalog_root / "catalog.json"
         if catalog_path.exists():
-            catalog_data = json.loads(catalog_path.read_text())
+            catalog_data = json.loads(catalog_path.read_text(encoding="utf-8"))
             catalog_data["links"] = [
                 link
                 for link in catalog_data.get("links", [])
                 if not link.get("href", "").endswith(f"/{collection_id}/collection.json")
             ]
-            catalog_path.write_text(json.dumps(catalog_data, indent=2))
+            catalog_path.write_text(json.dumps(catalog_data, indent=2), encoding="utf-8")
     else:
         # Remove single item
         collection_id, item_id = dataset_id.split("/", 1)
@@ -2845,13 +2845,13 @@ def remove_dataset(
         # Update collection links
         collection_path = catalog_root / collection_id / "collection.json"
         if collection_path.exists():
-            collection_data = json.loads(collection_path.read_text())
+            collection_data = json.loads(collection_path.read_text(encoding="utf-8"))
             collection_data["links"] = [
                 link
                 for link in collection_data.get("links", [])
                 if not link.get("href", "").startswith(f"./{item_id}/")
             ]
-            collection_path.write_text(json.dumps(collection_data, indent=2))
+            collection_path.write_text(json.dumps(collection_data, indent=2), encoding="utf-8")
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/portolan_cli/external.py
+++ b/portolan_cli/external.py
@@ -255,6 +255,11 @@ def add_external_dataset(
     collection_dir.mkdir(parents=True, exist_ok=True)
     _save_collection_with_links(collection, collection_dir, catalog_root, resolved_id)
 
+    # Issue #502: backfill the human-readable title onto the new child link.
+    from portolan_cli.catalog import ensure_link_titles
+
+    ensure_link_titles(catalog_root)
+
     collection_path = collection_dir / "collection.json"
 
     resolved_via = via_url or url

--- a/portolan_cli/humanize.py
+++ b/portolan_cli/humanize.py
@@ -1,0 +1,82 @@
+"""Convert machine slugs into human-readable titles (Issue #502).
+
+STAC Browser renders ``child``/``item`` link titles directly, so every
+collection, item, and catalog portolan generates must carry a human-readable
+``title``. When no human title is available we derive one from the slug:
+
+    publico_areas_programaticas_desarrollo_social
+    -> "Publico Areas Programaticas Desarrollo Social"
+
+This is the inverse of the ``normalize_collection_id`` slugging in
+:mod:`portolan_cli.collection_id`. The technical-name detection lives in
+:func:`portolan_cli.stac.is_technical_name`; we reuse it (lazy import to avoid
+a circular dependency, since ``stac`` imports this module).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Separators that join words inside a slug. Forward slashes delimit nested
+# collection paths (ADR-0032) and are handled separately (leaf only).
+_SLUG_SEPARATORS: re.Pattern[str] = re.compile(r"[_\-]+")
+
+
+def humanize_slug(slug: str) -> str:
+    """Turn a machine slug into a human-readable, title-cased string.
+
+    Only the leaf segment of a nested id is used (``climate/hittekaart`` ->
+    ``Hittekaart``), since the title describes the leaf collection. Tokens that
+    already contain an uppercase letter (acronyms like ``IGN``, CamelCase like
+    ``DenHaag``) are preserved verbatim; all-lowercase tokens are capitalized.
+
+    Args:
+        slug: The slug to humanize (e.g. a collection/item id or directory name).
+
+    Returns:
+        A human-readable title, or "" for empty/None input.
+    """
+    if not slug:
+        return ""
+
+    # Use the leaf segment of a nested path (ADR-0032).
+    leaf = slug.split("/")[-1]
+
+    # Underscores/hyphens become word boundaries.
+    spaced = _SLUG_SEPARATORS.sub(" ", leaf)
+
+    tokens = spaced.split()
+    humanized = [_capitalize_token(token) for token in tokens]
+    return " ".join(humanized)
+
+
+def _capitalize_token(token: str) -> str:
+    """Capitalize a single token, preserving acronyms/CamelCase.
+
+    A token that already contains an uppercase letter is assumed to be an
+    acronym or intentional casing and is left untouched.
+    """
+    if any(char.isupper() for char in token):
+        return token
+    return token[:1].upper() + token[1:]
+
+
+def derive_title(existing: str | None, fallback_id: str) -> str:
+    """Return a human-readable title, preferring an existing human title.
+
+    If ``existing`` is set and not a technical name, it is returned unchanged.
+    Otherwise a title is derived from ``fallback_id`` via :func:`humanize_slug`.
+
+    Args:
+        existing: A title that may already be set (from source metadata, etc.).
+        fallback_id: The slug/id to humanize when ``existing`` is unusable.
+
+    Returns:
+        A human-readable title string.
+    """
+    # Lazy import: stac imports this module, so a top-level import would cycle.
+    from portolan_cli.stac import is_technical_name
+
+    if existing and not is_technical_name(existing):
+        return existing
+    return humanize_slug(fallback_id)

--- a/portolan_cli/metadata/fix.py
+++ b/portolan_cli/metadata/fix.py
@@ -9,6 +9,7 @@ fixes for all issues in a MetadataReport:
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -137,6 +138,127 @@ def fix_metadata(
         fix_results.append(result)
 
     return FixReport(results=fix_results, skipped_count=skipped_count)
+
+
+def repair_titles_and_links(catalog_root: Path, *, dry_run: bool = False) -> list[FixResult]:
+    """Populate human-readable titles/descriptions and link titles (Issue #502).
+
+    Repairs what :class:`~portolan_cli.validation.stac_rules.MandatoryTitlesRule`
+    flags:
+
+    - every catalog/collection gets a human-readable title (derived from its id
+      when missing or technical) and a description (defaulting to the title);
+    - every item referenced by an item link gets a title in its properties;
+    - every ``child``/``item`` link gets its target's title backfilled.
+
+    Existing human-authored titles/descriptions are preserved.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+        dry_run: If True, report what would change without writing.
+
+    Returns:
+        FixResults for each file that was (or would be) modified.
+    """
+    from portolan_cli.catalog import ensure_link_titles
+    from portolan_cli.humanize import derive_title
+
+    results: list[FixResult] = []
+
+    stac_files = sorted(catalog_root.rglob("catalog.json")) + sorted(
+        catalog_root.rglob("collection.json")
+    )
+    for stac_file in stac_files:
+        try:
+            data = json.loads(stac_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        obj_id = str(data.get("id") or stac_file.parent.name)
+        new_title = derive_title(data.get("title"), obj_id)
+
+        changed = False
+        if data.get("title") != new_title:
+            if not dry_run:
+                data["title"] = new_title
+            changed = True
+
+        description = data.get("description")
+        if not isinstance(description, str) or not description.strip():
+            if not dry_run:
+                data["description"] = new_title
+            changed = True
+
+        if changed:
+            if not dry_run:
+                stac_file.write_text(json.dumps(data, indent=2))
+            results.append(
+                FixResult(
+                    file_path=stac_file,
+                    action=FixAction.UPDATED,
+                    success=True,
+                    message="Set human-readable title/description",
+                )
+            )
+
+        # Repair item titles referenced by this collection's item links so the
+        # link-title backfill below has a title to copy.
+        results.extend(_repair_item_titles(stac_file, data, dry_run=dry_run))
+
+    # Backfill child/item link titles from their (now-titled) targets.
+    if not dry_run:
+        ensure_link_titles(catalog_root)
+
+    return results
+
+
+def _repair_item_titles(
+    stac_file: Path,
+    data: dict[str, Any],
+    *,
+    dry_run: bool,
+) -> list[FixResult]:
+    """Ensure items referenced by ``item`` links have a human-readable title."""
+    from portolan_cli.humanize import derive_title
+
+    results: list[FixResult] = []
+    links = data.get("links", [])
+    if not isinstance(links, list):
+        return results
+
+    for link in links:
+        if not isinstance(link, dict) or link.get("rel") != "item":
+            continue
+        href = link.get("href")
+        if not isinstance(href, str) or not href:
+            continue
+        item_file = (stac_file.parent / href).resolve()
+        if not item_file.exists():
+            continue
+        try:
+            item_data = json.loads(item_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        properties = item_data.setdefault("properties", {})
+        if not isinstance(properties, dict):
+            continue
+        item_id = str(item_data.get("id") or item_file.stem)
+        new_title = derive_title(properties.get("title"), item_id)
+        if properties.get("title") != new_title:
+            if not dry_run:
+                properties["title"] = new_title
+                item_file.write_text(json.dumps(item_data, indent=2))
+            results.append(
+                FixResult(
+                    file_path=item_file,
+                    action=FixAction.UPDATED,
+                    success=True,
+                    message="Set human-readable item title",
+                )
+            )
+
+    return results
 
 
 def _fix_single_file(

--- a/portolan_cli/metadata/fix.py
+++ b/portolan_cli/metadata/fix.py
@@ -170,8 +170,8 @@ def repair_titles_and_links(catalog_root: Path, *, dry_run: bool = False) -> lis
     )
     for stac_file in stac_files:
         try:
-            data = json.loads(stac_file.read_text())
-        except (OSError, json.JSONDecodeError):
+            data = json.loads(stac_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
 
         obj_id = str(data.get("id") or stac_file.parent.name)
@@ -191,7 +191,7 @@ def repair_titles_and_links(catalog_root: Path, *, dry_run: bool = False) -> lis
 
         if changed:
             if not dry_run:
-                stac_file.write_text(json.dumps(data, indent=2))
+                stac_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
             results.append(
                 FixResult(
                     file_path=stac_file,
@@ -236,8 +236,8 @@ def _repair_item_titles(
         if not item_file.exists():
             continue
         try:
-            item_data = json.loads(item_file.read_text())
-        except (OSError, json.JSONDecodeError):
+            item_data = json.loads(item_file.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
             continue
 
         properties = item_data.setdefault("properties", {})
@@ -248,7 +248,7 @@ def _repair_item_titles(
         if properties.get("title") != new_title:
             if not dry_run:
                 properties["title"] = new_title
-                item_file.write_text(json.dumps(item_data, indent=2))
+                item_file.write_text(json.dumps(item_data, indent=2), encoding="utf-8")
             results.append(
                 FixResult(
                     file_path=item_file,

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -374,6 +374,28 @@ def _validate_doi(metadata: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_title_description(metadata: dict[str, Any]) -> list[str]:
+    """Validate optional title/description overrides (Issue #502).
+
+    Both are optional human overrides for the auto-derived values. When
+    present they must be non-empty strings.
+
+    Args:
+        metadata: The full metadata dictionary.
+
+    Returns:
+        List of validation error messages.
+    """
+    errors: list[str] = []
+    for field in ("title", "description"):
+        value = metadata.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"Field '{field}' must be a non-empty string when provided")
+    return errors
+
+
 def validate_metadata(metadata: dict[str, Any]) -> list[str]:
     """Validate a metadata dictionary against the schema.
 
@@ -398,6 +420,7 @@ def validate_metadata(metadata: dict[str, Any]) -> list[str]:
 
     # Optional fields with format validation
     errors.extend(_validate_doi(metadata))
+    errors.extend(_validate_title_description(metadata))
 
     # Validate defaults section if present (optional)
     defaults = metadata.get("defaults")
@@ -566,8 +589,8 @@ def generate_metadata_template() -> str:
     Returns a YAML string with required and optional fields,
     with comments explaining each field's purpose.
 
-    Note: title and description are NOT included - they come from STAC
-    (set during catalog/collection init).
+    Note: title and description are auto-derived from the collection id
+    (humanized, per Issue #502); the optional keys below override them.
 
     Returns:
         YAML template string ready to write to file.
@@ -575,10 +598,19 @@ def generate_metadata_template() -> str:
     return """# .portolan/metadata.yaml
 #
 # Human-enrichable metadata that supplements STAC.
-# Title and description come from your catalog/collection STAC metadata.
 # Columns and bands are auto-extracted from data files.
 #
 # Only contact and license are REQUIRED here.
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Human-readable title / description override (Issue #502)
+# Portolan auto-derives a human-readable title from the collection id
+# (e.g. "publico_arbolado" -> "Publico Arbolado"). Set these to override it
+# with a better name/description; leave blank to keep the auto-derived value.
+# -----------------------------------------------------------------------------
+
+# title: ""                         # optional - overrides the auto-derived title
+# description: ""                    # optional - overrides the auto-derived description
 
 # -----------------------------------------------------------------------------
 # REQUIRED: Accountability

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -377,8 +377,11 @@ def _validate_doi(metadata: dict[str, Any]) -> list[str]:
 def _validate_title_description(metadata: dict[str, Any]) -> list[str]:
     """Validate optional title/description overrides (Issue #502).
 
-    Both are optional human overrides for the auto-derived values. When
-    present they must be non-empty strings.
+    Both are optional human overrides for the auto-derived values. A blank
+    string (``""`` or whitespace) is treated as "not provided" — same as an
+    omitted key and consistent with the template's ``# title: ""`` guidance and
+    the other optional fields — so the auto-derived value is used. Only a
+    non-string value is invalid.
 
     Args:
         metadata: The full metadata dictionary.
@@ -389,10 +392,10 @@ def _validate_title_description(metadata: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     for field in ("title", "description"):
         value = metadata.get(field)
-        if value is None:
+        # None or any string (including blank) is acceptable; blank == absent.
+        if value is None or isinstance(value, str):
             continue
-        if not isinstance(value, str) or not value.strip():
-            errors.append(f"Field '{field}' must be a non-empty string when provided")
+        errors.append(f"Field '{field}' must be a string when provided")
     return errors
 
 

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -1311,7 +1311,7 @@ def add_via_link(
     if not collection_path.exists():
         return
 
-    collection_data = json.loads(collection_path.read_text())
+    collection_data = json.loads(collection_path.read_text(encoding="utf-8"))
     links = collection_data.setdefault("links", [])
 
     # Check if via link already exists with same href
@@ -1328,7 +1328,7 @@ def add_via_link(
     }
     links.append(via_link)
 
-    collection_path.write_text(json.dumps(collection_data, indent=2) + "\n")
+    collection_path.write_text(json.dumps(collection_data, indent=2) + "\n", encoding="utf-8")
 
 
 def is_technical_name(text: str | None) -> bool:
@@ -1425,7 +1425,7 @@ def update_stac_metadata(
         return False
 
     try:
-        stac_data = json.loads(path.read_text())
+        stac_data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
         import logging
 
@@ -1445,6 +1445,8 @@ def update_stac_metadata(
         updated = True
 
     if updated:
-        path.write_text(json.dumps(stac_data, indent=2, ensure_ascii=False) + "\n")
+        path.write_text(
+            json.dumps(stac_data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
 
     return updated

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pystac
 from pystac.summaries import Summarizer, SummaryStrategy
 
+from portolan_cli.humanize import humanize_slug
+
 
 class MergeStrategy(Enum):
     """Strategy for merging existing metadata with auto-detected values.
@@ -94,7 +96,8 @@ def create_collection(
     Args:
         collection_id: Unique identifier for the collection.
         description: Human-readable description.
-        title: Optional display title (defaults to None).
+        title: Optional display title. Defaults to a human-readable title
+            derived from ``collection_id`` (Issue #502: titles are mandatory).
         license: SPDX license identifier (default: "proprietary").
         bbox: Spatial extent as [min_x, min_y, max_x, max_y] in WGS84.
               Defaults to global extent if not specified.
@@ -104,6 +107,15 @@ def create_collection(
     Returns:
         A pystac.Collection object.
     """
+    # Issue #502: titles and descriptions are mandatory and must be
+    # human-readable. Derive a title from the id when none is supplied, and
+    # fall back to the title for an empty description rather than leaving a
+    # placeholder like "Collection: <slug>".
+    if not title:
+        title = humanize_slug(collection_id)
+    if not description:
+        description = title
+
     # Default to global extent if not specified
     if bbox is None:
         bbox = [-180, -90, 180, 90]
@@ -156,6 +168,12 @@ def create_item(
 
     # Merge any custom properties
     item_properties = dict(properties) if properties else {}
+
+    # Issue #502: items must carry a human-readable title for STAC Browser.
+    # Derive one from the item id when source metadata didn't supply a usable
+    # title (humanize_slug also normalizes technical ids).
+    if not item_properties.get("title") or is_technical_name(str(item_properties.get("title"))):
+        item_properties["title"] = humanize_slug(item_id)
 
     # Per ADR-0035: If datetime not provided, mark as provisional so
     # portolan check can flag incomplete items.
@@ -438,6 +456,31 @@ def add_collection_properties_from_metadata(
             collection.stac_extensions = []
         if proj_ext_url not in collection.stac_extensions:
             collection.stac_extensions.append(proj_ext_url)
+
+
+def apply_human_titles(collection: pystac.Collection, metadata: object) -> None:
+    """Apply human-authored title/description from metadata.yaml (Issue #502).
+
+    Per ADR-0038 (revised), ``metadata.yaml`` may carry optional ``title`` and
+    ``description`` keys as the human override for the auto-derived values.
+    These are the highest-precedence source: a human-authored title always wins
+    over the slug-humanized default. Missing/blank values leave the existing
+    collection title/description untouched.
+
+    Args:
+        collection: The collection to update in place.
+        metadata: The merged metadata.yaml mapping (other types are ignored).
+    """
+    if not isinstance(metadata, dict):
+        return
+
+    title = metadata.get("title")
+    if isinstance(title, str) and title.strip():
+        collection.title = title.strip()
+
+    description = metadata.get("description")
+    if isinstance(description, str) and description.strip():
+        collection.description = description.strip()
 
 
 def add_partition_metadata_to_collection(

--- a/portolan_cli/validation/runner.py
+++ b/portolan_cli/validation/runner.py
@@ -18,7 +18,11 @@ from portolan_cli.validation.rules import (
     StacFieldsRule,
     ValidationRule,
 )
-from portolan_cli.validation.stac_rules import StacLintRule, StacSchemaRule
+from portolan_cli.validation.stac_rules import (
+    MandatoryTitlesRule,
+    StacLintRule,
+    StacSchemaRule,
+)
 
 # Default rules (no configuration options)
 # Immutable tuple to prevent accidental mutation
@@ -28,6 +32,7 @@ DEFAULT_RULES: tuple[ValidationRule, ...] = (
     StacFieldsRule(),
     StacSchemaRule(),
     StacLintRule(),
+    MandatoryTitlesRule(),
     PMTilesRecommendedRule(),
     MetadataFreshRule(),
     ProvisionalDatetimeRule(),
@@ -56,6 +61,7 @@ def _build_rules(
         StacFieldsRule(),
         StacSchemaRule(strict=strict),
         StacLintRule(strict=strict, config=config),
+        MandatoryTitlesRule(),
         PMTilesRecommendedRule(),
         MetadataFreshRule(),
         ProvisionalDatetimeRule(),

--- a/portolan_cli/validation/stac_rules.py
+++ b/portolan_cli/validation/stac_rules.py
@@ -7,6 +7,7 @@ Uses stac-check as the validation engine. Two rules:
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -301,3 +302,98 @@ class StacLintRule(ValidationRule):
                         pass  # Invalid severity, keep default
 
         return result
+
+
+# Namespace-prefixed technical names like "ns:LayerName" (a GeoServer/WFS habit).
+_NAMESPACE_PREFIX_RE = re.compile(r"^[a-z0-9_]+:[A-Za-z]")
+
+
+def _is_raw_slug_title(title: str) -> bool:
+    """True if a title is an un-humanized raw slug (Issue #502).
+
+    Intentionally narrow: a title is only "raw" when it still carries the
+    markers that :func:`portolan_cli.humanize.humanize_slug` strips —
+    underscores (``publico_arbolado``) or a namespace prefix (``ns:Layer``).
+    This keeps the rule consistent with the auto-fix: a humanized title never
+    contains those markers, so ``check --fix`` always converges (no looping on
+    short ids like ``T502`` that cannot be humanized further).
+    """
+    stripped = title.strip()
+    return "_" in stripped or bool(_NAMESPACE_PREFIX_RE.match(stripped))
+
+
+class MandatoryTitlesRule(ValidationRule):
+    """Require human-readable titles + descriptions across the catalog (Issue #502).
+
+    STAC Browser renders ``child``/``item`` link titles directly; without them
+    it must fetch every child just to show its name. Portolan therefore makes
+    titles mandatory and human-readable. This rule fails (ERROR) when:
+
+    - a catalog or collection is missing a title, has a technical-looking title
+      (e.g. a raw ``snake_case`` slug), or is missing a description, or
+    - any ``child``/``item`` link is missing a ``title``.
+
+    ``portolan check --fix`` repairs all of these (see
+    :func:`portolan_cli.metadata.fix.repair_titles_and_links`).
+    """
+
+    name = "mandatory_titles"
+    severity = Severity.ERROR
+    description = "Verify catalogs/collections and child/item links have human-readable titles"
+
+    def check(self, catalog_path: Path) -> ValidationResult:
+        """Walk the catalog and flag missing/raw-slug titles + untitled links."""
+        problems: list[str] = []
+
+        stac_files = sorted(catalog_path.rglob("catalog.json")) + sorted(
+            catalog_path.rglob("collection.json")
+        )
+        for stac_file in stac_files:
+            try:
+                data = json.loads(stac_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                # Malformed JSON is reported by other rules; skip here.
+                continue
+            rel = stac_file.relative_to(catalog_path)
+            problems.extend(self._check_object(data, rel))
+            problems.extend(self._check_links(data, rel))
+
+        if problems:
+            preview = "; ".join(problems[:5])
+            if len(problems) > 5:
+                preview += f" (+{len(problems) - 5} more)"
+            return self._fail(
+                f"{len(problems)} title/description issue(s): {preview}",
+                fix_hint="Run 'portolan check --fix' to populate human-readable titles",
+            )
+        return self._pass("All catalogs, collections, and links have human-readable titles")
+
+    @staticmethod
+    def _check_object(data: dict[str, Any], rel: Path) -> list[str]:
+        """Check a catalog/collection object's own title + description."""
+        problems: list[str] = []
+        title = data.get("title")
+        if not isinstance(title, str) or not title.strip():
+            problems.append(f"{rel}: missing title")
+        elif _is_raw_slug_title(title):
+            problems.append(f"{rel}: title is a raw slug, not human-readable ('{title}')")
+        description = data.get("description")
+        if not isinstance(description, str) or not description.strip():
+            problems.append(f"{rel}: missing description")
+        return problems
+
+    @staticmethod
+    def _check_links(data: dict[str, Any], rel: Path) -> list[str]:
+        """Check that every child/item link carries a title."""
+        problems: list[str] = []
+        links = data.get("links", [])
+        if not isinstance(links, list):
+            return problems
+        for link in links:
+            if not isinstance(link, dict) or link.get("rel") not in ("child", "item"):
+                continue
+            link_title = link.get("title")
+            if not isinstance(link_title, str) or not link_title.strip():
+                href = link.get("href", "?")
+                problems.append(f"{rel}: {link.get('rel')} link '{href}' missing title")
+        return problems

--- a/tests/benchmark/test_validation_benchmark.py
+++ b/tests/benchmark/test_validation_benchmark.py
@@ -42,6 +42,7 @@ def valid_catalog(tmp_path: Path) -> Path:
                 "type": "Catalog",
                 "stac_version": "1.0.0",
                 "id": "benchmark-catalog",
+                "title": "Benchmark Catalog",
                 "description": "A catalog for benchmarking",
                 "links": [],
             }

--- a/tests/integration/test_check_command.py
+++ b/tests/integration/test_check_command.py
@@ -725,6 +725,9 @@ class TestCheckMetadataFixFlag:
                     "type": "Catalog",
                     "stac_version": "1.0.0",
                     "id": "test-catalog",
+                    # Title present so the Issue #502 title-repair is a no-op and
+                    # this test stays focused on the scanner's empty report.
+                    "title": "Test Catalog",
                     "description": "Test",
                     "links": [],
                 }

--- a/tests/integration/test_cli_json.py
+++ b/tests/integration/test_cli_json.py
@@ -38,6 +38,7 @@ def valid_catalog(tmp_path: Path) -> Path:
                 "type": "Catalog",
                 "stac_version": "1.0.0",
                 "id": "test-catalog",
+                "title": "Test Catalog",
                 "description": "A test catalog",
                 "links": [],
             }

--- a/tests/integration/test_mandatory_titles_add.py
+++ b/tests/integration/test_mandatory_titles_add.py
@@ -48,7 +48,7 @@ def _add_slug_collection(root: Path, *, metadata_yaml: dict | None = None) -> Pa
     if metadata_yaml is not None:
         portolan = collection_dir / ".portolan"
         portolan.mkdir()
-        (portolan / "metadata.yaml").write_text(yaml.dump(metadata_yaml))
+        (portolan / "metadata.yaml").write_text(yaml.dump(metadata_yaml), encoding="utf-8")
     dest = collection_dir / "data.parquet"
     shutil.copy(FIXTURE, dest)
 
@@ -99,11 +99,11 @@ class TestAddProducesHumanReadableTitles:
             },
         )
 
-        coll = json.loads((collection_dir / "collection.json").read_text())
+        coll = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
         assert coll["title"] == "Áreas Programáticas de Desarrollo Social"
         assert coll["description"] == "Polígonos de áreas programáticas."
 
         # And the override propagates to the parent child link.
-        catalog = json.loads((root / "catalog.json").read_text())
+        catalog = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
         child = next(link for link in catalog["links"] if link.get("rel") == "child")
         assert child["title"] == "Áreas Programáticas de Desarrollo Social"

--- a/tests/integration/test_mandatory_titles_add.py
+++ b/tests/integration/test_mandatory_titles_add.py
@@ -1,0 +1,109 @@
+"""Integration tests: `portolan add` produces human-readable titles (Issue #502).
+
+Verifies the full add workflow yields:
+- a humanized collection title + non-placeholder description,
+- a child link in the root catalog carrying that title + type,
+- and that a metadata.yaml title/description override wins.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
+
+
+def _init_catalog(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "catalog.json").write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "stac_version": "1.1.0",
+                "id": "demo-catalog",
+                "title": "Demo Catalog",
+                "description": "Demo",
+                "links": [],
+            }
+        )
+    )
+    portolan_dir = root / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text(
+        yaml.dump({"version": 1, "statistics": {"enabled": False}})
+    )
+
+
+def _add_slug_collection(root: Path, *, metadata_yaml: dict | None = None) -> Path:
+    collection_dir = root / "publico_areas_programaticas_desarrollo_social"
+    collection_dir.mkdir(parents=True)
+    if metadata_yaml is not None:
+        portolan = collection_dir / ".portolan"
+        portolan.mkdir()
+        (portolan / "metadata.yaml").write_text(yaml.dump(metadata_yaml))
+    dest = collection_dir / "data.parquet"
+    shutil.copy(FIXTURE, dest)
+
+    result = CliRunner().invoke(
+        cli,
+        ["add", "--portolan-dir", str(root), str(dest)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    return collection_dir
+
+
+@pytest.mark.integration
+class TestAddProducesHumanReadableTitles:
+    def test_collection_title_and_description_humanized(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        collection_dir = _add_slug_collection(root)
+
+        coll = json.loads((collection_dir / "collection.json").read_text())
+        assert coll["title"] == "Publico Areas Programaticas Desarrollo Social"
+        # Description defaults to the title, never "Collection: <slug>".
+        assert coll["description"] == "Publico Areas Programaticas Desarrollo Social"
+        assert "Collection:" not in coll["description"]
+
+    def test_root_child_link_has_title_and_type(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        _add_slug_collection(root)
+
+        catalog = json.loads((root / "catalog.json").read_text())
+        child_links = [link for link in catalog["links"] if link.get("rel") == "child"]
+        assert len(child_links) == 1
+        link = child_links[0]
+        assert link["title"] == "Publico Areas Programaticas Desarrollo Social"
+        assert link["type"] == "application/json"
+
+    def test_metadata_yaml_title_override_wins(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        collection_dir = _add_slug_collection(
+            root,
+            metadata_yaml={
+                "contact": {"name": "IGN", "email": "x@example.com"},
+                "license": "CC-BY-4.0",
+                "title": "Áreas Programáticas de Desarrollo Social",
+                "description": "Polígonos de áreas programáticas.",
+            },
+        )
+
+        coll = json.loads((collection_dir / "collection.json").read_text())
+        assert coll["title"] == "Áreas Programáticas de Desarrollo Social"
+        assert coll["description"] == "Polígonos de áreas programáticas."
+
+        # And the override propagates to the parent child link.
+        catalog = json.loads((root / "catalog.json").read_text())
+        child = next(link for link in catalog["links"] if link.get("rel") == "child")
+        assert child["title"] == "Áreas Programáticas de Desarrollo Social"

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -45,6 +45,7 @@ def _write_catalog_json(catalog_dir: Path) -> None:
                 "type": "Catalog",
                 "id": "test-catalog",
                 "stac_version": "1.1.0",
+                "title": "Test Catalog",
                 "description": "Test catalog",
                 "links": [{"rel": "self", "href": "./catalog.json"}],
             },
@@ -64,6 +65,7 @@ def _write_collection_json(
         "type": "Collection",
         "id": collection_id,
         "stac_version": "1.1.0",
+        "title": f"Test collection {collection_id}",
         "description": f"Test collection {collection_id}",
         "license": "CC0-1.0",
         "extent": {

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -143,10 +143,14 @@ class TestCliInitInteractive:
             assert data.get("description") == "Interactive Description"
 
     @pytest.mark.unit
-    def test_interactive_skips_title_on_empty_input(
+    def test_interactive_derives_title_on_empty_input(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:
-        """Empty title input should leave title as None."""
+        """Empty title input derives a human-readable title (Issue #502).
+
+        Titles are mandatory, so an empty prompt falls back to a title
+        humanized from the catalog directory name rather than None.
+        """
         import json
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -159,8 +163,10 @@ class TestCliInitInteractive:
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             data = json.loads(Path("catalog.json").read_text())
-            # Title should not be present or be None
-            assert data.get("title") is None
+            # Title is mandatory and must be present + human-readable.
+            title = data.get("title")
+            assert title, "Expected a derived title, got falsy value"
+            assert "_" not in title  # humanized, not a raw slug
             assert data.get("description") == "Custom Description"
 
     @pytest.mark.unit

--- a/tests/unit/test_humanize.py
+++ b/tests/unit/test_humanize.py
@@ -1,0 +1,70 @@
+"""Unit tests for the slug humanizer (Issue #502).
+
+Titles on collections, items, and child/item links must be human-readable.
+These tests pin down how a machine slug like
+``publico_areas_programaticas_desarrollo_social`` becomes
+``Publico Areas Programaticas Desarrollo Social``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portolan_cli.humanize import derive_title, humanize_slug
+
+
+@pytest.mark.unit
+class TestHumanizeSlug:
+    def test_issue_example_spanish_slug(self) -> None:
+        assert (
+            humanize_slug("publico_areas_programaticas_desarrollo_social")
+            == "Publico Areas Programaticas Desarrollo Social"
+        )
+
+    def test_simple_snake_case(self) -> None:
+        assert humanize_slug("arbolado_publico") == "Arbolado Publico"
+
+    def test_hyphenated_slug(self) -> None:
+        assert humanize_slug("land-use") == "Land Use"
+
+    def test_mixed_separators(self) -> None:
+        assert humanize_slug("land-use_2018") == "Land Use 2018"
+
+    def test_numeric_token_preserved(self) -> None:
+        assert humanize_slug("census_2020") == "Census 2020"
+
+    def test_nested_id_uses_leaf_segment(self) -> None:
+        assert humanize_slug("climate/hittekaart") == "Hittekaart"
+        assert humanize_slug("rivers/2020/q1") == "Q1"
+
+    def test_acronym_token_preserved(self) -> None:
+        # A token that already contains uppercase is left untouched.
+        assert humanize_slug("ign_layers") == "Ign Layers"
+        assert humanize_slug("IGN_layers") == "IGN Layers"
+
+    def test_camelcase_token_preserved(self) -> None:
+        assert humanize_slug("DenHaagHousing") == "DenHaagHousing"
+
+    def test_collapses_repeated_and_edge_separators(self) -> None:
+        assert humanize_slug("__foo__bar__") == "Foo Bar"
+
+    def test_empty_and_none(self) -> None:
+        assert humanize_slug("") == ""
+        assert humanize_slug(None) == ""  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestDeriveTitle:
+    def test_uses_existing_human_title(self) -> None:
+        assert derive_title("Arbolado Público", "arbolado_publico") == "Arbolado Público"
+
+    def test_humanizes_when_existing_is_technical(self) -> None:
+        assert derive_title("arbolado_publico", "arbolado_publico") == "Arbolado Publico"
+
+    def test_humanizes_when_existing_missing(self) -> None:
+        assert derive_title(None, "arbolado_publico") == "Arbolado Publico"
+        assert derive_title("", "climate/hittekaart") == "Hittekaart"
+
+    def test_preserves_camelcase_existing(self) -> None:
+        # CamelCase is considered human-readable by is_technical_name.
+        assert derive_title("DenHaagHousing", "den_haag") == "DenHaagHousing"

--- a/tests/unit/test_mandatory_titles.py
+++ b/tests/unit/test_mandatory_titles.py
@@ -11,7 +11,9 @@ from pathlib import Path
 
 import pytest
 
+from portolan_cli.catalog import ensure_link_titles
 from portolan_cli.metadata.fix import repair_titles_and_links
+from portolan_cli.metadata_yaml import _validate_title_description
 from portolan_cli.stac import apply_human_titles, create_collection
 from portolan_cli.validation.results import Severity
 from portolan_cli.validation.stac_rules import MandatoryTitlesRule, _is_raw_slug_title
@@ -150,6 +152,46 @@ class TestRepairTitlesAndLinks:
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         assert catalog["title"] == "My Lovely Catalog"
         assert catalog["description"] == "A real description"
+
+
+@pytest.mark.unit
+class TestEnsureLinkTitlesTraversal:
+    def test_ignores_href_outside_catalog_root(self, tmp_path: Path) -> None:
+        """A ``../`` href that escapes the catalog is not read/backfilled."""
+        catalog_root = tmp_path / "catalog"
+        # A sensitive file with a title, living OUTSIDE the catalog.
+        _write(tmp_path / "outside.json", {"title": "Secret"})
+        _write(
+            catalog_root / "catalog.json",
+            {
+                "type": "Catalog",
+                "stac_version": "1.0.0",
+                "id": "demo",
+                "title": "Demo",
+                "description": "d",
+                "links": [{"rel": "child", "href": "../outside.json"}],
+            },
+        )
+
+        changed = ensure_link_titles(catalog_root)
+
+        catalog = json.loads((catalog_root / "catalog.json").read_text())
+        # The outside title must NOT leak into the catalog link.
+        assert "title" not in catalog["links"][0] or catalog["links"][0].get("title") != "Secret"
+        assert changed in (True, False)  # may set type, but never the foreign title
+
+
+@pytest.mark.unit
+class TestValidateTitleDescription:
+    def test_blank_string_is_accepted_as_absent(self) -> None:
+        assert _validate_title_description({"title": "", "description": "   "}) == []
+
+    def test_omitted_is_accepted(self) -> None:
+        assert _validate_title_description({}) == []
+
+    def test_non_string_is_rejected(self) -> None:
+        errors = _validate_title_description({"title": 123})
+        assert errors and "title" in errors[0]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_mandatory_titles.py
+++ b/tests/unit/test_mandatory_titles.py
@@ -182,6 +182,48 @@ class TestEnsureLinkTitlesTraversal:
 
 
 @pytest.mark.unit
+class TestEnsureLinkTitlesUnicode:
+    def test_accented_title_roundtrips(self, tmp_path: Path) -> None:
+        """Accented (UTF-8) titles backfill correctly regardless of OS locale.
+
+        Regression: STAC files are UTF-8; a bare read_text() uses the platform
+        locale (cp1252 on Windows) and chokes on byte 0x81 of e.g. 'Á'.
+        """
+        # Write collection.json as UTF-8 with an accented Spanish title.
+        coll_path = tmp_path / "areas" / "collection.json"
+        coll_path.parent.mkdir(parents=True)
+        coll_path.write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "stac_version": "1.0.0",
+                    "id": "areas",
+                    "title": "Áreas Programáticas",
+                    "description": "d",
+                    "links": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        _write(
+            tmp_path / "catalog.json",
+            {
+                "type": "Catalog",
+                "stac_version": "1.0.0",
+                "id": "demo",
+                "title": "Demo",
+                "description": "d",
+                "links": [{"rel": "child", "href": "./areas/collection.json"}],
+            },
+        )
+
+        ensure_link_titles(tmp_path)
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text(encoding="utf-8"))
+        assert catalog["links"][0]["title"] == "Áreas Programáticas"
+
+
+@pytest.mark.unit
 class TestValidateTitleDescription:
     def test_blank_string_is_accepted_as_absent(self) -> None:
         assert _validate_title_description({"title": "", "description": "   "}) == []

--- a/tests/unit/test_mandatory_titles.py
+++ b/tests/unit/test_mandatory_titles.py
@@ -1,0 +1,188 @@
+"""Unit tests for mandatory human-readable titles (Issue #502).
+
+Covers the MandatoryTitlesRule, the check --fix repair helper, creation-time
+defaults, and the metadata.yaml override.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.metadata.fix import repair_titles_and_links
+from portolan_cli.stac import apply_human_titles, create_collection
+from portolan_cli.validation.results import Severity
+from portolan_cli.validation.stac_rules import MandatoryTitlesRule, _is_raw_slug_title
+
+
+def _write(path: Path, data: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+
+
+def _slug_catalog(root: Path) -> None:
+    """A catalog whose collection/links lack human-readable titles."""
+    _write(
+        root / "catalog.json",
+        {
+            "type": "Catalog",
+            "stac_version": "1.0.0",
+            "id": "demo",
+            "description": "d",
+            "links": [
+                {
+                    "rel": "child",
+                    "href": "./publico_arbolado/collection.json",
+                }
+            ],
+        },
+    )
+    _write(
+        root / "publico_arbolado" / "collection.json",
+        {
+            "type": "Collection",
+            "stac_version": "1.0.0",
+            "id": "publico_arbolado",
+            "title": "publico_arbolado",  # raw slug
+            "description": "",
+            "links": [{"rel": "item", "href": "./tree_census/tree_census.json"}],
+        },
+    )
+    _write(
+        root / "publico_arbolado" / "tree_census" / "tree_census.json",
+        {
+            "type": "Feature",
+            "stac_version": "1.0.0",
+            "id": "tree_census",
+            "properties": {},
+            "links": [],
+        },
+    )
+
+
+@pytest.mark.unit
+class TestIsRawSlugTitle:
+    def test_underscore_is_raw(self) -> None:
+        assert _is_raw_slug_title("publico_arbolado") is True
+
+    def test_namespace_prefix_is_raw(self) -> None:
+        assert _is_raw_slug_title("ns:LayerName") is True
+
+    def test_humanized_is_not_raw(self) -> None:
+        assert _is_raw_slug_title("Publico Arbolado") is False
+
+    def test_short_token_is_not_raw(self) -> None:
+        # Cannot be humanized further; must not loop check --fix.
+        assert _is_raw_slug_title("T502") is False
+
+
+@pytest.mark.unit
+class TestMandatoryTitlesRule:
+    def test_severity_is_error(self) -> None:
+        assert MandatoryTitlesRule().severity is Severity.ERROR
+
+    def test_fails_on_slug_catalog(self, tmp_path: Path) -> None:
+        _slug_catalog(tmp_path)
+        result = MandatoryTitlesRule().check(tmp_path)
+        assert result.passed is False
+        # Flags: catalog missing title, child link missing title,
+        # collection raw-slug title, collection missing description.
+        assert "title" in result.message.lower()
+
+    def test_passes_after_repair(self, tmp_path: Path) -> None:
+        _slug_catalog(tmp_path)
+        repair_titles_and_links(tmp_path)
+        result = MandatoryTitlesRule().check(tmp_path)
+        assert result.passed is True, result.message
+
+
+@pytest.mark.unit
+class TestRepairTitlesAndLinks:
+    def test_humanizes_and_backfills_links(self, tmp_path: Path) -> None:
+        _slug_catalog(tmp_path)
+        repair_titles_and_links(tmp_path)
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        coll = json.loads((tmp_path / "publico_arbolado" / "collection.json").read_text())
+
+        # Collection title humanized; description defaulted to it.
+        assert coll["title"] == "Publico Arbolado"
+        assert coll["description"] == "Publico Arbolado"
+        # Child link carries the target's title + type.
+        child = catalog["links"][0]
+        assert child["title"] == "Publico Arbolado"
+        assert child["type"] == "application/json"
+        # Item link carries the (now-titled) item's title.
+        item_link = coll["links"][0]
+        assert item_link["title"] == "Tree Census"
+        assert item_link["type"] == "application/geo+json"
+
+    def test_is_idempotent(self, tmp_path: Path) -> None:
+        _slug_catalog(tmp_path)
+        repair_titles_and_links(tmp_path)
+        # Second run changes nothing.
+        second = repair_titles_and_links(tmp_path)
+        assert second == []
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path) -> None:
+        _slug_catalog(tmp_path)
+        before = (tmp_path / "publico_arbolado" / "collection.json").read_text()
+        results = repair_titles_and_links(tmp_path, dry_run=True)
+        after = (tmp_path / "publico_arbolado" / "collection.json").read_text()
+        assert results  # reports what it would change
+        assert before == after
+
+    def test_preserves_existing_human_title(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "catalog.json",
+            {
+                "type": "Catalog",
+                "stac_version": "1.0.0",
+                "id": "demo",
+                "title": "My Lovely Catalog",
+                "description": "A real description",
+                "links": [],
+            },
+        )
+        repair_titles_and_links(tmp_path)
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "My Lovely Catalog"
+        assert catalog["description"] == "A real description"
+
+
+@pytest.mark.unit
+class TestCreateCollectionDefaults:
+    def test_derives_title_and_description(self) -> None:
+        coll = create_collection(
+            collection_id="publico_arbolado",
+            description="",
+        )
+        assert coll.title == "Publico Arbolado"
+        assert coll.description == "Publico Arbolado"
+
+    def test_respects_explicit_title(self) -> None:
+        coll = create_collection(
+            collection_id="publico_arbolado",
+            description="Real description",
+            title="Arbolado Público",
+        )
+        assert coll.title == "Arbolado Público"
+        assert coll.description == "Real description"
+
+
+@pytest.mark.unit
+class TestApplyHumanTitles:
+    def test_override_wins(self) -> None:
+        coll = create_collection(collection_id="publico_arbolado", description="")
+        apply_human_titles(
+            coll, {"title": "Árboles de la Ciudad", "description": "Censo de arbolado"}
+        )
+        assert coll.title == "Árboles de la Ciudad"
+        assert coll.description == "Censo de arbolado"
+
+    def test_blank_override_ignored(self) -> None:
+        coll = create_collection(collection_id="publico_arbolado", description="")
+        apply_human_titles(coll, {"title": "  ", "description": None})
+        assert coll.title == "Publico Arbolado"

--- a/tests/unit/test_stac_metadata_update.py
+++ b/tests/unit/test_stac_metadata_update.py
@@ -33,7 +33,8 @@ class TestUpdateStacMetadata:
                     "stac_version": "1.1.0",
                     "links": [],
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         result = update_stac_metadata(
@@ -43,7 +44,7 @@ class TestUpdateStacMetadata:
         )
 
         assert result is True
-        data = json.loads(catalog_path.read_text())
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert data["title"] == "Bâtiments INSPIRE"
         assert data["description"] == "Couches de données spatiales des bâtiments"
 
@@ -67,7 +68,8 @@ class TestUpdateStacMetadata:
                     "links": [],
                     "license": "proprietary",
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         result = update_stac_metadata(
@@ -77,7 +79,7 @@ class TestUpdateStacMetadata:
         )
 
         assert result is True
-        data = json.loads(collection_path.read_text())
+        data = json.loads(collection_path.read_text(encoding="utf-8"))
         assert data["title"] == "Building - building_emprise"
         assert (
             data["description"]
@@ -99,13 +101,14 @@ class TestUpdateStacMetadata:
                     "stac_version": "1.1.0",
                     "links": [],
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         result = update_stac_metadata(catalog_path, title="New Title")
 
         assert result is True
-        data = json.loads(catalog_path.read_text())
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert data["title"] == "New Title"
         assert data["description"] == "Original description"
 
@@ -130,7 +133,8 @@ class TestUpdateStacMetadata:
                     "links": [],
                     "license": "proprietary",
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         result = update_stac_metadata(
@@ -138,7 +142,7 @@ class TestUpdateStacMetadata:
         )
 
         assert result is True
-        data = json.loads(collection_path.read_text())
+        data = json.loads(collection_path.read_text(encoding="utf-8"))
         assert data["title"] == "Original Title"
         assert data["description"] == "Rich description from ISO 19139"
 
@@ -155,13 +159,13 @@ class TestUpdateStacMetadata:
             "stac_version": "1.1.0",
             "links": [],
         }
-        catalog_path.write_text(json.dumps(original))
+        catalog_path.write_text(json.dumps(original), encoding="utf-8")
 
         result = update_stac_metadata(catalog_path, title=None, description=None)
 
         assert result is False
         # File should be unchanged
-        data = json.loads(catalog_path.read_text())
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert data == original
 
     @pytest.mark.unit
@@ -197,12 +201,13 @@ class TestUpdateStacMetadata:
                     "summaries": {"proj:code": ["EPSG:4326"]},
                     "keywords": ["buildings", "inspire"],
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         update_stac_metadata(collection_path, title="New Title", description="New Description")
 
-        data = json.loads(collection_path.read_text())
+        data = json.loads(collection_path.read_text(encoding="utf-8"))
         # Updated fields
         assert data["title"] == "New Title"
         assert data["description"] == "New Description"
@@ -231,14 +236,15 @@ class TestUpdateStacMetadata:
                     "stac_version": "1.1.0",
                     "links": [],
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         # Technical name should be skipped
         result = update_stac_metadata(catalog_path, title="bu_building_emprise")
 
         assert result is False
-        data = json.loads(catalog_path.read_text())
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert data["title"] == "Human Readable Title"
 
     @pytest.mark.unit
@@ -261,14 +267,15 @@ class TestUpdateStacMetadata:
                     "links": [],
                     "license": "proprietary",
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         # Technical name should be skipped
         result = update_stac_metadata(collection_path, description="ns:layer_name_v2")
 
         assert result is False
-        data = json.loads(collection_path.read_text())
+        data = json.loads(collection_path.read_text(encoding="utf-8"))
         assert data["description"] == "Good existing description"
 
     @pytest.mark.unit
@@ -286,7 +293,8 @@ class TestUpdateStacMetadata:
                     "stac_version": "1.1.0",
                     "links": [],
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         # Good title, technical description (description skipped, title applied)
@@ -297,7 +305,7 @@ class TestUpdateStacMetadata:
         )
 
         assert result is True
-        data = json.loads(catalog_path.read_text())
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert data["title"] == "Buildings Dataset"
         assert data["description"] == "Original"  # Technical description skipped
 
@@ -316,7 +324,8 @@ class TestUpdateStacMetadata:
                     "stac_version": "1.1.0",
                     "links": [],
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         result = update_stac_metadata(
@@ -326,6 +335,6 @@ class TestUpdateStacMetadata:
         )
 
         assert result is True
-        data = json.loads(catalog_path.read_text())
+        data = json.loads(catalog_path.read_text(encoding="utf-8"))
         assert data["title"] == "Données géographiques françaises"
         assert "caractères spéciaux: éàüö" in data["description"]

--- a/tests/unit/test_validation_runner.py
+++ b/tests/unit/test_validation_runner.py
@@ -24,6 +24,7 @@ class TestCheck:
                     "type": "Catalog",
                     "stac_version": "1.0.0",
                     "id": "test-catalog",
+                    "title": "Test Catalog",
                     "description": "A test catalog",
                     "links": [],
                 }
@@ -88,7 +89,7 @@ class TestCheck:
         # No .portolan dir = first rule fails
         report = check(tmp_path)
 
-        # Should have run all 10 default rules even though the first one failed
-        # (6 original + 2 partition rules + 2 STAC rules: StacSchemaRule, StacLintRule)
-        # This verifies the runner doesn't short-circuit on failure
-        assert len(report.results) == 10
+        # Should have run all 11 default rules even though the first one failed
+        # (6 original + 2 partition rules + 3 STAC rules: StacSchemaRule,
+        # StacLintRule, MandatoryTitlesRule). Verifies no short-circuit on failure.
+        assert len(report.results) == 11


### PR DESCRIPTION
Closes #502.

## Why
STAC Browser renders the `title` of `child`/`item` links directly. Without it, the browser must fetch every child's `collection.json` just to display a name — the pergamino catalog showed `data.source.coop` placeholders for seconds while 100+ requests resolved. Portolan never populated titles on auto-created collections or on links.

Per Matthias Mohr (STAC Browser) and Chris's feedback, titles/descriptions should be **mandatory and human-readable** — not raw slugs like `publico_areas_programaticas_desarrollo_social`, but `Publico Areas Programaticas Desarrollo Social`.

## What changed
- **`humanize.py`** — `humanize_slug` / `derive_title`: slug → title-cased, preserving acronyms/CamelCase, leaf-only for nested ids.
- **Creation-time defaults** — `create_collection`, `create_item`, `init_catalog`, and tabular collections now get a humanized title and a description defaulting to the title (no more `Collection: <slug>` placeholder). SMART merge never overwrites human values.
- **`metadata.yaml` override** — optional `title`/`description` keys take highest precedence (ADR-0038 amended); template + validation updated.
- **Link propagation** — `ensure_link_titles()` backfills `title` + `type` onto every `child`/`item` link from its target; run once per add batch (O(catalog), not O(n²)), plus external/tabular paths.
- **Enforcement** — new `MandatoryTitlesRule` (ERROR) fails `check` on missing/raw-slug titles, missing descriptions, or untitled child/item links. `check --fix` repairs all of it via `repair_titles_and_links`. The rule flags only the markers `humanize_slug` strips (underscores, `ns:` prefixes), so `--fix` always converges.
- **ADR-0053** documents the decision; ADR-0038 + CLAUDE.md index updated.

## Decisions (confirmed with maintainer)
- Auto-humanize **and** allow `metadata.yaml` title/description override.
- Default description = title when none provided.
- Validation severity = ERROR with auto-fix.

## Verification
- `mypy --strict` (123 files), `ruff`, `xenon`, `vulture`, `validate_claude_md.py`: all green.
- New unit tests: `test_humanize.py`, `test_mandatory_titles.py` (rule, repair convergence/idempotency, creation defaults, metadata.yaml override).
- New integration test: `test_mandatory_titles_add.py` — full `add` yields humanized collection title, description=title, parent child link with title+type, and metadata.yaml override propagating to the link.
- End-to-end: slug catalog fails `check`, `check --fix` repairs, re-`check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic human-readable title/description generation and backfill for catalogs, collections, items, and child/item links
  * CLI check/fix now repairs missing/invalid titles and propagates link titles

* **Validation**
  * New rule flags missing or technical/raw titles/descriptions (ERROR severity)

* **Documentation**
  * ADRs updated/added to require human-readable titles and clarify metadata precedence

* **Tests**
  * Added unit/integration tests covering humanization, repair, and validation

* **Chores**
  * Standardized UTF-8 JSON/YAML read-write handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->