### PR TITLE
fix(readme): use metadata.yaml title/description in READMEs (#534)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -885,7 +885,11 @@ Only two fields are required in `metadata.yaml`:
 - **`contact.name`** and **`contact.email`** - Who maintains this data
 - **`license`** - SPDX identifier (validated against common licenses)
 
-Title and description come from STAC metadata (set during `portolan init`).
+Title and description come from STAC metadata (set during `portolan init`). You
+may optionally set `title` and `description` in `metadata.yaml` to override the
+auto-derived values; a human-authored title there is the highest-precedence
+source and is honored by `portolan readme` (precedence:
+`metadata.yaml` > STAC > humanized id).
 
 ### Hierarchical Inheritance
 
@@ -907,7 +911,7 @@ Child values override parent values. Use this to set catalog-wide defaults (lice
 The `portolan readme` command generates `README.md` by combining:
 
 **From STAC (automatic):**
-- Title, description
+- Title, description (overridable via `metadata.yaml` `title`/`description`)
 - Spatial/temporal coverage
 - Schema columns (from `table:columns`)
 - Bands (from `eo:bands`, `raster:bands`)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -888,8 +888,8 @@ Only two fields are required in `metadata.yaml`:
 Title and description come from STAC metadata (set during `portolan init`). You
 may optionally set `title` and `description` in `metadata.yaml` to override the
 auto-derived values; a human-authored title there is the highest-precedence
-source and is honored by `portolan readme` (precedence:
-`metadata.yaml` > STAC > humanized id).
+source and is honored by `portolan readme` (see [README Generation](#readme-generation)
+for the full precedence).
 
 ### Hierarchical Inheritance
 
@@ -911,7 +911,9 @@ Child values override parent values. Use this to set catalog-wide defaults (lice
 The `portolan readme` command generates `README.md` by combining:
 
 **From STAC (automatic):**
-- Title, description (overridable via `metadata.yaml` `title`/`description`)
+- Title, description — `metadata.yaml` `title`/`description` override these when
+  set; precedence is `metadata.yaml` > STAC > humanized id, and a blank/null
+  value at any level falls through to the next source
 - Spatial/temporal coverage
 - Schema columns (from `table:columns`)
 - Bands (from `eo:bands`, `raster:bands`)

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -5,7 +5,7 @@ This module generates README.md files from STAC metadata and
 generated, never hand-edited.
 
 **Sections auto-filled from STAC:**
-- Title, description (from catalog/collection)
+- Title, description (metadata.yaml override > catalog/collection STAC > id, #534)
 - Spatial/temporal coverage (from extent)
 - Schema/columns (from table:columns)
 - Bands (from eo:bands, raster:bands)
@@ -115,15 +115,51 @@ print(gdf.head())
 # =============================================================================
 
 
-def _add_title_section(sections: list[str], stac: dict[str, Any]) -> None:
-    """Add title and description from STAC."""
-    title = stac.get("title") or stac.get("id", "Untitled Collection")
+def _metadata_override(metadata: dict[str, Any], field: str) -> str | None:
+    """Return a non-blank human override for ``field`` from metadata.yaml (#534).
+
+    ``metadata.yaml`` may carry optional ``title``/``description`` keys as the
+    highest-precedence human override (Issue #502, mirrored by
+    :func:`portolan_cli.stac.apply_human_titles`). A blank/whitespace value is
+    treated as "not provided" so the auto-derived STAC value is used instead.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    value = metadata.get(field)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _resolve_title_description(
+    stac: dict[str, Any],
+    metadata: dict[str, Any],
+) -> tuple[str, str]:
+    """Resolve title/description with metadata.yaml override precedence (#534).
+
+    Precedence: metadata.yaml human override > STAC value > humanized id.
+    """
+    title = (
+        _metadata_override(metadata, "title")
+        or stac.get("title")
+        or stac.get("id", "Untitled Collection")
+    )
+    description = _metadata_override(metadata, "description") or stac.get("description", "")
+    return str(title), str(description)
+
+
+def _add_title_section(
+    sections: list[str],
+    stac: dict[str, Any],
+    metadata: dict[str, Any],
+) -> None:
+    """Add title and description, preferring metadata.yaml overrides (#534)."""
+    title, description = _resolve_title_description(stac, metadata)
     sections.append(f"# {title}")
     sections.append("")
 
-    description = stac.get("description", "")
     if description:
-        sections.append(str(description).strip())
+        sections.append(description.strip())
         sections.append("")
 
 
@@ -585,8 +621,8 @@ def generate_readme(
             if namespaced_key not in assets and asset_key not in assets:
                 assets[namespaced_key] = asset_value
 
-    # STAC-sourced sections
-    _add_title_section(sections, stac)
+    # STAC-sourced sections (title/description honor metadata.yaml overrides, #534)
+    _add_title_section(sections, stac, metadata)
     _add_keywords_section(sections, metadata)  # Visual badges after title
     _add_spatial_section(sections, stac)
     _add_temporal_section(sections, stac)
@@ -794,17 +830,22 @@ def _add_collections_section(
         sections.append("")
 
     for coll_id in sorted(collections):
-        coll_json = catalog_path / coll_id / "collection.json"
-        title = coll_id
-        description = ""
+        coll_dir = catalog_path / coll_id
+        coll_json = coll_dir / "collection.json"
+        stac: dict[str, Any] = {"id": coll_id}
 
         if coll_json.exists():
             try:
-                data = json.loads(coll_json.read_text())
-                title = data.get("title", coll_id)
-                description = data.get("description", "")
+                stac = json.loads(coll_json.read_text())
             except (json.JSONDecodeError, OSError):
-                pass
+                stac = {"id": coll_id}
+
+        # metadata.yaml title/description override the STAC values (#534).
+        try:
+            coll_metadata = load_merged_metadata(coll_dir, catalog_path)
+        except Exception:
+            coll_metadata = {}
+        title, description = _resolve_title_description(stac, coll_metadata)
 
         # Link to collection directory
         sections.append(f"### [{title}](./{coll_id}/)")
@@ -882,9 +923,13 @@ def generate_catalog_readme(catalog_path: Path) -> str:
     # Load merged metadata
     metadata = load_merged_metadata(catalog_path, catalog_path)
 
-    # Title and description
-    title = catalog.get("title", catalog.get("id", "Data Catalog"))
-    description = catalog.get("description", "")
+    # Title and description (metadata.yaml overrides catalog.json, #534)
+    title = (
+        _metadata_override(metadata, "title")
+        or catalog.get("title")
+        or catalog.get("id", "Data Catalog")
+    )
+    description = _metadata_override(metadata, "description") or catalog.get("description", "")
 
     sections.append(f"# {title}")
     sections.append("")

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -37,6 +37,7 @@ from typing import Any
 from urllib.parse import quote
 
 from portolan_cli.config import load_merged_metadata
+from portolan_cli.errors import ConfigInvalidStructureError
 
 # Keyword-badge rendering limits (#515). A junk-dominated list is a machine dump
 # (e.g. WFS layer ids seeded into metadata.yaml at extraction) and is suppressed;
@@ -139,12 +140,16 @@ def _resolve_title_description(
 
     Precedence: metadata.yaml human override > STAC value > humanized id.
     """
+    # `or` chains (not stac.get defaults) so an explicit null in STAC
+    # (e.g. {"id": null} or {"description": null}) falls through to the literal
+    # fallback instead of becoming the string "None".
     title = (
         _metadata_override(metadata, "title")
         or stac.get("title")
-        or stac.get("id", "Untitled Collection")
+        or stac.get("id")
+        or "Untitled Collection"
     )
-    description = _metadata_override(metadata, "description") or stac.get("description", "")
+    description = _metadata_override(metadata, "description") or stac.get("description") or ""
     return str(title), str(description)
 
 
@@ -840,10 +845,12 @@ def _add_collections_section(
             except (json.JSONDecodeError, OSError):
                 stac = {"id": coll_id}
 
-        # metadata.yaml title/description override the STAC values (#534).
+        # metadata.yaml title/description override the STAC values (#534). A
+        # malformed metadata.yaml in one collection must not abort the catalog
+        # README, so fall back to STAC-only for that entry.
         try:
             coll_metadata = load_merged_metadata(coll_dir, catalog_path)
-        except Exception:
+        except (ConfigInvalidStructureError, OSError):
             coll_metadata = {}
         title, description = _resolve_title_description(stac, coll_metadata)
 

--- a/tests/integration/test_readme_recursive.py
+++ b/tests/integration/test_readme_recursive.py
@@ -182,11 +182,11 @@ class TestReadmeRecursive:
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):
             runner.invoke(cli, ["readme"])
 
-        # Modify a collection to make its README stale
-        coll_json = catalog_with_collections / "alpha" / "collection.json"
-        data = json.loads(coll_json.read_text())
-        data["title"] = "MODIFIED TITLE"
-        coll_json.write_text(json.dumps(data))
+        # Modify a collection to make its README stale. The alpha collection has
+        # a metadata.yaml title, which is the highest-precedence source for the
+        # README heading (#534), so mutate that to actually change the output.
+        meta_yaml = catalog_with_collections / "alpha" / ".portolan" / "metadata.yaml"
+        meta_yaml.write_text("title: MODIFIED TITLE\n")
 
         # Check should now fail
         with runner.isolated_filesystem(temp_dir=catalog_with_collections):

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -126,6 +126,22 @@ class TestGenerateReadme:
         assert "# my-collection" in readme
 
     @pytest.mark.unit
+    def test_explicit_null_stac_fields_do_not_render_none(self) -> None:
+        """Explicit nulls in STAC fall back, never render the string 'None' (#534)."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {"type": "Collection", "id": None, "title": None, "description": None}
+        metadata = {
+            "contact": {"name": "Name", "email": "a@b.c"},
+            "license": "MIT",
+        }
+
+        readme = generate_readme(stac=stac, metadata=metadata)
+
+        assert "# Untitled Collection" in readme
+        assert "None" not in readme
+
+    @pytest.mark.unit
     def test_description_comes_from_stac(self) -> None:
         """generate_readme uses description from STAC."""
         from portolan_cli.readme import generate_readme

--- a/tests/unit/test_readme.py
+++ b/tests/unit/test_readme.py
@@ -1,7 +1,7 @@
 """Tests for README generation (ADR-0038).
 
 Tests README generation from STAC metadata + metadata.yaml:
-- Title/description from STAC (not metadata.yaml)
+- Title/description from metadata.yaml override, else STAC, else id (#534, #502)
 - Columns from table:columns extension
 - Code examples based on format
 - Checksums from STAC assets
@@ -45,7 +45,7 @@ class TestGenerateReadme:
 
     @pytest.mark.unit
     def test_title_comes_from_stac(self) -> None:
-        """generate_readme uses title from STAC, not metadata.yaml."""
+        """generate_readme uses STAC title when metadata.yaml has no override."""
         from portolan_cli.readme import generate_readme
 
         stac = {"type": "Collection", "id": "test", "title": "STAC Title"}
@@ -57,6 +57,58 @@ class TestGenerateReadme:
         readme = generate_readme(stac=stac, metadata=metadata)
 
         assert "# STAC Title" in readme
+
+    @pytest.mark.unit
+    def test_title_from_metadata_overrides_stac(self) -> None:
+        """metadata.yaml title/description override STAC values (#534, #502).
+
+        A human-authored title in metadata.yaml is the highest-precedence source
+        (consistent with apply_human_titles), so ``readme`` honors it even when
+        the STAC title/description is still the slug-humanized default.
+        """
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "depth-rp100",
+            "title": "Depth Rp100",
+            "description": "Depth Rp100",
+        }
+        metadata = {
+            "contact": {"name": "Name", "email": "a@b.c"},
+            "license": "MIT",
+            "title": "Flood Depth - 100-Year Return Period",
+            "description": "Modeled riverine flood water depth (meters).",
+        }
+
+        readme = generate_readme(stac=stac, metadata=metadata)
+
+        assert "# Flood Depth - 100-Year Return Period" in readme
+        assert "Modeled riverine flood water depth (meters)." in readme
+        assert "# Depth Rp100" not in readme
+
+    @pytest.mark.unit
+    def test_blank_metadata_title_falls_back_to_stac(self) -> None:
+        """A blank metadata.yaml title is treated as absent (#502); STAC wins."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "test",
+            "title": "STAC Title",
+            "description": "STAC description.",
+        }
+        metadata = {
+            "contact": {"name": "Name", "email": "a@b.c"},
+            "license": "MIT",
+            "title": "   ",
+            "description": "",
+        }
+
+        readme = generate_readme(stac=stac, metadata=metadata)
+
+        assert "# STAC Title" in readme
+        assert "STAC description." in readme
 
     @pytest.mark.unit
     def test_title_falls_back_to_id(self) -> None:

--- a/tests/unit/test_readme_catalog_aggregation.py
+++ b/tests/unit/test_readme_catalog_aggregation.py
@@ -292,6 +292,77 @@ class TestGenerateCatalogReadme:
         assert "Demographics Data" in readme or "Census" in readme
 
     @pytest.mark.unit
+    def test_collections_listing_uses_collection_metadata_yaml(self, tmp_path: Path) -> None:
+        """Collections listing uses each collection's metadata.yaml title/description (#534).
+
+        When a collection's STAC title/description is still the slug-humanized
+        default but its .portolan/metadata.yaml carries a human-authored
+        title/description, the catalog README must show the metadata.yaml values.
+        """
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "my-catalog",
+                    "title": "My Catalog",
+                    "description": "Test",
+                }
+            )
+        )
+
+        (tmp_path / "depth-rp100").mkdir()
+        (tmp_path / "depth-rp100" / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "depth-rp100",
+                    "title": "Depth Rp100",
+                    "description": "Depth Rp100",
+                    "extent": {
+                        "spatial": {"bbox": [[-10, -10, 10, 10]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                }
+            )
+        )
+        (tmp_path / "depth-rp100" / ".portolan").mkdir()
+        (tmp_path / "depth-rp100" / ".portolan" / "metadata.yaml").write_text(
+            'title: "Flood Depth - 100-Year Return Period"\n'
+            'description: "Modeled riverine flood water depth (meters)."\n'
+        )
+
+        readme = generate_catalog_readme(tmp_path)
+
+        assert "Flood Depth - 100-Year Return Period" in readme
+        assert "Modeled riverine flood water depth (meters)." in readme
+        # The slug-humanized STAC heading must not appear.
+        assert "[Depth Rp100]" not in readme
+
+    @pytest.mark.unit
+    def test_catalog_title_uses_metadata_yaml_override(self, tmp_path: Path) -> None:
+        """Catalog title/description come from metadata.yaml when set (#534)."""
+        (tmp_path / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "my-catalog",
+                    "title": "My Catalog",
+                    "description": "Slug description",
+                }
+            )
+        )
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "metadata.yaml").write_text(
+            'title: "Curated Catalog Name"\ndescription: "A human-authored catalog description."\n'
+        )
+
+        readme = generate_catalog_readme(tmp_path)
+
+        assert "# Curated Catalog Name" in readme
+        assert "A human-authored catalog description." in readme
+        assert "# My Catalog" not in readme
+
+    @pytest.mark.unit
     def test_includes_aggregated_extent(self, tmp_path: Path) -> None:
         """Catalog README should show aggregated spatial extent."""
         (tmp_path / "catalog.json").write_text(


### PR DESCRIPTION
## Summary

Fixes #534. Collection- and catalog-level READMEs ignored the human-authored `title`/`description` in `.portolan/metadata.yaml` and rendered the slug-humanized collection id instead (e.g. `# Depth Rp100` / `Depth Rp100`).

## Root cause

`generate_readme()` loaded and passed the merged `metadata` dict to `_add_title_section()`, but that function only read from the STAC dict and never consulted `metadata`. Separately, the catalog README's collections listing (`_add_collections_section()`) read each `collection.json` but never loaded the per-collection `.portolan/metadata.yaml`.

## Fix

Apply the same highest-precedence override that `stac.apply_human_titles` already uses for `add` (Issue #502):

> precedence: `metadata.yaml` title/description **>** STAC value **>** humanized id

with blank/whitespace values treated as absent. This makes `portolan readme` self-consistent whether or not `add` was re-run after enrichment.

- `generate_readme` — collection title/description honor the override
- `generate_catalog_readme` — catalog title/description honor the override
- `_add_collections_section` — loads each collection's `metadata.yaml` for the listing
- docs: document the override in `configuration.md`

## Before / After

Given `metadata.yaml` with `title: "Flood Depth - 100-Year Return Period"`:

```diff
- # Depth Rp100
-
- Depth Rp100
+ # Flood Depth - 100-Year Return Period
+
+ Modeled riverine flood water depth (meters) for a 100-year return period event.
```

## Testing

TDD: 4 new unit tests (collection override, blank-override fallback, catalog collections listing, catalog title override) written red, then made green. Full README suite (145 tests) passes; `mypy`, `ruff`, `vulture`, `lint-imports`, and the doc-freshness gate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that custom metadata overrides STAC-derived titles and descriptions when generating READMEs.

* **Tests**
  * Added tests verifying that collection and catalog READMEs properly respect custom metadata overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->