### PR TITLE
Forward AWS session token to S3 store (fix temporary/STS credentials)

### DIFF
--- a/portolan_cli/upload.py
+++ b/portolan_cli/upload.py
@@ -161,7 +161,7 @@ def parse_object_store_url(url: str) -> tuple[str, str]:
 
 def _load_aws_credentials_from_profile(
     profile: str = "default",
-) -> tuple[str | None, str | None, str | None]:
+) -> tuple[str | None, str | None, str | None, str | None]:
     """Load AWS credentials from ~/.aws/credentials file.
 
     Uses Python's built-in configparser to read credentials without requiring boto3.
@@ -170,14 +170,16 @@ def _load_aws_credentials_from_profile(
         profile: AWS profile name (default: "default")
 
     Returns:
-        Tuple of (access_key_id, secret_access_key, region)
-        Any value may be None if not found.
+        Tuple of (access_key_id, secret_access_key, session_token, region)
+        Any value may be None if not found. session_token is present for
+        temporary (STS) credentials (access key id starting with "ASIA").
     """
     creds_file = Path.home() / ".aws" / "credentials"
     config_file = Path.home() / ".aws" / "config"
 
     access_key: str | None = None
     secret_key: str | None = None
+    session_token: str | None = None
     region: str | None = None
 
     # Read credentials
@@ -189,9 +191,11 @@ def _load_aws_credentials_from_profile(
             section = parser[profile]
             access_key = section.get("aws_access_key_id")
             secret_key = section.get("aws_secret_access_key")
+            session_token = section.get("aws_session_token")
         elif profile == "default" and "DEFAULT" in parser:
             access_key = parser["DEFAULT"].get("aws_access_key_id")
             secret_key = parser["DEFAULT"].get("aws_secret_access_key")
+            session_token = parser["DEFAULT"].get("aws_session_token")
 
     # Read region from config
     if config_file.exists():
@@ -205,7 +209,7 @@ def _load_aws_credentials_from_profile(
         elif profile == "default" and "DEFAULT" in config:
             region = config["DEFAULT"].get("region")
 
-    return access_key, secret_key, region
+    return access_key, secret_key, session_token, region
 
 
 def _try_infer_region_from_bucket(bucket: str) -> str | None:
@@ -253,7 +257,7 @@ def _check_s3_credentials(profile: str | None = None) -> tuple[bool, str]:
     """
     # If profile specified, check credentials file
     if profile:
-        access_key, secret_key, _ = _load_aws_credentials_from_profile(profile)
+        access_key, secret_key, _, _ = _load_aws_credentials_from_profile(profile)
         if access_key and secret_key:
             return True, ""
         else:
@@ -278,7 +282,7 @@ def _check_s3_credentials(profile: str | None = None) -> tuple[bool, str]:
         return True, ""
 
     # Fall back to default profile in ~/.aws/credentials
-    access_key, secret_key, _ = _load_aws_credentials_from_profile("default")
+    access_key, secret_key, _, _ = _load_aws_credentials_from_profile("default")
     if access_key and secret_key:
         return True, ""
 
@@ -448,20 +452,30 @@ def _setup_store_and_kwargs(
         # Load credentials from profile, environment, or default profile
         access_key: str | None = None
         secret_key: str | None = None
+        session_token: str | None = None
         profile_region: str | None = None
 
         if profile:
-            access_key, secret_key, profile_region = _load_aws_credentials_from_profile(profile)
+            (
+                access_key,
+                secret_key,
+                session_token,
+                profile_region,
+            ) = _load_aws_credentials_from_profile(profile)
         else:
             # Try environment variables first
             access_key = os.environ.get("AWS_ACCESS_KEY_ID")
             secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+            session_token = os.environ.get("AWS_SESSION_TOKEN")
 
             # Fall back to default profile if no env vars
             if not (access_key and secret_key):
-                access_key, secret_key, profile_region = _load_aws_credentials_from_profile(
-                    "default"
-                )
+                (
+                    access_key,
+                    secret_key,
+                    session_token,
+                    profile_region,
+                ) = _load_aws_credentials_from_profile("default")
 
         # Determine region: explicit flag > env var > profile config > bucket heuristic
         region = s3_region
@@ -480,6 +494,11 @@ def _setup_store_and_kwargs(
         if access_key and secret_key:
             store_kwargs["access_key_id"] = access_key
             store_kwargs["secret_access_key"] = secret_key
+            # Forward the session token for temporary (STS) credentials, e.g.
+            # those issued by Source Cooperative. Without it, obstore sends an
+            # 'ASIA…' key with no token and S3 returns 403 InvalidAccessKeyId.
+            if session_token:
+                store_kwargs["aws_session_token"] = session_token
 
         # Bucket names with dots (e.g., us-west-2.opendata.source.coop) require
         # path-style requests because virtual-hosted style would create invalid

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -1292,7 +1292,7 @@ class TestMultiCloudStoreSetup:
         from portolan_cli.upload import setup_store
 
         with patch("portolan_cli.upload._load_aws_credentials_from_profile") as mock_load:
-            mock_load.return_value = ("access_key", "secret_key", "us-east-1")
+            mock_load.return_value = ("access_key", "secret_key", None, "us-east-1")
 
             with patch("portolan_cli.upload.S3Store") as mock_s3:
                 mock_s3.return_value = MagicMock()

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -74,6 +74,11 @@ aws_secret_access_key = defaultsecret
 [myprofile]
 aws_access_key_id = AKIAPROFILEKEY
 aws_secret_access_key = profilesecret
+
+[temp-sts]
+aws_access_key_id = ASIATEMPKEY
+aws_secret_access_key = tempsecret
+aws_session_token = temp-session-token-value
 """)
 
     config_file = aws_dir / "config"
@@ -448,7 +453,7 @@ class TestCheckCredentials:
 
         with patch.dict(os.environ, {}, clear=True):
             with patch("portolan_cli.upload._load_aws_credentials_from_profile") as mock_load:
-                mock_load.return_value = (None, None, None)
+                mock_load.return_value = (None, None, None, None)
                 valid, hint = check_credentials("s3://mybucket/path")
 
         assert valid is False
@@ -1003,10 +1008,13 @@ class TestLoadAwsCredentials:
 
         # Fixture patches Path.home() - assert it exists to mark as used
         assert mock_aws_credentials.exists()
-        access_key, secret_key, region = _load_aws_credentials_from_profile("default")
+        access_key, secret_key, session_token, region = _load_aws_credentials_from_profile(
+            "default"
+        )
 
         assert access_key == "AKIADEFAULTKEY"
         assert secret_key == "defaultsecret"
+        assert session_token is None
         assert region == "us-east-1"
 
     @pytest.mark.unit
@@ -1016,11 +1024,30 @@ class TestLoadAwsCredentials:
 
         # Fixture patches Path.home() - assert it exists to mark as used
         assert mock_aws_credentials.exists()
-        access_key, secret_key, region = _load_aws_credentials_from_profile("myprofile")
+        access_key, secret_key, session_token, region = _load_aws_credentials_from_profile(
+            "myprofile"
+        )
 
         assert access_key == "AKIAPROFILEKEY"
         assert secret_key == "profilesecret"
+        assert session_token is None
         assert region == "eu-west-1"
+
+    @pytest.mark.unit
+    def test_load_temporary_credentials_with_session_token(
+        self, mock_aws_credentials: Path
+    ) -> None:
+        """Should load the session token for temporary (STS) credentials."""
+        from portolan_cli.upload import _load_aws_credentials_from_profile
+
+        assert mock_aws_credentials.exists()
+        access_key, secret_key, session_token, _region = _load_aws_credentials_from_profile(
+            "temp-sts"
+        )
+
+        assert access_key == "ASIATEMPKEY"
+        assert secret_key == "tempsecret"
+        assert session_token == "temp-session-token-value"
 
     @pytest.mark.unit
     def test_load_missing_profile(self, mock_aws_credentials: Path) -> None:
@@ -1029,11 +1056,70 @@ class TestLoadAwsCredentials:
 
         # Fixture patches Path.home() - assert it exists to mark as used
         assert mock_aws_credentials.exists()
-        access_key, secret_key, region = _load_aws_credentials_from_profile("nonexistent")
+        access_key, secret_key, session_token, region = _load_aws_credentials_from_profile(
+            "nonexistent"
+        )
 
         assert access_key is None
         assert secret_key is None
+        assert session_token is None
         assert region is None
+
+
+class TestSetupStoreSessionToken:
+    """Tests that temporary (STS) session tokens are forwarded to the S3 store."""
+
+    @pytest.mark.unit
+    def test_session_token_forwarded_to_s3store(self, mock_aws_credentials: Path) -> None:
+        """A profile with aws_session_token must pass it through to S3Store."""
+        from portolan_cli.upload import _setup_store_and_kwargs
+
+        assert mock_aws_credentials.exists()
+        with patch("portolan_cli.upload.S3Store") as mock_s3_store:
+            _setup_store_and_kwargs(
+                "s3://us-west-2.opendata.source.coop",
+                profile="temp-sts",
+                chunk_concurrency=4,
+            )
+
+        _args, kwargs = mock_s3_store.call_args
+        assert kwargs["access_key_id"] == "ASIATEMPKEY"
+        assert kwargs["secret_access_key"] == "tempsecret"
+        assert kwargs["aws_session_token"] == "temp-session-token-value"
+
+    @pytest.mark.unit
+    def test_no_session_token_for_long_term_credentials(self, mock_aws_credentials: Path) -> None:
+        """Long-term credentials (no token) must not set aws_session_token."""
+        from portolan_cli.upload import _setup_store_and_kwargs
+
+        assert mock_aws_credentials.exists()
+        with patch("portolan_cli.upload.S3Store") as mock_s3_store:
+            _setup_store_and_kwargs(
+                "s3://us-west-2.opendata.source.coop",
+                profile="myprofile",
+                chunk_concurrency=4,
+            )
+
+        _args, kwargs = mock_s3_store.call_args
+        assert "aws_session_token" not in kwargs
+
+    @pytest.mark.unit
+    def test_session_token_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """AWS_SESSION_TOKEN env var is forwarded when no profile is given."""
+        from portolan_cli.upload import _setup_store_and_kwargs
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ASIAENVKEY")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "envsecret")
+        monkeypatch.setenv("AWS_SESSION_TOKEN", "env-session-token")
+        with patch("portolan_cli.upload.S3Store") as mock_s3_store:
+            _setup_store_and_kwargs(
+                "s3://us-west-2.opendata.source.coop",
+                profile=None,
+                chunk_concurrency=4,
+            )
+
+        _args, kwargs = mock_s3_store.call_args
+        assert kwargs["aws_session_token"] == "env-session-token"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #541. S3 operations (`push`/`pull`/`clone`/`sync`) could not authenticate with **temporary AWS credentials** (STS, access key id `ASIA…`, which require an `aws_session_token`): the session token was never read from the profile nor passed to the obstore `S3Store`, so S3 returned `403 InvalidAccessKeyId`. This blocked publishing to **Source Cooperative**, which issues only temporary, ~1h-expiring credentials.

## Changes

- `_load_aws_credentials_from_profile()` now also reads `aws_session_token` and returns it (4-tuple `(access_key, secret_key, session_token, region)`); its callers are updated.
- `_setup_store_and_kwargs()` reads the token from the profile **or** the `AWS_SESSION_TOKEN` environment variable and forwards it to `S3Store` as `aws_session_token`. Long-term credentials (no token) are unaffected.
- Since `setup_store()` routes through `_setup_store_and_kwargs()`, this fixes every S3 path (push/pull/clone/sync), not just `upload`.

## Tests

`tests/unit/test_upload.py` and `tests/unit/test_push.py`:
- Load a session token from a profile (and `None` for long-term profiles).
- Forward the token to `S3Store` from a profile and from `AWS_SESSION_TOKEN`.
- Long-term credentials do **not** set `aws_session_token`.

All unit tests in both files pass (151 passed). Verified independently that obstore's `S3Store` accepts the `aws_session_token` kwarg, and that a `boto3` PUT with the same profile (incl. token) succeeds — confirming the credentials are valid and only the token forwarding was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 uploads now support authentication using temporary AWS session credentials, providing greater flexibility for credential management alongside existing long-term access key support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->