### PR TITLE
feat(check): re-optimize valid COGs via --force + parallel conversion (#530)

### DIFF
--- a/portolan_cli/check.py
+++ b/portolan_cli/check.py
@@ -31,6 +31,8 @@ from portolan_cli.convert import (
 )
 from portolan_cli.formats import (
     CloudNativeStatus,
+    FormatType,
+    detect_format,
     get_cloud_native_status,
     get_effective_status,
     is_geoparquet,
@@ -304,6 +306,8 @@ def check_directory(
     fix: bool = False,
     dry_run: bool = False,
     remove_legacy: bool = False,
+    force: bool = False,
+    workers: int | None = None,
     on_progress: Callable[[ConversionResult], None] | None = None,
     catalog_path: Path | None = None,
 ) -> CheckReport:
@@ -325,6 +329,12 @@ def check_directory(
         remove_legacy: If True, delete source files after successful conversion.
             Requires fix=True. Handles sidecars (.dbf, .shx, etc.) and
             FileGDB directories (.gdb). Only removes files converted in THIS run.
+        force: If True, also re-optimize already-cloud-native RASTERS (valid COGs)
+            by re-applying current COG settings, e.g. to add missing overviews.
+            Requires fix=True. Raster-scoped: valid GeoParquet is left untouched
+            (issue #530).
+        workers: Parallel worker processes for conversion. None/1 runs serially;
+            >1 uses a process pool. Threaded to convert_directory.
         on_progress: Optional callback for conversion progress (--fix mode).
         catalog_path: Optional catalog root for loading conversion config.
             If provided, loads conversion overrides from .portolan/config.yaml.
@@ -345,6 +355,9 @@ def check_directory(
     # Validate parameter combinations
     if remove_legacy and not fix:
         raise ValueError("remove_legacy requires fix=True")
+
+    if force and not fix:
+        raise ValueError("force requires fix=True")
 
     if not path.exists():
         raise FileNotFoundError(f"Directory not found: {path}")
@@ -382,15 +395,21 @@ def check_directory(
 
     # Handle fix mode
     if fix and not dry_run:
-        # Only convert files that are CONVERTIBLE (not cloud-native, not unsupported)
-        convertible_files = [
+        # Convert CONVERTIBLE files, plus (when --force) already-cloud-native
+        # RASTERS so valid-but-unoptimized COGs get re-encoded with current
+        # settings (issue #530). Valid vectors are never force-re-processed.
+        files_to_convert = [
             f.path for f in file_statuses if f.status == CloudNativeStatus.CONVERTIBLE
         ]
+        if force:
+            files_to_convert.extend(_forced_raster_paths(file_statuses))
         conversion_report = convert_directory(
             path,
             on_progress=on_progress,
-            file_paths=convertible_files,
+            file_paths=files_to_convert,
             catalog_path=catalog_path,
+            workers=workers,
+            force=force,
         )
         report.conversion_report = conversion_report
 
@@ -405,26 +424,68 @@ def check_directory(
                 )
 
     elif fix and dry_run:
-        # Preview mode - create results showing what would be converted
-        preview_results = [
+        # Preview mode - show what would be converted (no changes on disk).
+        report.conversion_report = ConversionReport(
+            results=_build_preview_results(file_statuses, force=force)
+        )
+        # Note: remove_legacy is ignored in dry_run mode (no actual removal)
+
+    return report
+
+
+def _forced_raster_paths(file_statuses: list[FileStatus]) -> list[Path]:
+    """Paths of already-cloud-native RASTERS eligible for --force re-optimization.
+
+    These are valid COGs that `--fix` would normally skip. Vectors are excluded
+    so `--force` only re-encodes rasters (issue #530).
+    """
+    return [
+        f.path
+        for f in file_statuses
+        if f.status == CloudNativeStatus.CLOUD_NATIVE and detect_format(f.path) == FormatType.RASTER
+    ]
+
+
+def _build_preview_results(
+    file_statuses: list[FileStatus], *, force: bool
+) -> list[ConversionResult]:
+    """Build dry-run preview ConversionResults for --fix (and --force)."""
+
+    def predicted_output(f: FileStatus) -> Path:
+        if f.target_format == "GeoParquet":
+            return f.path.parent / f"{f.path.stem}.parquet"
+        return f.path.parent / f"{f.path.stem}.tif"
+
+    previews = [
+        ConversionResult(
+            source=f.path,
+            output=predicted_output(f),
+            format_from=f.display_name,
+            format_to=f.target_format,
+            status=ConversionStatus.SUCCESS,  # Predicted outcome
+            error=None,
+            duration_ms=0,
+        )
+        for f in file_statuses
+        if f.status == CloudNativeStatus.CONVERTIBLE
+    ]
+    if force:
+        # Forced rasters re-encode in place: COG -> COG, same path.
+        forced = set(_forced_raster_paths(file_statuses))
+        previews.extend(
             ConversionResult(
                 source=f.path,
-                output=f.path.parent / f"{f.path.stem}.parquet"
-                if f.target_format == "GeoParquet"
-                else f.path.parent / f"{f.path.stem}.tif",
+                output=f.path.parent / f"{f.path.stem}.tif",
                 format_from=f.display_name,
-                format_to=f.target_format,
+                format_to="COG",
                 status=ConversionStatus.SUCCESS,  # Predicted outcome
                 error=None,
                 duration_ms=0,
             )
             for f in file_statuses
-            if f.status == CloudNativeStatus.CONVERTIBLE
-        ]
-        report.conversion_report = ConversionReport(results=preview_results)
-        # Note: remove_legacy is ignored in dry_run mode (no actual removal)
-
-    return report
+            if f.path in forced
+        )
+    return previews
 
 
 def _scan_for_files(path: Path) -> list[Path]:

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -1175,6 +1175,20 @@ def _output_combined_check_json(
     help="Remove source files after successful conversion (use with --fix)",
 )
 @click.option(
+    "--force",
+    is_flag=True,
+    help="Re-optimize already-valid COGs by re-applying current COG settings, "
+    "e.g. to add missing overviews (use with --fix; rasters only)",
+)
+@click.option(
+    "--workers",
+    "-w",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Parallel worker processes for conversion (default: auto-detect from "
+    "CPU count; use 1 for sequential). Applies to --fix.",
+)
+@click.option(
     "--metadata",
     is_flag=True,
     help="Only check/fix STAC metadata (links, schema, staleness)",
@@ -1199,6 +1213,8 @@ def check(
     fix: bool,
     dry_run: bool,
     remove_legacy: bool,
+    force: bool,
+    workers: int | None,
     metadata: bool,
     geo_assets: bool,
     strict: bool,
@@ -1245,6 +1261,14 @@ def check(
     if remove_legacy and not fix:
         warn("--remove-legacy requires --fix")
 
+    # Warn if --force is used without --fix
+    if force and not fix:
+        warn("--force requires --fix")
+
+    # Resolve worker count: auto-detect from CPU count when unset, so a large
+    # --fix run parallelizes by default (issue #530). An explicit value wins.
+    resolved_workers = workers if workers is not None else (os.cpu_count() or 1)
+
     # Determine which checks to run based on scope flags
     run_metadata, run_geo_assets, mode = _determine_check_mode(metadata, geo_assets)
 
@@ -1257,6 +1281,8 @@ def check(
         fix=fix,
         dry_run=dry_run,
         remove_legacy=remove_legacy,
+        force=force,
+        workers=resolved_workers,
         use_json=use_json,
         verbose=verbose,
         strict=strict,
@@ -1412,6 +1438,8 @@ def _execute_check_workflow(
     use_json: bool,
     verbose: bool,
     strict: bool = False,
+    force: bool = False,
+    workers: int | None = None,
 ) -> None:
     """Execute the check workflow based on flags.
 
@@ -1439,6 +1467,8 @@ def _execute_check_workflow(
             remove_legacy=remove_legacy,
             use_json=use_json,
             verbose=verbose,
+            force=force,
+            workers=workers,
         )
         return
 
@@ -1486,6 +1516,8 @@ def _run_fix_workflow(
     remove_legacy: bool,
     use_json: bool,
     verbose: bool,
+    force: bool = False,
+    workers: int | None = None,
 ) -> None:
     """Execute the fix workflow for selected scope.
 
@@ -1498,6 +1530,8 @@ def _run_fix_workflow(
         remove_legacy: Remove source files after successful conversion.
         use_json: Output JSON envelope.
         verbose: Show detailed output.
+        force: Re-optimize already-valid COGs (raster-scoped, issue #530).
+        workers: Parallel worker processes for conversion.
     """
     metadata_fix_report: FixReport | None = None
     format_fix_report = None
@@ -1561,6 +1595,8 @@ def _run_fix_workflow(
             fix=True,
             dry_run=dry_run,
             remove_legacy=remove_legacy,
+            force=force,
+            workers=workers,
             on_progress=show_conversion_progress,
             catalog_path=path,
         )

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -321,12 +321,62 @@ def _discover_style_for_thumbnail(collection_dir: Path) -> Path | None:
     return None
 
 
+def _early_exit_result(
+    source: Path,
+    format_info: Any,
+    *,
+    force: bool,
+    start_time: float,
+) -> ConversionResult | None:
+    """Return a SKIPPED/UNSUPPORTED result if no conversion should run, else None.
+
+    Cloud-native files are skipped, EXCEPT when ``force`` is set and the file is a
+    RASTER (a valid COG) — that case re-optimizes in place (issue #530), so this
+    returns None to let conversion proceed. Vectors are never force-re-processed.
+    Unsupported formats are accepted with no error (ADR-0014).
+    """
+    if format_info.status == CloudNativeStatus.CLOUD_NATIVE:
+        force_raster = force and detect_format(source) == FormatType.RASTER
+        if force_raster:
+            return None
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        return ConversionResult(
+            source=source,
+            output=None,
+            format_from=format_info.display_name,
+            format_to=None,
+            status=ConversionStatus.SKIPPED,
+            error=None,
+            duration_ms=duration_ms,
+        )
+
+    if format_info.status == CloudNativeStatus.UNSUPPORTED:
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        logger.info(
+            "Unsupported format, skipping: %s (%s)",
+            source,
+            format_info.display_name,
+        )
+        return ConversionResult(
+            source=source,
+            output=None,
+            format_from=format_info.display_name,
+            format_to=None,
+            status=ConversionStatus.UNSUPPORTED,
+            error=None,  # Not an error - just unsupported
+            duration_ms=duration_ms,
+        )
+
+    return None
+
+
 def convert_file(
     source: Path,
     output_dir: Path | None = None,
     catalog_path: Path | None = None,
     cog_settings: CogSettings | None = None,
     vector_settings: VectorSettings | None = None,
+    force: bool = False,
 ) -> ConversionResult:
     """Convert a single file to cloud-native format.
 
@@ -345,6 +395,10 @@ def convert_file(
         vector_settings: Explicit vector settings override. Takes precedence over
             ``catalog_path``-loaded settings. If None, loads from
             ``catalog_path`` or falls back to no spatial optimization.
+        force: Re-optimize an already-cloud-native RASTER by re-applying current
+            ``cog_settings`` (e.g. to add missing overviews). Raster-scoped only:
+            cloud-native vectors are still skipped (issue #530). Has no effect on
+            CONVERTIBLE or UNSUPPORTED files.
 
     Returns:
         ConversionResult with conversion outcome, timing, and paths.
@@ -360,36 +414,11 @@ def convert_file(
     # Get format info
     format_info = get_cloud_native_status(source)
 
-    # Skip if already cloud-native
-    if format_info.status == CloudNativeStatus.CLOUD_NATIVE:
-        duration_ms = int((time.perf_counter() - start_time) * 1000)
-        return ConversionResult(
-            source=source,
-            output=None,
-            format_from=format_info.display_name,
-            format_to=None,
-            status=ConversionStatus.SKIPPED,
-            error=None,
-            duration_ms=duration_ms,
-        )
-
-    # Handle unsupported formats (not an error, just not convertible)
-    if format_info.status == CloudNativeStatus.UNSUPPORTED:
-        duration_ms = int((time.perf_counter() - start_time) * 1000)
-        logger.info(
-            "Unsupported format, skipping: %s (%s)",
-            source,
-            format_info.display_name,
-        )
-        return ConversionResult(
-            source=source,
-            output=None,
-            format_from=format_info.display_name,
-            format_to=None,
-            status=ConversionStatus.UNSUPPORTED,
-            error=None,  # Not an error - just unsupported
-            duration_ms=duration_ms,
-        )
+    # Cloud-native (skip, unless forcing raster re-optimization) and unsupported
+    # files exit early without conversion.
+    early_exit = _early_exit_result(source, format_info, force=force, start_time=start_time)
+    if early_exit is not None:
+        return early_exit
 
     # Determine output directory and format type
     out_dir = output_dir if output_dir else source.parent
@@ -839,6 +868,8 @@ def convert_directory(
     recursive: bool = True,
     file_paths: list[Path] | None = None,
     catalog_path: Path | None = None,
+    workers: int | None = None,
+    force: bool = False,
 ) -> ConversionReport:
     """Convert all geospatial files in a directory to cloud-native formats.
 
@@ -857,6 +888,13 @@ def convert_directory(
             when the caller has already scanned and filtered the files.
         catalog_path: Path to the catalog root for loading conversion config.
             If None, uses ADR-0019 defaults for COG conversion.
+        workers: Number of parallel worker processes. ``None`` or ``1`` runs
+            serially (the default, so existing callers are unchanged). A value
+            > 1 uses a ``ProcessPoolExecutor`` for CPU-bound raster re-encoding
+            (issue #530). Callers wanting parallel-by-default resolve a concrete
+            count (e.g. ``os.cpu_count()``) before calling.
+        force: Re-optimize already-cloud-native rasters (passed through to
+            :func:`convert_file`). Raster-scoped; valid vectors stay skipped.
 
     Returns:
         ConversionReport with results for all processed files.
@@ -886,13 +924,42 @@ def convert_directory(
                     files.append(item)
         files.sort()
 
-    # Process each file
-    results: list[ConversionResult] = []
+    # Load conversion settings once and pass them explicitly to every file, so a
+    # large batch does not re-read .portolan/config.yaml per file (4,200+ tiles).
+    cog_settings = get_cog_settings(catalog_path) if catalog_path else None
+    vector_settings = get_vector_settings(catalog_path) if catalog_path else None
+
+    # Parallelize only when explicitly asked for (>1 worker) and there is more
+    # than one file. A single file or workers<=1 stays serial to avoid pool
+    # overhead and preserve the default behavior of every existing caller.
+    effective_workers = workers if workers is not None else 1
+    if effective_workers > 1 and len(files) > 1:
+        results = _convert_files_parallel(
+            files,
+            output_dir=output_dir,
+            catalog_path=catalog_path,
+            cog_settings=cog_settings,
+            vector_settings=vector_settings,
+            force=force,
+            on_progress=on_progress,
+            workers=effective_workers,
+        )
+        return ConversionReport(results=results)
+
+    # Serial path
+    results = []
     for file_path in files:
         # Determine output directory for this file
         file_output_dir = output_dir if output_dir else file_path.parent
 
-        result = convert_file(file_path, output_dir=file_output_dir, catalog_path=catalog_path)
+        result = convert_file(
+            file_path,
+            output_dir=file_output_dir,
+            catalog_path=catalog_path,
+            cog_settings=cog_settings,
+            vector_settings=vector_settings,
+            force=force,
+        )
         results.append(result)
 
         # Invoke callback if provided
@@ -900,6 +967,69 @@ def convert_directory(
             on_progress(result)
 
     return ConversionReport(results=results)
+
+
+def _convert_files_parallel(
+    files: list[Path],
+    *,
+    output_dir: Path | None,
+    catalog_path: Path | None,
+    cog_settings: CogSettings | None,
+    vector_settings: VectorSettings | None,
+    force: bool,
+    on_progress: Callable[[ConversionResult], None] | None,
+    workers: int,
+) -> list[ConversionResult]:
+    """Convert files concurrently with a ProcessPoolExecutor (issue #530).
+
+    Conversion is CPU/GDAL-bound, so true parallelism needs separate processes,
+    not threads. The ``on_progress`` callback is invoked in the PARENT process as
+    each future completes (it is never pickled into a worker), preserving the
+    streaming-progress contract (ADR-0040). A worker that dies or raises is
+    captured into a FAILED result so one bad file does not abort the batch.
+    """
+    import multiprocessing
+    from concurrent.futures import ProcessPoolExecutor, as_completed
+
+    # Use a "spawn" context, not fork. GDAL/rasterio run worker threads, and
+    # fork()-ing a multi-threaded process can deadlock the child (and aborts on
+    # macOS). Spawn re-imports this module cleanly in each worker.
+    mp_context = multiprocessing.get_context("spawn")
+
+    results: list[ConversionResult] = []
+    with ProcessPoolExecutor(max_workers=workers, mp_context=mp_context) as executor:
+        future_to_file = {
+            executor.submit(
+                convert_file,
+                file_path,
+                output_dir=output_dir if output_dir else file_path.parent,
+                catalog_path=catalog_path,
+                cog_settings=cog_settings,
+                vector_settings=vector_settings,
+                force=force,
+            ): file_path
+            for file_path in files
+        }
+        for future in as_completed(future_to_file):
+            file_path = future_to_file[future]
+            try:
+                result = future.result()
+            except Exception as e:  # pragma: no cover - defensive (process crash/pickle)
+                logger.exception("Parallel conversion worker failed for %s", file_path)
+                result = ConversionResult(
+                    source=file_path,
+                    output=None,
+                    format_from=file_path.suffix.lstrip(".").upper(),
+                    format_to=None,
+                    status=ConversionStatus.FAILED,
+                    error=str(e),
+                    duration_ms=0,
+                )
+            results.append(result)
+            if on_progress is not None:
+                on_progress(result)
+
+    return results
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_cog_reoptimize.py
+++ b/tests/integration/test_cog_reoptimize.py
@@ -1,0 +1,246 @@
+"""Tests for COG re-optimization (--force) and parallel conversion (issue #530).
+
+Covers:
+- convert_file(force=True): re-encodes already-valid COGs (raster only), adding
+  overviews via current CogSettings; leaves vectors skipped.
+- convert_directory(workers=N): parallel conversion via ProcessPoolExecutor with
+  per-file on_progress callbacks, matching the serial result set.
+- check_directory(force=, workers=): unions CLOUD_NATIVE rasters into the fix set
+  and threads force/workers through; dry-run preview lists forced COGs.
+
+Per ADR-0010, conversion itself is delegated to rio-cogeo; these tests verify
+Portolan's orchestration (the force bypass, parallelism, and check threading),
+not raster math.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_bounds
+
+
+def _make_cog_without_overviews(path: Path, size: int = 1500) -> Path:
+    """Write a valid COG that has NO internal overviews.
+
+    rio-cogeo's ``cog_translate`` with ``overview_level=0`` produces a COG that
+    passes ``cog_validate`` (overviews are warnings, not errors) but lacks the
+    pyramid that makes web rendering fast. This reproduces the JRC GloFAS source
+    tiles from issue #530. ``size`` is larger than the 512px default tile size so
+    that a forced re-encode auto-generates at least one overview level.
+    """
+    from rio_cogeo.cogeo import cog_translate
+    from rio_cogeo.profiles import cog_profiles
+
+    plain = path.parent / f".{path.stem}.plain.tif"
+    transform = from_bounds(-122.5, 37.7, -122.3, 37.9, size, size)
+    with rasterio.open(
+        plain,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype="uint8",
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write((np.indices((size, size)).sum(axis=0) % 256).astype("uint8"), 1)
+
+    profile = cog_profiles.get("deflate")
+    cog_translate(str(plain), str(path), profile, quiet=True, overview_level=0)
+    plain.unlink()
+    return path
+
+
+def _overview_count(path: Path) -> int:
+    """Number of overview levels on band 1 of a raster."""
+    with rasterio.open(path) as src:
+        return len(src.overviews(1))
+
+
+class TestConvertFileForce:
+    """convert_file(force=True) re-optimizes valid COGs (rasters only)."""
+
+    @pytest.mark.integration
+    def test_force_reencodes_cog_and_adds_overviews(self, tmp_path: Path) -> None:
+        """A valid COG without overviews is re-encoded in place WITH overviews."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+        from portolan_cli.formats import is_cloud_optimized_geotiff
+
+        cog = _make_cog_without_overviews(tmp_path / "tile.tif")
+        # Precondition: it is already a valid COG (so --fix would normally skip it)
+        # and it has no overviews.
+        assert is_cloud_optimized_geotiff(cog) is True
+        assert _overview_count(cog) == 0
+
+        result = convert_file(cog, force=True)
+
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+        # In-place re-encode (ADR-0020: rasters convert in place).
+        assert result.output.resolve() == cog.resolve()
+        assert _overview_count(cog) >= 1
+
+    @pytest.mark.integration
+    def test_force_false_still_skips_valid_cog(self, tmp_path: Path) -> None:
+        """Without force, a valid COG is still SKIPPED (unchanged behavior)."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        cog = _make_cog_without_overviews(tmp_path / "tile.tif")
+
+        result = convert_file(cog, force=False)
+
+        assert result.status == ConversionStatus.SKIPPED
+        assert result.output is None
+        assert _overview_count(cog) == 0
+
+    @pytest.mark.integration
+    def test_force_does_not_touch_geoparquet(self, valid_points_parquet: Path) -> None:
+        """force is raster-scoped: a valid GeoParquet stays SKIPPED."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        result = convert_file(valid_points_parquet, force=True)
+
+        assert result.status == ConversionStatus.SKIPPED
+        assert result.output is None
+        assert result.format_from == "GeoParquet"
+
+
+class TestConvertDirectoryParallel:
+    """convert_directory(workers=N) parallelizes via ProcessPoolExecutor."""
+
+    @pytest.mark.integration
+    def test_parallel_converts_all_files_with_progress(self, tmp_path: Path) -> None:
+        """workers>1 converts every file and fires on_progress once per file."""
+        from portolan_cli.convert import (
+            ConversionResult,
+            ConversionStatus,
+            convert_directory,
+        )
+
+        input_dir = tmp_path / "tiles"
+        input_dir.mkdir()
+        cogs = [_make_cog_without_overviews(input_dir / f"tile_{i}.tif") for i in range(4)]
+
+        seen: list[ConversionResult] = []
+
+        def on_progress(result: ConversionResult) -> None:
+            seen.append(result)
+
+        report = convert_directory(
+            input_dir,
+            file_paths=cogs,
+            on_progress=on_progress,
+            workers=4,
+            force=True,
+        )
+
+        assert report.total == 4
+        assert all(r.status == ConversionStatus.SUCCESS for r in report.results)
+        # Callback fired exactly once per file (in the parent process).
+        assert len(seen) == 4
+        assert {r.source.name for r in seen} == {f"tile_{i}.tif" for i in range(4)}
+        # Every COG now has overviews.
+        assert all(_overview_count(c) >= 1 for c in cogs)
+
+    @pytest.mark.integration
+    def test_parallel_matches_serial_result_set(self, tmp_path: Path) -> None:
+        """Parallel and serial runs produce the same set of outcomes."""
+        from portolan_cli.convert import convert_directory
+
+        def build(dir_name: str) -> tuple[Path, list[Path]]:
+            d = tmp_path / dir_name
+            d.mkdir()
+            files = [_make_cog_without_overviews(d / f"t_{i}.tif") for i in range(3)]
+            return d, files
+
+        serial_dir, serial_files = build("serial")
+        parallel_dir, parallel_files = build("parallel")
+
+        serial = convert_directory(serial_dir, file_paths=serial_files, workers=1, force=True)
+        parallel = convert_directory(parallel_dir, file_paths=parallel_files, workers=3, force=True)
+
+        assert parallel.total == serial.total == 3
+        serial_statuses = sorted(r.status.value for r in serial.results)
+        parallel_statuses = sorted(r.status.value for r in parallel.results)
+        assert parallel_statuses == serial_statuses
+
+    @pytest.mark.integration
+    def test_parallel_one_bad_file_does_not_abort_batch(self, tmp_path: Path) -> None:
+        """A failing file yields a FAILED result; the rest still convert."""
+        from portolan_cli.convert import ConversionStatus, convert_directory
+
+        input_dir = tmp_path / "tiles"
+        input_dir.mkdir()
+        good = [_make_cog_without_overviews(input_dir / f"good_{i}.tif") for i in range(2)]
+        # A .tif that is not a real raster -> conversion fails for this one only.
+        bad = input_dir / "bad.tif"
+        bad.write_bytes(b"not a real geotiff")
+
+        report = convert_directory(
+            input_dir,
+            file_paths=[*good, bad],
+            workers=3,
+            force=True,
+        )
+
+        assert report.total == 3
+        statuses = {r.source.name: r.status for r in report.results}
+        assert statuses["bad.tif"] == ConversionStatus.FAILED
+        assert statuses["good_0.tif"] == ConversionStatus.SUCCESS
+        assert statuses["good_1.tif"] == ConversionStatus.SUCCESS
+
+
+class TestCheckDirectoryForce:
+    """check_directory(force=, workers=) re-optimizes valid COGs."""
+
+    @pytest.mark.integration
+    def test_force_fix_reoptimizes_cog_leaves_geoparquet(
+        self, tmp_path: Path, valid_points_parquet: Path
+    ) -> None:
+        """--fix --force re-encodes valid COGs but leaves valid GeoParquet alone."""
+        from portolan_cli.check import check_directory
+
+        cog = _make_cog_without_overviews(tmp_path / "tile.tif")
+        gpq = tmp_path / "vector.parquet"
+        shutil.copy(valid_points_parquet, gpq)
+        assert _overview_count(cog) == 0
+
+        report = check_directory(tmp_path, fix=True, force=True, workers=2)
+
+        assert report.conversion_report is not None
+        results = {r.source.name: r for r in report.conversion_report.results}
+        # COG was re-optimized.
+        assert results["tile.tif"].status.value == "success"
+        assert _overview_count(cog) >= 1
+        # GeoParquet was never re-processed (not in the convert set).
+        assert "vector.parquet" not in results
+
+    @pytest.mark.integration
+    def test_force_requires_fix(self, tmp_path: Path) -> None:
+        """force without fix is a programmer error (mirrors remove_legacy guard)."""
+        from portolan_cli.check import check_directory
+
+        with pytest.raises(ValueError):
+            check_directory(tmp_path, fix=False, force=True)
+
+    @pytest.mark.integration
+    def test_force_dry_run_previews_cog_reoptimization(self, tmp_path: Path) -> None:
+        """--fix --force --dry-run lists the valid COG as a would-re-optimize COG."""
+        from portolan_cli.check import check_directory
+
+        cog = _make_cog_without_overviews(tmp_path / "tile.tif")
+
+        report = check_directory(tmp_path, fix=True, force=True, dry_run=True)
+
+        assert report.conversion_report is not None
+        previews = {r.source.name: r for r in report.conversion_report.results}
+        assert "tile.tif" in previews
+        assert previews["tile.tif"].format_to == "COG"
+        # Dry run must not modify the file.
+        assert _overview_count(cog) == 0

--- a/tests/unit/test_cli_check.py
+++ b/tests/unit/test_cli_check.py
@@ -797,3 +797,110 @@ class TestCheckMetadataFixFlag:
             # Both fix functions should be called
             mock_fix.assert_called_once()
             mock_check.assert_called_once()
+
+
+class TestCheckForceWorkers:
+    """Tests for the --force and --workers flags (issue #530)."""
+
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        """Create a CLI test runner."""
+        return CliRunner()
+
+    @pytest.fixture
+    def catalog(self, tmp_path: Path) -> Path:
+        """A minimal managed catalog directory."""
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "stac_version": "1.0.0",
+                    "id": "c",
+                    "description": "d",
+                    "links": [],
+                }
+            )
+        )
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("{}")
+        return tmp_path
+
+    @pytest.mark.unit
+    def test_force_flag_exists(self, runner: CliRunner) -> None:
+        """--force is advertised in help."""
+        result = runner.invoke(cli, ["check", "--help"])
+        assert "--force" in result.output
+
+    @pytest.mark.unit
+    def test_workers_flag_exists(self, runner: CliRunner) -> None:
+        """--workers is advertised in help."""
+        result = runner.invoke(cli, ["check", "--help"])
+        assert "--workers" in result.output
+
+    @pytest.mark.unit
+    def test_force_and_workers_threaded_to_check_directory(
+        self, runner: CliRunner, catalog: Path
+    ) -> None:
+        """--fix --force --workers N reaches check_directory with those values."""
+        from portolan_cli.check import CheckReport
+
+        with patch("portolan_cli.cli.check_directory") as mock_check:
+            mock_check.return_value = CheckReport(root=catalog, files=[], conversion_report=None)
+            result = runner.invoke(
+                cli,
+                [
+                    "check",
+                    str(catalog),
+                    "--geo-assets",
+                    "--fix",
+                    "--force",
+                    "--workers",
+                    "3",
+                ],
+            )
+
+        assert result.exit_code in (0, 1)
+        mock_check.assert_called_once()
+        kwargs = mock_check.call_args.kwargs
+        assert kwargs.get("force") is True
+        assert kwargs.get("workers") == 3
+
+    @pytest.mark.unit
+    def test_workers_defaults_to_cpu_count_when_unset(
+        self, runner: CliRunner, catalog: Path
+    ) -> None:
+        """Without --workers, the CLI resolves a concrete worker count (parallel by default)."""
+        import os
+
+        from portolan_cli.check import CheckReport
+
+        with patch("portolan_cli.cli.check_directory") as mock_check:
+            mock_check.return_value = CheckReport(root=catalog, files=[], conversion_report=None)
+            result = runner.invoke(
+                cli,
+                ["check", str(catalog), "--geo-assets", "--fix", "--force"],
+            )
+
+        assert result.exit_code in (0, 1)
+        kwargs = mock_check.call_args.kwargs
+        assert kwargs.get("workers") == (os.cpu_count() or 1)
+
+    @pytest.mark.unit
+    def test_force_without_fix_warns(self, runner: CliRunner, catalog: Path) -> None:
+        """--force without --fix warns and does not enter the fix path."""
+        with patch("portolan_cli.cli.validate_catalog") as mock_validate:
+            from portolan_cli.validation.results import ValidationReport
+
+            mock_validate.return_value = ValidationReport(results=[])
+            result = runner.invoke(cli, ["check", str(catalog), "--force"])
+
+        assert "--force requires --fix" in result.output
+
+    @pytest.mark.unit
+    def test_workers_rejects_zero(self, runner: CliRunner, catalog: Path) -> None:
+        """--workers 0 is rejected by click.IntRange(min=1)."""
+        result = runner.invoke(
+            cli, ["check", str(catalog), "--geo-assets", "--fix", "--workers", "0"]
+        )
+        assert result.exit_code != 0


### PR DESCRIPTION
Closes #530.

## Problem

COGs without internal overviews still pass rio-cogeo's `cog_validate` (overviews are *warnings*, not errors), so `get_cloud_native_status()` classifies them `CLOUD_NATIVE` and `check --fix` skips them — there was no way to re-optimize existing COGs. Publishing the JRC GloFAS flood dataset (~28 GB, 4,200+ tiles) also exposed that `convert_directory()` ran a serial loop, unusable at that scale.

**Key finding:** `cog_translate()` *already* generates overviews by default and already passes `overview_resampling=settings.resampling`, so acceptance criterion #3 was already satisfied during conversion. The real gaps were (a) the hard skip of valid COGs and (b) serial conversion — no `CogSettings` change was needed.

## Changes

- **`convert_file`** — new raster-scoped `force` flag bypasses the `CLOUD_NATIVE` skip for valid COGs so current `CogSettings` (overviews, compression, tile size) are re-applied. Vectors and unsupported files are unaffected.
- **`convert_directory`** — new `workers`/`force`. A `ProcessPoolExecutor` path (CPU/GDAL-bound work) collects results via `as_completed` and fires `on_progress` **in the parent** (callback never pickled), preserving streaming progress (ADR-0040). Uses a **spawn** context — fork()-ing a process with GDAL worker threads can deadlock (and aborts on macOS). Default (`workers` None/1) stays **serial**, so every existing caller is unchanged. Conversion settings are loaded once and passed to each worker (no per-file YAML re-read across thousands of tiles).
- **`check_directory`** — threads `force`/`workers`; unions already-cloud-native **rasters** into the convert set when forced; dry-run preview lists forced COGs as `COG → COG`. `force` requires `fix`.
- **CLI `check`** — `--force` and `--workers`/`-w` (mirrors `push`/`pull`). `--workers` auto-detects from CPU count when unset (parallel-by-default for `--fix`); `--force` without `--fix` warns.

## Acceptance criteria

- [x] Can add overviews to existing COGs that pass `cog_validate` (`--force`)
- [x] Conversion parallelized with configurable worker count (`--workers`, `ProcessPoolExecutor`)
- [x] `CogSettings.resampling` applied to overview generation (already wired; verified)
- [x] Progress callback still streams during parallel runs

## Tests

`tests/integration/test_cog_reoptimize.py` (new) + `tests/unit/test_cli_check.py`:
force re-encodes a valid no-overview COG (0 → ≥1 overviews) but leaves GeoParquet `SKIPPED`; parallel run converts all files, fires `on_progress` once per file, matches the serial result set, and a bad file yields `FAILED` without aborting the batch; check `--fix --force` re-optimizes COGs only; dry-run previews without writing; CLI threads `force`/`workers`, auto-resolves workers, and warns on `--force` without `--fix`.

Full unit tier (4589) + `ruff`/`mypy`/`xenon`/`vulture`/`lint-imports` green.

## Manual verification

`portolan check tiles/ --geo-assets --fix --force --workers 2 -v` on 3 valid no-overview COGs: overviews went `[0,0,0] → [2,2,2]` with per-file progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--force` flag to re-optimize already-valid Cloud Optimized GeoTIFFs
  * Added `--workers` flag for parallel conversion processing
  * `--dry-run` mode now previews forced re-optimization without modifying files
  * Validation enforces `--force` usage requires `--fix` mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->