### PR TITLE
feat(wfs): adopt gpio 1.3+ defaults (100K page_size, auto_tile) (#529)

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -6943,8 +6943,14 @@ def extract_arcgis_cmd(
 @click.option(
     "--page-size",
     type=click.IntRange(min=100),
-    default=10000,
-    help="Features per page for large layer pagination (default: 10000).",
+    default=100000,
+    help="Features per page for large layer pagination (default: 100000).",
+)
+@click.option(
+    "--auto-tile/--no-auto-tile",
+    default=True,
+    help="Subdivide the bbox and retry when a server caps maxFeatures, so "
+    "capped layers extract completely (default: enabled).",
 )
 @click.option(
     "--resume",
@@ -6987,6 +6993,7 @@ def extract_wfs_cmd(
     retries: int,
     timeout: float,
     page_size: int,
+    auto_tile: bool,
     resume: bool,
     dry_run: bool,
     json_output: bool,
@@ -7077,6 +7084,7 @@ def extract_wfs_cmd(
         bbox=bbox_tuple,
         limit=limit,
         page_size=page_size,
+        auto_tile=auto_tile,
     )
 
     # Progress callback for text output

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -75,7 +75,11 @@ class ExtractionOptions:
         bbox: Bounding box filter (xmin, ymin, xmax, ymax) in output CRS.
         limit: Maximum features per layer (None for unlimited).
         page_size: Features per page when gpio uses parallel pagination for
-            very large layers (1M+ features). Default: 10000.
+            very large layers (1M+ features). Default: 100000 (gpio 1.3+ default,
+            ~10x fewer HTTP roundtrips than the old 10000).
+        auto_tile: When True (default), gpio subdivides the bbox and retries when
+            a server caps maxFeatures below the requested page, so capped layers
+            extract completely instead of silently truncating (gpio 1.3+).
     """
 
     workers: int = 1
@@ -89,7 +93,8 @@ class ExtractionOptions:
     output_crs: str | None = None
     bbox: tuple[float, float, float, float] | None = None
     limit: int | None = None
-    page_size: int = 10000
+    page_size: int = 100000
+    auto_tile: bool = True
 
 
 @dataclass
@@ -262,6 +267,7 @@ def _extract_single_layer(
         output_crs=options.output_crs,
         limit=options.limit,
         page_size=options.page_size,
+        auto_tile=options.auto_tile,
         overwrite=True,  # We control overwrites via resume logic
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "antimeridian>=0.3.11",  # RFC 7946 compliant antimeridian handling for STAC bbox
     "click>=8.3.1",
     "defusedxml>=0.7.1",  # Safe XML parsing (XXE protection) for CSW/ISO 19139 metadata
-    "geoparquet-io>=1.2.0",  # v1.2.0 adds non-geo table write support (geometry_column=None)
+    "geoparquet-io>=1.3.0",  # WFS auto-tile + 100K page_size defaults (Issue #529); git main pinned via [tool.uv.sources]
     "httpx>=0.27.0",  # HTTP client for ArcGIS REST API discovery
     "obstore>=0.8.2",  # Cloud object storage (S3, GCS, Azure) via Rust bindings
     "python-dotenv>=1.0.0",  # Load .env files for credentials (ADR-0024, Issue #356)
@@ -325,6 +325,13 @@ dev = [
     "pytest-xdist>=3.8.0",
     "types-pyyaml>=6.0.12.20250915",
 ]
+
+[tool.uv.sources]
+# Track geoparquet-io git main during fast co-development (Issue #529). The
+# published-metadata spec stays `geoparquet-io>=1.3.0` (PyPI-valid); this
+# dev-only source override pulls main so portolan picks up upstream WFS fixes
+# (auto-tile, 100K page_size) before they hit a PyPI release.
+geoparquet-io = { git = "https://github.com/geoparquet/geoparquet-io.git", branch = "main" }
 
 [tool.menard]
 mode = "block"

--- a/tests/unit/extract/wfs/test_orchestrator.py
+++ b/tests/unit/extract/wfs/test_orchestrator.py
@@ -65,7 +65,52 @@ class TestExtractionOptions:
         assert options.raw is False
         assert options.dry_run is False
         assert options.wfs_version == "auto"
-        assert options.page_size == 10000
+        # Issue #529: adopt gpio 1.3+ defaults.
+        assert options.page_size == 100000
+        assert options.auto_tile is True
+
+
+class TestExtractSingleLayer:
+    """Tests for _extract_single_layer gpio delegation (Issue #529)."""
+
+    def test_passes_page_size_and_auto_tile_to_gpio(self, tmp_path: Path) -> None:
+        """page_size and auto_tile from options are forwarded to gpio."""
+        from portolan_cli.extract.wfs.orchestrator import _extract_single_layer
+
+        layer = make_layer_info("buildings", 0)
+        options = ExtractionOptions(page_size=100000, auto_tile=True)
+
+        with patch("geoparquet_io.core.wfs.convert_wfs_to_geoparquet") as mock_convert:
+            _extract_single_layer(
+                service_url="https://example.com/wfs",
+                layer=layer,
+                output_path=tmp_path / "buildings.parquet",
+                options=options,
+                negotiated_version="2.0.0",
+            )
+
+        mock_convert.assert_called_once()
+        kwargs = mock_convert.call_args.kwargs
+        assert kwargs["page_size"] == 100000
+        assert kwargs["auto_tile"] is True
+
+    def test_auto_tile_disabled_is_forwarded(self, tmp_path: Path) -> None:
+        """auto_tile=False is forwarded so users can opt out."""
+        from portolan_cli.extract.wfs.orchestrator import _extract_single_layer
+
+        layer = make_layer_info("roads", 1)
+        options = ExtractionOptions(auto_tile=False)
+
+        with patch("geoparquet_io.core.wfs.convert_wfs_to_geoparquet") as mock_convert:
+            _extract_single_layer(
+                service_url="https://example.com/wfs",
+                layer=layer,
+                output_path=tmp_path / "roads.parquet",
+                options=options,
+                negotiated_version="2.0.0",
+            )
+
+        assert mock_convert.call_args.kwargs["auto_tile"] is False
 
 
 class TestExtractWfsCatalog:

--- a/tests/unit/test_cli_extract_wfs.py
+++ b/tests/unit/test_cli_extract_wfs.py
@@ -1,0 +1,81 @@
+"""CLI wiring tests for `extract wfs` page-size and auto-tile flags (Issue #529)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.extract.common.report import ExtractionReport
+from portolan_cli.extract.wfs.orchestrator import (
+    ExtractionOptions,
+    _build_dry_run_report,
+)
+
+
+def _make_capturing_fake(
+    captured: dict[str, object],
+) -> Callable[..., ExtractionReport]:
+    """Build a fake extract_wfs_catalog that records the resolved options."""
+
+    def fake_extract(
+        url: str,
+        output_dir: Path,
+        *,
+        layer_filter: list[str] | None = None,
+        layer_exclude: list[str] | None = None,
+        options: ExtractionOptions | None = None,
+        on_progress: object = None,
+    ) -> ExtractionReport:
+        assert options is not None
+        captured["page_size"] = options.page_size
+        captured["auto_tile"] = options.auto_tile
+        return _build_dry_run_report(url=url, layers=[], discovery_result=None)
+
+    return fake_extract
+
+
+@pytest.mark.unit
+def test_extract_wfs_has_page_size_and_auto_tile_flags() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "wfs", "--help"])
+    assert result.exit_code == 0
+    for flag in ("--page-size", "--auto-tile", "--no-auto-tile"):
+        assert flag in result.output
+
+
+@pytest.mark.unit
+def test_extract_wfs_defaults_thread_gpio_13_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default invocation builds options with page_size=100000 and auto_tile=True."""
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "portolan_cli.extract.wfs.orchestrator.extract_wfs_catalog",
+        _make_capturing_fake(captured),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["extract", "wfs", "https://example.com/wfs", "--dry-run", "--auto"]
+    )
+    assert result.exit_code == 0
+    assert captured["page_size"] == 100000
+    assert captured["auto_tile"] is True
+
+
+@pytest.mark.unit
+def test_extract_wfs_no_auto_tile_threads_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--no-auto-tile threads auto_tile=False into ExtractionOptions."""
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "portolan_cli.extract.wfs.orchestrator.extract_wfs_catalog",
+        _make_capturing_fake(captured),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["extract", "wfs", "https://example.com/wfs", "--no-auto-tile", "--dry-run", "--auto"],
+    )
+    assert result.exit_code == 0
+    assert captured["auto_tile"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -1819,8 +1819,8 @@ wheels = [
 
 [[package]]
 name = "geoparquet-io"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
+version = "1.3.0"
+source = { git = "https://github.com/geoparquet/geoparquet-io.git?branch=main#505f3f06f5e3a8eafeb3df79c69e8dfeae4d2a03" }
 dependencies = [
     { name = "aiohttp" },
     { name = "click" },
@@ -1846,10 +1846,6 @@ dependencies = [
     { name = "rich" },
     { name = "s3fs" },
     { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/57/45/3d19550b391cc15f2161c53b8e6247e0419ef459ebd7e3673eb501abb6c8/geoparquet_io-1.2.0.tar.gz", hash = "sha256:12691cd24caa2daac0a27163746a4d2eaeb9d01e8fe54224c57a7ae20d9a64d4", size = 1520658, upload-time = "2026-06-02T10:55:03.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/da/8d162fad7882fe1727ab5c83f46a288239776449fb475748b43ce69f7143/geoparquet_io-1.2.0-py3-none-any.whl", hash = "sha256:b8044a057aa9c837f1e8a460cd0465e73b18b923ab434afa44e06ecacd539c20", size = 468509, upload-time = "2026-06-02T10:55:01.297Z" },
 ]
 
 [[package]]
@@ -4713,7 +4709,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.1" },
     { name = "geopandas", marker = "extra == 'thumbnails'", specifier = ">=0.14.0" },
-    { name = "geoparquet-io", specifier = ">=1.2.0" },
+    { name = "geoparquet-io", git = "https://github.com/geoparquet/geoparquet-io.git?branch=main" },
     { name = "gitingest", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "gpio-pmtiles", marker = "extra == 'pmtiles'", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary

Closes #529. Adopts the WFS extraction improvements from geoparquet-io 1.3 ([gpio PR #502](https://github.com/geoparquet/geoparquet-io/pull/502)):

- **`page_size` default 10000 → 100000** — ~10x fewer HTTP roundtrips on large layers.
- **`auto_tile` (new, default on)** — gpio subdivides the bbox and retries when a server caps `maxFeatures` below the requested page, so capped layers extract completely instead of silently truncating.

Portolan was overriding `page_size` back to the old 10K and never passing `auto_tile` through, so it missed both wins.

## Changes

| Layer | Change |
|-------|--------|
| `ExtractionOptions` | `page_size` default `10000` → `100000`; added `auto_tile: bool = True` |
| `_extract_single_layer` | forwards `auto_tile=options.auto_tile` to `convert_wfs_to_geoparquet` |
| CLI `extract wfs` | `--page-size` default `100000`; new `--auto-tile/--no-auto-tile` flag |
| `pyproject.toml` | track `geoparquet-io` git `main` via `[tool.uv.sources]` (dev-only source override; published spec stays `geoparquet-io>=1.3.0`, PyPI-valid) so portolan picks up upstream WFS fixes ahead of PyPI releases |

## Tests (TDD — written first, verified RED then GREEN)

- `tests/unit/extract/wfs/test_orchestrator.py`: updated default-values test; new `TestExtractSingleLayer` asserts `page_size`/`auto_tile` are forwarded to gpio, and that `--no-auto-tile` opt-out is honored.
- `tests/unit/test_cli_extract_wfs.py` (new): flag presence in `--help`; default invocation threads `page_size=100000` + `auto_tile=True`; `--no-auto-tile` threads `auto_tile=False`.

## Verification

- Full unit tier: **4602 passed, 5 skipped** (gpio 1.2.0 → 1.3.0 git main bump introduced no regressions).
- Extract suite (unit + WFS integration): **683 passed**.
- `ruff check`, `ruff format --check`, `mypy` (source + new tests), `lint-imports` (3/3 contracts kept), `deptry` (no issues) — all green.
- `portolan extract wfs --help` renders both `--page-size` and `--auto-tile / --no-auto-tile`.

## Related

- geoparquet/geoparquet-io#502

🤖 Generated with [Claude Code](https://claude.com/claude-code)