### PR TITLE
fix(readme): suppress technical-slug keyword badge wall (#515)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -921,7 +921,7 @@ The `portolan readme` command generates `README.md` by combining:
 - Upstream version (with optional URL)
 - Known issues
 - Source URL, processing notes
-- Keywords (as [shields.io](https://shields.io) badges with proper URL encoding)
+- Keywords (as [shields.io](https://shields.io) badges with proper URL encoding). Technical slugs (snake_case ids, `field:value` summary entries, short alphanumeric codes) are filtered out; a junk-dominated list seeded from extraction is suppressed entirely, and an otherwise-curated list is truncated to a readable count, so machine-generated tags never bury the description.
 - Attribution
 
 ```bash

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -31,11 +31,18 @@ Usage:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
 from portolan_cli.config import load_merged_metadata
+
+# Keyword-badge rendering limits (#515). A junk-dominated list is a machine dump
+# (e.g. WFS layer ids seeded into metadata.yaml at extraction) and is suppressed;
+# an otherwise-curated list is filtered then truncated to a readable count.
+MAX_KEYWORD_BADGES = 12  # cap on rendered badges (curated lists are truncated)
+TECHNICAL_KEYWORD_RATIO = 0.6  # >60% technical entries -> non-curated dump -> omit
 
 
 def _format_size(size_bytes: int) -> str:
@@ -354,23 +361,68 @@ def _add_version_section(sections: list[str], metadata: dict[str, Any]) -> None:
     sections.append("")
 
 
-def _add_keywords_section(sections: list[str], metadata: dict[str, Any]) -> None:
-    """Add keywords as shield.io badges.
+def _is_meaningful_keyword(keyword: str) -> bool:
+    """Return True if a keyword is a meaningful discovery term, not a slug (#515).
 
-    Renders keywords as visual badges for quick scanning and
-    potential use in search/filtering.
+    Filters out the technical junk that extraction seeds verbatim into
+    ``metadata.yaml`` (WFS layer ids, FACC codes, STAC summary values). The junk
+    is characterised by structure, not case: lowercase common nouns (``census``,
+    ``roads``) are valid keywords and must be kept, so this deliberately does
+    *not* reuse :func:`is_technical_name`, which is title-oriented and treats
+    any lowercase single word as a slug.
+
+    Dropped: anything with an underscore (``vial_nacional``,
+    ``lineas_de_geomorfologia_CA010``), a colon (``orden:30``, ``ns:Name``), or a
+    short letters-then-digits code (``AP010``, ``DB120``). Kept: ``census``,
+    ``land use``, ``Provincia``, ``COVID19``.
+    """
+    text = keyword.strip()
+    if not text:
+        return False
+    # snake_case slugs and WFS layer ids.
+    if "_" in text:
+        return False
+    # field:value summary entries (orden:30) and namespace prefixes (ns:Name).
+    if ":" in text:
+        return False
+    # Short alphanumeric codes (FACC: AP010, DB120, BH020, CA010).
+    if len(text) <= 8 and re.fullmatch(r"[A-Za-z]{1,3}\d{1,4}[A-Za-z0-9]*", text):
+        return False
+    return True
+
+
+def _add_keywords_section(sections: list[str], metadata: dict[str, Any]) -> None:
+    """Add curated keywords as shield.io badges.
+
+    Renders keywords as visual badges for quick scanning. Technical junk is
+    filtered out; a junk-dominated list (a machine dump rather than curated
+    keywords) is omitted entirely so it cannot bury the description, and an
+    otherwise-curated list is truncated to a readable count (#515).
     """
     keywords = metadata.get("keywords")
-    if not keywords or not isinstance(keywords, list) or len(keywords) == 0:
+    if not keywords or not isinstance(keywords, list):
+        return
+    kws = [str(k).strip() for k in keywords if str(k).strip()]
+    if not kws:
+        return
+
+    meaningful = [k for k in kws if _is_meaningful_keyword(k)]
+    if not meaningful:
+        return
+
+    # A junk-dominated list is a machine dump, not curation -> omit. The
+    # proportion (not the length) is the signal: it tells a real curated list
+    # from one where a few clean tokens survived by coincidence.
+    technical_ratio = (len(kws) - len(meaningful)) / len(kws)
+    if technical_ratio > TECHNICAL_KEYWORD_RATIO:
         return
 
     badges = []
-    for keyword in keywords:
+    for keyword_str in meaningful[:MAX_KEYWORD_BADGES]:
         # Shield.io badge format requires:
         # - Spaces become underscores (or %20)
         # - Hyphens become double hyphens (--)
         # - Other special chars need URL encoding
-        keyword_str = str(keyword)
         # First handle shield.io-specific escaping
         safe_keyword = keyword_str.replace("-", "--")
         # Then URL-encode the rest (safe='' encodes everything except alphanumerics)

--- a/tests/unit/test_readme_catalog_aggregation.py
+++ b/tests/unit/test_readme_catalog_aggregation.py
@@ -198,6 +198,64 @@ class TestGenerateCatalogReadme:
         assert "# My Data Catalog" in readme
 
     @pytest.mark.unit
+    def test_omits_seeded_junk_keyword_wall(self, tmp_path: Path) -> None:
+        """A catalog seeded with a junk keyword dump renders no badge wall (#515).
+
+        Reproduces the IGN Argentina case: extraction seeds hundreds of WFS
+        layer ids / FACC codes into catalog .portolan/metadata.yaml. The catalog
+        README must not render them as badges and bury the description.
+        """
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "ign-argentina",
+                    "title": "IGN Argentina",
+                    "description": "Geospatial reference data from IGN Argentina.",
+                }
+            )
+        )
+        # Seed a junk keyword dump (the kind extraction writes verbatim) plus a
+        # couple of clean terms.
+        junk = [f"vial_AP{i:03d}" for i in range(40)] + ["AP010", "orden:30"]
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "metadata.yaml").write_text(
+            "keywords:\n" + "".join(f"  - {k}\n" for k in junk + ["roads", "census"])
+        )
+
+        readme = generate_catalog_readme(tmp_path)
+
+        # The long, junk-dominated list is suppressed entirely.
+        assert "shields.io" not in readme
+        assert "vial_AP000" not in readme
+        assert "AP010" not in readme
+        # The description still renders.
+        assert "Geospatial reference data from IGN Argentina." in readme
+
+    @pytest.mark.unit
+    def test_renders_curated_catalog_keywords(self, tmp_path: Path) -> None:
+        """A small curated keyword list still renders as badges (#515)."""
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "census",
+                    "title": "Census Catalog",
+                    "description": "Curated census data.",
+                }
+            )
+        )
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "metadata.yaml").write_text(
+            "keywords:\n  - census\n  - demographics\n  - population\n"
+        )
+
+        readme = generate_catalog_readme(tmp_path)
+
+        assert "![census]" in readme
+        assert "shields.io" in readme
+
+    @pytest.mark.unit
     def test_includes_collections_section(self, tmp_path: Path) -> None:
         """Catalog README should list collections."""
         (tmp_path / "catalog.json").write_text(

--- a/tests/unit/test_readme_metadata_sections.py
+++ b/tests/unit/test_readme_metadata_sections.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 import pytest
 
 from portolan_cli.readme import (
+    MAX_KEYWORD_BADGES,
     _add_attribution_section,
     _add_keywords_section,
     _add_processing_section,
     _add_source_section,
+    _is_meaningful_keyword,
     generate_readme,
 )
 
@@ -137,6 +139,103 @@ class TestKeywordsSection:
 
         # Spaces should be encoded as %20 or replaced with underscores
         assert "land" in sections[0].lower()
+
+    @pytest.mark.unit
+    def test_truncates_long_curated_list(self) -> None:
+        """A long but clean list is truncated, not omitted (#515).
+
+        Regression guard: the dump signal is the technical ratio, not the
+        length, so a genuinely curated long list still renders (capped).
+        """
+        sections: list[str] = []
+        # 20 clean, meaningful keywords (ratio 0.0).
+        metadata = {"keywords": [f"Theme{chr(65 + i)}" for i in range(20)]}
+
+        _add_keywords_section(sections, metadata)
+
+        output = "\n".join(sections)
+        assert output.count("shields.io") == MAX_KEYWORD_BADGES
+
+    @pytest.mark.unit
+    def test_omits_when_mostly_technical(self) -> None:
+        """A junk-dominated list (>60% technical) is omitted entirely (#515)."""
+        sections: list[str] = []
+        # 4 of 5 are technical (ratio 0.8).
+        metadata = {"keywords": ["census", "AP010", "orden:30", "vial_nacional", "DB120"]}
+
+        _add_keywords_section(sections, metadata)
+
+        assert len(sections) == 0
+
+    @pytest.mark.unit
+    def test_drops_junk_keeps_meaningful(self) -> None:
+        """In a clean-majority list, technical keywords are dropped (#515)."""
+        sections: list[str] = []
+        # ratio 0.33 technical - not a dump, so render the meaningful ones.
+        metadata = {"keywords": ["census", "demographics", "AP010"]}
+
+        _add_keywords_section(sections, metadata)
+
+        output = "\n".join(sections)
+        assert "![census]" in output
+        assert "![demographics]" in output
+        assert "AP010" not in output
+
+    @pytest.mark.unit
+    def test_caps_badge_count(self) -> None:
+        """No more than MAX_KEYWORD_BADGES badges are rendered (#515)."""
+        sections: list[str] = []
+        # 14 distinct meaningful keywords: under the dump threshold, over the cap.
+        metadata = {"keywords": [f"Theme{chr(65 + i)}" for i in range(14)]}
+
+        _add_keywords_section(sections, metadata)
+
+        output = "\n".join(sections)
+        assert output.count("shields.io") == MAX_KEYWORD_BADGES
+
+    @pytest.mark.unit
+    def test_omits_when_all_junk(self) -> None:
+        """A list of only technical slugs renders nothing (the IGN case) (#515)."""
+        sections: list[str] = []
+        metadata = {"keywords": ["AP010", "orden:30", "vial_nacional"]}
+
+        _add_keywords_section(sections, metadata)
+
+        assert len(sections) == 0
+
+
+class TestIsMeaningfulKeyword:
+    """Tests for _is_meaningful_keyword (the keyword-quality predicate, #515)."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "keyword",
+        ["census", "demographics", "Provincia", "land use", "COVID19"],
+    )
+    def test_keeps_meaningful_keywords(self, keyword: str) -> None:
+        """Human-readable discovery terms are kept."""
+        assert _is_meaningful_keyword(keyword) is True
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "keyword",
+        [
+            "AP010",  # FACC code (is_technical_name gap)
+            "DB120",
+            "BH020",
+            "CA010",
+            "orden:30",  # STAC summary value
+            "ns:Name",  # namespace prefix
+            "Foo:Bar",  # colon-bearing, uppercase (is_technical_name gap)
+            "vial_nacional",  # snake_case slug
+            "vial_AP050",
+            "lineas_de_geomorfologia_CA010",  # WFS layer id
+            "",  # empty
+        ],
+    )
+    def test_drops_technical_keywords(self, keyword: str) -> None:
+        """Technical slugs, codes, and summary values are dropped."""
+        assert _is_meaningful_keyword(keyword) is False
 
 
 class TestAttributionSection:


### PR DESCRIPTION
## Problem

`portolan readme` rendered one shields.io badge per entry in `metadata["keywords"]`, with no filtering or cap. For catalogs seeded from WFS/ArcGIS extraction this dumps hundreds of technical slugs as badges, burying the description below the fold and making the catalog look broken in every viewer (Portolan web, STAC Browser, GitHub).

Real example — the IGN Argentina catalog seeds **184** keywords into the catalog-level `.portolan/metadata.yaml`: WFS layer ids (`lineas_de_geomorfologia_CA010`), FACC codes (`AP010`, `DB120`), STAC summary values (`orden:30`), collection slugs (`vial_nacional`). All 184 rendered as badges.

Closes #515.

## Fix

Deterministic fix at **render time** in `_add_keywords_section` (`portolan_cli/readme.py`), so it is robust to any keyword source and repairs already-extracted catalogs without re-extraction. The same function feeds both catalog and collection READMEs.

- **`_is_meaningful_keyword`** — drops entries with underscores (`vial_nacional`), colons (`orden:30`, `ns:Name`), or short letters-then-digits codes (`AP010`, `DB120`). It deliberately does **not** reuse `is_technical_name`, which is title-oriented and would wrongly drop lowercase common-noun keywords like `census` / `roads`.
- **Omit when junk-dominated** (>60% technical). The *proportion*, not the length, distinguishes a machine dump from a genuinely curated list. IGN's ratio is **0.97** → section omitted, description renders at the top.
- **Truncate** an otherwise-curated list to `MAX_KEYWORD_BADGES` (12), so a long-but-clean list still renders instead of vanishing.

Human keyword curation continues via the `metadata.yaml` `keywords` field (ADR-0038); this only governs how that field renders.

### Effect on IGN Argentina

| | before | after |
|---|---|---|
| badges rendered | 184 | 0 (suppressed; description at top) |

A small curated list (e.g. `census`, `demographics`, `population`) still renders as badges as before.

## Tests

- `TestIsMeaningfulKeyword` — parametrized keep/drop table (keeps `census`, `Provincia`, `land use`, `COVID19`; drops FACC codes, colon/summary entries, snake_case slugs).
- `TestKeywordsSection` — junk-dominated omit, all-junk omit, drop-junk-keep-meaningful, cap, and a regression guard that a long *clean* list is truncated (not omitted).
- `test_readme_catalog_aggregation.py` — end-to-end through `generate_catalog_readme` → `load_merged_metadata`: a seeded junk dump renders no badge wall and the description survives; a curated list still renders.

All 88 readme tests pass · mypy strict clean · ruff clean · import contracts kept · xenon OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keywords now intelligently filtered to remove technical junk and machine-generated entries
  * Keyword lists automatically truncated to a readable count
  * Enhanced keyword badge rendering with proper URL encoding

* **Documentation**
  * Updated keyword behavior documentation with new filtering and truncation rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->