### PR TITLE
fix(stac): stop PMTiles 3857 from clobbering source CRS in proj:epsg (#488)

### DIFF
--- a/portolan_cli/metadata/geoparquet.py
+++ b/portolan_cli/metadata/geoparquet.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Any, Literal, overload
 
 import pyarrow.parquet as pq
+from pyproj import CRS
+from pyproj.exceptions import CRSError
 
 from portolan_cli.models.schema import ColumnSchema, SchemaModel
 
@@ -47,9 +49,41 @@ class GeoParquetMetadata:
             "schema": self.schema,
         }
 
+    def _crs_to_epsg(self) -> int | None:
+        """Resolve the CRS to an EPSG code, or None if unavailable.
+
+        ``crs`` may be an EPSG/WKT/OGC-URN string or a PROJJSON dict. A PROJJSON
+        dict that already carries ``id.code`` is read directly (mirroring
+        ``_extract_crs``); otherwise pyproj resolves it.
+        """
+        crs = self.crs
+        if crs is None:
+            return None
+
+        if isinstance(crs, dict):
+            code = crs.get("id", {}).get("code")
+            if code is not None:
+                try:
+                    return int(code)
+                except (TypeError, ValueError):
+                    pass
+
+        try:
+            return CRS.from_user_input(crs).to_epsg()
+        except CRSError:
+            return None  # Unknown CRS format, skip proj:epsg
+
     def to_stac_properties(self) -> dict[str, Any]:
         """Convert to STAC Item properties format."""
         props: dict[str, Any] = {}
+
+        # Derive proj:epsg from the file's real CRS (issue #488). Without this
+        # a GeoParquet collection-level asset contributes no CRS, so a tracked
+        # .pmtiles companion's hardcoded 3857 (the Web-Mercator tiles) becomes
+        # the collection's proj:epsg.
+        epsg = self._crs_to_epsg()
+        if epsg is not None:
+            props["proj:epsg"] = epsg
 
         if self.geometry_type:
             props["geoparquet:geometry_type"] = self.geometry_type

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -430,9 +430,16 @@ def add_collection_properties_from_metadata(
     should be applied directly to the collection instead of an item.
 
     Handles:
-    - PMTilesMetadata: proj:epsg=3857, pmtiles:* properties
+    - PMTilesMetadata: pmtiles:* properties, and proj:epsg=3857 only as a
+      fallback (the 3857 describes the Web-Mercator tiles, not the source data)
     - FlatGeobufMetadata: proj:epsg from CRS, flatgeobuf:* properties
     - GeoParquetMetadata: proj:epsg from CRS (table extension handled separately)
+
+    The collection-level ``proj:epsg`` must reflect the source *data* CRS. A
+    tracked ``.pmtiles`` companion (ADR-0028 tracks all files) reports a
+    hardcoded ``proj:epsg: 3857`` for its tiles; that visualization artifact
+    must never overwrite a real source CRS contributed by the vector data asset,
+    regardless of the order assets are applied (issue #488).
 
     Args:
         collection: The collection to add properties to.
@@ -445,8 +452,15 @@ def add_collection_properties_from_metadata(
     if not props:
         return
 
+    from portolan_cli.metadata.pmtiles import PMTilesMetadata
+
+    is_pmtiles = isinstance(metadata, PMTilesMetadata)
+
     # Add properties to collection.extra_fields (STAC collection properties)
     for key, value in props.items():
+        # PMTiles tile CRS is a fallback: never clobber a real source-data CRS.
+        if key == "proj:epsg" and is_pmtiles and "proj:epsg" in collection.extra_fields:
+            continue
         collection.extra_fields[key] = value
 
     # Add projection extension declaration if proj:epsg is present

--- a/tests/unit/test_collection_proj_epsg_488.py
+++ b/tests/unit/test_collection_proj_epsg_488.py
@@ -1,0 +1,79 @@
+"""Regression tests for issue #488.
+
+`portolan add` wrote ``proj:epsg: 3857`` into a collection regardless of the
+source data's real CRS. Root cause: a tracked ``.pmtiles`` companion contributes
+a hardcoded ``proj:epsg: 3857`` (the Web-Mercator *tiles*), and the GeoParquet
+vector asset contributed no ``proj:epsg`` at all, so the tile CRS became the
+collection's CRS.
+
+The collection-level ``proj:epsg`` must reflect the source *data* CRS. The
+PMTiles tile CRS is a visualization artifact and must never overwrite a real
+source CRS, regardless of the order the assets are applied.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portolan_cli.metadata.geoparquet import GeoParquetMetadata
+from portolan_cli.metadata.pmtiles import PMTilesMetadata
+from portolan_cli.stac import add_collection_properties_from_metadata, create_collection
+
+
+def _geoparquet(crs: str) -> GeoParquetMetadata:
+    return GeoParquetMetadata(
+        bbox=None,
+        crs=crs,
+        geometry_type="Polygon",
+        geometry_column="standardized_location",
+        feature_count=10,
+        schema={},
+    )
+
+
+def _pmtiles() -> PMTilesMetadata:
+    return PMTilesMetadata(
+        bbox=(-180.0, -90.0, 180.0, 90.0),
+        min_zoom=0,
+        max_zoom=14,
+        tile_type="mvt",
+        center=None,
+        layer_name="data",
+    )
+
+
+class TestCollectionProjEpsg488:
+    @pytest.mark.unit
+    def test_pmtiles_does_not_clobber_geoparquet_crs(self) -> None:
+        """GeoParquet applied first, then PMTiles: real CRS must survive."""
+        collection = create_collection(
+            collection_id="soil-maps",
+            description="Soil maps in RD New.",
+        )
+        add_collection_properties_from_metadata(collection, _geoparquet("EPSG:4258"))
+        add_collection_properties_from_metadata(collection, _pmtiles())
+
+        assert collection.extra_fields["proj:epsg"] == 4258
+
+    @pytest.mark.unit
+    def test_geoparquet_crs_wins_regardless_of_order(self) -> None:
+        """PMTiles applied first, then GeoParquet: real CRS must still win."""
+        collection = create_collection(
+            collection_id="soil-maps",
+            description="Soil maps in RD New.",
+        )
+        add_collection_properties_from_metadata(collection, _pmtiles())
+        add_collection_properties_from_metadata(collection, _geoparquet("EPSG:28992"))
+
+        assert collection.extra_fields["proj:epsg"] == 28992
+
+    @pytest.mark.unit
+    def test_pmtiles_only_collection_still_reports_tile_crs(self) -> None:
+        """With no vector source CRS, PMTiles 3857 remains a valid fallback."""
+        collection = create_collection(
+            collection_id="tiles-only",
+            description="A PMTiles-only collection.",
+        )
+        add_collection_properties_from_metadata(collection, _pmtiles())
+
+        assert collection.extra_fields["proj:epsg"] == 3857

--- a/tests/unit/test_metadata_geoparquet.py
+++ b/tests/unit/test_metadata_geoparquet.py
@@ -154,6 +154,63 @@ class TestGeoParquetMetadata:
         # geometry_type should not be included if None
         assert "geoparquet:geometry_type" not in props
 
+    @pytest.mark.unit
+    def test_to_stac_properties_includes_proj_epsg_from_epsg_string(self) -> None:
+        """to_stac_properties() derives proj:epsg from an EPSG-string CRS (issue #488)."""
+        metadata = GeoParquetMetadata(
+            bbox=None,
+            crs="EPSG:4258",
+            geometry_type="Polygon",
+            geometry_column="standardized_location",
+            feature_count=5,
+            schema={},
+        )
+        props = metadata.to_stac_properties()
+        # The collection proj:epsg must reflect the file's real CRS, not 3857.
+        assert props["proj:epsg"] == 4258
+
+    @pytest.mark.unit
+    def test_to_stac_properties_includes_proj_epsg_from_projected_crs(self) -> None:
+        """to_stac_properties() derives proj:epsg from a projected CRS (issue #488)."""
+        metadata = GeoParquetMetadata(
+            bbox=None,
+            crs="EPSG:28992",
+            geometry_type="Polygon",
+            geometry_column="geom",
+            feature_count=5,
+            schema={},
+        )
+        props = metadata.to_stac_properties()
+        assert props["proj:epsg"] == 28992
+
+    @pytest.mark.unit
+    def test_to_stac_properties_includes_proj_epsg_from_projjson(self) -> None:
+        """to_stac_properties() derives proj:epsg from a PROJJSON dict CRS (issue #488)."""
+        metadata = GeoParquetMetadata(
+            bbox=None,
+            crs={"type": "GeographicCRS", "id": {"authority": "EPSG", "code": 4258}},
+            geometry_type="Polygon",
+            geometry_column="geometry",
+            feature_count=5,
+            schema={},
+        )
+        props = metadata.to_stac_properties()
+        assert props["proj:epsg"] == 4258
+
+    @pytest.mark.unit
+    def test_to_stac_properties_omits_proj_epsg_when_crs_none(self) -> None:
+        """to_stac_properties() omits proj:epsg when CRS is unknown."""
+        metadata = GeoParquetMetadata(
+            bbox=None,
+            crs=None,
+            geometry_type="Point",
+            geometry_column="geometry",
+            feature_count=5,
+            schema={},
+        )
+        props = metadata.to_stac_properties()
+        assert "proj:epsg" not in props
+
 
 class TestProjectedCRS:
     """Tests for projected CRS extraction from GeoParquet."""


### PR DESCRIPTION
## Summary

Fixes #488. `portolan add` wrote `proj:epsg: 3857` into a collection regardless of the source data's real CRS — datasets in EPSG:4258 (ETRS89) and EPSG:28992 (RD New) were all reported as Web Mercator. The geometry read fine (bbox correct in WGS84); only `proj:epsg` was wrong.

This is **not** the same bug as geoparquet-io#499 / PR #500 (which fixes WFS-extraction CRS mislabeling in the file gpio *creates*). Here the on-disk GeoParquet's `geo` metadata is already correct; the wrong value is introduced entirely in portolan's own STAC-generation layer.

## Root cause (two compounding defects)

1. `GeoParquetMetadata.to_stac_properties()` emitted **no `proj:epsg`** — unlike the FlatGeobuf extractor. So a GeoParquet collection-level asset contributed no CRS to the collection. (The stac.py docstring claiming it did was stale.)
2. A tracked `.pmtiles` companion (ADR-0028 tracks all files in a collection dir) reports a hardcoded `proj:epsg: 3857` for its Web-Mercator *tiles*. With nothing else setting `proj:epsg`, that `3857` became the collection's CRS.

## Fix

- **`metadata/geoparquet.py`** — derive `proj:epsg` from the file's real CRS via pyproj, handling EPSG/WKT/OGC-URN strings and PROJJSON dicts (mirrors the FlatGeobuf extractor and the `id.code` shortcut already used in `_extract_crs`).
- **`stac.py`** — in `add_collection_properties_from_metadata`, treat the PMTiles tile CRS as a **fallback**: never overwrite an existing real source CRS. The vector-data CRS wins regardless of asset-apply order; a PMTiles-only collection still reports `3857`.

Aligns with the repo rule *"Re-derive `proj:epsg` from the actual file on every add"* and *"`proj:epsg` comes from the data asset."*

## Tests (TDD — red before, green after)

- `tests/unit/test_metadata_geoparquet.py` — `proj:epsg` derived from EPSG-string, projected, and PROJJSON-dict CRS; omitted when CRS is unknown/None.
- `tests/unit/test_collection_proj_epsg_488.py` — PMTiles `3857` does not clobber a real GeoParquet CRS (both apply orders); PMTiles-only collection still reports `3857`.

All related unit/integration/spec-compliance suites pass; ruff, ruff-format, mypy --strict, and import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)