### PR TITLE
docs(extract): fix stale 'non-spatial tables are skipped' carto help

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -7257,9 +7257,10 @@ def extract_carto_cmd(
 ) -> None:
     """Extract tables from a Carto SQL API account.
 
-    Downloads vector tables from a Carto account and creates a Portolan catalog
-    with GeoParquet files and STAC metadata. Tables are discovered via
-    CDB_UserTables(); non-spatial tables are skipped.
+    Downloads tables from a Carto account and creates a Portolan catalog with
+    STAC metadata. Tables are discovered via CDB_UserTables(). Spatial tables
+    become GeoParquet; non-spatial tables become plain Parquet in tabular
+    collections (ADR-0047).
 
     URL is the Carto SQL API endpoint or account domain
     (e.g. https://phl.carto.com or https://phl.carto.com/api/v2/sql).
@@ -7267,7 +7268,7 @@ def extract_carto_cmd(
 
     \b
     Examples:
-        # Extract all (spatial) tables from an account
+        # Extract all tables from an account
         portolan extract carto https://phl.carto.com ./output
 
         # Extract specific tables by glob

--- a/tests/unit/test_cli_extract_carto.py
+++ b/tests/unit/test_cli_extract_carto.py
@@ -50,6 +50,19 @@ def test_extract_carto_help_lists_flags() -> None:
         assert flag in result.output
 
 
+def test_extract_carto_help_describes_tabular_not_skipped() -> None:
+    """Non-spatial tables are extracted as plain Parquet, not skipped (regression).
+
+    The original help text claimed "non-spatial tables are skipped"; that became
+    false once tabular extraction landed. Guard the description against regressing.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "carto", "--help"])
+    assert result.exit_code == 0
+    assert "skipped" not in result.output.lower()
+    assert "tabular" in result.output.lower()
+
+
 def test_extract_carto_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
     monkeypatch.setattr(


### PR DESCRIPTION
## What

The merged `portolan extract carto --help` (from #535) still claims:

> Tables are discovered via CDB_UserTables(); **non-spatial tables are skipped.**

That became false in the same PR — tabular extraction landed, so non-spatial tables are now extracted as **plain Parquet in tabular collections** (ADR-0047). This corrects the docstring and drops the misleading `(spatial)` qualifier from the all-tables example.

## Why it matters

The help text is the agent- and user-facing contract for what the command does. Claiming tables are skipped when they're actually extracted misrepresents the capability.

## Testing

Adds a regression test (`test_extract_carto_help_describes_tabular_not_skipped`) asserting the help no longer says "skipped" and does describe tabular extraction. Full Carto suite green (27 tests).

## Note (not in this PR)

A richer follow-up is planned: a **propose-and-confirm metadata-enrichment skill** that harvests descriptive metadata (description/license/keywords/contact) from external open-data catalogs (CKAN, DCAT `data.json`, Socrata) and matches it to extracted collections — since Carto's SQL API (unlike WFS GetCapabilities / ArcGIS service docs) exposes no descriptive metadata to harvest directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)