### PR TITLE
fix(readme): prefix collection links with catalog dir name (#549)

### DIFF
--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -854,8 +854,13 @@ def _add_collections_section(
             coll_metadata = {}
         title, description = _resolve_title_description(stac, coll_metadata)
 
-        # Link to collection directory
-        sections.append(f"### [{title}](./{coll_id}/)")
+        # Link to collection directory. Prefix with the catalog directory name
+        # rather than using a bare "./" relative link (#549): static hosts like
+        # source.coop serve the catalog README at a URL with no trailing slash
+        # (e.g. /tyler/colombia-ecosystems-map), so "./ecosistemas/" resolves
+        # against /tyler/ and drops the catalog name. Including the catalog dir
+        # name makes it resolve to /tyler/colombia-ecosystems-map/ecosistemas/.
+        sections.append(f"### [{title}]({catalog_path.name}/{coll_id}/)")
         sections.append("")
         if description:
             # Truncate long descriptions

--- a/tests/unit/test_readme_catalog_aggregation.py
+++ b/tests/unit/test_readme_catalog_aggregation.py
@@ -292,6 +292,51 @@ class TestGenerateCatalogReadme:
         assert "Demographics Data" in readme or "Census" in readme
 
     @pytest.mark.unit
+    def test_collection_link_includes_catalog_dir(self, tmp_path: Path) -> None:
+        """Collection links include the catalog directory name (#549).
+
+        Static hosts like source.coop serve the catalog README at a URL with no
+        trailing slash (e.g. ``/tyler/colombia-ecosystems-map``). A bare
+        ``./ecosistemas/`` link then resolves against ``/tyler/``, dropping the
+        catalog name and 404-ing. Prefixing the link with the catalog directory
+        name makes it resolve to ``/tyler/colombia-ecosystems-map/ecosistemas/``.
+        """
+        catalog_dir = tmp_path / "colombia-ecosystems-map"
+        catalog_dir.mkdir()
+        (catalog_dir / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": "catalog",
+                    "title": "Colombia Ecosystems Map",
+                    "description": "Test",
+                }
+            )
+        )
+
+        (catalog_dir / "ecosistemas").mkdir()
+        (catalog_dir / "ecosistemas" / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "ecosistemas",
+                    "title": "Ecosistemas",
+                    "description": "Ecosystems",
+                    "extent": {
+                        "spatial": {"bbox": [[-82, -5, -66, 16]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                }
+            )
+        )
+
+        readme = generate_catalog_readme(catalog_dir)
+
+        assert "[Ecosistemas](colombia-ecosystems-map/ecosistemas/)" in readme
+        # The old root-relative link dropped the catalog name and 404-ed.
+        assert "(./ecosistemas/)" not in readme
+
+    @pytest.mark.unit
     def test_collections_listing_uses_collection_metadata_yaml(self, tmp_path: Path) -> None:
         """Collections listing uses each collection's metadata.yaml title/description (#534).
 


### PR DESCRIPTION
## Summary

Fixes #549 — a collection link in the generated catalog README leads to a "Not Found" page on source.coop.

The catalog README listed collections with a bare root-relative link, e.g. `[Ecosistemas](./ecosistemas/)`. Static hosts like source.coop serve the catalog README at a URL with **no trailing slash** (`https://source.coop/tyler/colombia-ecosystems-map`), so the browser treats the last path segment as a filename and resolves `./ecosistemas/` against `/tyler/` → `https://source.coop/tyler/ecosistemas/` (404 — the catalog name is dropped).

## Fix

Prefix the link with the catalog directory name so it resolves correctly:

```
[Ecosistemas](colombia-ecosystems-map/ecosistemas/)
```

→ resolves to `https://source.coop/tyler/colombia-ecosystems-map/ecosistemas/`.

This is the single code path shared by both the normal and the collapsible (`<details>`) collection listings. The catalog directory name (`catalog_path.name`) is the only deployment-slug signal available at README-generation time — README generation has no access to the published/remote base URL.

## Caveat

This assumes the local catalog directory name matches the deployed slug (it did in the reported case: `colombia-ecosystems-map`).

## Test

Added `test_collection_link_includes_catalog_dir` (TDD): verified it fails before the change (produced `(./ecosistemas/)`) and passes after. It asserts the exact `(colombia-ecosystems-map/ecosistemas/)` link and that the old root-relative form is gone.

All README tests (95) and unit readme/catalog tests (151) pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed catalog README collection links so they now point to the catalog directory path instead of using a bare relative link.
  * This improves link accuracy when the README is viewed from static-hosted locations.

* **Tests**
  * Added coverage to verify collection links include the catalog directory name and no longer use the old link format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->