### PR TITLE
feat(stac): populate file:size and aggregate statistics on STAC assets (#501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,12 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --all-extras
 
       - name: Check code formatting
         run: uv run ruff format --check .
@@ -73,7 +78,12 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --all-extras
 
       - name: Run bandit security scan
         run: uv run bandit -r portolan_cli -c pyproject.toml
@@ -149,7 +159,12 @@ jobs:
         run: brew install tippecanoe
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --all-extras
 
       - name: Run tests (unit + integration, no network, no iceberg)
         run: uv run pytest tests/ --ignore=tests/iceberg/ -v --tb=short -m "not network and not slow and not benchmark" -n auto --dist loadscope --cov=portolan_cli --cov-report=term-missing --cov-report=xml
@@ -190,7 +205,12 @@ jobs:
           command: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra iceberg --extra dev
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --extra iceberg --extra dev
 
       - name: Run unit and integration tests
         run: uv run pytest tests/iceberg/ -v --tb=short -m "not e2e and not e2e_slow and not network and not slow" --cov=portolan_cli/backends/iceberg --cov-report=term-missing --cov-report=xml
@@ -229,7 +249,12 @@ jobs:
           command: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra iceberg --extra dev --extra e2e
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --extra iceberg --extra dev --extra e2e
 
       - name: Start Docker services
         run: docker compose -f tests/iceberg/e2e/docker-compose.yml up -d --wait
@@ -266,7 +291,12 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --all-extras
 
       - name: Check for dead code
         run: uv run vulture portolan_cli tests --min-confidence 80
@@ -292,7 +322,12 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --all-extras
 
       - name: Build documentation
         run: uv run mkdocs build --strict

--- a/docs/guides/nested-catalogs.md
+++ b/docs/guides/nested-catalogs.md
@@ -171,6 +171,8 @@ portolan pull s3://bucket/my-catalog --restore
 
 The `--restore` flag checks file existence locally and downloads any missing assets, regardless of version metadata. Useful for recovering from accidental deletions.
 
+After downloading, pull operations automatically enrich STAC assets with `file:size` metadata via HTTP HEAD requests when the remote catalog lacks this information.
+
 ## Tips
 
 **Start flat, restructure later.** You can reorganize directories and re-run `portolan add .` — Portolan regenerates the STAC hierarchy from the current structure.

--- a/portolan_cli/backends/protocol.py
+++ b/portolan_cli/backends/protocol.py
@@ -62,11 +62,17 @@ class SchemaFingerprint(TypedDict):
 
 
 class PostAddItemContext(TypedDict):
-    """Per-item context within PostAddContext.items list."""
+    """Per-item context within PostAddContext.items list.
+
+    Attributes:
+        item_id: The STAC item identifier.
+        item_dir: Path to the item directory containing assets.
+        asset_files: Dict mapping filename to (path, checksum, size) tuples.
+    """
 
     item_id: str
     item_dir: Path
-    asset_files: dict[str, tuple[Path, str]]
+    asset_files: dict[str, tuple[Path, str, int]]
 
 
 class PostAddContext(TypedDict):
@@ -94,7 +100,7 @@ class PostAddContext(TypedDict):
     collection: Any  # pystac.Collection (typed as Any to avoid import)
     item_id: str
     item_dir: Path
-    asset_files: dict[str, tuple[Path, str]]
+    asset_files: dict[str, tuple[Path, str, int]]
     remote: str | None
     items: list[PostAddItemContext]
 

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -168,17 +168,6 @@ _MEDIA_TYPE_MAP: dict[str, str] = {
     ".html": "text/html",
 }
 
-# Default titles for well-known STAC asset roles. Matches the convention
-# used by Element 84 Earth Search (e.g. Sentinel-2 items always carry a
-# "title" on every asset). Used by _scan_item_assets when no explicit title
-# is set.
-_ROLE_TITLES: dict[str, str] = {
-    "data": "Data",
-    "thumbnail": "Thumbnail",
-    "metadata": "Metadata",
-    "documentation": "Documentation",
-}
-
 # Asset keys reserved for well-known roles. _scan_item_assets prefers these
 # keys over filename-derived stems so STAC consumers can find assets by role
 # without inspecting file paths. Order matters for collision priority: an

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -248,7 +248,7 @@ def _scan_item_assets(
     item_id: str,
     primary_file: Path,
     collection_dir: Path,
-) -> tuple[dict[str, pystac.Asset], dict[str, tuple[Path, str]], list[str]]:
+) -> tuple[dict[str, pystac.Asset], dict[str, tuple[Path, str, int]], list[str]]:
     """Scan an item directory for all trackable assets.
 
     Per issue #133, ALL files in item directories are tracked as assets.
@@ -264,11 +264,11 @@ def _scan_item_assets(
     Returns:
         Tuple of (stac_assets, asset_files, asset_paths):
         - stac_assets: Dict mapping asset key to pystac.Asset
-        - asset_files: Dict mapping filename to (path, checksum) tuples
+        - asset_files: Dict mapping filename to (path, checksum, size) tuples
         - asset_paths: List of absolute path strings
     """
     stac_assets: dict[str, pystac.Asset] = {}
-    asset_files: dict[str, tuple[Path, str]] = {}
+    asset_files: dict[str, tuple[Path, str, int]] = {}
     asset_paths: list[str] = []
 
     for file_path in item_dir.iterdir():
@@ -344,13 +344,16 @@ def _scan_item_assets(
             href=asset_href,
             media_type=file_media_type,
             roles=[file_role],
-            title=_ROLE_TITLES.get(file_role),
+            # NOTE: Don't set title here - it's a human-enrichable field (Issue #446).
+            # Titles should come from metadata.yaml or be preserved from existing
+            # metadata via merge strategy. Role-based default titles are NOT
+            # auto-detected values, so they shouldn't appear with OVERWRITE.
             extra_fields={
                 "file:size": file_size,
                 "file:checksum": f"sha256:{file_checksum}",
             },
         )
-        asset_files[file_path.name] = (file_path, file_checksum)
+        asset_files[file_path.name] = (file_path, file_checksum, file_size)
         asset_paths.append(str(file_path))
 
     return stac_assets, asset_files, asset_paths
@@ -412,7 +415,7 @@ class PreparedDataset:
         collection_id: Collection identifier (may include '/' for nested).
         format_type: Vector or raster format.
         bbox: Bounding box [min_x, min_y, max_x, max_y] in WGS84.
-        asset_files: Dict mapping filename to (path, checksum) tuples.
+        asset_files: Dict mapping filename to (path, checksum, size) tuples.
         item_json_path: Path to item.json (None for collection-level vector assets per ADR-0031).
         is_collection_level_asset: If True, asset is at collection level (ADR-0031).
         stac_item: The PySTAC Item object (None for collection-level vector assets).
@@ -425,7 +428,7 @@ class PreparedDataset:
     collection_id: str
     format_type: FormatType
     bbox: list[float]
-    asset_files: dict[str, tuple[Path, str]]
+    asset_files: dict[str, tuple[Path, str, int]]
     item_json_path: Path | None  # None for collection-level vector assets
     is_collection_level_asset: bool = False
     stac_item: pystac.Item | None = None
@@ -479,7 +482,7 @@ def _maybe_partition_large_file(
     # Find the primary parquet file in asset_files
     parquet_files = [
         path
-        for filename, (path, _checksum) in prepared.asset_files.items()
+        for filename, (path, _checksum, _size) in prepared.asset_files.items()
         if filename.endswith(".parquet")
     ]
     if not parquet_files:
@@ -1871,7 +1874,9 @@ def finalize_datasets(
                     collection_id=p.collection_id,
                     format_type=p.format_type,
                     bbox=p.bbox,
-                    asset_paths=[str(path) for _name, (path, _checksum) in p.asset_files.items()],
+                    asset_paths=[
+                        str(path) for _name, (path, _checksum, _size) in p.asset_files.items()
+                    ],
                 )
             )
 
@@ -1919,7 +1924,7 @@ def _finalize_with_backend(
     # Publish version snapshot via the plugin backend
     assets: dict[str, str] = {}
     for p in items:
-        for filename, (file_path, _checksum) in p.asset_files.items():
+        for filename, (file_path, _checksum, _size) in p.asset_files.items():
             if p.is_collection_level_asset:
                 asset_key = filename
             else:
@@ -2010,7 +2015,7 @@ def _batch_update_versions(
     # Build assets dict from ALL items (batch)
     all_assets: dict[str, Asset] = {}
     for p in items:
-        for filename, (file_path, file_checksum) in p.asset_files.items():
+        for filename, (file_path, file_checksum, file_size) in p.asset_files.items():
             # For collection-level assets (ADR-0031), omit item_id from path
             # asset_key is collection-relative; href is catalog-relative
             if p.is_collection_level_asset:
@@ -2021,10 +2026,10 @@ def _batch_update_versions(
                 asset_key = f"{p.item_id}/{filename}"
 
             stat = file_path.stat()
-            size_bytes = stat.st_size if file_path.is_file() else 0
+            # Use pre-computed file_size (handles directories like FileGDB correctly)
             all_assets[asset_key] = Asset(
                 sha256=file_checksum,
-                size_bytes=size_bytes,
+                size_bytes=file_size,
                 href=href,
                 mtime=stat.st_mtime,
             )
@@ -2664,7 +2669,7 @@ def _update_versions(
     output_path: Path | None = None,
     checksum: str | None = None,
     *,
-    asset_files: dict[str, tuple[Path, str]] | None = None,
+    asset_files: dict[str, tuple[Path, str, int]] | None = None,
     is_collection_level_asset: bool = False,
     catalog_root: Path | None = None,
 ) -> None:
@@ -2680,7 +2685,7 @@ def _update_versions(
         collection_id: Collection identifier (full path like "climate/hittekaart" for nested).
         output_path: Path to single output file (legacy mode).
         checksum: SHA-256 checksum for single file (legacy mode).
-        asset_files: Dict mapping filename to (path, checksum) tuples.
+        asset_files: Dict mapping filename to (path, checksum, size) tuples.
             If provided, output_path/checksum are ignored.
         is_collection_level_asset: If True, asset is at collection level (per ADR-0031).
             Affects href construction (no item_id in path).
@@ -2696,7 +2701,7 @@ def _update_versions(
     assets: dict[str, str] = {}
     if asset_files is not None:
         # Multi-asset mode (per issue #133)
-        for filename, (file_path, _checksum) in asset_files.items():
+        for filename, (file_path, _checksum, _size) in asset_files.items():
             # For collection-level assets (Issue #250, ADR-0031), use filename only.
             # Both backends prepend collection/ when building the href,
             # so do NOT include collection_id here to avoid doubling.
@@ -3703,7 +3708,7 @@ def add_files(
     # ========================================================================
     # PHASE 3: Process deferred non-geo files (sequential)
     # ========================================================================
-    _process_deferred_non_geo_files(
+    affected_collections = _process_deferred_non_geo_files(
         deferred_non_geo=deferred_non_geo,
         source_to_item_dir=source_to_item_dir,
         source_to_collection_dir=source_to_collection_dir,
@@ -3711,6 +3716,18 @@ def add_files(
         skipped=skipped,
         failures=failures,
     )
+
+    # ========================================================================
+    # PHASE 3.5: Recompute file statistics for collections with deferred assets
+    # ========================================================================
+    # Deferred assets are added after finalize_datasets, so file statistics
+    # must be recomputed to include them (Issue #501)
+    for collection_dir in affected_collections:
+        collection_json_path = collection_dir / "collection.json"
+        if collection_json_path.exists():
+            collection = pystac.Collection.from_file(str(collection_json_path))
+            update_collection_file_statistics(collection)
+            collection.save_object(include_self_link=False)
 
     return added, skipped, failures
 
@@ -3723,7 +3740,7 @@ def _process_deferred_non_geo_files(
     catalog_root: Path,
     skipped: list[Path],
     failures: list[AddFailure],
-) -> None:
+) -> set[Path]:
     """Process deferred non-geospatial files (ADR-0028).
 
     These files were deferred during the main add loop because they lack
@@ -3737,7 +3754,11 @@ def _process_deferred_non_geo_files(
         catalog_root: Root directory of the catalog.
         skipped: List to append skipped files to (modified in place).
         failures: List to append failures to (modified in place).
+
+    Returns:
+        Set of collection directories that received deferred assets (for statistics recomputation).
     """
+    affected_collections: set[Path] = set()
     for file_path, source_dir, coll_id in deferred_non_geo:
         try:
             if source_dir in source_to_item_dir:
@@ -3764,6 +3785,9 @@ def _process_deferred_non_geo_files(
                     asset_path=dest_path,
                 )
 
+                # Track for statistics recomputation
+                affected_collections.add(catalog_root / coll_id)
+
                 # Add to skipped (tracked but not converted)
                 skipped.append(file_path)
 
@@ -3789,7 +3813,8 @@ def _process_deferred_non_geo_files(
 
                 # Update versions.json so is_current() finds the asset
                 file_checksum = compute_checksum(file_path)
-                asset_files = {file_path.name: (file_path, file_checksum)}
+                file_size = file_path.stat().st_size
+                asset_files = {file_path.name: (file_path, file_checksum, file_size)}
                 _update_versions(
                     collection_dir=resolved_collection_dir,
                     item_id=file_path.stem,  # Use file stem as item_id for collection-level
@@ -3798,6 +3823,9 @@ def _process_deferred_non_geo_files(
                     is_collection_level_asset=True,
                     catalog_root=catalog_root,
                 )
+
+                # Track for statistics recomputation
+                affected_collections.add(resolved_collection_dir)
 
                 # Add to skipped (tracked but not converted)
                 skipped.append(file_path)
@@ -3889,10 +3917,12 @@ def _process_deferred_non_geo_files(
 
                     # Update versions.json so is_current() finds the asset(s)
                     asset_checksum = compute_checksum(asset_path)
-                    asset_files = {asset_path.name: (asset_path, asset_checksum)}
+                    asset_size = asset_path.stat().st_size
+                    asset_files = {asset_path.name: (asset_path, asset_checksum, asset_size)}
                     if source_tracked:
                         source_checksum = compute_checksum(file_path)
-                        asset_files[file_path.name] = (file_path, source_checksum)
+                        source_size = file_path.stat().st_size
+                        asset_files[file_path.name] = (file_path, source_checksum, source_size)
                     _update_versions(
                         collection_dir=collection_dir,
                         item_id=asset_path.stem,  # Use file stem as item_id
@@ -3902,11 +3932,16 @@ def _process_deferred_non_geo_files(
                         catalog_root=catalog_root,
                     )
 
+                    # Track for statistics recomputation
+                    affected_collections.add(collection_dir)
+
                     # Add to skipped (tracked, possibly converted)
                     skipped.append(file_path)
         except Exception as err:
             # Record failure and continue (Issue #175).
             failures.append(AddFailure(path=file_path, error=str(err)))
+
+    return affected_collections
 
 
 def _update_item_with_asset(
@@ -4055,10 +4090,16 @@ def _update_collection_with_asset(
             # Different file with same stem - use full filename to avoid collision
             asset_key = asset_path.name
 
+    # Compute file size and checksum for file extension metadata
+    file_size = asset_path.stat().st_size
+    file_checksum = compute_checksum(asset_path)
+
     assets[asset_key] = {
         "href": f"./{asset_path.name}",
         "type": media_type,
         "roles": [role],
+        "file:size": file_size,
+        "file:checksum": f"sha256:{file_checksum}",
     }
 
     # Write updated collection

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -83,6 +83,8 @@ from portolan_cli.stac import (
     create_collection,
     create_item,
     load_catalog,
+    update_catalog_file_statistics,
+    update_collection_file_statistics,
     update_collection_summaries,
 )
 from portolan_cli.style import enrich_cog_assets
@@ -284,6 +286,7 @@ def _scan_item_assets(
             if not is_filegdb(file_path):
                 continue
             file_checksum = compute_dir_checksum(file_path)
+            file_size = compute_dir_size(file_path)
             # FileGDB is always a geospatial asset
             file_media_type = "application/x-filegdb"
             file_role = "data"
@@ -291,6 +294,7 @@ def _scan_item_assets(
             if file_path.is_symlink():
                 continue
             file_checksum = compute_checksum(file_path)
+            file_size = file_path.stat().st_size
             file_media_type = _get_media_type(file_path)
             file_role = _get_asset_role(file_path)
         else:
@@ -341,6 +345,10 @@ def _scan_item_assets(
             media_type=file_media_type,
             roles=[file_role],
             title=_ROLE_TITLES.get(file_role),
+            extra_fields={
+                "file:size": file_size,
+                "file:checksum": f"sha256:{file_checksum}",
+            },
         )
         asset_files[file_path.name] = (file_path, file_checksum)
         asset_paths.append(str(file_path))
@@ -1166,6 +1174,9 @@ def _fix_collection_level_asset_hrefs(
             href=fixed_href,
             media_type=asset.media_type,
             roles=asset.roles,
+            title=asset.title,
+            description=asset.description,
+            extra_fields=asset.extra_fields,
         )
     return fixed_assets
 
@@ -1794,6 +1805,9 @@ def finalize_datasets(
         # available immediately after add, not just after push.
         update_collection_summaries(collection)
 
+        # Compute aggregate file statistics (Issue #501)
+        update_collection_file_statistics(collection)
+
         # Add extension declarations based on summaries (Issue #336)
         # Collections should declare extensions used by their items
         if collection.summaries is not None:
@@ -1867,6 +1881,17 @@ def finalize_datasets(
     from portolan_cli.catalog import ensure_link_titles
 
     ensure_link_titles(catalog_root)
+
+    # Issue #501: update catalog-level aggregate file statistics
+    # Done after all collections are finalized so totals are accurate.
+    try:
+        update_catalog_file_statistics(catalog_root)
+    except Exception:
+        logger.warning(
+            "Failed to update catalog-level file statistics. "
+            "Catalog may have stale or missing aggregate size data.",
+            exc_info=True,
+        )
 
     return results
 
@@ -2288,6 +2313,42 @@ def compute_dir_checksum(path: Path) -> str:
     for rel_path, size, mtime in entries:
         sha256.update(f"{rel_path}\x00{size}\x00{mtime:.6f}\n".encode())
     return sha256.hexdigest()
+
+
+def compute_dir_size(path: Path) -> int:
+    """Compute total size of all files in a directory.
+
+    Used for directory-format assets such as FileGDB (.gdb) to populate
+    the STAC file:size field.
+
+    Args:
+        path: Path to the directory.
+
+    Returns:
+        Total size in bytes of all files in the directory.
+
+    Raises:
+        ValueError: If path is not a directory.
+        FileNotFoundError: If path does not exist.
+    """
+    resolved = path.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Directory not found: {path}")
+    if not resolved.is_dir():
+        raise ValueError(f"Not a directory: {path} (resolves to {resolved})")
+
+    total_size = 0
+    try:
+        for fpath in resolved.rglob("*"):
+            if fpath.is_file():
+                try:
+                    total_size += fpath.stat().st_size
+                except OSError:
+                    pass
+    except OSError as exc:
+        raise ValueError(f"Cannot read directory contents: {path}") from exc
+
+    return total_size
 
 
 def _get_or_create_collection(

--- a/portolan_cli/download.py
+++ b/portolan_cli/download.py
@@ -682,3 +682,56 @@ def download_directory(
         total_bytes=successful_bytes,
         errors=errors,
     )
+
+
+# =============================================================================
+# HTTP HEAD for Remote File Sizes (Issue #501)
+# =============================================================================
+
+
+def get_remote_file_size(url: str, timeout: float = 30.0) -> int | None:
+    """Get file size from a remote URL via HTTP HEAD request.
+
+    Used to populate file:size for STAC assets that lack size information
+    (e.g., remote catalogs during pull/clone).
+
+    Args:
+        url: HTTP(S) URL to check.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        File size in bytes, or None if the size cannot be determined
+        (e.g., server doesn't support HEAD, no Content-Length header).
+    """
+    import httpx
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.head(url, follow_redirects=True)
+            response.raise_for_status()
+            content_length = response.headers.get("content-length")
+            return int(content_length) if content_length else None
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
+async def get_remote_file_size_async(url: str, timeout: float = 30.0) -> int | None:
+    """Async version of get_remote_file_size.
+
+    Args:
+        url: HTTP(S) URL to check.
+        timeout: Request timeout in seconds.
+
+    Returns:
+        File size in bytes, or None if the size cannot be determined.
+    """
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.head(url, follow_redirects=True)
+            response.raise_for_status()
+            content_length = response.headers.get("content-length")
+            return int(content_length) if content_length else None
+    except (httpx.HTTPError, ValueError):
+        return None

--- a/portolan_cli/download.py
+++ b/portolan_cli/download.py
@@ -692,6 +692,9 @@ def download_directory(
 def get_remote_file_size(url: str, timeout: float = 30.0) -> int | None:
     """Get file size from a remote URL via HTTP HEAD request.
 
+    Public API for synchronous callers. The async version
+    (get_remote_file_size_async) is used internally by pull operations.
+
     Used to populate file:size for STAC assets that lack size information
     (e.g., remote catalogs during pull/clone).
 

--- a/portolan_cli/pull.py
+++ b/portolan_cli/pull.py
@@ -40,7 +40,7 @@ from portolan_cli.async_utils import (
     get_default_concurrency,
 )
 from portolan_cli.dataset import compute_checksum
-from portolan_cli.download import download_file
+from portolan_cli.download import download_file, get_remote_file_size_async
 from portolan_cli.output import detail, error, info, output_section, success, warn
 from portolan_cli.upload import _setup_store_and_kwargs, parse_object_store_url
 from portolan_cli.versions import (
@@ -859,6 +859,158 @@ async def _download_assets_async(
 
 
 # =============================================================================
+# Populate Missing File Sizes (Issue #501)
+# =============================================================================
+
+
+def _resolve_asset_url(href: str, base_url: str, rel_path: str = "") -> str:
+    """Resolve an asset href to a full URL for HTTP HEAD requests."""
+    if href.startswith(("http://", "https://")):
+        return href
+    if href.startswith("../"):
+        parent = "/".join(rel_path.split("/")[:-1]) if "/" in rel_path else ""
+        return f"{base_url}/{parent}/{href[3:]}" if parent else f"{base_url}/{href[3:]}"
+    if href.startswith("./"):
+        return f"{base_url}/{rel_path}/{href[2:]}" if rel_path else f"{base_url}/{href[2:]}"
+    return f"{base_url}/{rel_path}/{href}" if rel_path else f"{base_url}/{href}"
+
+
+async def _fetch_and_set_file_size(
+    asset: dict[str, Any],
+    asset_url: str,
+) -> bool:
+    """Fetch file size via HTTP HEAD and set on asset if successful."""
+    size = await get_remote_file_size_async(asset_url)
+    if size is not None:
+        asset["file:size"] = size
+        return True
+    return False
+
+
+async def _populate_missing_file_sizes(
+    local_root: Path,
+    collection: str,
+    remote_url: str,
+    *,
+    verbose: bool = False,
+) -> int:
+    """Populate missing file:size values in STAC assets via HTTP HEAD.
+
+    After pulling a remote catalog, some assets may not have file:size
+    populated. This function reads the collection.json and item.json files,
+    identifies assets missing file:size, fetches sizes via HTTP HEAD,
+    and updates the STAC files.
+
+    Args:
+        local_root: Local catalog root directory.
+        collection: Collection name.
+        remote_url: Remote catalog URL for constructing asset URLs.
+        verbose: If True, log each file size fetch.
+
+    Returns:
+        Number of file sizes populated.
+    """
+
+    collection_dir = local_root / collection
+    collection_json = collection_dir / "collection.json"
+
+    if not collection_json.exists():
+        return 0
+
+    populated = 0
+    base_url = f"{remote_url}/{collection}"
+
+    # Process collection.json assets
+    populated += await _process_stac_file_sizes(collection_json, base_url, "", verbose)
+
+    # Process item.json files
+    for item_json in collection_dir.rglob("*.json"):
+        if item_json.name in ("collection.json", "versions.json"):
+            continue
+        rel_path = item_json.parent.relative_to(local_root).as_posix()
+        item_base = f"{remote_url}/{rel_path}"
+        populated += await _process_stac_file_sizes(item_json, item_base, rel_path, verbose)
+
+    return populated
+
+
+async def _enrich_file_sizes_safe(
+    local_root: Path,
+    collection: str,
+    remote_url: str,
+    *,
+    verbose: bool = False,
+) -> None:
+    """Safely enrich STAC assets with file:size metadata.
+
+    This is a non-fatal wrapper around _populate_missing_file_sizes.
+    File sizes are nice-to-have, so failures are silently ignored.
+
+    Args:
+        local_root: Local catalog root directory.
+        collection: Collection name.
+        remote_url: Remote catalog URL.
+        verbose: If True, log each file size fetch.
+    """
+    try:
+        sizes_populated = await _populate_missing_file_sizes(
+            local_root=local_root,
+            collection=collection,
+            remote_url=remote_url,
+            verbose=verbose,
+        )
+        if sizes_populated > 0 and verbose:
+            detail(f"Populated file:size for {sizes_populated} asset(s)")
+    except Exception:
+        # Non-fatal: file sizes are nice-to-have, don't fail the pull
+        pass
+
+
+async def _process_stac_file_sizes(
+    stac_file: Path,
+    base_url: str,
+    rel_path: str,
+    verbose: bool,
+) -> int:
+    """Process a single STAC file and populate missing file:size values."""
+    import json
+
+    try:
+        data = json.loads(stac_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    # Skip non-STAC files
+    stac_type = data.get("type")
+    if stac_type not in ("Collection", "Feature"):
+        return 0
+
+    assets = data.get("assets", {})
+    if not assets:
+        return 0
+
+    populated = 0
+    modified = False
+
+    for asset_key, asset in assets.items():
+        if "file:size" in asset:
+            continue
+        href = asset.get("href", "")
+        asset_url = _resolve_asset_url(href, base_url, rel_path)
+
+        if await _fetch_and_set_file_size(asset, asset_url):
+            modified = True
+            populated += 1
+            if verbose:
+                detail(f"Fetched file:size for {stac_file.name}:{asset_key}")
+
+    if modified:
+        stac_file.write_text(json.dumps(data, indent=2) + "\n")
+
+    return populated
+
+
+# =============================================================================
 # Async Pull Function
 # =============================================================================
 
@@ -1023,6 +1175,14 @@ async def pull_async(
             remote_version=diff.remote_version,
             files_restored=min(downloaded, restore_count),
         )
+
+    # Issue #501: Populate missing file:size values via HTTP HEAD
+    await _enrich_file_sizes_safe(
+        local_root=local_root,
+        collection=collection,
+        remote_url=remote_url,
+        verbose=verbose,
+    )
 
     # Update local versions.json (only if version actually changed)
     versions_path.parent.mkdir(parents=True, exist_ok=True)

--- a/portolan_cli/pull.py
+++ b/portolan_cli/pull.py
@@ -929,7 +929,8 @@ async def _populate_missing_file_sizes(
             continue
         rel_path = item_json.parent.relative_to(local_root).as_posix()
         item_base = f"{remote_url}/{rel_path}"
-        populated += await _process_stac_file_sizes(item_json, item_base, rel_path, verbose)
+        # item_base already includes rel_path, so pass "" to avoid URL duplication
+        populated += await _process_stac_file_sizes(item_json, item_base, "", verbose)
 
     return populated
 
@@ -961,8 +962,7 @@ async def _enrich_file_sizes_safe(
         )
         if sizes_populated > 0 and verbose:
             detail(f"Populated file:size for {sizes_populated} asset(s)")
-    except Exception:
-        # Non-fatal: file sizes are nice-to-have, don't fail the pull
+    except Exception:  # noqa: BLE001  # nosec B110 - Non-fatal: file sizes are nice-to-have
         pass
 
 

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -1282,6 +1282,100 @@ def update_collection_summaries(collection: pystac.Collection) -> None:
     collection.summaries = summarizer.summarize(items)
 
 
+def update_collection_file_statistics(collection: pystac.Collection) -> None:
+    """Compute and set aggregate file statistics on a collection.
+
+    Aggregates file:size from all assets (collection-level and item-level)
+    and stores the totals in portolan: extension fields.
+
+    Also declares the file extension when any asset has file:size.
+
+    Sets:
+        portolan:total_size_bytes: Sum of all asset file:size values
+        portolan:asset_count: Number of assets with file:size
+
+    Args:
+        collection: The collection to update statistics for.
+    """
+    total_size = 0
+    asset_count = 0
+    has_file_extension = False
+
+    # Count collection-level assets
+    for asset in collection.assets.values():
+        size = asset.extra_fields.get("file:size") if asset.extra_fields else None
+        if size is not None:
+            total_size += size
+            asset_count += 1
+            has_file_extension = True
+
+    # Count item-level assets
+    for item in collection.get_items(recursive=True):
+        for asset in item.assets.values():
+            size = asset.extra_fields.get("file:size") if asset.extra_fields else None
+            if size is not None:
+                total_size += size
+                asset_count += 1
+                has_file_extension = True
+
+    collection.extra_fields["portolan:total_size_bytes"] = total_size
+    collection.extra_fields["portolan:asset_count"] = asset_count
+
+    # Declare file extension if any asset has file:size
+    if has_file_extension:
+        file_ext_url = EXTENSION_URLS["file"]
+        if file_ext_url not in collection.stac_extensions:
+            collection.stac_extensions.append(file_ext_url)
+
+
+def update_catalog_file_statistics(catalog_root: Path) -> None:
+    """Compute and set aggregate file statistics on a catalog.
+
+    Reads all collection.json files under the catalog root and aggregates
+    their portolan:total_size_bytes and portolan:asset_count fields.
+
+    Sets on catalog.json:
+        portolan:total_size_bytes: Sum across all collections
+        portolan:asset_count: Sum across all collections
+        portolan:collection_count: Number of collections
+
+    Args:
+        catalog_root: Root directory of the catalog.
+    """
+    import json
+
+    catalog_path = catalog_root / "catalog.json"
+    if not catalog_path.exists():
+        return
+
+    total_size = 0
+    asset_count = 0
+    collection_count = 0
+
+    # Walk catalog looking for collection.json files
+    for collection_json in catalog_root.rglob("collection.json"):
+        # Skip if it's not a direct child pattern (avoid nested catalogs confusion)
+        try:
+            data = json.loads(collection_json.read_text())
+            if data.get("type") != "Collection":
+                continue
+            collection_count += 1
+            total_size += data.get("portolan:total_size_bytes", 0)
+            asset_count += data.get("portolan:asset_count", 0)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    # Update catalog.json
+    try:
+        catalog_data = json.loads(catalog_path.read_text())
+        catalog_data["portolan:total_size_bytes"] = total_size
+        catalog_data["portolan:asset_count"] = asset_count
+        catalog_data["portolan:collection_count"] = collection_count
+        catalog_path.write_text(json.dumps(catalog_data, indent=2) + "\n")
+    except (json.JSONDecodeError, OSError):
+        pass
+
+
 def add_via_link(
     collection_path: Path,
     source_url: str,

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -1301,9 +1301,25 @@ def update_collection_file_statistics(collection: pystac.Collection) -> None:
     asset_count = 0
     has_file_extension = False
 
+    def _validate_file_size(size: object) -> int | None:
+        """Validate and coerce file:size to int, rejecting invalid types."""
+        if size is None:
+            return None
+        if isinstance(size, bool):
+            return None
+        if isinstance(size, int):
+            return size
+        if isinstance(size, str):
+            try:
+                return int(size)
+            except ValueError:
+                return None
+        return None
+
     # Count collection-level assets
     for asset in collection.assets.values():
-        size = asset.extra_fields.get("file:size") if asset.extra_fields else None
+        raw_size = asset.extra_fields.get("file:size") if asset.extra_fields else None
+        size = _validate_file_size(raw_size)
         if size is not None:
             total_size += size
             asset_count += 1
@@ -1312,7 +1328,8 @@ def update_collection_file_statistics(collection: pystac.Collection) -> None:
     # Count item-level assets
     for item in collection.get_items(recursive=True):
         for asset in item.assets.values():
-            size = asset.extra_fields.get("file:size") if asset.extra_fields else None
+            raw_size = asset.extra_fields.get("file:size") if asset.extra_fields else None
+            size = _validate_file_size(raw_size)
             if size is not None:
                 total_size += size
                 asset_count += 1
@@ -1324,6 +1341,8 @@ def update_collection_file_statistics(collection: pystac.Collection) -> None:
     # Declare file extension if any asset has file:size
     if has_file_extension:
         file_ext_url = EXTENSION_URLS["file"]
+        if collection.stac_extensions is None:
+            collection.stac_extensions = []
         if file_ext_url not in collection.stac_extensions:
             collection.stac_extensions.append(file_ext_url)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 # Set matplotlib backend to Agg BEFORE any matplotlib imports.
 # Required for headless CI environments (Windows/Linux without display).
-import matplotlib
+# Conditional: matplotlib is in the [thumbnails] extra, not needed for all tests.
+try:
+    import matplotlib
 
-matplotlib.use("Agg")
+    matplotlib.use("Agg")
+except ModuleNotFoundError:
+    pass  # Iceberg tests don't need matplotlib
 
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/tests/iceberg/unit/test_on_post_add.py
+++ b/tests/iceberg/unit/test_on_post_add.py
@@ -64,7 +64,7 @@ def _make_context(
         "collection": collection,
         "item_id": "item1",
         "item_dir": item_dir,
-        "asset_files": {"data.parquet": (item_dir / "data.parquet", "abc")},
+        "asset_files": {"data.parquet": (item_dir / "data.parquet", "abc", 1024)},
         "remote": remote,
     }
 

--- a/tests/integration/test_add_file_size.py
+++ b/tests/integration/test_add_file_size.py
@@ -1,0 +1,184 @@
+"""Integration tests for file:size population (Issue #501).
+
+Verifies that `portolan add` correctly populates file:size and file:checksum
+on STAC assets, and that collection/catalog aggregates are computed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def initialized_catalog(tmp_path: Path) -> Path:
+    """Create an initialized Portolan catalog using CLI."""
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+    return tmp_path
+
+
+@pytest.fixture
+def sample_parquet_fixture() -> Path:
+    """Path to sample GeoParquet fixture."""
+    fixture_path = Path(__file__).parent.parent / "fixtures" / "simple.parquet"
+    if not fixture_path.exists():
+        pytest.skip("GeoParquet fixture not found")
+    return fixture_path
+
+
+@pytest.fixture
+def sample_parquet_in_catalog(initialized_catalog: Path, sample_parquet_fixture: Path) -> Path:
+    """Copy sample parquet into catalog for testing."""
+    collection_dir = initialized_catalog / "test-data"
+    collection_dir.mkdir()
+    target = collection_dir / "data.parquet"
+    shutil.copy(sample_parquet_fixture, target)
+    return target
+
+
+class TestFileSizePopulation:
+    """Tests for file:size and file:checksum population."""
+
+    @pytest.mark.integration
+    def test_add_populates_file_size_on_asset(
+        self, runner: CliRunner, initialized_catalog: Path, sample_parquet_in_catalog: Path
+    ) -> None:
+        """portolan add should populate file:size on STAC assets."""
+        # Act
+        result = runner.invoke(
+            cli,
+            ["add", "--portolan-dir", str(initialized_catalog), str(sample_parquet_in_catalog)],
+            catch_exceptions=False,
+        )
+
+        # Assert - add succeeded
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Find collection.json
+        collection_jsons = list(initialized_catalog.rglob("collection.json"))
+        assert len(collection_jsons) == 1, "Expected exactly one collection.json"
+
+        collection_data = json.loads(collection_jsons[0].read_text())
+        assets = collection_data.get("assets", {})
+
+        # At least one asset should exist
+        assert len(assets) > 0, "No assets found in collection"
+
+        # Check that file:size is populated
+        for asset_key, asset in assets.items():
+            assert "file:size" in asset, f"Asset {asset_key} missing file:size"
+            assert isinstance(asset["file:size"], int), "file:size should be int"
+            assert asset["file:size"] > 0, "file:size should be positive"
+
+    @pytest.mark.integration
+    def test_add_populates_file_checksum_on_asset(
+        self, runner: CliRunner, initialized_catalog: Path, sample_parquet_in_catalog: Path
+    ) -> None:
+        """portolan add should populate file:checksum on STAC assets."""
+        # Act
+        result = runner.invoke(
+            cli,
+            ["add", "--portolan-dir", str(initialized_catalog), str(sample_parquet_in_catalog)],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Find collection.json
+        collection_jsons = list(initialized_catalog.rglob("collection.json"))
+        collection_data = json.loads(collection_jsons[0].read_text())
+        assets = collection_data.get("assets", {})
+
+        # Check that file:checksum is populated with sha256 prefix
+        for asset_key, asset in assets.items():
+            assert "file:checksum" in asset, f"Asset {asset_key} missing file:checksum"
+            checksum = asset["file:checksum"]
+            assert checksum.startswith("sha256:"), "Checksum should start with sha256:"
+            assert len(checksum) > 70, f"Checksum too short: {checksum}"
+
+    @pytest.mark.integration
+    def test_add_populates_collection_aggregates(
+        self, runner: CliRunner, initialized_catalog: Path, sample_parquet_in_catalog: Path
+    ) -> None:
+        """portolan add should populate portolan:total_size_bytes on collection."""
+        # Act
+        result = runner.invoke(
+            cli,
+            ["add", "--portolan-dir", str(initialized_catalog), str(sample_parquet_in_catalog)],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Find collection.json
+        collection_jsons = list(initialized_catalog.rglob("collection.json"))
+        collection_data = json.loads(collection_jsons[0].read_text())
+
+        # Check aggregates
+        assert "portolan:total_size_bytes" in collection_data
+        assert "portolan:asset_count" in collection_data
+        assert collection_data["portolan:total_size_bytes"] > 0
+        assert collection_data["portolan:asset_count"] > 0
+
+    @pytest.mark.integration
+    def test_add_populates_catalog_aggregates(
+        self, runner: CliRunner, initialized_catalog: Path, sample_parquet_in_catalog: Path
+    ) -> None:
+        """portolan add should populate portolan:total_size_bytes on catalog."""
+        # Act
+        result = runner.invoke(
+            cli,
+            ["add", "--portolan-dir", str(initialized_catalog), str(sample_parquet_in_catalog)],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Check catalog.json
+        catalog_json = initialized_catalog / "catalog.json"
+        assert catalog_json.exists()
+        catalog_data = json.loads(catalog_json.read_text())
+
+        # Check aggregates
+        assert "portolan:total_size_bytes" in catalog_data
+        assert "portolan:asset_count" in catalog_data
+        assert "portolan:collection_count" in catalog_data
+        assert catalog_data["portolan:total_size_bytes"] > 0
+        assert catalog_data["portolan:asset_count"] > 0
+        assert catalog_data["portolan:collection_count"] == 1
+
+    @pytest.mark.integration
+    def test_add_declares_file_extension(
+        self, runner: CliRunner, initialized_catalog: Path, sample_parquet_in_catalog: Path
+    ) -> None:
+        """portolan add should declare file extension when file:size is present."""
+        # Act
+        result = runner.invoke(
+            cli,
+            ["add", "--portolan-dir", str(initialized_catalog), str(sample_parquet_in_catalog)],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        # Find collection.json
+        collection_jsons = list(initialized_catalog.rglob("collection.json"))
+        collection_data = json.loads(collection_jsons[0].read_text())
+
+        # Check file extension is declared
+        extensions = collection_data.get("stac_extensions", [])
+        file_ext = "https://stac-extensions.github.io/file/v2.1.0/schema.json"
+        assert file_ext in extensions, f"File extension not declared. Got: {extensions}"

--- a/tests/unit/test_add_continue_on_errors.py
+++ b/tests/unit/test_add_continue_on_errors.py
@@ -124,7 +124,7 @@ class TestAddFilesContinuesOnErrors:
                 collection_id="collection",
                 format_type=FormatType.VECTOR,
                 bbox=[-122.5, 37.5, -122.0, 38.0],
-                asset_files={"good.parquet": (path, "abc123")},
+                asset_files={"good.parquet": (path, "abc123", 1024)},
                 is_collection_level_asset=False,
             )
 
@@ -182,7 +182,7 @@ class TestAddFilesContinuesOnErrors:
                 collection_id="collection",
                 format_type=FormatType.VECTOR,
                 bbox=[0, 0, 1, 1],
-                asset_files={"file2.parquet": (path, "abc123")},
+                asset_files={"file2.parquet": (path, "abc123", 1024)},
                 is_collection_level_asset=False,
             )
 
@@ -446,7 +446,7 @@ class TestAddFilesReturnContract:
                     collection_id="collection",
                     format_type=FormatType.VECTOR,
                     bbox=[0, 0, 1, 1],
-                    asset_files={"test.parquet": (f, "abc123")},
+                    asset_files={"test.parquet": (f, "abc123", 1024)},
                     is_collection_level_asset=False,
                 ),
             ),

--- a/tests/unit/test_asset_key_normalization.py
+++ b/tests/unit/test_asset_key_normalization.py
@@ -1,11 +1,13 @@
-"""Tests for STAC asset key normalization and titles.
+"""Tests for STAC asset key normalization.
 
 When _scan_item_assets builds STAC asset entries, well-known roles
 (thumbnail, metadata, documentation) should:
 - Use the role name as the asset key (e.g., "thumbnail" not "preview")
   so STAC consumers can find the asset by role without inspecting paths.
-- Carry a default title matching the convention used by Element 84
-  Earth Search (every asset has a title).
+
+Note: Titles are human-enrichable fields (Issue #446) and should NOT be
+auto-generated. They come from metadata.yaml or preserved from existing
+metadata via merge strategy.
 
 Falls back to stem on collision so a user with two thumbnails or two
 metadata files still gets stable keys.
@@ -127,10 +129,15 @@ class TestAssetKeyNormalization:
 
 
 class TestAssetTitles:
-    """Well-known roles carry a default title."""
+    """Asset titles are human-enrichable fields (Issue #446).
+
+    Titles should NOT be auto-generated from role names. They should come from
+    metadata.yaml or be preserved from existing metadata via merge strategy.
+    """
 
     @pytest.mark.unit
-    def test_thumbnail_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+    def test_thumbnail_has_no_auto_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """Thumbnail assets should not get auto-generated titles."""
         item_dir, data_file = item_dir_with_data
         (item_dir / "preview.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
 
@@ -141,10 +148,11 @@ class TestAssetTitles:
             collection_dir=item_dir.parent,
         )
 
-        assert assets["thumbnail"].title == "Thumbnail"
+        assert assets["thumbnail"].title is None
 
     @pytest.mark.unit
-    def test_metadata_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+    def test_metadata_has_no_auto_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """Metadata assets should not get auto-generated titles."""
         item_dir, data_file = item_dir_with_data
         (item_dir / "iso.xml").write_text("<x/>")
 
@@ -155,10 +163,11 @@ class TestAssetTitles:
             collection_dir=item_dir.parent,
         )
 
-        assert assets["metadata"].title == "Metadata"
+        assert assets["metadata"].title is None
 
     @pytest.mark.unit
-    def test_documentation_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+    def test_documentation_has_no_auto_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """Documentation assets should not get auto-generated titles."""
         item_dir, data_file = item_dir_with_data
         (item_dir / "README.md").write_text("# Hi")
 
@@ -169,10 +178,11 @@ class TestAssetTitles:
             collection_dir=item_dir.parent,
         )
 
-        assert assets["documentation"].title == "Documentation"
+        assert assets["documentation"].title is None
 
     @pytest.mark.unit
-    def test_data_has_default_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+    def test_data_has_no_auto_title(self, item_dir_with_data: tuple[Path, Path]) -> None:
+        """Data assets should not get auto-generated titles."""
         item_dir, data_file = item_dir_with_data
 
         assets, _, _ = _scan_item_assets(
@@ -182,4 +192,4 @@ class TestAssetTitles:
             collection_dir=item_dir.parent,
         )
 
-        assert assets["data"].title == "Data"
+        assert assets["data"].title is None

--- a/tests/unit/test_batch_versioning.py
+++ b/tests/unit/test_batch_versioning.py
@@ -31,7 +31,7 @@ class TestPreparedDataset:
             collection_id="test-collection",
             format_type=FormatType.VECTOR,
             bbox=[-122.5, 37.5, -122.0, 38.0],
-            asset_files={"data.parquet": (Path("/tmp/data.parquet"), "abc123")},
+            asset_files={"data.parquet": (Path("/tmp/data.parquet"), "abc123", 1024)},
             item_json_path=Path("/tmp/item.json"),
         )
 
@@ -50,7 +50,7 @@ class TestPreparedDataset:
             collection_id="test-collection",
             format_type=FormatType.RASTER,
             bbox=[0, 0, 1, 1],
-            asset_files={"data.tif": (Path("/tmp/data.tif"), "def456")},
+            asset_files={"data.tif": (Path("/tmp/data.tif"), "def456", 2048)},
             item_json_path=Path("/tmp/item.json"),
             is_collection_level_asset=True,
         )
@@ -78,7 +78,7 @@ class TestPreparedDataset:
             collection_id="test-collection",
             format_type=FormatType.VECTOR,
             bbox=[0, 0, 1, 1],
-            asset_files={"data.parquet": (Path("/tmp/data.parquet"), "abc123")},
+            asset_files={"data.parquet": (Path("/tmp/data.parquet"), "abc123", 1024)},
             item_json_path=Path("/tmp/item.json"),
             metadata=metadata,
         )
@@ -250,7 +250,7 @@ class TestFinalizeDatasets:
             collection_id="test-collection",
             format_type=FormatType.VECTOR,
             bbox=[-122.5, 37.5, -122.0, 38.0],
-            asset_files={"data1.parquet": (asset1, "checksum1")},
+            asset_files={"data1.parquet": (asset1, "checksum1", 14)},
             item_json_path=item1_dir / "item-1.json",
         )
         prepared2 = PreparedDataset(
@@ -258,7 +258,7 @@ class TestFinalizeDatasets:
             collection_id="test-collection",
             format_type=FormatType.VECTOR,
             bbox=[-122.0, 37.0, -121.5, 37.5],
-            asset_files={"data2.parquet": (asset2, "checksum2")},
+            asset_files={"data2.parquet": (asset2, "checksum2", 14)},
             item_json_path=item2_dir / "item-2.json",
         )
 
@@ -303,6 +303,7 @@ class TestFinalizeDatasets:
                 "data.parquet": (
                     initialized_catalog / "collection-a/item-1/data.parquet",
                     "checksum-a",
+                    4,
                 )
             },
             item_json_path=initialized_catalog / "collection-a/item-1/item-1.json",
@@ -316,6 +317,7 @@ class TestFinalizeDatasets:
                 "data.parquet": (
                     initialized_catalog / "collection-b/item-1/data.parquet",
                     "checksum-b",
+                    4,
                 )
             },
             item_json_path=initialized_catalog / "collection-b/item-1/item-1.json",
@@ -360,6 +362,7 @@ class TestFinalizeDatasets:
                     f"data{i}.parquet": (
                         collection_dir / f"item-{i}/data{i}.parquet",
                         f"checksum{i}",
+                        100 * i,
                     )
                 },
                 item_json_path=collection_dir / f"item-{i}/item-{i}.json",

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -21,6 +21,7 @@ from portolan_cli.dataset import (
     _get_media_type,
     _update_versions,
     add_dataset,
+    compute_dir_size,
     get_dataset_info,
     list_datasets,
     remove_dataset,
@@ -1635,3 +1636,73 @@ class TestMultiAssetListAndInfo:
         assert len(info.asset_paths) == 2
         assert "data.parquet" in info.asset_paths
         assert "thumb.png" in info.asset_paths
+
+
+class TestComputeDirSize:
+    """Tests for compute_dir_size (Issue #501)."""
+
+    @pytest.mark.unit
+    def test_compute_dir_size_single_file(self, tmp_path: Path) -> None:
+        """compute_dir_size returns size of single file in directory."""
+        test_dir = tmp_path / "test_gdb"
+        test_dir.mkdir()
+
+        # Create a file with known content
+        content = b"Hello, World!"  # 13 bytes
+        (test_dir / "data.bin").write_bytes(content)
+
+        size = compute_dir_size(test_dir)
+        assert size == 13
+
+    @pytest.mark.unit
+    def test_compute_dir_size_multiple_files(self, tmp_path: Path) -> None:
+        """compute_dir_size sums sizes of all files in directory."""
+        test_dir = tmp_path / "test_gdb"
+        test_dir.mkdir()
+
+        # Create multiple files
+        (test_dir / "file1.bin").write_bytes(b"A" * 100)  # 100 bytes
+        (test_dir / "file2.bin").write_bytes(b"B" * 200)  # 200 bytes
+
+        size = compute_dir_size(test_dir)
+        assert size == 300
+
+    @pytest.mark.unit
+    def test_compute_dir_size_nested_files(self, tmp_path: Path) -> None:
+        """compute_dir_size includes files in subdirectories."""
+        test_dir = tmp_path / "test_gdb"
+        test_dir.mkdir()
+        subdir = test_dir / "subdir"
+        subdir.mkdir()
+
+        (test_dir / "root.bin").write_bytes(b"A" * 50)  # 50 bytes
+        (subdir / "nested.bin").write_bytes(b"B" * 75)  # 75 bytes
+
+        size = compute_dir_size(test_dir)
+        assert size == 125
+
+    @pytest.mark.unit
+    def test_compute_dir_size_empty_directory(self, tmp_path: Path) -> None:
+        """compute_dir_size returns 0 for empty directory."""
+        test_dir = tmp_path / "empty_gdb"
+        test_dir.mkdir()
+
+        size = compute_dir_size(test_dir)
+        assert size == 0
+
+    @pytest.mark.unit
+    def test_compute_dir_size_not_directory(self, tmp_path: Path) -> None:
+        """compute_dir_size raises ValueError for non-directory."""
+        test_file = tmp_path / "not_a_dir.txt"
+        test_file.write_text("content")
+
+        with pytest.raises(ValueError, match="Not a directory"):
+            compute_dir_size(test_file)
+
+    @pytest.mark.unit
+    def test_compute_dir_size_not_found(self, tmp_path: Path) -> None:
+        """compute_dir_size raises FileNotFoundError for missing path."""
+        missing = tmp_path / "does_not_exist"
+
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
+            compute_dir_size(missing)

--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -1040,7 +1040,7 @@ class TestUpdateVersionsHref:
             item_id="census-2020",
             collection_id="agriculture",
             asset_files={
-                "census-2020.parquet": (output_file, "abc123"),
+                "census-2020.parquet": (output_file, "abc123", 17),
             },
         )
 
@@ -1066,7 +1066,7 @@ class TestUpdateVersionsHref:
             item_id="pop-data",
             collection_id="demographics",
             asset_files={
-                "pop-data.parquet": (output_file, "def456"),
+                "pop-data.parquet": (output_file, "def456", 17),
             },
         )
 
@@ -1487,9 +1487,9 @@ class TestMultiAssetUpdateVersions:
             item_id="my-item",
             collection_id="my-collection",
             asset_files={
-                "my-item.parquet": (parquet_file, "hash1"),
-                "thumbnail.png": (thumbnail, "hash2"),
-                "metadata.xml": (metadata, "hash3"),
+                "my-item.parquet": (parquet_file, "hash1", 100),
+                "thumbnail.png": (thumbnail, "hash2", 200),
+                "metadata.xml": (metadata, "hash3", 50),
             },
         )
 
@@ -1528,7 +1528,7 @@ class TestMultiAssetUpdateVersions:
             item_id="census-2020",
             collection_id="agriculture",
             asset_files={
-                "census-2020.parquet": (output_file, "abc123"),
+                "census-2020.parquet": (output_file, "abc123", 17),
             },
         )
 

--- a/tests/unit/test_download.py
+++ b/tests/unit/test_download.py
@@ -1330,3 +1330,74 @@ class TestExceptionCleanupInDownloadFile:
 
                         assert result.success is False
                         # Should not raise, just continue with error result
+
+
+class TestGetRemoteFileSize:
+    """Tests for HTTP HEAD file size retrieval (Issue #501)."""
+
+    @pytest.mark.unit
+    def test_get_remote_file_size_returns_content_length(self) -> None:
+        """get_remote_file_size returns Content-Length header value."""
+        from portolan_cli.download import get_remote_file_size
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.headers = {"content-length": "12345"}
+            mock_client.head.return_value = mock_response
+
+            size = get_remote_file_size("https://example.com/data.parquet")
+
+            assert size == 12345
+            mock_client.head.assert_called_once_with(
+                "https://example.com/data.parquet", follow_redirects=True
+            )
+
+    @pytest.mark.unit
+    def test_get_remote_file_size_returns_none_on_missing_header(self) -> None:
+        """get_remote_file_size returns None when Content-Length is missing."""
+        from portolan_cli.download import get_remote_file_size
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.headers = {}  # No Content-Length
+            mock_client.head.return_value = mock_response
+
+            size = get_remote_file_size("https://example.com/data.parquet")
+
+            assert size is None
+
+    @pytest.mark.unit
+    def test_get_remote_file_size_returns_none_on_http_error(self) -> None:
+        """get_remote_file_size returns None on HTTP errors."""
+        import httpx
+
+        from portolan_cli.download import get_remote_file_size
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+            mock_client.head.side_effect = httpx.HTTPError("Connection failed")
+
+            size = get_remote_file_size("https://example.com/data.parquet")
+
+            assert size is None
+
+    @pytest.mark.unit
+    def test_get_remote_file_size_uses_custom_timeout(self) -> None:
+        """get_remote_file_size respects custom timeout."""
+        from portolan_cli.download import get_remote_file_size
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+            mock_response = MagicMock()
+            mock_response.headers = {"content-length": "100"}
+            mock_client.head.return_value = mock_response
+
+            get_remote_file_size("https://example.com/data.parquet", timeout=60.0)
+
+            mock_client_class.assert_called_once_with(timeout=60.0)

--- a/tests/unit/test_finalize_with_backend.py
+++ b/tests/unit/test_finalize_with_backend.py
@@ -40,7 +40,7 @@ def _make_item(
         collection_id=collection_id,
         format_type=FormatType.VECTOR,
         bbox=[-10.0, -10.0, 10.0, 10.0],
-        asset_files={filename: (asset_path, "abc123")},
+        asset_files={filename: (asset_path, "abc123", 1024)},
         item_json_path=item_json,
         is_collection_level_asset=is_collection_level,
     )
@@ -236,8 +236,8 @@ class TestFinalizeWithBackend:
             format_type=FormatType.VECTOR,
             bbox=[0, 0, 1, 1],
             asset_files={
-                "data.parquet": (file_a, "hash1"),
-                "metadata.json": (file_b, "hash2"),
+                "data.parquet": (file_a, "hash1", 7),
+                "metadata.json": (file_b, "hash2", 4),
             },
             item_json_path=item_json,
         )

--- a/tests/unit/test_issue_354_asset_paths.py
+++ b/tests/unit/test_issue_354_asset_paths.py
@@ -232,7 +232,7 @@ class TestBatchUpdateVersionsAssetKeys:
             collection_id="my_collection",
             format_type=FormatType.VECTOR,
             bbox=[0, 0, 1, 1],
-            asset_files={"my_collection.parquet": (asset_path, "abc123")},
+            asset_files={"my_collection.parquet": (asset_path, "abc123", 1024)},
             item_json_path=collection_dir / "item.json",
             is_collection_level_asset=True,
         )
@@ -270,7 +270,7 @@ class TestBatchUpdateVersionsAssetKeys:
             collection_id="my_collection",
             format_type=FormatType.VECTOR,
             bbox=[0, 0, 1, 1],
-            asset_files={"data.parquet": (asset_path, "abc123")},
+            asset_files={"data.parquet": (asset_path, "abc123", 1024)},
             item_json_path=item_dir / "item.json",
             is_collection_level_asset=False,
         )

--- a/tests/unit/test_pull.py
+++ b/tests/unit/test_pull.py
@@ -2009,3 +2009,87 @@ class TestPopulateMissingFileSizes:
         )
 
         assert count == 0
+
+
+class TestResolveAssetUrl:
+    """Tests for _resolve_asset_url helper function."""
+
+    @pytest.mark.unit
+    def test_absolute_url_returned_unchanged(self) -> None:
+        """Absolute URLs are returned as-is."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("https://example.com/file.parquet", "https://host/cat", "coll")
+            == "https://example.com/file.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_relative_dot_slash_with_rel_path(self) -> None:
+        """./href is resolved relative to base_url/rel_path."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("./data.parquet", "https://host/cat", "coll")
+            == "https://host/cat/coll/data.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_relative_dot_slash_empty_rel_path(self) -> None:
+        """./href with empty rel_path resolves to base_url/href."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("./data.parquet", "https://host/cat", "")
+            == "https://host/cat/data.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_parent_path_with_nested_rel_path(self) -> None:
+        """../href navigates up one level from rel_path."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("../shared/data.parquet", "https://host/cat", "coll/item")
+            == "https://host/cat/coll/shared/data.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_parent_path_with_single_segment_rel_path(self) -> None:
+        """../href with single-segment rel_path resolves to base_url."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("../data.parquet", "https://host/cat", "coll")
+            == "https://host/cat/data.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_parent_path_empty_rel_path(self) -> None:
+        """../href with empty rel_path still resolves (edge case)."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("../data.parquet", "https://host/cat", "")
+            == "https://host/cat/data.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_bare_filename_with_rel_path(self) -> None:
+        """Bare filename is resolved relative to base_url/rel_path."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("data.parquet", "https://host/cat", "coll")
+            == "https://host/cat/coll/data.parquet"
+        )
+
+    @pytest.mark.unit
+    def test_bare_filename_empty_rel_path(self) -> None:
+        """Bare filename with empty rel_path resolves to base_url/filename."""
+        from portolan_cli.pull import _resolve_asset_url
+
+        assert (
+            _resolve_asset_url("data.parquet", "https://host/cat", "")
+            == "https://host/cat/data.parquet"
+        )

--- a/tests/unit/test_pull.py
+++ b/tests/unit/test_pull.py
@@ -1890,3 +1890,122 @@ class TestDryRunNetworkIsolation:
         assert result.local_version is None  # no versions.json = no local version
         assert result.remote_version is None  # dry-run = no remote check
         assert result.files_downloaded == 0
+
+
+class TestPopulateMissingFileSizes:
+    """Tests for _populate_missing_file_sizes (Issue #501)."""
+
+    @pytest.mark.unit
+    def test_populate_missing_file_sizes_collection_assets(self, tmp_path: Path) -> None:
+        """_populate_missing_file_sizes updates collection.json assets."""
+        import asyncio
+        import json
+
+        from portolan_cli.pull import _populate_missing_file_sizes
+
+        # Create collection.json with assets missing file:size
+        collection_dir = tmp_path / "test-collection"
+        collection_dir.mkdir()
+        collection_data = {
+            "type": "Collection",
+            "id": "test-collection",
+            "assets": {
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                },
+                "has_size": {
+                    "href": "./other.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "file:size": 500,
+                },
+            },
+        }
+        (collection_dir / "collection.json").write_text(json.dumps(collection_data))
+
+        async def mock_get_size(url: str, timeout: float = 30.0) -> int | None:
+            if "data.parquet" in url:
+                return 12345
+            return None
+
+        with patch("portolan_cli.pull.get_remote_file_size_async", mock_get_size):
+            count = asyncio.run(
+                _populate_missing_file_sizes(
+                    local_root=tmp_path,
+                    collection="test-collection",
+                    remote_url="https://example.com/catalog",
+                )
+            )
+
+        assert count == 1
+
+        # Check file was updated
+        updated = json.loads((collection_dir / "collection.json").read_text())
+        assert updated["assets"]["data"]["file:size"] == 12345
+        assert updated["assets"]["has_size"]["file:size"] == 500  # unchanged
+
+    @pytest.mark.unit
+    def test_populate_missing_file_sizes_item_assets(self, tmp_path: Path) -> None:
+        """_populate_missing_file_sizes updates item.json assets."""
+        import asyncio
+        import json
+
+        from portolan_cli.pull import _populate_missing_file_sizes
+
+        # Create collection with an item
+        collection_dir = tmp_path / "test-collection"
+        collection_dir.mkdir()
+        (collection_dir / "collection.json").write_text(
+            json.dumps({"type": "Collection", "id": "test", "assets": {}})
+        )
+
+        item_dir = collection_dir / "item1"
+        item_dir.mkdir()
+        item_data = {
+            "type": "Feature",
+            "id": "item1",
+            "assets": {
+                "data": {
+                    "href": "data.tif",
+                    "type": "image/tiff",
+                },
+            },
+        }
+        (item_dir / "item1.json").write_text(json.dumps(item_data))
+
+        async def mock_get_size(url: str, timeout: float = 30.0) -> int | None:
+            if "data.tif" in url:
+                return 9999
+            return None
+
+        with patch("portolan_cli.pull.get_remote_file_size_async", mock_get_size):
+            count = asyncio.run(
+                _populate_missing_file_sizes(
+                    local_root=tmp_path,
+                    collection="test-collection",
+                    remote_url="https://example.com/catalog",
+                )
+            )
+
+        assert count == 1
+
+        # Check item file was updated
+        updated = json.loads((item_dir / "item1.json").read_text())
+        assert updated["assets"]["data"]["file:size"] == 9999
+
+    @pytest.mark.unit
+    def test_populate_missing_file_sizes_no_collection(self, tmp_path: Path) -> None:
+        """_populate_missing_file_sizes returns 0 when collection.json missing."""
+        import asyncio
+
+        from portolan_cli.pull import _populate_missing_file_sizes
+
+        count = asyncio.run(
+            _populate_missing_file_sizes(
+                local_root=tmp_path,
+                collection="nonexistent",
+                remote_url="https://example.com/catalog",
+            )
+        )
+
+        assert count == 0

--- a/tests/unit/test_stac.py
+++ b/tests/unit/test_stac.py
@@ -342,3 +342,133 @@ class TestItemManagement:
         assert len(items) == 2
         item_ids = {i.id for i in items}
         assert item_ids == {"item1", "item2"}
+
+
+class TestFileStatistics:
+    """Tests for file statistics aggregation (Issue #501)."""
+
+    @pytest.mark.unit
+    def test_update_collection_file_statistics_collection_assets(self) -> None:
+        """update_collection_file_statistics aggregates collection-level assets."""
+        from portolan_cli.stac import update_collection_file_statistics
+
+        collection = create_collection(
+            collection_id="stats-test",
+            description="Test file statistics",
+        )
+
+        # Add assets with file:size
+        asset1 = pystac.Asset(
+            href="./data1.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"file:size": 1000, "file:checksum": "sha256:abc123"},
+        )
+        asset2 = pystac.Asset(
+            href="./data2.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"file:size": 2000, "file:checksum": "sha256:def456"},
+        )
+        collection.add_asset("data1", asset1)
+        collection.add_asset("data2", asset2)
+
+        update_collection_file_statistics(collection)
+
+        assert collection.extra_fields["portolan:total_size_bytes"] == 3000
+        assert collection.extra_fields["portolan:asset_count"] == 2
+
+    @pytest.mark.unit
+    def test_update_collection_file_statistics_item_assets(self) -> None:
+        """update_collection_file_statistics includes item-level assets."""
+        from portolan_cli.stac import update_collection_file_statistics
+
+        collection = create_collection(
+            collection_id="stats-items",
+            description="Test item statistics",
+        )
+
+        # Add an item with assets
+        item = create_item(item_id="item1", bbox=[0, 0, 1, 1])
+        item_asset = pystac.Asset(
+            href="./item1/data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"file:size": 5000},
+        )
+        item.add_asset("data", item_asset)
+        add_item_to_collection(collection, item)
+
+        update_collection_file_statistics(collection)
+
+        assert collection.extra_fields["portolan:total_size_bytes"] == 5000
+        assert collection.extra_fields["portolan:asset_count"] == 1
+
+    @pytest.mark.unit
+    def test_update_collection_file_statistics_adds_extension(self) -> None:
+        """update_collection_file_statistics declares file extension."""
+        from portolan_cli.stac import EXTENSION_URLS, update_collection_file_statistics
+
+        collection = create_collection(
+            collection_id="ext-test",
+            description="Test extension declaration",
+        )
+
+        asset = pystac.Asset(
+            href="./data.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"file:size": 1000},
+        )
+        collection.add_asset("data", asset)
+
+        update_collection_file_statistics(collection)
+
+        assert EXTENSION_URLS["file"] in collection.stac_extensions
+
+    @pytest.mark.unit
+    def test_update_collection_file_statistics_no_assets(self) -> None:
+        """update_collection_file_statistics handles empty collections."""
+        from portolan_cli.stac import update_collection_file_statistics
+
+        collection = create_collection(
+            collection_id="empty",
+            description="Empty collection",
+        )
+
+        update_collection_file_statistics(collection)
+
+        assert collection.extra_fields["portolan:total_size_bytes"] == 0
+        assert collection.extra_fields["portolan:asset_count"] == 0
+
+    @pytest.mark.unit
+    def test_update_collection_file_statistics_missing_size(self) -> None:
+        """update_collection_file_statistics skips assets without file:size."""
+        from portolan_cli.stac import update_collection_file_statistics
+
+        collection = create_collection(
+            collection_id="partial",
+            description="Partial file sizes",
+        )
+
+        # Asset with file:size
+        asset1 = pystac.Asset(
+            href="./with_size.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+            extra_fields={"file:size": 1000},
+        )
+        # Asset without file:size
+        asset2 = pystac.Asset(
+            href="./without_size.parquet",
+            media_type="application/vnd.apache.parquet",
+            roles=["data"],
+        )
+        collection.add_asset("with_size", asset1)
+        collection.add_asset("without_size", asset2)
+
+        update_collection_file_statistics(collection)
+
+        # Only counts the asset with file:size
+        assert collection.extra_fields["portolan:total_size_bytes"] == 1000
+        assert collection.extra_fields["portolan:asset_count"] == 1


### PR DESCRIPTION
## Summary

- Populates `file:size` and `file:checksum` on all STAC assets during `portolan add`
- Computes aggregate statistics (`portolan:total_size_bytes`, `portolan:asset_count`) at collection and catalog levels
- Enriches pulled catalogs via HTTP HEAD requests when `file:size` is missing from remote assets
- Updates `nested-catalogs.md` documentation to reflect new pull behavior

## Key Changes

| File | Change |
|------|--------|
| `dataset.py` | Add `file:size`/`file:checksum` to assets in `_scan_item_assets()` |
| `stac.py` | Add `update_collection_file_statistics()` and `update_catalog_file_statistics()` |
| `download.py` | Add sync and async `get_remote_file_size()` for HTTP HEAD |
| `pull.py` | Add `_populate_missing_file_sizes()` to enrich STAC after pull |

## Test plan

- [x] Unit tests: 23 new tests covering file statistics, HTTP HEAD, and STAC enrichment
- [x] Integration tests: 5 tests verifying end-to-end `portolan add` behavior
- [x] Pre-commit hooks: All passing (ruff, mypy, xenon, vulture, docs freshness)

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assets now include file size (including directory-format assets); pull operations enrich remote assets with missing file:size using HTTP HEAD (non-fatal).
  * Collection and catalog aggregates (total size, asset count, collection count) are computed and updated; collection stats are recomputed after deferred asset processing.

* **Documentation**
  * Guides updated to describe file size enrichment behavior.

* **Tests**
  * New and updated integration/unit tests covering size capture, remote size lookup, enrichment, and aggregate stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->