### PR TITLE
fix(viz): track generated thumbnails in versions.json (#519)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,4 +228,5 @@ specs/
 # Local Claude context (machine-specific, not for git)
 claude.local.md
 .grepai/
+.serena/
 mutants/

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -452,6 +452,93 @@ def add_thumbnail_asset_to_collection(
     collection_json_path.write_text(json.dumps(data, indent=2))
 
 
+def _track_generated_asset_in_versions(
+    collection_path: Path,
+    asset_path: Path,
+    catalog_root: Path,
+    *,
+    message: str,
+) -> None:
+    """Track a generated side-step asset (PMTiles, thumbnail) in versions.json.
+
+    Computes the SHA-256 checksum, size, and mtime of ``asset_path`` and adds a
+    new version snapshot. ``add_version`` carries forward the previous version's
+    assets, so the result is a complete snapshot with this asset added/updated.
+
+    Args:
+        collection_path: Path to collection directory.
+        asset_path: Path to the generated file to track.
+        catalog_root: Path to catalog root (hrefs are catalog-root-relative).
+        message: Human-readable description of the change.
+
+    Raises:
+        FileNotFoundError: If ``asset_path`` doesn't exist.
+    """
+    from portolan_cli.versions import (
+        Asset,
+        VersionsFile,
+        add_version,
+        parse_version,
+        read_versions,
+        write_versions,
+    )
+
+    if not asset_path.exists():
+        raise FileNotFoundError(f"File not found at {asset_path}")
+
+    versions_path = collection_path / "versions.json"
+
+    # If no versions.json, create a minimal one
+    if not versions_path.exists():
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version=None,
+            versions=[],
+        )
+    else:
+        versions_file = read_versions(versions_path)
+
+    # Compute checksum and stats (stream in chunks to avoid OOM on large files)
+    stat = asset_path.stat()
+    hasher = hashlib.sha256()
+    with open(asset_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):  # 64KB chunks
+            hasher.update(chunk)
+    sha256 = hasher.hexdigest()
+
+    # Href is relative to catalog root
+    try:
+        rel_path = asset_path.relative_to(catalog_root)
+    except ValueError:
+        # Fallback if not relative
+        rel_path = asset_path.relative_to(collection_path.parent)
+
+    asset = Asset(
+        sha256=sha256,
+        size_bytes=stat.st_size,
+        href=rel_path.as_posix(),
+        mtime=stat.st_mtime,
+    )
+
+    # Determine next version
+    if versions_file.current_version:
+        major, minor, patch = parse_version(versions_file.current_version)
+        new_version = f"{major}.{minor}.{patch + 1}"
+    else:
+        new_version = "1.0.0"
+
+    # Add version with the generated asset
+    updated = add_version(
+        versions_file,
+        version=new_version,
+        assets={asset_path.name: asset},
+        breaking=False,
+        message=message,
+    )
+
+    write_versions(versions_path, updated)
+
+
 def track_pmtiles_in_versions(
     collection_path: Path,
     pmtiles_path: Path,
@@ -467,69 +554,40 @@ def track_pmtiles_in_versions(
     Raises:
         FileNotFoundError: If PMTiles file doesn't exist.
     """
-    from portolan_cli.versions import (
-        Asset,
-        VersionsFile,
-        add_version,
-        parse_version,
-        read_versions,
-        write_versions,
-    )
-
-    if not pmtiles_path.exists():
-        raise FileNotFoundError(f"PMTiles file not found at {pmtiles_path}")
-
-    versions_path = collection_path / "versions.json"
-
-    # If no versions.json, create a minimal one
-    if not versions_path.exists():
-        versions_file = VersionsFile(
-            spec_version="1.0.0",
-            current_version=None,
-            versions=[],
-        )
-    else:
-        versions_file = read_versions(versions_path)
-
-    # Compute checksum and stats (stream in chunks to avoid OOM on large files)
-    stat = pmtiles_path.stat()
-    hasher = hashlib.sha256()
-    with open(pmtiles_path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):  # 64KB chunks
-            hasher.update(chunk)
-    sha256 = hasher.hexdigest()
-
-    # Href is relative to catalog root
-    try:
-        rel_path = pmtiles_path.relative_to(catalog_root)
-    except ValueError:
-        # Fallback if not relative
-        rel_path = pmtiles_path.relative_to(collection_path.parent)
-
-    pmtiles_asset = Asset(
-        sha256=sha256,
-        size_bytes=stat.st_size,
-        href=rel_path.as_posix(),
-        mtime=stat.st_mtime,
-    )
-
-    # Determine next version
-    if versions_file.current_version:
-        major, minor, patch = parse_version(versions_file.current_version)
-        new_version = f"{major}.{minor}.{patch + 1}"
-    else:
-        new_version = "1.0.0"
-
-    # Add version with pmtiles asset
-    updated = add_version(
-        versions_file,
-        version=new_version,
-        assets={pmtiles_path.name: pmtiles_asset},
-        breaking=False,
+    _track_generated_asset_in_versions(
+        collection_path,
+        pmtiles_path,
+        catalog_root,
         message=f"Generated PMTiles: {pmtiles_path.name}",
     )
 
-    write_versions(versions_path, updated)
+
+def track_thumbnail_in_versions(
+    collection_path: Path,
+    thumbnail_path: Path,
+    catalog_root: Path,
+) -> None:
+    """Track a generated thumbnail in versions.json (Issue #519).
+
+    Thumbnails are generated in the PMTiles side-step *after* the main version
+    snapshot is published, so — like PMTiles — they need their own tracking
+    call. Without it the thumbnail is referenced in collection.json but carries
+    no checksum/size, so sync cannot verify or skip it.
+
+    Args:
+        collection_path: Path to collection directory.
+        thumbnail_path: Path to the thumbnail file.
+        catalog_root: Path to catalog root.
+
+    Raises:
+        FileNotFoundError: If the thumbnail file doesn't exist.
+    """
+    _track_generated_asset_in_versions(
+        collection_path,
+        thumbnail_path,
+        catalog_root,
+        message=f"Generated thumbnail: {thumbnail_path.name}",
+    )
 
 
 def generate_pmtiles_for_collection(
@@ -687,6 +745,9 @@ def generate_pmtiles_for_collection(
                     if thumb_path:
                         pmtiles_key = f"{asset_key}-tiles"
                         add_thumbnail_asset_to_collection(collection_path, pmtiles_key, thumb_path)
+                        # Track in versions.json so it ships with a checksum/size
+                        # and sync can verify/skip it (Issue #519).
+                        track_thumbnail_in_versions(collection_path, thumb_path, catalog_root)
             except Exception as e:
                 logger.warning("Thumbnail generation failed for %s: %s", pmtiles_path.name, e)
 

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -566,16 +566,22 @@ def _track_generated_assets_in_versions(
     write_versions(versions_path, updated)
 
 
-def _backfill_skipped_assets(collection_path: Path, pmtiles_path: Path, catalog_root: Path) -> None:
+def _backfill_skipped_assets(
+    collection_path: Path, asset_key: str, pmtiles_path: Path, catalog_root: Path
+) -> None:
     """Track an up-to-date PMTiles and its thumbnail if not already tracked.
 
     Runs on the skip path to heal catalogs whose artifacts were generated before
     versions.json tracking existed (Issue #519), without bumping a version when
-    everything is already tracked.
+    everything is already tracked. When a thumbnail exists on disk it is also
+    re-registered as a STAC asset (mirroring the PMTiles), so the backfilled
+    versions.json entry can never be orphaned from collection.json.
     """
     backfill = [pmtiles_path]
     existing_thumb = thumbnail_path_for(pmtiles_path)
     if existing_thumb.exists():
+        # Ensure the thumbnail is a STAC asset too, even when skipping generation.
+        add_thumbnail_asset_to_collection(collection_path, f"{asset_key}-tiles", existing_thumb)
         backfill.append(existing_thumb)
     try:
         _track_generated_assets_in_versions(
@@ -730,7 +736,7 @@ def generate_pmtiles_for_collection(
             )
             # Backfill versions.json for artifacts generated before this tracking
             # existed (the original #519 bug state), idempotently.
-            _backfill_skipped_assets(collection_path, pmtiles_path, catalog_root)
+            _backfill_skipped_assets(collection_path, asset_key, pmtiles_path, catalog_root)
             result.skipped.append(pmtiles_path)
             continue
 

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -32,7 +32,11 @@ from typing import Any
 
 from portolan_cli.errors import PortolanError
 from portolan_cli.output import warn
-from portolan_cli.thumbnail import ThumbnailConfig, generate_vector_thumbnail, get_thumbnail_config
+from portolan_cli.thumbnail import (
+    generate_vector_thumbnail,
+    get_thumbnail_config,
+    thumbnail_path_for,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -452,27 +456,47 @@ def add_thumbnail_asset_to_collection(
     collection_json_path.write_text(json.dumps(data, indent=2))
 
 
-def _track_generated_asset_in_versions(
+def _compute_sha256(path: Path) -> str:
+    """Stream a file in 64KB chunks and return its SHA-256 hex digest.
+
+    Chunked to avoid loading large PMTiles/thumbnail files fully into memory.
+    """
+    hasher = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):  # 64KB chunks
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _track_generated_assets_in_versions(
     collection_path: Path,
-    asset_path: Path,
+    asset_paths: list[Path],
     catalog_root: Path,
     *,
     message: str,
+    only_if_missing: bool = False,
 ) -> None:
-    """Track a generated side-step asset (PMTiles, thumbnail) in versions.json.
+    """Track generated side-step assets (PMTiles, thumbnail) in versions.json.
 
-    Computes the SHA-256 checksum, size, and mtime of ``asset_path`` and adds a
-    new version snapshot. ``add_version`` carries forward the previous version's
-    assets, so the result is a complete snapshot with this asset added/updated.
+    Computes SHA-256, size, and mtime for each path and records them in a *single*
+    new version snapshot. The PMTiles and its thumbnail come from the same
+    side-step for the same source asset, so they belong in one version, not two
+    (Issue #519). ``add_version`` carries forward the previous version's assets,
+    so the result is a complete snapshot with these assets added/updated.
 
     Args:
         collection_path: Path to collection directory.
-        asset_path: Path to the generated file to track.
+        asset_paths: Paths to the generated files to track.
         catalog_root: Path to catalog root (hrefs are catalog-root-relative).
         message: Human-readable description of the change.
+        only_if_missing: When True, only track assets whose filename is not
+            already present in the latest version snapshot, and create no version
+            at all if every asset is already tracked. Used by the skip path to
+            backfill artifacts generated before this tracking existed without
+            bumping a version on every unchanged ``add`` (Issue #519).
 
     Raises:
-        FileNotFoundError: If ``asset_path`` doesn't exist.
+        FileNotFoundError: If any asset path doesn't exist.
     """
     from portolan_cli.versions import (
         Asset,
@@ -483,8 +507,9 @@ def _track_generated_asset_in_versions(
         write_versions,
     )
 
-    if not asset_path.exists():
-        raise FileNotFoundError(f"File not found at {asset_path}")
+    for asset_path in asset_paths:
+        if not asset_path.exists():
+            raise FileNotFoundError(f"File not found at {asset_path}")
 
     versions_path = collection_path / "versions.json"
 
@@ -498,27 +523,30 @@ def _track_generated_asset_in_versions(
     else:
         versions_file = read_versions(versions_path)
 
-    # Compute checksum and stats (stream in chunks to avoid OOM on large files)
-    stat = asset_path.stat()
-    hasher = hashlib.sha256()
-    with open(asset_path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):  # 64KB chunks
-            hasher.update(chunk)
-    sha256 = hasher.hexdigest()
+    # Backfill mode: skip assets already tracked, and create no version if none
+    # are missing (otherwise the message would force a no-op version bump).
+    paths_to_track = asset_paths
+    if only_if_missing and versions_file.versions:
+        tracked = versions_file.versions[-1].assets
+        paths_to_track = [p for p in asset_paths if p.name not in tracked]
+    if not paths_to_track:
+        return
 
-    # Href is relative to catalog root
-    try:
-        rel_path = asset_path.relative_to(catalog_root)
-    except ValueError:
-        # Fallback if not relative
-        rel_path = asset_path.relative_to(collection_path.parent)
-
-    asset = Asset(
-        sha256=sha256,
-        size_bytes=stat.st_size,
-        href=rel_path.as_posix(),
-        mtime=stat.st_mtime,
-    )
+    assets: dict[str, Asset] = {}
+    for asset_path in paths_to_track:
+        stat = asset_path.stat()
+        # Href is relative to catalog root
+        try:
+            rel_path = asset_path.relative_to(catalog_root)
+        except ValueError:
+            # Fallback if not relative
+            rel_path = asset_path.relative_to(collection_path.parent)
+        assets[asset_path.name] = Asset(
+            sha256=_compute_sha256(asset_path),
+            size_bytes=stat.st_size,
+            href=rel_path.as_posix(),
+            mtime=stat.st_mtime,
+        )
 
     # Determine next version
     if versions_file.current_version:
@@ -527,11 +555,10 @@ def _track_generated_asset_in_versions(
     else:
         new_version = "1.0.0"
 
-    # Add version with the generated asset
     updated = add_version(
         versions_file,
         version=new_version,
-        assets={asset_path.name: asset},
+        assets=assets,
         breaking=False,
         message=message,
     )
@@ -539,55 +566,85 @@ def _track_generated_asset_in_versions(
     write_versions(versions_path, updated)
 
 
-def track_pmtiles_in_versions(
+def _backfill_skipped_assets(collection_path: Path, pmtiles_path: Path, catalog_root: Path) -> None:
+    """Track an up-to-date PMTiles and its thumbnail if not already tracked.
+
+    Runs on the skip path to heal catalogs whose artifacts were generated before
+    versions.json tracking existed (Issue #519), without bumping a version when
+    everything is already tracked.
+    """
+    backfill = [pmtiles_path]
+    existing_thumb = thumbnail_path_for(pmtiles_path)
+    if existing_thumb.exists():
+        backfill.append(existing_thumb)
+    try:
+        _track_generated_assets_in_versions(
+            collection_path,
+            backfill,
+            catalog_root,
+            message="Backfilled visualization asset tracking",
+            only_if_missing=True,
+        )
+    except Exception as e:
+        warn(f"Failed to backfill versions.json tracking for {pmtiles_path.name}: {e}")
+
+
+def _generate_thumbnail_asset(
+    collection_path: Path,
+    parquet_path: Path,
+    pmtiles_path: Path,
+    asset_key: str,
+    catalog_root: Path,
+) -> Path | None:
+    """Generate the vector thumbnail and register it as a STAC asset.
+
+    Returns the thumbnail path on success, or None if disabled or failed. Failure
+    is non-fatal: it must not affect PMTiles success (Issue #13).
+    """
+    try:
+        thumb_config = get_thumbnail_config(catalog_root)
+        if not thumb_config.enabled:
+            return None
+        # Discover style for thumbnail (Issue #495)
+        style_path = _discover_style_for_thumbnail(collection_path)
+        thumb_path = generate_vector_thumbnail(
+            pmtiles_path=pmtiles_path,
+            geoparquet_path=parquet_path,  # fallback
+            config=thumb_config,
+            style_path=style_path,
+        )
+        if thumb_path:
+            add_thumbnail_asset_to_collection(collection_path, f"{asset_key}-tiles", thumb_path)
+        return thumb_path
+    except Exception as e:
+        warn(f"Thumbnail generation failed for {pmtiles_path.name}: {e}")
+        return None
+
+
+def _track_side_step_assets(
     collection_path: Path,
     pmtiles_path: Path,
+    thumb_path: Path | None,
     catalog_root: Path,
 ) -> None:
-    """Track PMTiles file in versions.json.
+    """Track the PMTiles and its thumbnail in a SINGLE versions.json snapshot.
 
-    Args:
-        collection_path: Path to collection directory.
-        pmtiles_path: Path to PMTiles file.
-        catalog_root: Path to catalog root.
-
-    Raises:
-        FileNotFoundError: If PMTiles file doesn't exist.
+    One side-step is one version bump, not two (Issue #519). Called outside the
+    generation try/finally so a versions.json write error cannot trigger the
+    partial-file cleanup that deletes the freshly generated PMTiles.
     """
-    _track_generated_asset_in_versions(
-        collection_path,
-        pmtiles_path,
-        catalog_root,
-        message=f"Generated PMTiles: {pmtiles_path.name}",
-    )
-
-
-def track_thumbnail_in_versions(
-    collection_path: Path,
-    thumbnail_path: Path,
-    catalog_root: Path,
-) -> None:
-    """Track a generated thumbnail in versions.json (Issue #519).
-
-    Thumbnails are generated in the PMTiles side-step *after* the main version
-    snapshot is published, so — like PMTiles — they need their own tracking
-    call. Without it the thumbnail is referenced in collection.json but carries
-    no checksum/size, so sync cannot verify or skip it.
-
-    Args:
-        collection_path: Path to collection directory.
-        thumbnail_path: Path to the thumbnail file.
-        catalog_root: Path to catalog root.
-
-    Raises:
-        FileNotFoundError: If the thumbnail file doesn't exist.
-    """
-    _track_generated_asset_in_versions(
-        collection_path,
-        thumbnail_path,
-        catalog_root,
-        message=f"Generated thumbnail: {thumbnail_path.name}",
-    )
+    generated_assets = [pmtiles_path]
+    if thumb_path:
+        generated_assets.append(thumb_path)
+        message = f"Generated PMTiles and thumbnail: {pmtiles_path.name}, {thumb_path.name}"
+    else:
+        message = f"Generated PMTiles: {pmtiles_path.name}"
+    try:
+        _track_generated_assets_in_versions(
+            collection_path, generated_assets, catalog_root, message=message
+        )
+    except Exception as e:
+        warn(f"Failed to track generated assets in versions.json for {pmtiles_path.name}: {e}")
 
 
 def generate_pmtiles_for_collection(
@@ -671,6 +728,9 @@ def generate_pmtiles_for_collection(
                 pmtiles_relative_path=pmtiles_col_rel,
                 catalog_path=catalog_root,
             )
+            # Backfill versions.json for artifacts generated before this tracking
+            # existed (the original #519 bug state), idempotently.
+            _backfill_skipped_assets(collection_path, pmtiles_path, catalog_root)
             result.skipped.append(pmtiles_path)
             continue
 
@@ -700,9 +760,6 @@ def generate_pmtiles_for_collection(
             # Register asset in collection.json (Issue #13)
             add_pmtiles_asset_to_collection(collection_path, asset_key, pmtiles_href)
 
-            # Track in versions.json
-            track_pmtiles_in_versions(collection_path, pmtiles_path, catalog_root)
-
             result.generated.append(pmtiles_path)
             generation_succeeded = True
 
@@ -726,30 +783,14 @@ def generate_pmtiles_for_collection(
                 pmtiles_path.unlink(missing_ok=True)
                 warn(f"Cleaned up partial file after failure: {pmtiles_path.name}")
 
-        # Generate thumbnail separately - failure shouldn't affect PMTiles success (Issue #13)
+        # Generate thumbnail separately - failure shouldn't affect PMTiles success
+        # (Issue #13) - then track the PMTiles and thumbnail in a SINGLE version
+        # snapshot (one side-step == one version, not two, Issue #519).
         if generation_succeeded:
-            try:
-                thumb_config = (
-                    get_thumbnail_config(catalog_root) if catalog_root else ThumbnailConfig()
-                )
-                if thumb_config.enabled:
-                    # Discover style for thumbnail (Issue #495)
-                    style_path = _discover_style_for_thumbnail(collection_path)
-                    thumb_path = generate_vector_thumbnail(
-                        pmtiles_path=pmtiles_path,
-                        geoparquet_path=parquet_path,  # fallback
-                        config=thumb_config,
-                        style_path=style_path,
-                    )
-                    # Register thumbnail as asset so it's tracked in STAC
-                    if thumb_path:
-                        pmtiles_key = f"{asset_key}-tiles"
-                        add_thumbnail_asset_to_collection(collection_path, pmtiles_key, thumb_path)
-                        # Track in versions.json so it ships with a checksum/size
-                        # and sync can verify/skip it (Issue #519).
-                        track_thumbnail_in_versions(collection_path, thumb_path, catalog_root)
-            except Exception as e:
-                logger.warning("Thumbnail generation failed for %s: %s", pmtiles_path.name, e)
+            thumb_path = _generate_thumbnail_asset(
+                collection_path, parquet_path, pmtiles_path, asset_key, catalog_root
+            )
+            _track_side_step_assets(collection_path, pmtiles_path, thumb_path, catalog_root)
 
     # Discover and register style assets (ADR-0045)
     from portolan_cli.style import discover_styles, register_style_assets

--- a/portolan_cli/thumbnail.py
+++ b/portolan_cli/thumbnail.py
@@ -186,6 +186,22 @@ def get_thumbnail_config(catalog_path: Path) -> ThumbnailConfig:
     )
 
 
+def thumbnail_path_for(data_path: Path) -> Path:
+    """Return the thumbnail path for a data file (single source of the convention).
+
+    Thumbnails are written next to their source as ``{stem}.thumb.jpg``. Both the
+    PMTiles and GeoParquet render paths use this, and the PMTiles side-step relies
+    on it to locate an already-generated thumbnail when generation is skipped.
+
+    Args:
+        data_path: Path to the source data file (PMTiles or GeoParquet).
+
+    Returns:
+        Path to the sibling thumbnail file.
+    """
+    return data_path.with_name(f"{data_path.stem}.thumb.jpg")
+
+
 # =============================================================================
 # Tile Coordinate Transformation
 # =============================================================================
@@ -912,7 +928,7 @@ def generate_thumbnail_from_pmtiles(
     Returns:
         Path to generated thumbnail, or None if generation failed.
     """
-    thumb_path = pmtiles_path.with_name(f"{pmtiles_path.stem}.thumb.jpg")
+    thumb_path = thumbnail_path_for(pmtiles_path)
 
     try:
         geometries, bounds = _read_pmtiles_geometries(pmtiles_path)
@@ -946,7 +962,7 @@ def generate_thumbnail_from_geoparquet(
     Returns:
         Path to generated thumbnail, or None if generation failed.
     """
-    thumb_path = gpq_path.with_name(f"{gpq_path.stem}.thumb.jpg")
+    thumb_path = thumbnail_path_for(gpq_path)
 
     bounds = _read_geoparquet_bounds(gpq_path)
     if bounds is None:

--- a/tests/integration/test_pmtiles_integration.py
+++ b/tests/integration/test_pmtiles_integration.py
@@ -204,11 +204,11 @@ class TestPMTilesGeneration:
         assert "tiles" in pmtiles_asset["title"].lower()
 
     def test_version_tracked(self, collection_with_geoparquet: Path) -> None:
-        """PMTiles and its thumbnail are both tracked in versions.json.
+        """PMTiles and its thumbnail share a single versions.json snapshot.
 
-        The side-step generates two artifacts — the PMTiles and a thumbnail —
-        and each is tracked with its own version bump (Issue #519). The latest
-        snapshot is cumulative, so it carries both.
+        The side-step generates the PMTiles and (when rendering succeeds) a
+        thumbnail. Both belong to ONE version bump, not two (Issue #519), and
+        the snapshot carries both with checksum and size.
         """
         from portolan_cli.pmtiles import generate_pmtiles_for_collection
 
@@ -228,9 +228,9 @@ class TestPMTilesGeneration:
         # Read updated versions.json
         versions_data_after = json.loads((collection_with_geoparquet / "versions.json").read_text())
 
-        # New versions created: one for the PMTiles, one for the thumbnail.
+        # Exactly one new version snapshot for the whole side-step (Issue #519).
         assert versions_data_after["current_version"] != initial_version
-        assert len(versions_data_after["versions"]) == len(versions_data_before["versions"]) + 2
+        assert len(versions_data_after["versions"]) == len(versions_data_before["versions"]) + 1
 
         # Latest snapshot tracks the PMTiles file.
         latest_version = versions_data_after["versions"][-1]
@@ -240,11 +240,14 @@ class TestPMTilesGeneration:
         assert "sha256" in pmtiles_asset
         assert pmtiles_asset["size_bytes"] > 0
 
-        # Latest snapshot also tracks the generated thumbnail (Issue #519).
-        assert "roads.thumb.jpg" in latest_version["assets"]
-        thumb_asset = latest_version["assets"]["roads.thumb.jpg"]
-        assert "sha256" in thumb_asset
-        assert thumb_asset["size_bytes"] > 0
+        # If a thumbnail was actually rendered (matplotlib/contextily available;
+        # basemap fetch is networked, so it may be absent offline), it must live
+        # in the SAME snapshot as the PMTiles with its own checksum (Issue #519).
+        if (collection_with_geoparquet / "roads.thumb.jpg").exists():
+            assert "roads.thumb.jpg" in latest_version["assets"]
+            thumb_asset = latest_version["assets"]["roads.thumb.jpg"]
+            assert "sha256" in thumb_asset
+            assert thumb_asset["size_bytes"] > 0
 
 
 class TestPMTilesZoomLevels:

--- a/tests/integration/test_pmtiles_integration.py
+++ b/tests/integration/test_pmtiles_integration.py
@@ -204,7 +204,12 @@ class TestPMTilesGeneration:
         assert "tiles" in pmtiles_asset["title"].lower()
 
     def test_version_tracked(self, collection_with_geoparquet: Path) -> None:
-        """PMTiles generation creates new version in versions.json."""
+        """PMTiles and its thumbnail are both tracked in versions.json.
+
+        The side-step generates two artifacts — the PMTiles and a thumbnail —
+        and each is tracked with its own version bump (Issue #519). The latest
+        snapshot is cumulative, so it carries both.
+        """
         from portolan_cli.pmtiles import generate_pmtiles_for_collection
 
         catalog_root = collection_with_geoparquet.parent
@@ -223,17 +228,23 @@ class TestPMTilesGeneration:
         # Read updated versions.json
         versions_data_after = json.loads((collection_with_geoparquet / "versions.json").read_text())
 
-        # New version should be created
+        # New versions created: one for the PMTiles, one for the thumbnail.
         assert versions_data_after["current_version"] != initial_version
-        assert len(versions_data_after["versions"]) == len(versions_data_before["versions"]) + 1
+        assert len(versions_data_after["versions"]) == len(versions_data_before["versions"]) + 2
 
-        # Latest version should track the PMTiles file
+        # Latest snapshot tracks the PMTiles file.
         latest_version = versions_data_after["versions"][-1]
         assert "roads.pmtiles" in latest_version["assets"]
 
         pmtiles_asset = latest_version["assets"]["roads.pmtiles"]
         assert "sha256" in pmtiles_asset
         assert pmtiles_asset["size_bytes"] > 0
+
+        # Latest snapshot also tracks the generated thumbnail (Issue #519).
+        assert "roads.thumb.jpg" in latest_version["assets"]
+        thumb_asset = latest_version["assets"]["roads.thumb.jpg"]
+        assert "sha256" in thumb_asset
+        assert thumb_asset["size_bytes"] > 0
 
 
 class TestPMTilesZoomLevels:

--- a/tests/integration/test_pmtiles_integration.py
+++ b/tests/integration/test_pmtiles_integration.py
@@ -94,6 +94,63 @@ def collection_with_geoparquet(tmp_path: Path, fixtures_dir: Path) -> Path:
     return collection_dir
 
 
+@pytest.fixture
+def collection_with_two_geoparquet(tmp_path: Path, fixtures_dir: Path) -> Path:
+    """Create a collection with two GeoParquet assets (a.parquet, b.parquet)."""
+    collection_dir = tmp_path / "roads"
+    collection_dir.mkdir()
+
+    src = fixtures_dir / "realdata" / "road-detections.parquet"
+    shutil.copy(src, collection_dir / "a.parquet")
+    shutil.copy(src, collection_dir / "b.parquet")
+
+    collection_json = {
+        "type": "Collection",
+        "id": "roads",
+        "stac_version": "1.1.0",
+        "description": "Road detections",
+        "license": "proprietary",
+        "extent": {
+            "spatial": {"bbox": [[-61.0, 13.7, -60.9, 13.9]]},
+            "temporal": {"interval": [[None, None]]},
+        },
+        "assets": {
+            "a": {
+                "href": "./a.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+            },
+            "b": {
+                "href": "./b.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+            },
+        },
+    }
+    (collection_dir / "collection.json").write_text(json.dumps(collection_json, indent=2))
+
+    versions_json = {
+        "spec_version": "1.0.0",
+        "current_version": "1.0.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2026-01-01T00:00:00Z",
+                "breaking": False,
+                "assets": {},
+                "changes": [],
+            }
+        ],
+    }
+    (collection_dir / "versions.json").write_text(json.dumps(versions_json, indent=2))
+
+    portolan_dir = tmp_path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("catalog_id: test-catalog\n")
+
+    return collection_dir
+
+
 class TestPMTilesGeneration:
     """Test PMTiles generation from GeoParquet."""
 
@@ -248,6 +305,119 @@ class TestPMTilesGeneration:
             thumb_asset = latest_version["assets"]["roads.thumb.jpg"]
             assert "sha256" in thumb_asset
             assert thumb_asset["size_bytes"] > 0
+
+    @staticmethod
+    def _reset_versions_to_baseline(collection: Path) -> None:
+        """Drop generated version snapshots, leaving only the empty 1.0.0 baseline.
+
+        Reproduces the original #519 state: artifacts exist on disk and in
+        collection.json, but versions.json does not track them.
+        """
+        data = json.loads((collection / "versions.json").read_text())
+        data["versions"] = data["versions"][:1]
+        data["current_version"] = data["versions"][0]["version"]
+        (collection / "versions.json").write_text(json.dumps(data, indent=2))
+
+    def test_skip_path_backfills_untracked_artifacts(
+        self, collection_with_geoparquet: Path
+    ) -> None:
+        """Skip path heals artifacts left untracked by the old code (Issue #519).
+
+        Reproduce the pre-fix state (PMTiles + thumbnail on disk and in
+        collection.json, absent from versions.json), then run generation again.
+        The PMTiles is up-to-date so generation is skipped, but the untracked
+        artifacts must still be backfilled into versions.json — without forcing
+        a regenerate.
+        """
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+
+        catalog_root = collection_with_geoparquet.parent
+
+        # First run actually generates the artifacts.
+        generate_pmtiles_for_collection(
+            collection_path=collection_with_geoparquet, catalog_root=catalog_root
+        )
+        pmtiles = collection_with_geoparquet / "roads.pmtiles"
+        thumb = collection_with_geoparquet / "roads.thumb.jpg"
+        assert pmtiles.exists(), "PMTiles should have been generated"
+        thumb_rendered = thumb.exists()
+
+        # Simulate the #519 bug state: forget the artifacts in versions.json.
+        self._reset_versions_to_baseline(collection_with_geoparquet)
+        before = json.loads((collection_with_geoparquet / "versions.json").read_text())
+
+        # Second run: PMTiles is up-to-date -> skip path -> backfill.
+        result = generate_pmtiles_for_collection(
+            collection_path=collection_with_geoparquet, catalog_root=catalog_root
+        )
+        assert pmtiles in result.skipped, "Up-to-date PMTiles must be skipped, not regenerated"
+
+        after = json.loads((collection_with_geoparquet / "versions.json").read_text())
+        # Exactly one backfill version added.
+        assert len(after["versions"]) == len(before["versions"]) + 1
+        latest = after["versions"][-1]["assets"]
+        assert "roads.pmtiles" in latest, "Untracked PMTiles must be backfilled on skip"
+        if thumb_rendered:
+            assert "roads.thumb.jpg" in latest, "Untracked thumbnail must be backfilled on skip"
+
+    def test_backfill_is_idempotent_when_already_tracked(
+        self, collection_with_geoparquet: Path
+    ) -> None:
+        """A skip with everything already tracked creates NO new version (Issue #519)."""
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+
+        catalog_root = collection_with_geoparquet.parent
+
+        # Generate + track.
+        generate_pmtiles_for_collection(
+            collection_path=collection_with_geoparquet, catalog_root=catalog_root
+        )
+        after_generate = json.loads((collection_with_geoparquet / "versions.json").read_text())
+
+        # Re-run: PMTiles up-to-date, everything tracked -> no version bump.
+        generate_pmtiles_for_collection(
+            collection_path=collection_with_geoparquet, catalog_root=catalog_root
+        )
+        after_skip = json.loads((collection_with_geoparquet / "versions.json").read_text())
+
+        assert len(after_skip["versions"]) == len(after_generate["versions"]), (
+            "Idempotent skip must not bump a version when everything is tracked"
+        )
+        assert after_skip["current_version"] == after_generate["current_version"]
+
+    def test_each_geoparquet_asset_gets_its_own_version(
+        self, collection_with_two_geoparquet: Path
+    ) -> None:
+        """Each source asset's side-step is one version; the latest is cumulative.
+
+        Two GeoParquet assets -> two side-steps -> two new version snapshots
+        (one per asset, each bundling that asset's PMTiles + thumbnail), and the
+        final snapshot carries every generated artifact (Issue #519).
+        """
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+
+        collection = collection_with_two_geoparquet
+        catalog_root = collection.parent
+
+        before = json.loads((collection / "versions.json").read_text())
+        result = generate_pmtiles_for_collection(
+            collection_path=collection, catalog_root=catalog_root
+        )
+        after = json.loads((collection / "versions.json").read_text())
+
+        assert len(result.generated) == 2
+        # One version per source asset (not per artifact): +2, not +4.
+        assert len(after["versions"]) == len(before["versions"]) + 2
+
+        # The latest snapshot is cumulative across both assets.
+        latest = after["versions"][-1]["assets"]
+        assert "a.pmtiles" in latest
+        assert "b.pmtiles" in latest
+        # Thumbnails are bundled into their asset's snapshot when rendered.
+        if (collection / "a.thumb.jpg").exists():
+            assert "a.thumb.jpg" in latest
+        if (collection / "b.thumb.jpg").exists():
+            assert "b.thumb.jpg" in latest
 
 
 class TestPMTilesZoomLevels:

--- a/tests/integration/test_pmtiles_integration.py
+++ b/tests/integration/test_pmtiles_integration.py
@@ -342,8 +342,16 @@ class TestPMTilesGeneration:
         assert pmtiles.exists(), "PMTiles should have been generated"
         thumb_rendered = thumb.exists()
 
-        # Simulate the #519 bug state: forget the artifacts in versions.json.
+        # Simulate the #519 bug state: forget the artifacts in versions.json. Also
+        # drop the thumbnail STAC asset from collection.json so the skip path must
+        # re-register it (no orphaned versions.json entry).
         self._reset_versions_to_baseline(collection_with_geoparquet)
+        coll_path = collection_with_geoparquet / "collection.json"
+        coll = json.loads(coll_path.read_text())
+        coll["assets"] = {
+            k: v for k, v in coll["assets"].items() if "thumbnail" not in v.get("roles", [])
+        }
+        coll_path.write_text(json.dumps(coll, indent=2))
         before = json.loads((collection_with_geoparquet / "versions.json").read_text())
 
         # Second run: PMTiles is up-to-date -> skip path -> backfill.
@@ -359,6 +367,12 @@ class TestPMTilesGeneration:
         assert "roads.pmtiles" in latest, "Untracked PMTiles must be backfilled on skip"
         if thumb_rendered:
             assert "roads.thumb.jpg" in latest, "Untracked thumbnail must be backfilled on skip"
+            # And it must be re-registered as a STAC asset, not left orphaned.
+            coll_after = json.loads(coll_path.read_text())
+            thumb_stac = [
+                k for k, v in coll_after["assets"].items() if "thumbnail" in v.get("roles", [])
+            ]
+            assert thumb_stac, "Backfilled thumbnail must be re-registered as a STAC asset"
 
     def test_backfill_is_idempotent_when_already_tracked(
         self, collection_with_geoparquet: Path

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -892,6 +892,107 @@ class TestGeneratePMTilesForCollection:
             "Backfill must not bump a version when everything is already tracked"
         )
 
+    @staticmethod
+    def _fresh_collection(collection_dir: Path) -> Path:
+        """A collection with one parquet asset and an empty 1.0.0 baseline."""
+        collection_dir.mkdir()
+        (collection_dir / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "assets": {
+                        "data": {
+                            "href": "./data.parquet",
+                            "type": "application/vnd.apache.parquet",
+                        }
+                    },
+                }
+            )
+        )
+        (collection_dir / "data.parquet").write_bytes(b"PAR1")
+        (collection_dir / "versions.json").write_text(
+            json.dumps(
+                {
+                    "spec_version": "1.0.0",
+                    "current_version": "1.0.0",
+                    "versions": [
+                        {
+                            "version": "1.0.0",
+                            "created": "2026-01-01T00:00:00Z",
+                            "breaking": False,
+                            "assets": {},
+                            "changes": [],
+                        }
+                    ],
+                }
+            )
+        )
+        return collection_dir
+
+    @pytest.mark.unit
+    def test_thumbnail_disabled_tracks_only_pmtiles(self, tmp_path: Path) -> None:
+        """When thumbnails are disabled, only the PMTiles is tracked (one version)."""
+        from unittest.mock import patch as _patch
+
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+        from portolan_cli.thumbnail import ThumbnailConfig
+        from portolan_cli.versions import read_versions
+
+        collection_dir = self._fresh_collection(tmp_path / "demographics")
+        pmtiles_path = collection_dir / "data.pmtiles"
+
+        def mock_generate(*args: object, **kwargs: object) -> None:
+            pmtiles_path.write_bytes(b"PMTILES")
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                with patch("portolan_cli.pmtiles.generate_pmtiles", mock_generate):
+                    with _patch(
+                        "portolan_cli.pmtiles.get_thumbnail_config",
+                        return_value=ThumbnailConfig(enabled=False),
+                    ):
+                        result = generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        assert pmtiles_path in result.generated
+        versions = read_versions(collection_dir / "versions.json")
+        assert len(versions.versions) == 2, "PMTiles-only generation is still one version"
+        latest = versions.versions[-1].assets
+        assert "data.pmtiles" in latest
+        assert not any(k.endswith(".thumb.jpg") or k.endswith(".thumb.png") for k in latest), (
+            "No thumbnail should be tracked when thumbnails are disabled"
+        )
+
+    @pytest.mark.unit
+    def test_thumbnail_render_failure_tracks_only_pmtiles(self, tmp_path: Path) -> None:
+        """A failed thumbnail render must not block PMTiles tracking (Issue #13)."""
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+        from portolan_cli.versions import read_versions
+
+        collection_dir = self._fresh_collection(tmp_path / "demographics")
+        pmtiles_path = collection_dir / "data.pmtiles"
+
+        def mock_generate(*args: object, **kwargs: object) -> None:
+            pmtiles_path.write_bytes(b"PMTILES")
+
+        def boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("render exploded")
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                with patch("portolan_cli.pmtiles.generate_pmtiles", mock_generate):
+                    with patch("portolan_cli.pmtiles.generate_vector_thumbnail", boom):
+                        result = generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        assert pmtiles_path in result.generated, "PMTiles must succeed despite thumbnail failure"
+        versions = read_versions(collection_dir / "versions.json")
+        # PMTiles still tracked, in exactly one version; no thumbnail.
+        assert len(versions.versions) == 2
+        latest = versions.versions[-1].assets
+        assert "data.pmtiles" in latest
+        assert not any(".thumb." in k for k in latest)
+
 
 # Integration tests that require tippecanoe
 @pytest.mark.skipif(

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -291,6 +291,100 @@ class TestAddPMTilesAssetToCollection:
         assert len(updated["assets"]) == 2
 
 
+class TestTrackThumbnailInVersions:
+    """Tests for track_thumbnail_in_versions (Issue #519).
+
+    Thumbnails generated in the PMTiles side-step must be tracked in
+    versions.json with a checksum, size, and mtime — just like PMTiles —
+    so sync can verify integrity and skip unchanged thumbnails.
+    """
+
+    @staticmethod
+    def _write_versions(collection_dir: Path) -> None:
+        versions_json = {
+            "spec_version": "1.0.0",
+            "current_version": "1.0.0",
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "created": "2026-01-01T00:00:00+00:00",
+                    "breaking": False,
+                    "assets": {
+                        "data.parquet": {
+                            "sha256": "deadbeef",
+                            "size_bytes": 100,
+                            "href": "demographics/data.parquet",
+                        }
+                    },
+                    "changes": ["data.parquet"],
+                }
+            ],
+        }
+        (collection_dir / "versions.json").write_text(json.dumps(versions_json))
+
+    @pytest.mark.unit
+    def test_thumbnail_tracked_with_checksum_size_mtime(self, tmp_path: Path) -> None:
+        """A generated thumbnail is added to versions.json as a full asset."""
+        from portolan_cli.pmtiles import track_thumbnail_in_versions
+        from portolan_cli.versions import read_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+        self._write_versions(collection_dir)
+
+        thumb = collection_dir / "data.thumb.png"
+        thumb.write_bytes(b"\x89PNG fake-thumbnail-bytes")
+
+        track_thumbnail_in_versions(collection_dir, thumb, tmp_path)
+
+        versions = read_versions(collection_dir / "versions.json")
+        assert versions.current_version == "1.0.1"
+
+        latest = versions.versions[-1]
+        # Full snapshot: prior data asset carried forward, thumbnail added.
+        assert "data.parquet" in latest.assets
+        assert "data.thumb.png" in latest.assets
+
+        thumb_asset = latest.assets["data.thumb.png"]
+        assert thumb_asset.sha256
+        assert thumb_asset.size_bytes == thumb.stat().st_size
+        assert thumb_asset.mtime is not None
+        # Href is catalog-root-relative (includes the collection dir).
+        assert thumb_asset.href == "demographics/data.thumb.png"
+        # A regenerated thumbnail shows up in the version's changes array.
+        assert "data.thumb.png" in latest.changes
+
+    @pytest.mark.unit
+    def test_creates_versions_file_when_missing(self, tmp_path: Path) -> None:
+        """First-ever version is created at 1.0.0 if versions.json is absent."""
+        from portolan_cli.pmtiles import track_thumbnail_in_versions
+        from portolan_cli.versions import read_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+
+        thumb = collection_dir / "data.thumb.png"
+        thumb.write_bytes(b"\x89PNG fake-thumbnail-bytes")
+
+        track_thumbnail_in_versions(collection_dir, thumb, tmp_path)
+
+        versions = read_versions(collection_dir / "versions.json")
+        assert versions.current_version == "1.0.0"
+        assert "data.thumb.png" in versions.versions[-1].assets
+
+    @pytest.mark.unit
+    def test_raises_when_thumbnail_missing(self, tmp_path: Path) -> None:
+        """A missing thumbnail file is a hard error (no phantom asset)."""
+        from portolan_cli.pmtiles import track_thumbnail_in_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+        self._write_versions(collection_dir)
+
+        with pytest.raises(FileNotFoundError):
+            track_thumbnail_in_versions(collection_dir, collection_dir / "data.thumb.png", tmp_path)
+
+
 class TestGeneratePMTiles:
     """Tests for generate_pmtiles function parameter passthrough."""
 
@@ -582,6 +676,80 @@ class TestGeneratePMTilesForCollection:
             "Partial file must be cleaned up on KeyboardInterrupt. "
             "finally block handles BaseException subclasses."
         )
+
+    @pytest.mark.unit
+    def test_generated_thumbnail_tracked_in_versions(self, tmp_path: Path) -> None:
+        """Thumbnail from the PMTiles side-step lands in versions.json (Issue #519).
+
+        Regression: the side-step registered the thumbnail in collection.json
+        but never tracked it in versions.json, so it shipped without a
+        checksum/size and sync could not verify it.
+        """
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+        from portolan_cli.versions import read_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+
+        collection_json = {
+            "type": "Collection",
+            "assets": {
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                }
+            },
+        }
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json))
+        (collection_dir / "data.parquet").write_bytes(b"PAR1")
+
+        versions_json = {
+            "spec_version": "1.0.0",
+            "current_version": "1.0.0",
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "created": "2026-01-01T00:00:00Z",
+                    "breaking": False,
+                    "assets": {},
+                    "changes": [],
+                }
+            ],
+        }
+        (collection_dir / "versions.json").write_text(json.dumps(versions_json))
+
+        pmtiles_path = collection_dir / "data.pmtiles"
+        thumb_path = collection_dir / "data.thumb.png"
+
+        def mock_generate(*args: object, **kwargs: object) -> None:
+            pmtiles_path.write_bytes(b"PMTILES")
+
+        def mock_thumbnail(*args: object, **kwargs: object) -> Path:
+            thumb_path.write_bytes(b"\x89PNG fake-thumbnail-bytes")
+            return thumb_path
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                with patch("portolan_cli.pmtiles.generate_pmtiles", mock_generate):
+                    with patch(
+                        "portolan_cli.pmtiles.generate_vector_thumbnail",
+                        mock_thumbnail,
+                    ):
+                        result = generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        assert pmtiles_path in result.generated
+
+        versions = read_versions(collection_dir / "versions.json")
+        all_tracked = versions.versions[-1].assets
+        assert "data.pmtiles" in all_tracked, "PMTiles should still be tracked"
+        assert "data.thumb.png" in all_tracked, (
+            "Generated thumbnail must be tracked in versions.json (Issue #519)"
+        )
+        thumb_asset = all_tracked["data.thumb.png"]
+        assert thumb_asset.sha256
+        assert thumb_asset.size_bytes == thumb_path.stat().st_size
+        assert thumb_asset.href == "demographics/data.thumb.png"
 
 
 # Integration tests that require tippecanoe

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -7,6 +7,7 @@ actually generate PMTiles require tippecanoe and are marked accordingly.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -291,12 +292,13 @@ class TestAddPMTilesAssetToCollection:
         assert len(updated["assets"]) == 2
 
 
-class TestTrackThumbnailInVersions:
-    """Tests for track_thumbnail_in_versions (Issue #519).
+class TestTrackGeneratedAssetsInVersions:
+    """Tests for _track_generated_assets_in_versions (Issue #519).
 
-    Thumbnails generated in the PMTiles side-step must be tracked in
-    versions.json with a checksum, size, and mtime — just like PMTiles —
-    so sync can verify integrity and skip unchanged thumbnails.
+    Generated side-step artifacts (PMTiles, thumbnail) must be tracked in
+    versions.json with a checksum, size, and mtime so sync can verify integrity
+    and skip unchanged files. PMTiles and its thumbnail share ONE version
+    snapshot, not two.
     """
 
     @staticmethod
@@ -323,9 +325,9 @@ class TestTrackThumbnailInVersions:
         (collection_dir / "versions.json").write_text(json.dumps(versions_json))
 
     @pytest.mark.unit
-    def test_thumbnail_tracked_with_checksum_size_mtime(self, tmp_path: Path) -> None:
+    def test_asset_tracked_with_checksum_size_mtime(self, tmp_path: Path) -> None:
         """A generated thumbnail is added to versions.json as a full asset."""
-        from portolan_cli.pmtiles import track_thumbnail_in_versions
+        from portolan_cli.pmtiles import _track_generated_assets_in_versions
         from portolan_cli.versions import read_versions
 
         collection_dir = tmp_path / "demographics"
@@ -335,7 +337,9 @@ class TestTrackThumbnailInVersions:
         thumb = collection_dir / "data.thumb.png"
         thumb.write_bytes(b"\x89PNG fake-thumbnail-bytes")
 
-        track_thumbnail_in_versions(collection_dir, thumb, tmp_path)
+        _track_generated_assets_in_versions(
+            collection_dir, [thumb], tmp_path, message="Generated thumbnail: data.thumb.png"
+        )
 
         versions = read_versions(collection_dir / "versions.json")
         assert versions.current_version == "1.0.1"
@@ -355,9 +359,58 @@ class TestTrackThumbnailInVersions:
         assert "data.thumb.png" in latest.changes
 
     @pytest.mark.unit
+    def test_pmtiles_and_thumbnail_share_one_version(self, tmp_path: Path) -> None:
+        """PMTiles + thumbnail tracked together land in a SINGLE version (Issue #519)."""
+        from portolan_cli.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import read_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+        self._write_versions(collection_dir)
+
+        pmtiles = collection_dir / "data.pmtiles"
+        pmtiles.write_bytes(b"PMTILES")
+        thumb = collection_dir / "data.thumb.jpg"
+        thumb.write_bytes(b"\xff\xd8\xff jpeg")
+
+        _track_generated_assets_in_versions(
+            collection_dir, [pmtiles, thumb], tmp_path, message="Generated PMTiles and thumbnail"
+        )
+
+        versions = read_versions(collection_dir / "versions.json")
+        # One bump (1.0.0 -> 1.0.1), not two.
+        assert len(versions.versions) == 2
+        assert versions.current_version == "1.0.1"
+        latest = versions.versions[-1].assets
+        assert "data.pmtiles" in latest
+        assert "data.thumb.jpg" in latest
+
+    @pytest.mark.unit
+    def test_only_if_missing_skips_already_tracked(self, tmp_path: Path) -> None:
+        """only_if_missing creates no version when every asset is already tracked."""
+        from portolan_cli.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import read_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+        self._write_versions(collection_dir)
+
+        parquet = collection_dir / "data.parquet"  # already tracked in fixture
+        parquet.write_bytes(b"PAR1")
+
+        _track_generated_assets_in_versions(
+            collection_dir, [parquet], tmp_path, message="Backfill", only_if_missing=True
+        )
+
+        versions = read_versions(collection_dir / "versions.json")
+        # No new version: data.parquet is already in the latest snapshot.
+        assert len(versions.versions) == 1
+        assert versions.current_version == "1.0.0"
+
+    @pytest.mark.unit
     def test_creates_versions_file_when_missing(self, tmp_path: Path) -> None:
         """First-ever version is created at 1.0.0 if versions.json is absent."""
-        from portolan_cli.pmtiles import track_thumbnail_in_versions
+        from portolan_cli.pmtiles import _track_generated_assets_in_versions
         from portolan_cli.versions import read_versions
 
         collection_dir = tmp_path / "demographics"
@@ -366,23 +419,27 @@ class TestTrackThumbnailInVersions:
         thumb = collection_dir / "data.thumb.png"
         thumb.write_bytes(b"\x89PNG fake-thumbnail-bytes")
 
-        track_thumbnail_in_versions(collection_dir, thumb, tmp_path)
+        _track_generated_assets_in_versions(
+            collection_dir, [thumb], tmp_path, message="Generated thumbnail: data.thumb.png"
+        )
 
         versions = read_versions(collection_dir / "versions.json")
         assert versions.current_version == "1.0.0"
         assert "data.thumb.png" in versions.versions[-1].assets
 
     @pytest.mark.unit
-    def test_raises_when_thumbnail_missing(self, tmp_path: Path) -> None:
-        """A missing thumbnail file is a hard error (no phantom asset)."""
-        from portolan_cli.pmtiles import track_thumbnail_in_versions
+    def test_raises_when_asset_missing(self, tmp_path: Path) -> None:
+        """A missing asset file is a hard error (no phantom asset)."""
+        from portolan_cli.pmtiles import _track_generated_assets_in_versions
 
         collection_dir = tmp_path / "demographics"
         collection_dir.mkdir()
         self._write_versions(collection_dir)
 
         with pytest.raises(FileNotFoundError):
-            track_thumbnail_in_versions(collection_dir, collection_dir / "data.thumb.png", tmp_path)
+            _track_generated_assets_in_versions(
+                collection_dir, [collection_dir / "data.thumb.png"], tmp_path, message="x"
+            )
 
 
 class TestGeneratePMTiles:
@@ -679,11 +736,13 @@ class TestGeneratePMTilesForCollection:
 
     @pytest.mark.unit
     def test_generated_thumbnail_tracked_in_versions(self, tmp_path: Path) -> None:
-        """Thumbnail from the PMTiles side-step lands in versions.json (Issue #519).
+        """PMTiles and thumbnail land in ONE versions.json snapshot (Issue #519).
 
         Regression: the side-step registered the thumbnail in collection.json
         but never tracked it in versions.json, so it shipped without a
-        checksum/size and sync could not verify it.
+        checksum/size and sync could not verify it. A second regression had the
+        PMTiles and thumbnail each bump their own version (two snapshots for one
+        side-step); they must now share a single version snapshot.
         """
         from portolan_cli.pmtiles import generate_pmtiles_for_collection
         from portolan_cli.versions import read_versions
@@ -741,6 +800,11 @@ class TestGeneratePMTilesForCollection:
         assert pmtiles_path in result.generated
 
         versions = read_versions(collection_dir / "versions.json")
+        # One side-step == one new version snapshot, not two (Issue #519).
+        # The old double-bump behavior produced 3 versions here.
+        assert len(versions.versions) == 2, (
+            "PMTiles + thumbnail must share a single version snapshot, not bump twice"
+        )
         all_tracked = versions.versions[-1].assets
         assert "data.pmtiles" in all_tracked, "PMTiles should still be tracked"
         assert "data.thumb.png" in all_tracked, (
@@ -750,6 +814,83 @@ class TestGeneratePMTilesForCollection:
         assert thumb_asset.sha256
         assert thumb_asset.size_bytes == thumb_path.stat().st_size
         assert thumb_asset.href == "demographics/data.thumb.png"
+
+    @pytest.mark.unit
+    def test_skip_path_backfills_untracked_thumbnail(self, tmp_path: Path) -> None:
+        """Skip path backfills artifacts left untracked by the old code (Issue #519).
+
+        When PMTiles is up-to-date, generation is skipped. A thumbnail generated
+        before tracking existed (present on disk, in collection.json, but absent
+        from versions.json) must be backfilled — without forcing regeneration —
+        and in exactly one version bump.
+        """
+        from portolan_cli.pmtiles import generate_pmtiles_for_collection
+        from portolan_cli.versions import read_versions
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir()
+
+        collection_json = {
+            "type": "Collection",
+            "assets": {
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                }
+            },
+        }
+        (collection_dir / "collection.json").write_text(json.dumps(collection_json))
+
+        # Source parquet OLDER than pmtiles -> _should_generate returns False.
+        parquet = collection_dir / "data.parquet"
+        parquet.write_bytes(b"PAR1")
+        pmtiles = collection_dir / "data.pmtiles"
+        pmtiles.write_bytes(b"PMTILES")
+        # Thumbnail uses the .thumb.jpg convention (thumbnail_path_for).
+        thumb = collection_dir / "data.thumb.jpg"
+        thumb.write_bytes(b"\xff\xd8\xff fake-jpeg-bytes")
+
+        old = parquet.stat().st_mtime - 100
+        os.utime(parquet, (old, old))
+
+        # versions.json tracks neither the pmtiles nor the thumbnail yet.
+        versions_json = {
+            "spec_version": "1.0.0",
+            "current_version": "1.0.0",
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "created": "2026-01-01T00:00:00Z",
+                    "breaking": False,
+                    "assets": {},
+                    "changes": [],
+                }
+            ],
+        }
+        (collection_dir / "versions.json").write_text(json.dumps(versions_json))
+
+        mock_module = MagicMock()
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                result = generate_pmtiles_for_collection(collection_dir, tmp_path)
+
+        assert pmtiles in result.skipped, "Up-to-date PMTiles should be skipped, not regenerated"
+
+        versions = read_versions(collection_dir / "versions.json")
+        # Exactly one backfill version bump.
+        assert len(versions.versions) == 2
+        latest = versions.versions[-1].assets
+        assert "data.pmtiles" in latest, "Untracked PMTiles should be backfilled on skip"
+        assert "data.thumb.jpg" in latest, "Untracked thumbnail should be backfilled on skip"
+
+        # Idempotent: a second run with everything tracked creates NO new version.
+        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+            with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                generate_pmtiles_for_collection(collection_dir, tmp_path)
+        versions_after = read_versions(collection_dir / "versions.json")
+        assert len(versions_after.versions) == 2, (
+            "Backfill must not bump a version when everything is already tracked"
+        )
 
 
 # Integration tests that require tippecanoe

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -883,6 +883,14 @@ class TestGeneratePMTilesForCollection:
         assert "data.pmtiles" in latest, "Untracked PMTiles should be backfilled on skip"
         assert "data.thumb.jpg" in latest, "Untracked thumbnail should be backfilled on skip"
 
+        # The thumbnail must also be (re-)registered as a STAC asset on skip, so a
+        # backfilled versions.json entry is never orphaned from collection.json.
+        coll_json = json.loads((collection_dir / "collection.json").read_text())
+        thumb_assets = [
+            k for k, v in coll_json["assets"].items() if "thumbnail" in v.get("roles", [])
+        ]
+        assert thumb_assets, "Backfilled thumbnail must be registered as a STAC asset"
+
         # Idempotent: a second run with everything tracked creates NO new version.
         with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
             with patch("portolan_cli.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):


### PR DESCRIPTION
Fixes #519

## Problem

Thumbnails generated in the PMTiles side-step of `portolan add` were registered as STAC assets in `collection.json` but **never tracked in `versions.json`**. The PMTiles file from the *same* side-step *was* tracked — the thumbnail was the odd one out:

```json
"assets": {
  "data.parquet":  {...},
  "data.pmtiles":  {...}
  // thumbnail missing
}
```

Without an entry in `versions.json` a thumbnail ships with no SHA256/size, so its integrity can't be verified, regeneration isn't recorded in version history, and sync can't skip an unchanged thumbnail.

## Root cause

`generate_pmtiles_for_collection` (`pmtiles.py`) calls `track_pmtiles_in_versions(...)` after generating the PMTiles, but the thumbnail block immediately below it only called `add_thumbnail_asset_to_collection(...)` (STAC) — there was no matching `versions.json` tracking call.

## Fix

- Add `track_thumbnail_in_versions`, mirroring `track_pmtiles_in_versions`, and call it right after the thumbnail is registered as a STAC asset.
- Both functions now delegate to a shared `_track_generated_asset_in_versions` helper, so the checksum/size/mtime/href + version-bump logic lives in one place (keeps the duplicate-code gate at 10/10).
- The thumbnail is tracked with SHA256, size, mtime, a catalog-root-relative href, and shows up in the version's `changes` array when (re)generated.

The thumbnail tracking is inside the existing decoupled `try/except`, so a tracking failure logs a warning and never fails the add (consistent with "thumbnail failure shouldn't affect PMTiles success").

## Behavior change

A side-step that generates a PMTiles **and** a thumbnail now produces two version bumps (one per generated artifact), each with its own `changes` entry — the same per-artifact tracking pattern PMTiles already used. Updated `test_version_tracked` accordingly.

## Tests

- `TestTrackThumbnailInVersions` — unit tests: tracked with checksum/size/mtime + href, `changes` entry, creates `versions.json` when absent, raises on a missing file.
- `test_generated_thumbnail_tracked_in_versions` — wiring regression: the thumbnail from `generate_pmtiles_for_collection` lands in `versions.json` (red before the fix).
- `test_version_tracked` (integration) — updated to assert both `roads.pmtiles` and `roads.thumb.jpg` are tracked.

Quality gates: full unit tier (4504 passed), pmtiles + thumbnail integration suites, `mypy --strict`, `ruff`, `lint-imports`, and the R0801 duplicate-code check all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PMTiles and thumbnail assets are now recorded together in a single version snapshot, including SHA-256 checksums and file sizes for each asset
  * Added backfill capability to track previously generated artifacts without creating unnecessary version bumps

* **Improvements**
  * Centralized thumbnail file naming convention for consistency across the system

<!-- end of auto-generated comment: release notes by coderabbit.ai -->