### PR TITLE
fix(stac): stop is_technical_name clobbering single-word titles (#513)

### DIFF
--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -1488,10 +1488,16 @@ def is_technical_name(text: str | None) -> bool:
     Technical names are typically identifiers that aren't useful as metadata:
     - Pure snake_case names without spaces (e.g., "bu_building_emprise_v2")
     - Namespace-prefixed (e.g., "ns:LayerName")
-    - Short all-lowercase without spaces (e.g., "layer1")
+    - Short all-lowercase names without spaces (e.g., "layer", "parcels")
+    - Short names carrying digits (e.g., "layer1", "parcels2024", "Q4")
 
     Valid titles include:
     - CamelCase names (e.g., "DenHaagHousing")
+    - All-caps acronyms (e.g., "USA", "IGN")
+    - Capitalized, digit-free single words (e.g., "Provincia", "País") — Issue
+      #513. Note: this also keeps capitalized single-word source/layer titles
+      ("Buildings", "Parcels") that were previously filtered, which is the
+      intended behavior across all callers (extraction, metadata seeding).
     - Titles with spaces, even if they contain underscores (e.g., "Building - building_emprise")
 
     Args:
@@ -1524,7 +1530,9 @@ def is_technical_name(text: str | None) -> bool:
     # Identifiers are all-lowercase ("layer", "parcels") or carry digits
     # ("layer1", "parcels2024"). A capitalized, digit-free word ("Provincia",
     # "Localidad", "País") is a legitimate title and must be preserved.
-    # CamelCase (has uppercase after first char) is already allowed above.
+    # CamelCase and all-caps acronyms ("DenHaagHousing", "USA", "IGN") have an
+    # uppercase letter after the first char, so they fail this branch's guard
+    # and fall through to the final non-technical return below.
     if not re.search(r"[A-Z]", text[1:]) and len(text) < 20:
         has_digit = any(char.isdigit() for char in text)
         starts_capitalized = text[:1].isupper()

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -1519,10 +1519,18 @@ def is_technical_name(text: str | None) -> bool:
     if "_" in text:
         return True
 
-    # Short all-lowercase without CamelCase → technical (e.g., "layer1", "parcels2024")
-    # CamelCase (has uppercase after first char) is allowed
+    # Short tokens without an internal capital are ambiguous: distinguish
+    # technical identifiers from ordinary one-word proper titles (Issue #513).
+    # Identifiers are all-lowercase ("layer", "parcels") or carry digits
+    # ("layer1", "parcels2024"). A capitalized, digit-free word ("Provincia",
+    # "Localidad", "País") is a legitimate title and must be preserved.
+    # CamelCase (has uppercase after first char) is already allowed above.
     if not re.search(r"[A-Z]", text[1:]) and len(text) < 20:
-        return True
+        has_digit = any(char.isdigit() for char in text)
+        starts_capitalized = text[:1].isupper()
+        if has_digit or not starts_capitalized:
+            return True
+        return False
 
     return False
 

--- a/tests/unit/test_humanize.py
+++ b/tests/unit/test_humanize.py
@@ -90,12 +90,31 @@ class TestIsTechnicalName:
         # Issue #513: ordinary one-word proper titles are human-readable.
         assert is_technical_name(text) is False
 
+    @pytest.mark.parametrize("text", ["USA", "IGN", "COVID19"])
+    def test_acronyms_are_not_technical(self, text: str) -> None:
+        # An uppercase letter after the first char (acronym or CamelCase) fails
+        # the ambiguous-token guard, so these stay human-readable.
+        assert is_technical_name(text) is False
+
     @pytest.mark.parametrize(
         "text",
         ["layer1", "parcels2024", "bu_building_emprise_v2", "ns:LayerName", "parcels", "q4"],
     )
     def test_identifiers_are_technical(self, text: str) -> None:
         assert is_technical_name(text) is True
+
+    @pytest.mark.parametrize("text", ["Q4", "Zone5", "Route66"])
+    def test_capitalized_with_digit_is_technical(self, text: str) -> None:
+        # A capitalized word carrying a digit is still an identifier: the digit
+        # check fires before the capitalization check. Pin this ambiguous case.
+        assert is_technical_name(text) is True
+
+    @pytest.mark.parametrize("text", ["Buildings", "Parcels", "Roads"])
+    def test_capitalized_single_word_layer_titles_survive_filter(self, text: str) -> None:
+        # Issue #513 broadened scope: extraction/seeding callers gate on
+        # is_technical_name, so capitalized single-word source/layer titles now
+        # survive filtering instead of being clobbered by an id-derived slug.
+        assert is_technical_name(text) is False
 
     @pytest.mark.parametrize("text", ["", None])
     def test_empty_is_technical(self, text: str | None) -> None:

--- a/tests/unit/test_humanize.py
+++ b/tests/unit/test_humanize.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from portolan_cli.humanize import derive_title, humanize_slug
+from portolan_cli.stac import is_technical_name
 
 
 @pytest.mark.unit
@@ -68,3 +69,40 @@ class TestDeriveTitle:
     def test_preserves_camelcase_existing(self) -> None:
         # CamelCase is considered human-readable by is_technical_name.
         assert derive_title("DenHaagHousing", "den_haag") == "DenHaagHousing"
+
+    @pytest.mark.parametrize(
+        "title",
+        ["Provincia", "Municipio", "País", "Localidad", "Departamento"],
+    )
+    def test_preserves_single_word_proper_titles(self, title: str) -> None:
+        # Issue #513: a clean, capitalized single-word source title must not be
+        # clobbered by a worse id-derived slug (e.g. "Provincia" -> "Ign Provincia").
+        assert derive_title(title, f"ign_{title.lower()}") == title
+
+
+@pytest.mark.unit
+class TestIsTechnicalName:
+    @pytest.mark.parametrize(
+        "text",
+        ["Provincia", "Municipio", "País", "Localidad", "Departamento", "Río"],
+    )
+    def test_capitalized_single_word_is_not_technical(self, text: str) -> None:
+        # Issue #513: ordinary one-word proper titles are human-readable.
+        assert is_technical_name(text) is False
+
+    @pytest.mark.parametrize(
+        "text",
+        ["layer1", "parcels2024", "bu_building_emprise_v2", "ns:LayerName", "parcels", "q4"],
+    )
+    def test_identifiers_are_technical(self, text: str) -> None:
+        assert is_technical_name(text) is True
+
+    @pytest.mark.parametrize("text", ["", None])
+    def test_empty_is_technical(self, text: str | None) -> None:
+        assert is_technical_name(text) is True
+
+    def test_camelcase_is_not_technical(self) -> None:
+        assert is_technical_name("DenHaagHousing") is False
+
+    def test_spaces_are_not_technical(self) -> None:
+        assert is_technical_name("Área protegida") is False


### PR DESCRIPTION
## Summary

Fixes #513. `is_technical_name()` classified any short, spaceless,
underscore-free token without an internal capital as "technical". That
false-positive caught ordinary one-word proper titles — `Provincia`,
`Municipio`, `País`, `Localidad` — so `check --metadata --fix`
(`repair_titles_and_links`, Issue #502) replaced clean source titles with
*worse* id-derived slugs:

- `is_technical_name("Provincia")` → `True`
- `derive_title("Provincia", "ign_provincia")` → `"Ign Provincia"`

This clobbered ~63 of 192 collections in the IGN Argentina catalog.
Multi-word titles (`Área protegida`) were spared because they contain a space.

## Root cause

```python
if not re.search(r"[A-Z]", text[1:]) and len(text) < 20:
    return True
```

Meant to catch identifiers like `layer1` / `parcels2024`, it also caught
capitalized one-word proper nouns.

## Fix

Refine the short-token branch in `is_technical_name` (`portolan_cli/stac.py`):
a capitalized, digit-free word is a legitimate title and is preserved, while
identifiers (all-lowercase, or carrying digits) remain technical.

| Input | Before | After |
|-------|--------|-------|
| `Provincia` | technical | not technical ✓ |
| `País` | technical | not technical ✓ |
| `layer1` | technical | technical ✓ |
| `parcels2024` | technical | technical ✓ |
| `parcels` | technical | technical ✓ |

## Tests

TDD: added `TestIsTechnicalName` and a regression case in `TestDeriveTitle`
in `tests/unit/test_humanize.py` (fail before, pass after). Full title/seeding
unit sweep (230 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved name classification to better distinguish proper titles from technical identifiers, particularly for capitalized single-word entries used in European naming conventions.

* **Tests**
  * Added comprehensive test coverage for name classification across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->