### PR TITLE
feat(bbox): comprehensive bbox validation for inf/nan and anti-meridian (#516)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -939,7 +939,8 @@ portolan readme
 ```
 
 **Catalog-level README:** When run at catalog root, generates an index README with:
-- Aggregated spatial extent (envelope of all collections)
+
+- Aggregated spatial extent (envelope of all collections, invalid coordinates like inf/NaN are filtered)
 - Aggregated temporal extent (earliest to latest)
 - List of collections with links (collapsible when ≥10 collections)
 

--- a/portolan_cli/bbox.py
+++ b/portolan_cli/bbox.py
@@ -1,0 +1,362 @@
+"""Bounding box validation and utilities.
+
+Centralized bbox validation for issue #516:
+- Filter inf/nan coordinates that poison union computations
+- Validate WGS84 coordinate ranges
+- Handle antimeridian-crossing bboxes per RFC 7946 / STAC spec
+- Compute unions with proper multi-bbox support
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# WGS84 coordinate bounds
+LON_MIN = -180.0
+LON_MAX = 180.0
+LAT_MIN = -90.0
+LAT_MAX = 90.0
+
+
+@dataclass
+class BboxValidationResult:
+    """Result of filtering a list of bboxes for validity."""
+
+    valid: list[list[float]]
+    invalid: list[tuple[list[float], str]]  # (bbox, reason)
+
+    @property
+    def has_valid(self) -> bool:
+        """Check if any valid bboxes exist."""
+        return len(self.valid) > 0
+
+
+@dataclass
+class BboxUnionResult:
+    """Result of computing a bbox union."""
+
+    bbox: list[float] | None
+    """Single union bbox, or None if no valid inputs. For multi-bbox, this is the overall envelope."""
+
+    bboxes: list[list[float]] | None = None
+    """Multi-bbox list for STAC output when antimeridian crossing is involved."""
+
+    is_multi_bbox: bool = False
+    """True if the union requires multi-bbox representation."""
+
+    skipped: list[tuple[list[float], str]] = field(default_factory=list)
+    """Bboxes that were skipped due to validation failures."""
+
+
+def is_finite_bbox(bbox: list[float]) -> bool:
+    """Check if a bbox has finite coordinates (no inf/nan).
+
+    This is the universal validity check that applies to ANY CRS.
+    Use is_valid_wgs84_bbox() for WGS84-specific range checks.
+
+    Validates:
+    - Exactly 4 or 6 elements (2D or 3D bbox)
+    - All coordinates are finite (no inf, -inf, nan)
+
+    Args:
+        bbox: Bounding box as [west, south, east, north] or 6-element 3D variant.
+
+    Returns:
+        True if bbox has finite values, False otherwise.
+    """
+    if len(bbox) not in (4, 6):
+        return False
+
+    return all(math.isfinite(c) for c in bbox[:4])
+
+
+def is_valid_bbox(bbox: list[float], *, wgs84_only: bool = True) -> bool:
+    """Check if a bbox is valid.
+
+    Validates:
+    - Exactly 4 or 6 elements (2D or 3D bbox)
+    - All coordinates are finite (no inf, -inf, nan)
+    - If wgs84_only=True: Longitude in [-180, 180], Latitude in [-90, 90]
+    - South <= North (latitude ordering, only checked for WGS84)
+
+    Note: West > East is VALID per RFC 7946 for antimeridian-crossing bboxes.
+
+    Args:
+        bbox: Bounding box as [west, south, east, north] or 6-element 3D variant.
+        wgs84_only: If True (default), check WGS84 coordinate ranges.
+                   Set to False for projected coordinate bboxes.
+
+    Returns:
+        True if bbox is valid, False otherwise.
+    """
+    # Check finite first (universal for all CRS)
+    if not is_finite_bbox(bbox):
+        return False
+
+    # For non-WGS84 bboxes, finite check is sufficient
+    if not wgs84_only:
+        return True
+
+    west, south, east, north = bbox[0], bbox[1], bbox[2], bbox[3]
+
+    # Check longitude range (WGS84 only)
+    if not (LON_MIN <= west <= LON_MAX and LON_MIN <= east <= LON_MAX):
+        return False
+
+    # Check latitude range (WGS84 only)
+    if not (LAT_MIN <= south <= LAT_MAX and LAT_MIN <= north <= LAT_MAX):
+        return False
+
+    # Check latitude ordering (south must be <= north)
+    if south > north:
+        return False
+
+    return True
+
+
+def get_bbox_validation_reason(bbox: list[float], *, wgs84_only: bool = True) -> str | None:
+    """Get the reason why a bbox is invalid, or None if valid.
+
+    Args:
+        bbox: Bounding box to validate.
+        wgs84_only: If True (default), check WGS84 coordinate ranges.
+                   Set to False for projected coordinate bboxes.
+
+    Returns:
+        String describing why invalid, or None if valid.
+    """
+    if len(bbox) not in (4, 6):
+        return f"wrong element count: {len(bbox)} (expected 4 or 6)"
+
+    west, south, east, north = bbox[0], bbox[1], bbox[2], bbox[3]
+
+    # Check for non-finite values (universal for all CRS)
+    for name, val in [("west", west), ("south", south), ("east", east), ("north", north)]:
+        if math.isnan(val):
+            return f"{name} is NaN"
+        if math.isinf(val):
+            return f"{name} is infinite ({val})"
+
+    # WGS84-specific checks
+    if wgs84_only:
+        if not (LON_MIN <= west <= LON_MAX):
+            return f"west longitude {west} out of range [{LON_MIN}, {LON_MAX}]"
+        if not (LON_MIN <= east <= LON_MAX):
+            return f"east longitude {east} out of range [{LON_MIN}, {LON_MAX}]"
+        if not (LAT_MIN <= south <= LAT_MAX):
+            return f"south latitude {south} out of range [{LAT_MIN}, {LAT_MAX}]"
+        if not (LAT_MIN <= north <= LAT_MAX):
+            return f"north latitude {north} out of range [{LAT_MIN}, {LAT_MAX}]"
+
+        if south > north:
+            return f"south ({south}) > north ({north})"
+
+    return None
+
+
+def is_antimeridian_crossing(bbox: list[float]) -> bool:
+    """Check if a bbox crosses the antimeridian (180°/-180° line).
+
+    Per RFC 7946, a bbox crosses the antimeridian when west > east.
+    Example: Fiji [177, -20, -175, -15] crosses because 177 > -175.
+
+    Args:
+        bbox: Bounding box as [west, south, east, north].
+
+    Returns:
+        True if the bbox crosses the antimeridian.
+    """
+    if len(bbox) < 4:
+        return False
+    west, east = bbox[0], bbox[2]
+    return west > east
+
+
+def normalize_antimeridian_bbox(bbox: list[float]) -> list[list[float]]:
+    """Split an antimeridian-crossing bbox into two non-crossing bboxes.
+
+    Per STAC spec, antimeridian-crossing extents should be represented
+    as multiple bboxes: one from west to 180°, one from -180° to east.
+
+    Args:
+        bbox: Bounding box as [west, south, east, north].
+
+    Returns:
+        List of bboxes. Single-element list if not crossing,
+        two-element list if crossing antimeridian.
+    """
+    if not is_antimeridian_crossing(bbox):
+        return [bbox]
+
+    west, south, east, north = bbox[0], bbox[1], bbox[2], bbox[3]
+
+    # Split into western and eastern parts
+    western_part = [west, south, LON_MAX, north]  # West to 180°
+    eastern_part = [LON_MIN, south, east, north]  # -180° to east
+
+    return [western_part, eastern_part]
+
+
+def filter_valid_bboxes(
+    bboxes: list[list[float]],
+) -> BboxValidationResult:
+    """Filter a list of bboxes, separating valid from invalid.
+
+    Args:
+        bboxes: List of bboxes to filter.
+
+    Returns:
+        BboxValidationResult with valid and invalid (with reasons) lists.
+    """
+    valid: list[list[float]] = []
+    invalid: list[tuple[list[float], str]] = []
+
+    for bbox in bboxes:
+        reason = get_bbox_validation_reason(bbox)
+        if reason is None:
+            valid.append(bbox)
+        else:
+            invalid.append((bbox, reason))
+
+    return BboxValidationResult(valid=valid, invalid=invalid)
+
+
+def compute_bbox_union(
+    bboxes: list[list[float]],
+    *,
+    collection_ids: list[str] | None = None,
+) -> BboxUnionResult:
+    """Compute the union of multiple bboxes with validation and antimeridian handling.
+
+    Filters out invalid bboxes, handles antimeridian-crossing bboxes properly,
+    and produces STAC-compliant multi-bbox output when needed.
+
+    Args:
+        bboxes: List of bboxes to union.
+        collection_ids: Optional list of collection IDs for logging (parallel to bboxes).
+
+    Returns:
+        BboxUnionResult with union bbox(es) and any skipped invalid bboxes.
+    """
+    if not bboxes:
+        return BboxUnionResult(bbox=None, skipped=[])
+
+    # Filter invalid bboxes
+    validation = filter_valid_bboxes(bboxes)
+    _log_skipped_bboxes(validation.invalid, collection_ids)
+
+    if not validation.valid:
+        return BboxUnionResult(bbox=None, skipped=validation.invalid)
+
+    # Separate crossing and non-crossing bboxes
+    crossing = [b for b in validation.valid if is_antimeridian_crossing(b)]
+    normal = [b for b in validation.valid if not is_antimeridian_crossing(b)]
+
+    # If no crossing bboxes, simple union
+    if not crossing:
+        return BboxUnionResult(
+            bbox=_compute_simple_union(normal),
+            bboxes=None,
+            is_multi_bbox=False,
+            skipped=validation.invalid,
+        )
+
+    # Handle antimeridian crossing
+    return _compute_antimeridian_union(normal, crossing, validation.invalid)
+
+
+def _log_skipped_bboxes(
+    invalid: list[tuple[list[float], str]],
+    collection_ids: list[str] | None,
+) -> None:
+    """Log warnings for skipped invalid bboxes."""
+    for i, (bbox, reason) in enumerate(invalid):
+        coll_id = collection_ids[i] if collection_ids and i < len(collection_ids) else "unknown"
+        logger.warning(
+            "Skipping invalid bbox from collection '%s': %s (bbox: %s)",
+            coll_id,
+            reason,
+            bbox,
+        )
+
+
+def _compute_antimeridian_union(
+    normal_bboxes: list[list[float]],
+    crossing_bboxes: list[list[float]],
+    skipped: list[tuple[list[float], str]],
+) -> BboxUnionResult:
+    """Compute union when anti-meridian crossing bboxes are present."""
+    # Collect all bbox parts (normal + split crossing)
+    all_parts = list(normal_bboxes)
+    for bbox in crossing_bboxes:
+        all_parts.extend(normalize_antimeridian_bbox(bbox))
+
+    # Group by hemisphere
+    western = [b for b in all_parts if b[2] <= 0]
+    eastern = [b for b in all_parts if b[0] >= 0]
+    spanning = [b for b in all_parts if b[0] < 0 < b[2]]
+
+    # Spanning bboxes contribute to both hemispheres
+    if spanning:
+        western.extend(spanning)
+        eastern.extend(spanning)
+
+    # Build result bboxes from hemisphere unions
+    result_bboxes = _build_hemisphere_unions(western, eastern)
+
+    # Fallback if no results
+    if not result_bboxes:
+        result_bboxes = all_parts
+
+    envelope = _compute_simple_union(all_parts) if all_parts else None
+
+    return BboxUnionResult(
+        bbox=envelope,
+        bboxes=result_bboxes if len(result_bboxes) > 1 else None,
+        is_multi_bbox=len(result_bboxes) > 1,
+        skipped=skipped,
+    )
+
+
+def _build_hemisphere_unions(
+    western: list[list[float]],
+    eastern: list[list[float]],
+) -> list[list[float]]:
+    """Build union bboxes for western and eastern hemispheres."""
+    result: list[list[float]] = []
+
+    if western:
+        western_union = _compute_simple_union(western)
+        if western_union:
+            result.append(western_union)
+
+    if eastern:
+        eastern_union = _compute_simple_union(eastern)
+        if eastern_union and (not result or eastern_union != result[-1]):
+            result.append(eastern_union)
+
+    return result
+
+
+def _compute_simple_union(bboxes: list[list[float]]) -> list[float] | None:
+    """Compute simple min/max union of bboxes (no antimeridian handling).
+
+    Args:
+        bboxes: List of valid, non-crossing bboxes.
+
+    Returns:
+        Union bbox or None if empty.
+    """
+    if not bboxes:
+        return None
+
+    west = min(b[0] for b in bboxes)
+    south = min(b[1] for b in bboxes)
+    east = max(b[2] for b in bboxes)
+    north = max(b[3] for b in bboxes)
+
+    return [west, south, east, north]

--- a/portolan_cli/bbox.py
+++ b/portolan_cli/bbox.py
@@ -21,6 +21,13 @@ LON_MAX = 180.0
 LAT_MIN = -90.0
 LAT_MAX = 90.0
 
+# Sanity bound for any CRS. No real-world coordinate on Earth, in any projection,
+# approaches this magnitude (Web Mercator maxes near 2e7 m; the most extreme
+# projected grids stay well under 1e8). Values beyond it are "effectively
+# infinite" sentinels (e.g. WFS-served ±1.79e308 ~ ±float-max), not real data.
+# Used to reject such poison even for projected (non-WGS84) bboxes (issue #516).
+MAX_SANE_COORD = 1e9
+
 
 @dataclass
 class BboxValidationResult:
@@ -71,7 +78,7 @@ def is_finite_bbox(bbox: list[float]) -> bool:
     if len(bbox) not in (4, 6):
         return False
 
-    return all(math.isfinite(c) for c in bbox[:4])
+    return all(math.isfinite(c) for c in bbox)
 
 
 def is_valid_bbox(bbox: list[float], *, wgs84_only: bool = True) -> bool:
@@ -141,6 +148,21 @@ def get_bbox_validation_reason(bbox: list[float], *, wgs84_only: bool = True) ->
         if math.isinf(val):
             return f"{name} is infinite ({val})"
 
+    # 6-element (3D) bboxes carry elevation values beyond the first four;
+    # validate their finiteness too so poisoned Z values are caught (issue #516).
+    for i in range(4, len(bbox)):
+        if math.isnan(bbox[i]):
+            return f"elevation coordinate at index {i} is NaN"
+        if math.isinf(bbox[i]):
+            return f"elevation coordinate at index {i} is infinite ({bbox[i]})"
+
+    # Reject "effectively infinite" sentinel coordinates: finite, but far beyond
+    # any real-world magnitude in any CRS (e.g. ±1.79e308). Applied universally
+    # so poison is caught even for projected bboxes (wgs84_only=False) (#516).
+    for i, val in enumerate(bbox):
+        if abs(val) > MAX_SANE_COORD:
+            return f"coordinate at index {i} ({val}) exceeds sane magnitude"
+
     # WGS84-specific checks
     if wgs84_only:
         if not (LON_MIN <= west <= LON_MAX):
@@ -203,11 +225,16 @@ def normalize_antimeridian_bbox(bbox: list[float]) -> list[list[float]]:
 
 def filter_valid_bboxes(
     bboxes: list[list[float]],
+    *,
+    wgs84_only: bool = True,
 ) -> BboxValidationResult:
     """Filter a list of bboxes, separating valid from invalid.
 
     Args:
         bboxes: List of bboxes to filter.
+        wgs84_only: When True, also reject bboxes outside WGS84 ranges. Set to
+            False for source-CRS (e.g. projected) bboxes, where only finiteness
+            is universally meaningful (issue #516).
 
     Returns:
         BboxValidationResult with valid and invalid (with reasons) lists.
@@ -216,7 +243,7 @@ def filter_valid_bboxes(
     invalid: list[tuple[list[float], str]] = []
 
     for bbox in bboxes:
-        reason = get_bbox_validation_reason(bbox)
+        reason = get_bbox_validation_reason(bbox, wgs84_only=wgs84_only)
         if reason is None:
             valid.append(bbox)
         else:
@@ -229,6 +256,7 @@ def compute_bbox_union(
     bboxes: list[list[float]],
     *,
     collection_ids: list[str] | None = None,
+    wgs84_only: bool = True,
 ) -> BboxUnionResult:
     """Compute the union of multiple bboxes with validation and antimeridian handling.
 
@@ -238,6 +266,9 @@ def compute_bbox_union(
     Args:
         bboxes: List of bboxes to union.
         collection_ids: Optional list of collection IDs for logging (parallel to bboxes).
+        wgs84_only: When True, also reject bboxes outside WGS84 ranges. Set to
+            False when unioning source-CRS (e.g. projected) bboxes, where only
+            finiteness is universally meaningful (issue #516).
 
     Returns:
         BboxUnionResult with union bbox(es) and any skipped invalid bboxes.
@@ -246,7 +277,7 @@ def compute_bbox_union(
         return BboxUnionResult(bbox=None, skipped=[])
 
     # Filter invalid bboxes
-    validation = filter_valid_bboxes(bboxes)
+    validation = filter_valid_bboxes(bboxes, wgs84_only=wgs84_only)
     _log_skipped_bboxes(validation.invalid, collection_ids)
 
     if not validation.valid:

--- a/portolan_cli/crs.py
+++ b/portolan_cli/crs.py
@@ -83,7 +83,14 @@ def transform_bbox_to_wgs84(
 
     Raises:
         CRSMismatchError: When a CRS mismatch is detected and allow_guess=False.
+        ValueError: When input bbox contains inf/nan values (issue #516).
     """
+    # Validate input bbox for inf/nan (issue #516)
+    import math
+
+    if not all(math.isfinite(c) for c in bbox):
+        raise ValueError(f"Input bbox contains non-finite values (inf/nan): {bbox}")
+
     if source_crs is None:
         return bbox
 

--- a/portolan_cli/dataset.py
+++ b/portolan_cli/dataset.py
@@ -1473,6 +1473,71 @@ def prepare_dataset(
     )
 
 
+def _recompute_collection_extent_with_multibbox(collection: pystac.Collection) -> None:
+    """Recompute collection spatial extent with anti-meridian handling (issue #516).
+
+    Collects all item and asset bboxes from the collection and recomputes the
+    spatial extent using proper multi-bbox support for anti-meridian crossing.
+
+    If anti-meridian crossing is detected, the extent will use multiple bboxes
+    per the STAC spec (one for the western portion, one for the eastern portion).
+
+    Args:
+        collection: The pystac Collection to update.
+    """
+    from portolan_cli.bbox import compute_bbox_union
+
+    # Collect all bboxes from items
+    all_bboxes: list[list[float]] = []
+
+    # Get bboxes from linked items
+    for link in collection.links:
+        if link.rel == "item" and hasattr(link, "target") and link.target is not None:
+            item = link.target
+            if hasattr(item, "bbox") and item.bbox is not None:
+                all_bboxes.append(list(item.bbox))
+
+    # Get bboxes from collection-level assets (if they have proj:bbox)
+    if collection.assets:
+        for asset in collection.assets.values():
+            if hasattr(asset, "extra_fields") and asset.extra_fields:
+                proj_bbox = asset.extra_fields.get("proj:bbox")
+                if proj_bbox:
+                    all_bboxes.append(list(proj_bbox))
+
+    # Also use the existing collection extent as a fallback
+    if collection.extent and collection.extent.spatial:
+        for bbox in collection.extent.spatial.bboxes:
+            if bbox not in all_bboxes:
+                all_bboxes.append(list(bbox))
+
+    if not all_bboxes:
+        return  # No bboxes to process
+
+    # Compute union with anti-meridian handling
+    result = compute_bbox_union(all_bboxes)
+
+    if result.bbox is None:
+        logger.warning(
+            "Collection '%s': all bboxes are invalid, keeping existing extent",
+            collection.id,
+        )
+        return
+
+    # Update collection extent
+    if result.is_multi_bbox and result.bboxes:
+        # Use multi-bbox for anti-meridian crossing
+        collection.extent.spatial = pystac.SpatialExtent(bboxes=result.bboxes)
+        logger.info(
+            "Collection '%s': using multi-bbox extent for anti-meridian crossing (%d bboxes)",
+            collection.id,
+            len(result.bboxes),
+        )
+    else:
+        # Single bbox
+        collection.extent.spatial = pystac.SpatialExtent(bboxes=[result.bbox])
+
+
 def _add_prepared_items_to_collection(
     collection: pystac.Collection,
     items: list[PreparedDataset],
@@ -1798,6 +1863,11 @@ def finalize_datasets(
         # Collections should declare extensions used by their items
         if collection.summaries is not None:
             add_collection_extensions_from_summaries(collection, collection.summaries.to_dict())
+
+        # Issue #516: Recompute spatial extent with anti-meridian handling
+        # This step collects all item/asset bboxes and computes proper multi-bbox
+        # when anti-meridian crossing is detected.
+        _recompute_collection_extent_with_multibbox(collection)
 
         # Save collection.json ONCE for all items in this collection
         _save_collection_with_links(collection, collection_dir, catalog_root, collection_id)
@@ -2401,25 +2471,27 @@ def _get_sibling_collection_bboxes(catalog_root: Path) -> list[list[float]]:
 def _compute_union_bbox(bboxes: list[list[float]]) -> list[float]:
     """Compute the union (enclosing) bounding box from multiple bboxes.
 
-    Note: This uses simple min/max aggregation which does NOT correctly handle
-    antimeridian-crossing bboxes (where west > east, e.g., Fiji: [177, -20, -175, -15]).
-    For catalogs with such collections, use explicit bbox in metadata.yaml.
+    Filters out invalid bboxes (inf/nan/out-of-range) with warnings (issue #516).
+    Handles antimeridian-crossing bboxes properly.
 
     Args:
         bboxes: List of bboxes, each [west, south, east, north].
 
     Returns:
         Union bbox [min_west, min_south, max_east, max_north].
+        Returns global fallback if all bboxes are invalid.
     """
+    from portolan_cli.bbox import compute_bbox_union
+
     if not bboxes:
         return [-180.0, -90.0, 180.0, 90.0]  # Global fallback
 
-    west = min(bbox[0] for bbox in bboxes)
-    south = min(bbox[1] for bbox in bboxes)
-    east = max(bbox[2] for bbox in bboxes)
-    north = max(bbox[3] for bbox in bboxes)
+    result = compute_bbox_union(bboxes)
+    if result.bbox is None:
+        # All bboxes were invalid - return global fallback
+        return [-180.0, -90.0, 180.0, 90.0]
 
-    return [west, south, east, north]
+    return result.bbox
 
 
 def _get_metadata_yaml_bbox(collection_dir: Path) -> list[float] | None:

--- a/portolan_cli/metadata/geoparquet.py
+++ b/portolan_cli/metadata/geoparquet.py
@@ -139,17 +139,23 @@ def _extract_bbox(column_meta: dict[str, Any]) -> tuple[float, float, float, flo
     since source data may be in projected CRS.
     Returns None if bbox is missing, malformed, or contains inf/nan values.
     """
+    import logging
+
     from portolan_cli.bbox import is_finite_bbox
+
+    logger = logging.getLogger(__name__)
 
     bbox = column_meta.get("bbox")
     if bbox and len(bbox) >= 4:
-        bbox_list = [float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])]
+        try:
+            bbox_list = [float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])]
+        except (ValueError, TypeError):
+            # Non-numeric/malformed bbox entries - log and treat as missing
+            logger.warning("Malformed bbox in GeoParquet metadata (non-numeric): %s", bbox)
+            return None
         if is_finite_bbox(bbox_list):
             return (bbox_list[0], bbox_list[1], bbox_list[2], bbox_list[3])
         # Invalid bbox (inf/nan) - log and return None
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.warning("Invalid bbox in GeoParquet metadata (inf/nan): %s", bbox_list)
     return None
 

--- a/portolan_cli/metadata/geoparquet.py
+++ b/portolan_cli/metadata/geoparquet.py
@@ -133,10 +133,24 @@ def _parse_geo_metadata(metadata: dict[bytes, bytes]) -> dict[str, Any]:
 
 
 def _extract_bbox(column_meta: dict[str, Any]) -> tuple[float, float, float, float] | None:
-    """Extract bbox from column metadata."""
+    """Extract bbox from column metadata.
+
+    Validates bbox for finite values (issue #516). Does NOT check WGS84 range
+    since source data may be in projected CRS.
+    Returns None if bbox is missing, malformed, or contains inf/nan values.
+    """
+    from portolan_cli.bbox import is_finite_bbox
+
     bbox = column_meta.get("bbox")
     if bbox and len(bbox) >= 4:
-        return (float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3]))
+        bbox_list = [float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3])]
+        if is_finite_bbox(bbox_list):
+            return (bbox_list[0], bbox_list[1], bbox_list[2], bbox_list[3])
+        # Invalid bbox (inf/nan) - log and return None
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.warning("Invalid bbox in GeoParquet metadata (inf/nan): %s", bbox_list)
     return None
 
 

--- a/portolan_cli/metadata/update.py
+++ b/portolan_cli/metadata/update.py
@@ -12,6 +12,7 @@ Part of Phase 2c: Update Functions (check-metadata-handling feature).
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,8 @@ from portolan_cli.versions import (
     read_versions,
     write_versions,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def update_item_metadata(item_path: Path, file_path: Path) -> ItemModel:
@@ -194,6 +197,14 @@ def update_collection_extent(collection_path: Path) -> CollectionModel:
 
     # Compute union bbox
     union_bbox = _compute_union_bbox(bboxes)
+    if union_bbox is None:
+        # No valid child bboxes; keep the existing extent rather than persisting
+        # a synthetic global [-180, -90, 180, 90] that would mask the failure.
+        logger.warning(
+            "Collection '%s': all item bboxes invalid; keeping existing extent",
+            collection.id,
+        )
+        return collection
 
     # Update collection extent
     updated_extent = ExtentModel(
@@ -222,7 +233,7 @@ def update_collection_extent(collection_path: Path) -> CollectionModel:
     return updated_collection
 
 
-def _compute_union_bbox(bboxes: list[list[float]]) -> list[float]:
+def _compute_union_bbox(bboxes: list[list[float]]) -> list[float] | None:
     """Compute the union bounding box from multiple bboxes.
 
     Filters out invalid bboxes (inf/nan/out-of-range) with warnings (issue #516).
@@ -231,19 +242,17 @@ def _compute_union_bbox(bboxes: list[list[float]]) -> list[float]:
         bboxes: List of bounding boxes, each as [west, south, east, north].
 
     Returns:
-        Union bounding box [west, south, east, north].
-        Returns global fallback if all bboxes are invalid.
+        Union bounding box [west, south, east, north], or None when there are no
+        valid bboxes. Callers must not substitute a synthetic global extent, as
+        that would mask the failure (issue #516).
     """
     from portolan_cli.bbox import compute_bbox_union
 
     if not bboxes:
-        return [-180.0, -90.0, 180.0, 90.0]  # Global default
+        return None
 
     result = compute_bbox_union(bboxes)
-    if result.bbox is None:
-        return [-180.0, -90.0, 180.0, 90.0]  # All invalid - global fallback
-
-    return result.bbox
+    return result.bbox  # None when all bboxes are invalid
 
 
 def update_versions_tracking(file_path: Path, versions_path: Path) -> None:

--- a/portolan_cli/metadata/update.py
+++ b/portolan_cli/metadata/update.py
@@ -225,21 +225,25 @@ def update_collection_extent(collection_path: Path) -> CollectionModel:
 def _compute_union_bbox(bboxes: list[list[float]]) -> list[float]:
     """Compute the union bounding box from multiple bboxes.
 
+    Filters out invalid bboxes (inf/nan/out-of-range) with warnings (issue #516).
+
     Args:
         bboxes: List of bounding boxes, each as [west, south, east, north].
 
     Returns:
         Union bounding box [west, south, east, north].
+        Returns global fallback if all bboxes are invalid.
     """
+    from portolan_cli.bbox import compute_bbox_union
+
     if not bboxes:
         return [-180.0, -90.0, 180.0, 90.0]  # Global default
 
-    min_west = min(bbox[0] for bbox in bboxes)
-    min_south = min(bbox[1] for bbox in bboxes)
-    max_east = max(bbox[2] for bbox in bboxes)
-    max_north = max(bbox[3] for bbox in bboxes)
+    result = compute_bbox_union(bboxes)
+    if result.bbox is None:
+        return [-180.0, -90.0, 180.0, 90.0]  # All invalid - global fallback
 
-    return [min_west, min_south, max_east, max_north]
+    return result.bbox
 
 
 def update_versions_tracking(file_path: Path, versions_path: Path) -> None:

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -644,15 +644,17 @@ def _extract_collection_extent(
 
 
 def _compute_bbox_envelope(bboxes: list[list[float]]) -> list[float] | None:
-    """Compute bounding box envelope (union) from multiple bboxes."""
+    """Compute bounding box envelope (union) from multiple bboxes.
+
+    Filters out invalid bboxes (inf/nan/out-of-range) with warnings (issue #516).
+    """
+    from portolan_cli.bbox import compute_bbox_union
+
     if not bboxes:
         return None
-    return [
-        min(b[0] for b in bboxes),
-        min(b[1] for b in bboxes),
-        max(b[2] for b in bboxes),
-        max(b[3] for b in bboxes),
-    ]
+
+    result = compute_bbox_union(bboxes)
+    return result.bbox  # None if all invalid
 
 
 def aggregate_catalog_extent(catalog_path: Path) -> dict[str, Any]:

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -879,20 +879,26 @@ def _merge_schemas(metadata_list: Sequence[object]) -> tuple[dict[str, str], lis
 def _compute_bbox_union(
     metadata_list: Sequence[object],
 ) -> tuple[float, float, float, float]:
-    """Compute bounding box union from multiple metadata objects."""
-    all_bboxes: list[tuple[float, float, float, float]] = []
+    """Compute bounding box union from multiple metadata objects.
+
+    Filters out invalid bboxes (inf/nan/out-of-range) with warnings (issue #516).
+    """
+    from portolan_cli.bbox import compute_bbox_union
+
+    all_bboxes: list[list[float]] = []
     for m in metadata_list:
         bbox = getattr(m, "bbox", None)
         if bbox is not None:
-            all_bboxes.append(bbox)
+            all_bboxes.append(list(bbox))
+
     if not all_bboxes:
         raise ValueError("Cannot aggregate metadata: no items have valid bboxes")
-    return (
-        min(b[0] for b in all_bboxes),
-        min(b[1] for b in all_bboxes),
-        max(b[2] for b in all_bboxes),
-        max(b[3] for b in all_bboxes),
-    )
+
+    result = compute_bbox_union(all_bboxes)
+    if result.bbox is None:
+        raise ValueError("Cannot aggregate metadata: all bboxes are invalid (inf/nan/out of range)")
+
+    return (result.bbox[0], result.bbox[1], result.bbox[2], result.bbox[3])
 
 
 def _canonicalize_crs(crs: object) -> str | None:

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -575,6 +575,20 @@ def _update_collection_extent_from_bbox(
     if merge_strategy == MergeStrategy.KEEP:
         return
 
+    # Never let an invalid bbox (inf/nan/effectively-infinite sentinel) poison the
+    # collection extent. Use finiteness + sane-magnitude only, since this bbox may
+    # be in a projected source CRS (issue #516).
+    import logging
+
+    from portolan_cli.bbox import get_bbox_validation_reason
+
+    reason = get_bbox_validation_reason(list(bbox), wgs84_only=False)
+    if reason is not None:
+        logging.getLogger(__name__).warning(
+            "Skipping invalid bbox for collection '%s' extent: %s", collection.id, reason
+        )
+        return
+
     current_bbox = collection.extent.spatial.bboxes[0]
 
     # If current extent is placeholder, replace entirely with actual data
@@ -613,6 +627,19 @@ def _update_collection_extent(
 
     # KEEP strategy: preserve existing extent entirely
     if merge_strategy == MergeStrategy.KEEP:
+        return
+
+    # Never let an invalid item bbox (inf/nan/effectively-infinite sentinel)
+    # poison the collection extent (issue #516).
+    import logging
+
+    from portolan_cli.bbox import get_bbox_validation_reason
+
+    reason = get_bbox_validation_reason(list(item.bbox), wgs84_only=False)
+    if reason is not None:
+        logging.getLogger(__name__).warning(
+            "Skipping invalid bbox for collection '%s' extent: %s", collection.id, reason
+        )
         return
 
     current_bbox = collection.extent.spatial.bboxes[0]
@@ -881,7 +908,12 @@ def _compute_bbox_union(
 ) -> tuple[float, float, float, float]:
     """Compute bounding box union from multiple metadata objects.
 
-    Filters out invalid bboxes (inf/nan/out-of-range) with warnings (issue #516).
+    These bboxes are in the source CRS (reprojection to WGS84 happens later in
+    the add flow), and geoparquet-io does not preserve the CRS in the converted
+    file's metadata, so WGS84 range validation cannot be applied here. Bboxes are
+    filtered for finiteness and a sane coordinate magnitude only, which still
+    rejects inf/nan and "effectively infinite" sentinel poison values such as
+    ±1.79e308 while accepting legitimate projected coordinates (issue #516).
     """
     from portolan_cli.bbox import compute_bbox_union
 
@@ -894,7 +926,7 @@ def _compute_bbox_union(
     if not all_bboxes:
         raise ValueError("Cannot aggregate metadata: no items have valid bboxes")
 
-    result = compute_bbox_union(all_bboxes)
+    result = compute_bbox_union(all_bboxes, wgs84_only=False)
     if result.bbox is None:
         raise ValueError("Cannot aggregate metadata: all bboxes are invalid (inf/nan/out of range)")
 

--- a/portolan_cli/thumbnail.py
+++ b/portolan_cli/thumbnail.py
@@ -726,7 +726,15 @@ def _read_geoparquet_for_thumbnail(
 
         # If no bbox from metadata, compute from data
         if full_bbox is None:
+            from portolan_cli.bbox import is_finite_bbox
+
             bounds = gdf.total_bounds
+            bbox_list = [bounds[0], bounds[1], bounds[2], bounds[3]]
+            if not is_finite_bbox(bbox_list):
+                # Invalid bounds (inf/nan) would poison set_xlim/set_ylim — fail
+                # fast rather than render with a garbage extent (issue #516).
+                logger.warning("Invalid bounds from GeoParquet data (inf/nan): %s", bbox_list)
+                return None, None, None
             full_bbox = (bounds[0], bounds[1], bounds[2], bounds[3])
 
         return gdf, full_bbox, source_crs

--- a/portolan_cli/thumbnail.py
+++ b/portolan_cli/thumbnail.py
@@ -641,11 +641,17 @@ def _read_geoparquet_bounds(gpq_path: Path) -> tuple[float, float, float, float]
         geo_meta = json.loads(geo_meta_bytes.decode("utf-8"))
 
         # GeoParquet spec: columns.<geom_col>.bbox = [minx, miny, maxx, maxy]
+        # Validate for inf/nan values (issue #516) - CRS may not be WGS84
+        from portolan_cli.bbox import is_finite_bbox
+
         columns = geo_meta.get("columns", {})
         for col_meta in columns.values():
             bbox = col_meta.get("bbox")
             if bbox and len(bbox) >= 4:
-                return (bbox[0], bbox[1], bbox[2], bbox[3])
+                bbox_list = [bbox[0], bbox[1], bbox[2], bbox[3]]
+                if is_finite_bbox(bbox_list):
+                    return (bbox[0], bbox[1], bbox[2], bbox[3])
+                logger.warning("Invalid bbox in GeoParquet metadata (inf/nan): %s", bbox_list)
 
         # No bbox in metadata — fall back to reading data
         logger.debug("No bbox in GeoParquet metadata, falling back to data read")
@@ -657,18 +663,27 @@ def _read_geoparquet_bounds(gpq_path: Path) -> tuple[float, float, float, float]
 
 
 def _read_geoparquet_bounds_from_data(gpq_path: Path) -> tuple[float, float, float, float] | None:
-    """Fallback: compute bounds by reading GeoParquet data."""
+    """Fallback: compute bounds by reading GeoParquet data.
+
+    Validates bounds for inf/nan values (issue #516). CRS may not be WGS84.
+    """
     try:
         import geopandas as gpd  # type: ignore[import-untyped]
     except ImportError:
         return None
 
     try:
+        from portolan_cli.bbox import is_finite_bbox
+
         gdf = gpd.read_parquet(gpq_path)
         if gdf.empty:
             return None
         bounds = gdf.total_bounds
-        return (bounds[0], bounds[1], bounds[2], bounds[3])
+        bbox_list = [bounds[0], bounds[1], bounds[2], bounds[3]]
+        if is_finite_bbox(bbox_list):
+            return (bounds[0], bounds[1], bounds[2], bounds[3])
+        logger.warning("Invalid bounds from GeoParquet data (inf/nan): %s", bbox_list)
+        return None
     except Exception as e:
         logger.debug("Failed to read GeoParquet bounds from data: %s", e)
         return None

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -628,19 +628,23 @@ class BboxValidRule(ValidationRule):
         )
 
     def _check_catalog_bbox(self, catalog_json: Path) -> list[str]:
-        """Check catalog-level extent if present."""
+        """Check catalog-level extent if present (all bbox entries)."""
         from portolan_cli.bbox import get_bbox_validation_reason
 
+        invalid: list[str] = []
         try:
             data = json.loads(catalog_json.read_text(encoding="utf-8"))
-            bbox = data.get("extent", {}).get("spatial", {}).get("bbox", [[]])[0]
-            if bbox:
+            bbox_list = data.get("extent", {}).get("spatial", {}).get("bbox", [])
+            for i, bbox in enumerate(bbox_list):
+                if not bbox:
+                    continue
                 reason = get_bbox_validation_reason(bbox)
                 if reason:
-                    return [f"catalog: {reason}"]
+                    label = f"catalog bbox[{i}]" if len(bbox_list) > 1 else "catalog"
+                    invalid.append(f"{label}: {reason}")
         except (json.JSONDecodeError, OSError):
             pass
-        return []
+        return invalid
 
     def _check_collections(self, catalog_path: Path) -> list[str]:
         """Check all collection and item bboxes."""

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -588,3 +588,115 @@ class PartitionSchemaConsistencyRule(ValidationRule):
             f"Schema inconsistency: {issue_list}",
             fix_hint="Re-partition with consistent source data",
         )
+
+
+class BboxValidRule(ValidationRule):
+    """Check that all collection and item bboxes are valid (issue #516).
+
+    Validates that bboxes:
+    - Do not contain inf or nan values
+    - Have coordinates within WGS84 bounds (lon: -180 to 180, lat: -90 to 90)
+    - Have south <= north
+
+    This catches garbage coordinates that can poison catalog-level extent unions
+    and break map UI browsing (discovered in IGN Argentina with sentinel -1.79e308 values).
+    """
+
+    name = "bbox_valid"
+    severity = Severity.ERROR
+    description = "Check for invalid bbox coordinates (inf/nan/out of range)"
+
+    def check(self, catalog_path: Path) -> ValidationResult:
+        """Find collections and items with invalid bboxes."""
+        catalog_json = catalog_path / "catalog.json"
+        if not catalog_json.exists():
+            return self._pass("No catalog.json found")
+
+        invalid = self._check_catalog_bbox(catalog_json)
+        invalid.extend(self._check_collections(catalog_path))
+
+        if not invalid:
+            return self._pass("All bboxes are valid")
+
+        summary = ", ".join(invalid[:5])
+        if len(invalid) > 5:
+            summary += f" (+{len(invalid) - 5} more)"
+
+        return self._fail(
+            f"{len(invalid)} invalid bbox(es): {summary}",
+            fix_hint="Re-add the affected collections to regenerate with valid source data",
+        )
+
+    def _check_catalog_bbox(self, catalog_json: Path) -> list[str]:
+        """Check catalog-level extent if present."""
+        from portolan_cli.bbox import get_bbox_validation_reason
+
+        try:
+            data = json.loads(catalog_json.read_text(encoding="utf-8"))
+            bbox = data.get("extent", {}).get("spatial", {}).get("bbox", [[]])[0]
+            if bbox:
+                reason = get_bbox_validation_reason(bbox)
+                if reason:
+                    return [f"catalog: {reason}"]
+        except (json.JSONDecodeError, OSError):
+            pass
+        return []
+
+    def _check_collections(self, catalog_path: Path) -> list[str]:
+        """Check all collection and item bboxes."""
+
+        invalid: list[str] = []
+
+        for collection_json in catalog_path.rglob("collection.json"):
+            collection_dir = collection_json.parent
+            if any(part.startswith(".") for part in collection_dir.parts):
+                continue
+
+            coll_id = str(collection_dir.relative_to(catalog_path)).replace("\\", "/")
+            invalid.extend(self._check_collection_file(collection_json, coll_id))
+            invalid.extend(self._check_items(collection_dir, coll_id))
+
+        return invalid
+
+    def _check_collection_file(self, path: Path, coll_id: str) -> list[str]:
+        """Check a single collection.json for invalid bboxes."""
+        from portolan_cli.bbox import get_bbox_validation_reason
+
+        invalid: list[str] = []
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            bbox_list = data.get("extent", {}).get("spatial", {}).get("bbox", [])
+            for i, bbox in enumerate(bbox_list):
+                if not bbox:
+                    continue
+                reason = get_bbox_validation_reason(bbox)
+                if reason:
+                    label = f"{coll_id} bbox[{i}]" if len(bbox_list) > 1 else coll_id
+                    invalid.append(f"{label}: {reason}")
+        except (json.JSONDecodeError, OSError):
+            pass
+        return invalid
+
+    def _check_items(self, collection_dir: Path, coll_id: str) -> list[str]:
+        """Check item bboxes in a collection."""
+        from portolan_cli.bbox import get_bbox_validation_reason
+
+        invalid: list[str] = []
+        skip_names = {"collection.json", "versions.json", "catalog.json"}
+
+        for item_json in collection_dir.rglob("*.json"):
+            if item_json.name in skip_names:
+                continue
+            try:
+                data = json.loads(item_json.read_text(encoding="utf-8"))
+                if data.get("type") != "Feature":
+                    continue
+                bbox = data.get("bbox")
+                if bbox:
+                    reason = get_bbox_validation_reason(bbox)
+                    if reason:
+                        item_id = data.get("id", item_json.stem)
+                        invalid.append(f"{coll_id}/{item_id}: {reason}")
+            except (json.JSONDecodeError, OSError):
+                continue
+        return invalid

--- a/portolan_cli/validation/runner.py
+++ b/portolan_cli/validation/runner.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from portolan_cli.validation.results import ValidationReport, ValidationResult
 from portolan_cli.validation.rules import (
+    BboxValidRule,
     CatalogExistsRule,
     CatalogJsonValidRule,
     MetadataFreshRule,
@@ -33,6 +34,7 @@ DEFAULT_RULES: tuple[ValidationRule, ...] = (
     StacSchemaRule(),
     StacLintRule(),
     MandatoryTitlesRule(),
+    BboxValidRule(),
     PMTilesRecommendedRule(),
     MetadataFreshRule(),
     ProvisionalDatetimeRule(),
@@ -62,6 +64,7 @@ def _build_rules(
         StacSchemaRule(strict=strict),
         StacLintRule(strict=strict, config=config),
         MandatoryTitlesRule(),
+        BboxValidRule(),
         PMTilesRecommendedRule(),
         MetadataFreshRule(),
         ProvisionalDatetimeRule(),

--- a/tests/integration/test_bbox_validation.py
+++ b/tests/integration/test_bbox_validation.py
@@ -1,0 +1,348 @@
+"""Integration tests for bbox validation (issue #516).
+
+Tests that inf/nan coordinates are properly filtered during add
+and detected by the check command.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+def _create_geoparquet_with_inf_bbox(path: Path) -> None:
+    """Create a GeoParquet file with inf values in the bbox metadata.
+
+    This simulates the IGN Argentina issue where upstream WFS served
+    coordinates like -1.79e308 (near float min, effectively -inf).
+    """
+    # Create a simple geometry (point at origin)
+    # WKB for POINT(0 0)
+    wkb_point = bytes.fromhex("0101000000000000000000000000000000")
+
+    # Create table with one feature
+    table = pa.table(
+        {
+            "geometry": pa.array([wkb_point], type=pa.binary()),
+            "id": pa.array([1], type=pa.int64()),
+        }
+    )
+
+    # Add geo metadata with poisoned bbox (issue #516 sentinel value)
+    geo_meta = {
+        "version": "1.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                # This is the poisoned bbox - contains -inf-like sentinel values
+                "bbox": [-1.79e308, -1.79e308, 180.0, 66.55],
+            }
+        },
+    }
+
+    # Write with geo metadata
+    schema_with_meta = table.schema.with_metadata({b"geo": json.dumps(geo_meta).encode()})
+    table = table.cast(schema_with_meta)
+    pq.write_table(table, path)
+
+
+def _create_valid_geoparquet(path: Path) -> None:
+    """Create a valid GeoParquet file with proper bbox."""
+    wkb_point = bytes.fromhex("0101000000000000000000000000000000")
+
+    table = pa.table(
+        {
+            "geometry": pa.array([wkb_point], type=pa.binary()),
+            "id": pa.array([1], type=pa.int64()),
+        }
+    )
+
+    geo_meta = {
+        "version": "1.0.0",
+        "primary_column": "geometry",
+        "columns": {
+            "geometry": {
+                "encoding": "WKB",
+                "geometry_types": ["Point"],
+                "bbox": [-74.0, 40.0, -73.0, 41.0],  # Valid NYC-area bbox
+            }
+        },
+    }
+
+    schema_with_meta = table.schema.with_metadata({b"geo": json.dumps(geo_meta).encode()})
+    table = table.cast(schema_with_meta)
+    pq.write_table(table, path)
+
+
+@pytest.mark.integration
+class TestBboxValidationIntegration:
+    """Integration tests for bbox validation during add and check."""
+
+    def test_add_rejects_file_with_only_invalid_bbox(self) -> None:
+        """Add command should reject files where ALL bboxes are invalid (defense-in-depth)."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            # Initialize catalog by creating .portolan/config.yaml
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "id": "test-catalog",
+                        "stac_version": "1.1.0",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+
+            # Create collection directory with poisoned parquet
+            collection_dir = Path("test-collection")
+            collection_dir.mkdir()
+
+            parquet_path = collection_dir / "data.parquet"
+            _create_geoparquet_with_inf_bbox(parquet_path)
+
+            # Add the file - should fail because all bboxes are invalid
+            result = runner.invoke(cli, ["add", str(parquet_path)])
+
+            # The add should fail with a clear error message about invalid bbox
+            assert result.exit_code != 0, f"add should have failed: {result.output}"
+            assert "invalid" in result.output.lower() or "inf" in result.output.lower(), (
+                f"Error should mention invalid/inf: {result.output}"
+            )
+
+    def test_add_filters_inf_bbox_from_mixed_collection(self) -> None:
+        """Add should succeed when a collection has SOME valid bboxes, filtering invalid ones."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            # Initialize catalog
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "id": "test-catalog",
+                        "stac_version": "1.1.0",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+
+            # Create collection directory with a VALID parquet file
+            collection_dir = Path("test-collection")
+            collection_dir.mkdir()
+
+            parquet_path = collection_dir / "data.parquet"
+            _create_valid_geoparquet(parquet_path)
+
+            # Add the valid file
+            result = runner.invoke(cli, ["add", str(parquet_path)])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Check the collection extent - should have valid bbox
+            collection_json = collection_dir / "collection.json"
+            assert collection_json.exists(), "collection.json should exist"
+
+            with open(collection_json) as f:
+                collection_data = json.load(f)
+
+            extent = collection_data.get("extent", {})
+            spatial = extent.get("spatial", {})
+            bboxes = spatial.get("bbox", [[]])
+
+            # The bbox should be valid (not contain inf/nan)
+            for bbox in bboxes:
+                if bbox:
+                    for coord in bbox[:4]:
+                        assert np.isfinite(coord), f"Collection bbox has non-finite: {bbox}"
+                    assert -180 <= bbox[0] <= 180, f"west out of range: {bbox}"
+                    assert -90 <= bbox[1] <= 90, f"south out of range: {bbox}"
+                    assert -180 <= bbox[2] <= 180, f"east out of range: {bbox}"
+                    assert -90 <= bbox[3] <= 90, f"north out of range: {bbox}"
+
+    def test_check_detects_invalid_bbox_in_collection(self) -> None:
+        """Check command should detect collections with invalid bbox."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            # Initialize catalog
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "id": "test-catalog",
+                        "stac_version": "1.1.0",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+
+            # Create collection with valid file first
+            collection_dir = Path("test-collection")
+            collection_dir.mkdir()
+
+            parquet_path = collection_dir / "data.parquet"
+            _create_valid_geoparquet(parquet_path)
+
+            result = runner.invoke(cli, ["add", str(parquet_path)])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Manually corrupt the collection bbox (simulating upstream bug)
+            collection_json = collection_dir / "collection.json"
+            with open(collection_json) as f:
+                data = json.load(f)
+
+            # Inject poisoned bbox
+            data["extent"]["spatial"]["bbox"] = [[-1.79e308, -1.79e308, 180.0, 66.55]]
+
+            with open(collection_json, "w") as f:
+                json.dump(data, f)
+
+            # Run check - should detect the invalid bbox
+            result = runner.invoke(cli, ["check", "."])
+
+            # Check should fail or warn about invalid bbox
+            # The BboxValidRule should catch this
+            assert "bbox_valid" in result.output or "invalid" in result.output.lower(), (
+                f"Check should detect invalid bbox: {result.output}"
+            )
+
+    def test_check_passes_with_valid_bboxes(self) -> None:
+        """Check command should pass when all bboxes are valid."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            # Initialize catalog
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "id": "test-catalog",
+                        "stac_version": "1.1.0",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+
+            # Create collection with valid file
+            collection_dir = Path("test-collection")
+            collection_dir.mkdir()
+
+            parquet_path = collection_dir / "data.parquet"
+            _create_valid_geoparquet(parquet_path)
+
+            result = runner.invoke(cli, ["add", str(parquet_path)])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Run check - should pass (or at least not fail on bbox_valid)
+            result = runner.invoke(cli, ["check", "."])
+
+            # bbox_valid rule should pass
+            # Note: check may have other failures (pmtiles, etc.) but bbox should be OK
+            output_lower = result.output.lower()
+            assert "invalid bbox" not in output_lower, (
+                f"Check should not report invalid bbox: {result.output}"
+            )
+
+
+@pytest.mark.integration
+class TestAntimeridianBboxIntegration:
+    """Integration tests for anti-meridian crossing bbox handling."""
+
+    def test_collection_with_antimeridian_crossing_item(self) -> None:
+        """Collection with anti-meridian crossing should produce valid extent."""
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            # Initialize catalog
+            Path(".portolan").mkdir()
+            Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path("catalog.json").write_text(
+                json.dumps(
+                    {
+                        "type": "Catalog",
+                        "id": "test-catalog",
+                        "stac_version": "1.1.0",
+                        "description": "Test",
+                        "links": [],
+                    }
+                )
+            )
+
+            # Create collection directory
+            collection_dir = Path("fiji-data")
+            collection_dir.mkdir()
+
+            # Create GeoParquet with Fiji-like bbox (crosses antimeridian)
+            parquet_path = collection_dir / "data.parquet"
+            wkb_point = bytes.fromhex("0101000000000000000000000000000000")
+
+            table = pa.table(
+                {
+                    "geometry": pa.array([wkb_point], type=pa.binary()),
+                    "id": pa.array([1], type=pa.int64()),
+                }
+            )
+
+            # Fiji-style anti-meridian crossing bbox
+            geo_meta = {
+                "version": "1.0.0",
+                "primary_column": "geometry",
+                "columns": {
+                    "geometry": {
+                        "encoding": "WKB",
+                        "geometry_types": ["Point"],
+                        "bbox": [177.0, -20.0, -175.0, -15.0],  # Crosses 180°
+                    }
+                },
+            }
+
+            schema_with_meta = table.schema.with_metadata({b"geo": json.dumps(geo_meta).encode()})
+            table = table.cast(schema_with_meta)
+            pq.write_table(table, parquet_path)
+
+            # Add the file
+            result = runner.invoke(cli, ["add", str(parquet_path)])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            # Check the collection extent - should be valid
+            collection_json = collection_dir / "collection.json"
+            with open(collection_json) as f:
+                collection_data = json.load(f)
+
+            bboxes = collection_data["extent"]["spatial"]["bbox"]
+
+            # All bboxes should be valid (finite, within WGS84 bounds)
+            for bbox in bboxes:
+                for coord in bbox[:4]:
+                    assert np.isfinite(coord), f"Bbox contains non-finite: {bbox}"
+                assert -180 <= bbox[0] <= 180
+                assert -90 <= bbox[1] <= 90
+                assert -180 <= bbox[2] <= 180
+                assert -90 <= bbox[3] <= 90
+
+            # Run check - should pass
+            result = runner.invoke(cli, ["check", "."])
+            assert "invalid bbox" not in result.output.lower()

--- a/tests/integration/test_bbox_validation.py
+++ b/tests/integration/test_bbox_validation.py
@@ -144,18 +144,23 @@ class TestBboxValidationIntegration:
                 )
             )
 
-            # Create collection directory with a VALID parquet file
+            # Create a collection with BOTH a valid and an invalid parquet file.
+            # The invalid file carries the IGN Argentina poison bbox (effectively
+            # -inf sentinels). Adding them together must succeed by filtering the
+            # invalid bbox out of the aggregated collection extent (issue #516).
             collection_dir = Path("test-collection")
             collection_dir.mkdir()
 
-            parquet_path = collection_dir / "data.parquet"
-            _create_valid_geoparquet(parquet_path)
+            valid_path = collection_dir / "data_valid.parquet"
+            invalid_path = collection_dir / "data_invalid.parquet"
+            _create_valid_geoparquet(valid_path)  # bbox [-74, 40, -73, 41]
+            _create_geoparquet_with_inf_bbox(invalid_path)  # bbox [-1.79e308, ...]
 
-            # Add the valid file
-            result = runner.invoke(cli, ["add", str(parquet_path)])
+            # Add both files in one invocation
+            result = runner.invoke(cli, ["add", str(valid_path), str(invalid_path)])
             assert result.exit_code == 0, f"add failed: {result.output}"
 
-            # Check the collection extent - should have valid bbox
+            # Check the collection extent - should reflect ONLY the valid file
             collection_json = collection_dir / "collection.json"
             assert collection_json.exists(), "collection.json should exist"
 
@@ -166,15 +171,23 @@ class TestBboxValidationIntegration:
             spatial = extent.get("spatial", {})
             bboxes = spatial.get("bbox", [[]])
 
-            # The bbox should be valid (not contain inf/nan)
+            # The invalid file's poison value must NOT appear in any extent bbox,
+            # and every coordinate must be finite and in WGS84 range.
+            assert bboxes and any(bboxes), "collection extent should have a bbox"
             for bbox in bboxes:
                 if bbox:
                     for coord in bbox[:4]:
                         assert np.isfinite(coord), f"Collection bbox has non-finite: {bbox}"
+                        assert abs(coord) < 1e9, f"Collection bbox has poison coord: {bbox}"
                     assert -180 <= bbox[0] <= 180, f"west out of range: {bbox}"
                     assert -90 <= bbox[1] <= 90, f"south out of range: {bbox}"
                     assert -180 <= bbox[2] <= 180, f"east out of range: {bbox}"
                     assert -90 <= bbox[3] <= 90, f"north out of range: {bbox}"
+
+            # The surviving extent must be exactly the valid file's bbox.
+            assert [b[:4] for b in bboxes if b] == [[-74.0, 40.0, -73.0, 41.0]], (
+                f"Expected only the valid bbox to survive, got: {bboxes}"
+            )
 
     def test_check_detects_invalid_bbox_in_collection(self) -> None:
         """Check command should detect collections with invalid bbox."""
@@ -342,6 +355,27 @@ class TestAntimeridianBboxIntegration:
                 assert -90 <= bbox[1] <= 90
                 assert -180 <= bbox[2] <= 180
                 assert -90 <= bbox[3] <= 90
+
+            # An anti-meridian crossing input ([177, -20, -175, -15]) must be
+            # represented in STAC-compliant form: either a split into a western
+            # and an eastern half, or preserved as a single crossing bbox (west >
+            # east). It must NOT collapse into a whole-world-width [-180, ..., 180]
+            # envelope, which would falsely claim the dataset spans the globe.
+            halves = [b[:4] for b in bboxes]
+            if len(bboxes) == 2:
+                # Split form: one western half (touches -180), one eastern (touches 180)
+                western = [-180.0, -20.0, -175.0, -15.0]
+                eastern = [177.0, -20.0, 180.0, -15.0]
+                assert western in halves and eastern in halves, (
+                    f"Anti-meridian extent not split into expected halves: {bboxes}"
+                )
+            else:
+                # Single-bbox form must keep the crossing (west > east), not an envelope
+                assert len(bboxes) == 1, f"Unexpected bbox count: {bboxes}"
+                bbox = bboxes[0]
+                assert bbox[0] > bbox[2], (
+                    f"Anti-meridian extent collapsed to a non-crossing envelope: {bbox}"
+                )
 
             # Run check - should pass
             result = runner.invoke(cli, ["check", "."])

--- a/tests/unit/test_bbox.py
+++ b/tests/unit/test_bbox.py
@@ -1,0 +1,300 @@
+"""Unit tests for bbox validation utilities."""
+
+from __future__ import annotations
+
+from portolan_cli.bbox import (
+    BboxValidationResult,
+    compute_bbox_union,
+    filter_valid_bboxes,
+    is_antimeridian_crossing,
+    is_valid_bbox,
+    normalize_antimeridian_bbox,
+)
+
+
+class TestIsValidBbox:
+    """Tests for is_valid_bbox function."""
+
+    def test_valid_bbox_returns_true(self) -> None:
+        """Standard WGS84 bbox should be valid."""
+        assert is_valid_bbox([-74.0, 40.0, -73.0, 41.0]) is True
+
+    def test_global_bbox_valid(self) -> None:
+        """Global extent bbox should be valid."""
+        assert is_valid_bbox([-180.0, -90.0, 180.0, 90.0]) is True
+
+    def test_inf_west_invalid(self) -> None:
+        """Infinity in west coordinate should be invalid."""
+        assert is_valid_bbox([float("inf"), 40.0, -73.0, 41.0]) is False
+        assert is_valid_bbox([float("-inf"), 40.0, -73.0, 41.0]) is False
+
+    def test_inf_south_invalid(self) -> None:
+        """Infinity in south coordinate should be invalid."""
+        assert is_valid_bbox([-74.0, float("inf"), -73.0, 41.0]) is False
+
+    def test_inf_east_invalid(self) -> None:
+        """Infinity in east coordinate should be invalid."""
+        assert is_valid_bbox([-74.0, 40.0, float("inf"), 41.0]) is False
+
+    def test_inf_north_invalid(self) -> None:
+        """Infinity in north coordinate should be invalid."""
+        assert is_valid_bbox([-74.0, 40.0, -73.0, float("inf")]) is False
+
+    def test_nan_invalid(self) -> None:
+        """NaN in any coordinate should be invalid."""
+        assert is_valid_bbox([float("nan"), 40.0, -73.0, 41.0]) is False
+        assert is_valid_bbox([-74.0, float("nan"), -73.0, 41.0]) is False
+        assert is_valid_bbox([-74.0, 40.0, float("nan"), 41.0]) is False
+        assert is_valid_bbox([-74.0, 40.0, -73.0, float("nan")]) is False
+
+    def test_sentinel_inf_value_invalid(self) -> None:
+        """The specific sentinel value from IGN Argentina should be invalid."""
+        # This is the actual value that caused issue #516
+        sentinel = -1.79e308
+        assert is_valid_bbox([sentinel, sentinel, 180.0, 66.55]) is False
+
+    def test_longitude_out_of_range_invalid(self) -> None:
+        """Longitude outside [-180, 180] should be invalid."""
+        assert is_valid_bbox([-181.0, 40.0, -73.0, 41.0]) is False
+        assert is_valid_bbox([-74.0, 40.0, 181.0, 41.0]) is False
+
+    def test_latitude_out_of_range_invalid(self) -> None:
+        """Latitude outside [-90, 90] should be invalid."""
+        assert is_valid_bbox([-74.0, -91.0, -73.0, 41.0]) is False
+        assert is_valid_bbox([-74.0, 40.0, -73.0, 91.0]) is False
+
+    def test_south_greater_than_north_invalid(self) -> None:
+        """South > north should be invalid."""
+        assert is_valid_bbox([-74.0, 50.0, -73.0, 40.0]) is False
+
+    def test_antimeridian_crossing_valid(self) -> None:
+        """Antimeridian crossing bbox (west > east) should be valid per RFC 7946."""
+        # Fiji-style bbox crossing the antimeridian
+        assert is_valid_bbox([177.0, -20.0, -175.0, -15.0]) is True
+
+    def test_wrong_length_invalid(self) -> None:
+        """Bbox with wrong number of elements should be invalid."""
+        assert is_valid_bbox([-74.0, 40.0, -73.0]) is False  # 3 elements
+        assert is_valid_bbox([-74.0, 40.0, -73.0, 41.0, 0.0]) is False  # 5 elements
+
+    def test_6d_bbox_valid(self) -> None:
+        """6-element 3D bbox should be valid (uses first 4 elements)."""
+        assert is_valid_bbox([-74.0, 40.0, -73.0, 41.0, 0.0, 100.0]) is True
+
+    def test_6d_bbox_with_invalid_2d_components(self) -> None:
+        """6D bbox with invalid 2D components should be invalid."""
+        assert is_valid_bbox([float("inf"), 40.0, -73.0, 41.0, 0.0, 100.0]) is False
+
+
+class TestIsAntimeridianCrossing:
+    """Tests for antimeridian crossing detection."""
+
+    def test_normal_bbox_not_crossing(self) -> None:
+        """Standard bbox should not be detected as crossing."""
+        assert is_antimeridian_crossing([-74.0, 40.0, -73.0, 41.0]) is False
+
+    def test_fiji_bbox_crossing(self) -> None:
+        """Fiji-style bbox should be detected as crossing."""
+        assert is_antimeridian_crossing([177.0, -20.0, -175.0, -15.0]) is True
+
+    def test_russia_bbox_crossing(self) -> None:
+        """Russia far-east bbox crossing antimeridian."""
+        assert is_antimeridian_crossing([160.0, 50.0, -170.0, 70.0]) is True
+
+    def test_exactly_at_antimeridian_not_crossing(self) -> None:
+        """Bbox ending exactly at 180 should not be crossing."""
+        assert is_antimeridian_crossing([170.0, -20.0, 180.0, -15.0]) is False
+
+    def test_exactly_at_negative_antimeridian_not_crossing(self) -> None:
+        """Bbox starting exactly at -180 should not be crossing."""
+        assert is_antimeridian_crossing([-180.0, -20.0, -170.0, -15.0]) is False
+
+
+class TestNormalizeAntimeridianBbox:
+    """Tests for splitting antimeridian-crossing bboxes."""
+
+    def test_normal_bbox_returns_single(self) -> None:
+        """Non-crossing bbox should return single bbox in list."""
+        result = normalize_antimeridian_bbox([-74.0, 40.0, -73.0, 41.0])
+        assert result == [[-74.0, 40.0, -73.0, 41.0]]
+
+    def test_crossing_bbox_returns_two(self) -> None:
+        """Crossing bbox should be split into two bboxes."""
+        result = normalize_antimeridian_bbox([177.0, -20.0, -175.0, -15.0])
+        assert len(result) == 2
+        # Western part: from west to 180
+        assert result[0] == [177.0, -20.0, 180.0, -15.0]
+        # Eastern part: from -180 to east
+        assert result[1] == [-180.0, -20.0, -175.0, -15.0]
+
+    def test_russia_crossing_split(self) -> None:
+        """Russia crossing should split correctly."""
+        result = normalize_antimeridian_bbox([160.0, 50.0, -170.0, 70.0])
+        assert len(result) == 2
+        assert result[0] == [160.0, 50.0, 180.0, 70.0]
+        assert result[1] == [-180.0, 50.0, -170.0, 70.0]
+
+
+class TestFilterValidBboxes:
+    """Tests for filtering bbox lists."""
+
+    def test_all_valid_returns_all(self) -> None:
+        """All valid bboxes should be returned."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],
+            [-122.0, 37.0, -121.0, 38.0],
+        ]
+        result = filter_valid_bboxes(bboxes)
+        assert result.valid == bboxes
+        assert result.invalid == []
+
+    def test_filters_out_inf(self) -> None:
+        """Should filter out bboxes with inf."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],
+            [float("-inf"), float("-inf"), 180.0, 66.55],  # IGN Argentina poison
+        ]
+        result = filter_valid_bboxes(bboxes)
+        assert len(result.valid) == 1
+        assert result.valid[0] == [-74.0, 40.0, -73.0, 41.0]
+        assert len(result.invalid) == 1
+
+    def test_filters_out_nan(self) -> None:
+        """Should filter out bboxes with NaN."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],
+            [float("nan"), 40.0, -73.0, 41.0],
+        ]
+        result = filter_valid_bboxes(bboxes)
+        assert len(result.valid) == 1
+        assert len(result.invalid) == 1
+
+    def test_empty_list_returns_empty(self) -> None:
+        """Empty list should return empty results."""
+        result = filter_valid_bboxes([])
+        assert result.valid == []
+        assert result.invalid == []
+
+    def test_all_invalid_returns_empty_valid(self) -> None:
+        """All invalid bboxes should return empty valid list."""
+        bboxes = [
+            [float("inf"), 40.0, -73.0, 41.0],
+            [float("nan"), 40.0, -73.0, 41.0],
+        ]
+        result = filter_valid_bboxes(bboxes)
+        assert result.valid == []
+        assert len(result.invalid) == 2
+
+    def test_preserves_antimeridian_crossing(self) -> None:
+        """Antimeridian crossing bboxes should be preserved as valid."""
+        bboxes = [
+            [177.0, -20.0, -175.0, -15.0],  # Fiji
+        ]
+        result = filter_valid_bboxes(bboxes)
+        assert len(result.valid) == 1
+
+    def test_invalid_reasons_captured(self) -> None:
+        """Invalid bboxes should have reasons captured."""
+        bboxes = [
+            [float("inf"), 40.0, -73.0, 41.0],
+        ]
+        result = filter_valid_bboxes(bboxes)
+        assert len(result.invalid) == 1
+        bbox, reason = result.invalid[0]
+        assert "inf" in reason.lower() or "finite" in reason.lower()
+
+
+class TestComputeBboxUnion:
+    """Tests for computing bbox union with validation."""
+
+    def test_single_bbox_returns_same(self) -> None:
+        """Single bbox should return itself."""
+        result = compute_bbox_union([[-74.0, 40.0, -73.0, 41.0]])
+        assert result.bbox == [-74.0, 40.0, -73.0, 41.0]
+        assert result.is_multi_bbox is False
+
+    def test_two_bboxes_union(self) -> None:
+        """Two non-overlapping bboxes should union correctly."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],  # NYC area
+            [-122.5, 37.5, -122.0, 38.0],  # SF area
+        ]
+        result = compute_bbox_union(bboxes)
+        assert result.bbox == [-122.5, 37.5, -73.0, 41.0]
+
+    def test_filters_invalid_before_union(self) -> None:
+        """Invalid bboxes should be filtered before computing union."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],
+            [float("-inf"), float("-inf"), 180.0, 66.55],  # Poison
+            [-122.5, 37.5, -122.0, 38.0],
+        ]
+        result = compute_bbox_union(bboxes)
+        # Should only union the two valid bboxes
+        assert result.bbox == [-122.5, 37.5, -73.0, 41.0]
+        assert len(result.skipped) == 1
+
+    def test_all_invalid_returns_none(self) -> None:
+        """All invalid bboxes should return None."""
+        bboxes = [
+            [float("inf"), 40.0, -73.0, 41.0],
+            [float("nan"), 40.0, -73.0, 41.0],
+        ]
+        result = compute_bbox_union(bboxes)
+        assert result.bbox is None
+        assert len(result.skipped) == 2
+
+    def test_empty_list_returns_none(self) -> None:
+        """Empty list should return None."""
+        result = compute_bbox_union([])
+        assert result.bbox is None
+
+    def test_antimeridian_crossing_produces_multi_bbox(self) -> None:
+        """Union with antimeridian-crossing bbox should produce multi-bbox."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],  # NYC
+            [177.0, -20.0, -175.0, -15.0],  # Fiji (crossing)
+        ]
+        result = compute_bbox_union(bboxes)
+        assert result.is_multi_bbox is True
+        assert result.bboxes is not None
+        assert len(result.bboxes) >= 2
+
+    def test_multiple_crossing_bboxes(self) -> None:
+        """Multiple crossing bboxes should all be represented."""
+        bboxes = [
+            [177.0, -20.0, -175.0, -15.0],  # Fiji
+            [160.0, 50.0, -170.0, 70.0],  # Russia far east
+        ]
+        result = compute_bbox_union(bboxes)
+        assert result.is_multi_bbox is True
+
+    def test_union_with_mixed_normal_and_crossing(self) -> None:
+        """Mix of normal and crossing bboxes should handle correctly."""
+        bboxes = [
+            [-74.0, 40.0, -73.0, 41.0],  # NYC (normal)
+            [150.0, 30.0, 160.0, 40.0],  # Japan area (normal)
+            [177.0, -20.0, -175.0, -15.0],  # Fiji (crossing)
+        ]
+        result = compute_bbox_union(bboxes)
+        # Should produce multi-bbox representation
+        assert result.is_multi_bbox is True
+        # The crossing bbox should be split
+        assert result.bboxes is not None
+
+
+class TestBboxValidationResult:
+    """Tests for BboxValidationResult dataclass."""
+
+    def test_has_valid_true_when_valid_present(self) -> None:
+        """has_valid should be True when valid bboxes exist."""
+        result = BboxValidationResult(
+            valid=[[-74.0, 40.0, -73.0, 41.0]],
+            invalid=[],
+        )
+        assert result.has_valid is True
+
+    def test_has_valid_false_when_empty(self) -> None:
+        """has_valid should be False when no valid bboxes."""
+        result = BboxValidationResult(valid=[], invalid=[])
+        assert result.has_valid is False

--- a/tests/unit/test_validation_runner.py
+++ b/tests/unit/test_validation_runner.py
@@ -89,7 +89,8 @@ class TestCheck:
         # No .portolan dir = first rule fails
         report = check(tmp_path)
 
-        # Should have run all 11 default rules even though the first one failed
+        # Should have run all 12 default rules even though the first one failed
         # (6 original + 2 partition rules + 3 STAC rules: StacSchemaRule,
-        # StacLintRule, MandatoryTitlesRule). Verifies no short-circuit on failure.
-        assert len(report.results) == 11
+        # StacLintRule, MandatoryTitlesRule + 1 BboxValidRule for issue #516).
+        # Verifies no short-circuit on failure.
+        assert len(report.results) == 12


### PR DESCRIPTION
## Summary

- Add defense-in-depth bbox validation to prevent poisoned coordinates (inf/nan/-1.79e308 sentinels) from breaking catalog extent computation
- Implement anti-meridian crossing detection and STAC-compliant multi-bbox normalization per RFC 7946
- Add `BboxValidRule` to check command for detecting invalid bboxes in existing catalogs

Fixes #516

## Changes

**New module `portolan_cli/bbox.py`:**
- `is_finite_bbox()` — universal check for any CRS (filters inf/nan)
- `is_valid_bbox()` — WGS84 range validation (-180 to 180 lon, -90 to 90 lat)
- `is_antimeridian_crossing()` — RFC 7946 detection (west > east)
- `normalize_antimeridian_bbox()` — splits crossing bbox to `[west,s,180,n]` + `[-180,s,east,n]`
- `compute_bbox_union()` — filters invalid inputs, handles anti-meridian, returns STAC multi-bbox

**Defense-in-depth guards:**
- Extraction: `geoparquet.py`, `thumbnail.py` (filter at source)
- Transform: `crs.py` (reject invalid input to `transform_bbox_to_wgs84`)
- Union: all 4 union functions now delegate to `compute_bbox_union()`
- Validation: `BboxValidRule` catches invalid bboxes in check command

## Test plan

- [x] 40 unit tests in `tests/unit/test_bbox.py` covering all validation functions
- [x] 5 integration tests in `tests/integration/test_bbox_validation.py`:
  - Add rejects file with only invalid bbox
  - Add succeeds with valid bbox
  - Check detects corrupted collection bbox
  - Check passes with valid bboxes
  - Anti-meridian crossing produces valid extent
- [x] All 4605 unit tests pass
- [x] Xenon complexity checks pass (refactored to stay under threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a blocking validation rule that detects and reports invalid bbox values in catalogs; now enabled by default.

* **Bug Fixes**
  * Rejects/filter out non-finite or sentinel bbox values when computing collection extents.
  * Proper antimeridian-support: crossing extents are normalized and can produce multi-bbox extents.
  * Avoids substituting a synthetic global extent when no valid bboxes exist.

* **Documentation**
  * Clarified README/config about aggregated spatial-extent filtering for invalid coordinates.

* **Tests**
  * New unit and integration tests covering bbox validation, filtering, unioning, and antimeridian cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->