### PR TITLE
fix(push): upload intermediate catalogs and refresh metadata on --force (#496, #547, #552)

### DIFF
--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -542,6 +542,30 @@ class Catalog:
         return cls(root)
 
 
+def intermediate_catalog_ids(collection_id: str) -> list[str]:
+    """Return the ancestor sub-catalog ids for a nested collection (ADR-0032).
+
+    These are the intermediate directory levels between the catalog root and the
+    leaf collection, each of which holds a ``catalog.json`` (created by
+    ``create_intermediate_catalogs`` during ``add``). This is the single source
+    of truth for the path-segment walk, reused by both ``add`` (to create the
+    files) and ``push`` (to discover them as upload targets).
+
+    Examples:
+        "climate/hittekaart" -> ["climate"]
+        "env/air/quality"    -> ["env", "env/air"]
+        "demographics"       -> []  (leaf holds collection.json, no intermediates)
+
+    Args:
+        collection_id: The (possibly nested) collection ID, POSIX-separated.
+
+    Returns:
+        Ancestor sub-catalog ids in root-to-leaf order (empty for single-level).
+    """
+    parts = collection_id.split("/")
+    return ["/".join(parts[: i + 1]) for i in range(len(parts) - 1)]
+
+
 def create_intermediate_catalogs(collection_id: str, catalog_root: Path) -> None:
     """Create intermediate catalog.json files for nested collection paths (ADR-0032).
 
@@ -559,15 +583,10 @@ def create_intermediate_catalogs(collection_id: str, catalog_root: Path) -> None
         collection_id: The nested collection ID (e.g., "climate/hittekaart").
         catalog_root: Root directory of the catalog.
     """
-    parts = collection_id.split("/")
-
-    # No intermediates needed for single-level collections
-    if len(parts) <= 1:
-        return
-
-    # Create catalog.json at each intermediate level (all but the last)
-    for i in range(len(parts) - 1):
-        intermediate_path = "/".join(parts[: i + 1])
+    # Create catalog.json at each intermediate level (all but the last).
+    # intermediate_catalog_ids is the shared source of truth for this walk,
+    # also used by push discovery (keeps add/push in lockstep, ADR-0032).
+    for i, intermediate_path in enumerate(intermediate_catalog_ids(collection_id)):
         catalog_dir = catalog_root / intermediate_path
         catalog_file = catalog_dir / "catalog.json"
 

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -36,6 +36,7 @@ from portolan_cli.async_utils import (
     CircuitBreakerError,
     get_default_concurrency,
 )
+from portolan_cli.catalog import intermediate_catalog_ids
 from portolan_cli.output import detail, error, info, output_section, success, warn
 from portolan_cli.upload import ObjectStore, setup_store
 from portolan_cli.upload_progress import UploadProgressReporter
@@ -625,6 +626,12 @@ def _discover_stac_files(
         root_readme = catalog_root / "README.md"
         if root_readme.exists():
             stac_files["readmes"].append(root_readme)
+        # Intermediate catalog.json / README.md for nested collections (Issue #547, #552).
+        # Only relevant for standalone single-collection push (include_catalog=True);
+        # catalog-wide push handles these centrally after all collections succeed.
+        for inter_file in _discover_intermediate_catalog_files(catalog_root, [collection]):
+            key = "readmes" if inter_file.name == "README.md" else "catalog"
+            stac_files[key].append(inter_file)
 
     # 2. Collection's collection.json (required) and README.md (optional)
     collection_dir = catalog_root / collection
@@ -1228,6 +1235,13 @@ def _handle_push_dry_run(
         for f in metadata_files:
             rel_path = f.relative_to(catalog_root)
             detail(f"  {rel_path}")
+
+    # Show intermediate catalog.json / README.md for nested collections (Issue #547, #552)
+    intermediate_files = _discover_intermediate_catalog_files(catalog_root, [collection])
+    if intermediate_files:
+        info(f"[DRY RUN] Would upload {len(intermediate_files)} intermediate catalog file(s)")
+        for f in intermediate_files:
+            detail(f"  {f.relative_to(catalog_root).as_posix()}")
 
     warn("[DRY RUN] Remote conflict detection skipped (requires network)")
     warn("[DRY RUN] Actual versions pushed may be fewer if remote already has some")
@@ -1946,7 +1960,11 @@ async def _execute_push_uploads_async(
     info("Uploading versions.json...")
     try:
         await _upload_versions_json_async(store, prefix, collection, local_data, etag, force=force)
-        msg = f"Pushed {len(diff.local_only)} version(s): {diff.local_only}"
+        if diff.local_only:
+            msg = f"Pushed {len(diff.local_only)} version(s): {diff.local_only}"
+        else:
+            # Force re-push with no version delta refreshes metadata only (Issue #496)
+            msg = "Refreshed metadata (no new versions)"
         if metrics.total_bytes > 0:
             msg += (
                 f" ({format_file_size(metrics.total_bytes)}, {format_speed(metrics.average_speed)})"
@@ -2084,7 +2102,11 @@ async def push_async(
         )
 
     # Nothing to push?
-    if not diff.local_only and not (force and diff.remote_only):
+    # With --force, proceed even when the version list is unchanged so that
+    # regenerated metadata (collection.json, catalog.json, styles) is re-uploaded
+    # (Issue #496). Unchanged data assets are still skipped by the sha256 diff in
+    # _get_assets_to_upload, so this refreshes metadata without a full re-push.
+    if not force and not diff.local_only:
         info("Nothing to push - local and remote are in sync")
         return PushResult(
             success=True, files_uploaded=0, versions_pushed=0, conflicts=[], errors=[]
@@ -2264,6 +2286,42 @@ def _discover_root_metadata_files(catalog_root: Path) -> list[Path]:
     )
 
 
+def _discover_intermediate_catalog_files(catalog_root: Path, collections: list[str]) -> list[Path]:
+    """Discover intermediate catalog.json / README.md files for nested collections.
+
+    Per ADR-0032, a nested collection ``a/b/c`` has a ``catalog.json`` at each
+    intermediate level (``a/``, ``a/b/``) created by ``create_intermediate_catalogs``
+    during ``add``. These are neither leaf ``collection.json`` files nor the root
+    ``catalog.json``, so every other push discovery path misses them (Issue #547,
+    #552). This walks each collection's ancestor sub-catalog ids (shared
+    ``intermediate_catalog_ids`` helper) and returns the metadata files that
+    actually exist on disk, deduped across sibling collections and sorted for
+    deterministic output.
+
+    README.md is included only when present; ``create_intermediate_catalogs``
+    writes only ``catalog.json``, but real catalogs may carry authored READMEs at
+    sub-catalog levels (Issue #547).
+
+    Args:
+        catalog_root: Path to the catalog root directory.
+        collections: Leaf collection ids (from ``discover_collections``).
+
+    Returns:
+        Existing intermediate ``catalog.json``/``README.md`` paths, sorted.
+    """
+    seen: set[str] = set()
+    for collection in collections:
+        seen.update(intermediate_catalog_ids(collection))
+
+    files: list[Path] = []
+    for sub in sorted(seen):
+        for name in ("catalog.json", "README.md"):
+            path = catalog_root / sub / name
+            if path.exists():
+                files.append(path)
+    return files
+
+
 def _push_all_upload_root_files(
     catalog_root: Path,
     destination: str,
@@ -2271,16 +2329,22 @@ def _push_all_upload_root_files(
     region: str | None,
     dry_run: bool,
     stats: dict[str, Any],
+    collections: list[str] | None = None,
 ) -> bool:
-    """Upload root-level files after all collections (Issue #357, #426).
+    """Upload root-level files after all collections (Issue #357, #426, #547, #552).
 
     Uploads from catalog root (in order):
     1. README.md (documentation, optional)
     2. Root metadata files (style.json, thumbnails, etc.) - Issue #426
     3. catalog.json (STAC catalog metadata, required)
-    4. versions.json (manifest, required - uploaded LAST per manifest-last atomicity)
+    4. Intermediate catalog.json / README.md for nested collections - Issue #547, #552
+    5. versions.json (manifest, required - uploaded LAST per manifest-last atomicity)
 
     These are uploaded AFTER all collections succeed.
+
+    Args:
+        collections: Leaf collection ids (from ``discover_collections``), used to
+            discover intermediate catalogs. None/empty means no intermediates.
 
     Returns True if uploads succeeded or were skipped, False if any failed.
     """
@@ -2305,6 +2369,10 @@ def _push_all_upload_root_files(
     # Discover root metadata files (Issue #426)
     root_metadata = _discover_root_metadata_files(catalog_root)
 
+    # Discover intermediate catalog.json / README.md for nested collections
+    # (Issue #547, #552). Uploaded after root catalog.json, before versions.json.
+    intermediate_files = _discover_intermediate_catalog_files(catalog_root, collections or [])
+
     if dry_run:
         if root_readme.exists():
             info("[DRY RUN] Would upload README.md")
@@ -2313,6 +2381,10 @@ def _push_all_upload_root_files(
             for f in root_metadata:
                 detail(f"  {f.name}")
         info("[DRY RUN] Would upload catalog.json")
+        if intermediate_files:
+            info(f"[DRY RUN] Would upload {len(intermediate_files)} intermediate catalog file(s)")
+            for f in intermediate_files:
+                detail(f"  {f.relative_to(catalog_root).as_posix()}")
         if root_versions.exists():
             info("[DRY RUN] Would upload versions.json")
         return True
@@ -2342,6 +2414,16 @@ def _push_all_upload_root_files(
         obs.put(store, catalog_key, catalog_json.read_bytes())
         success("Uploaded catalog.json")
         stats["total_files"] += 1
+
+        # Upload intermediate catalog.json / README.md for nested collections
+        # (Issue #547, #552) - before versions.json to preserve manifest-last.
+        for inter_file in intermediate_files:
+            inter_key = f"{prefix}/{inter_file.relative_to(catalog_root).as_posix()}".lstrip("/")
+            obs.put(store, inter_key, inter_file.read_bytes())
+            detail(f"  Uploaded {inter_file.relative_to(catalog_root).as_posix()}")
+            stats["total_files"] += 1
+        if intermediate_files:
+            info(f"Uploaded {len(intermediate_files)} intermediate catalog file(s)")
 
         # Upload versions.json LAST (manifest-last atomicity per ADR-0005)
         if root_versions.exists():
@@ -2476,7 +2558,7 @@ async def push_all_collections_async(
             _push_all_process_result(coll, push_result, err_msg, i + 1, total, stats)
 
     catalog_ok = _push_all_upload_root_files(
-        catalog_root, destination, profile, region, dry_run, stats
+        catalog_root, destination, profile, region, dry_run, stats, collections
     )
 
     overall_success = stats["failed"] == 0 and catalog_ok

--- a/portolan_cli/push.py
+++ b/portolan_cli/push.py
@@ -2363,6 +2363,9 @@ def _push_all_upload_root_files(
         return True
 
     if not catalog_json.exists():
+        # No root catalog.json means the remote root is already broken, so we do
+        # not bother with intermediate catalog.json either (Issue #547, #552) -
+        # they are only reachable by walking child links from this missing root.
         warn(f"catalog.json not found at {catalog_root} - remote catalog may be incomplete")
         return True
 

--- a/tests/integration/test_s3_moto.py
+++ b/tests/integration/test_s3_moto.py
@@ -425,6 +425,126 @@ class TestPushS3Integration:
         assert "catalog/tst/latest/adm0/collection.json" in uploaded_keys, uploaded_keys
         assert "catalog/tst/latest/adm1/collection.json" in uploaded_keys, uploaded_keys
 
+    @pytest.mark.integration
+    def test_single_collection_push_uploads_intermediate_catalogs_to_s3(
+        self,
+        s3_bucket: tuple[str, str],
+        nested_catalog_with_data: Path,
+        _aws_env: None,
+    ) -> None:
+        """Issue #547/#552: the SINGLE-collection push path also lands intermediates.
+
+        Distinct code path from the catalog-wide test above: single-collection
+        push discovers intermediates via ``_discover_stac_files(include_catalog=True)``,
+        not the central ``_push_all_upload_root_files`` phase. Both must upload the
+        ancestor catalog.json, or a targeted ``push <collection>`` still leaves the
+        remote child-link chain broken.
+        """
+        bucket_name, endpoint_url = s3_bucket
+
+        from portolan_cli.push import push
+
+        result = push(
+            catalog_root=nested_catalog_with_data,
+            collection="tst/latest/adm0",
+            destination=f"s3://{bucket_name}/catalog",
+            force=False,
+        )
+        assert result.success is True, f"Push failed: {result}"
+
+        client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id="testing",
+            aws_secret_access_key="testing",
+            region_name="us-east-1",
+        )
+        response = client.list_objects_v2(Bucket=bucket_name, Prefix="catalog/")
+        uploaded_keys = {obj["Key"] for obj in response.get("Contents", [])}
+
+        assert "catalog/tst/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/latest/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/latest/adm0/collection.json" in uploaded_keys, uploaded_keys
+
+    @pytest.mark.integration
+    def test_force_refreshes_regenerated_collection_json_on_s3(
+        self,
+        s3_bucket: tuple[str, str],
+        nested_catalog_with_data: Path,
+        _aws_env: None,
+    ) -> None:
+        """Issue #496: --force re-uploads regenerated metadata with NO version delta.
+
+        Full round-trip against the bucket, reading actual bytes back:
+        1. push -> remote collection.json holds the original description;
+        2. regenerate collection.json in place (no version bump, versions.json
+           unchanged), push WITHOUT force -> "Nothing to push", remote unchanged
+           (the gate still guards against churn);
+        3. push WITH force -> remote collection.json now holds the new bytes.
+        """
+        bucket_name, endpoint_url = s3_bucket
+
+        from portolan_cli.push import push
+
+        collection = "tst/latest/adm0"
+        destination = f"s3://{bucket_name}/catalog"
+        coll_json = nested_catalog_with_data / "tst" / "latest" / "adm0" / "collection.json"
+
+        client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id="testing",
+            aws_secret_access_key="testing",
+            region_name="us-east-1",
+        )
+
+        def remote_collection_json() -> str:
+            obj = client.get_object(Bucket=bucket_name, Key=f"catalog/{collection}/collection.json")
+            body: str = obj["Body"].read().decode()
+            return body
+
+        # 1. Initial push: remote gets the original description.
+        assert (
+            push(
+                catalog_root=nested_catalog_with_data,
+                collection=collection,
+                destination=destination,
+                force=False,
+            ).success
+            is True
+        )
+        assert "Collection adm0" in remote_collection_json()
+
+        # 2. Regenerate collection.json locally (no version bump).
+        doc = json.loads(coll_json.read_text())
+        doc["description"] = "REGENERATED DESCRIPTION"
+        coll_json.write_text(json.dumps(doc))
+
+        # No-force push is a no-op: the remote keeps the ORIGINAL bytes.
+        assert (
+            push(
+                catalog_root=nested_catalog_with_data,
+                collection=collection,
+                destination=destination,
+                force=False,
+            ).success
+            is True
+        )
+        assert "REGENERATED DESCRIPTION" not in remote_collection_json()
+
+        # 3. Force push refreshes metadata even though the version list is identical.
+        assert (
+            push(
+                catalog_root=nested_catalog_with_data,
+                collection=collection,
+                destination=destination,
+                force=True,
+            ).success
+            is True
+        )
+        assert "REGENERATED DESCRIPTION" in remote_collection_json()
+
 
 # =============================================================================
 # Pull Integration Tests

--- a/tests/integration/test_s3_moto.py
+++ b/tests/integration/test_s3_moto.py
@@ -158,6 +158,83 @@ def catalog_with_data(tmp_path: Path, s3_bucket: tuple[str, str]) -> Path:
 
 
 @pytest.fixture
+def nested_catalog_with_data(tmp_path: Path, s3_bucket: tuple[str, str]) -> Path:
+    """A nested catalog (ADR-0032) with intermediate catalog.json files (Issue #547, #552)."""
+    bucket_name, endpoint_url = s3_bucket
+
+    catalog_dir = tmp_path / "catalog"
+    (catalog_dir / ".portolan").mkdir(parents=True)
+    (catalog_dir / ".portolan" / "config.yaml").write_text(
+        f"version: 1\nremote: s3://{bucket_name}/catalog\n"
+    )
+
+    def _catalog_json(path: Path, catalog_id: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "id": catalog_id,
+                    "stac_version": "1.1.0",
+                    "description": f"Catalog: {catalog_id}",
+                    "links": [],
+                }
+            )
+        )
+
+    _catalog_json(catalog_dir / "catalog.json", "root")
+    _catalog_json(catalog_dir / "tst" / "catalog.json", "tst")
+    _catalog_json(catalog_dir / "tst" / "latest" / "catalog.json", "tst/latest")
+
+    for layer in ("adm0", "adm1"):
+        leaf = catalog_dir / "tst" / "latest" / layer
+        leaf.mkdir(parents=True)
+        data = f"parquet-{layer}".encode()
+        (leaf / f"{layer}.parquet").write_bytes(data)
+        (leaf / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": f"tst/latest/{layer}",
+                    "stac_version": "1.1.0",
+                    "description": f"Collection {layer}",
+                    "license": "CC0-1.0",
+                    "extent": {
+                        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                    "links": [],
+                }
+            )
+        )
+        (leaf / "versions.json").write_text(
+            json.dumps(
+                {
+                    "spec_version": "1.0.0",
+                    "current_version": "1.0.0",
+                    "versions": [
+                        {
+                            "version": "1.0.0",
+                            "created": "2024-01-01T00:00:00Z",
+                            "breaking": False,
+                            "changes": [f"{layer}.parquet"],
+                            "assets": {
+                                f"{layer}.parquet": {
+                                    "sha256": hashlib.sha256(data).hexdigest(),
+                                    "size_bytes": len(data),
+                                    "href": f"tst/latest/{layer}/{layer}.parquet",
+                                }
+                            },
+                        }
+                    ],
+                }
+            )
+        )
+
+    return catalog_dir
+
+
+@pytest.fixture
 def _aws_env(s3_bucket: tuple[str, str]) -> Generator[None, None, None]:
     """Set up AWS environment variables for obstore to use moto server.
 
@@ -303,6 +380,50 @@ class TestPushS3Integration:
             f"Second push ({result2.files_uploaded} files) should not upload more "
             f"than initial push ({initial_uploads} files)"
         )
+
+    @pytest.mark.integration
+    def test_push_uploads_intermediate_catalogs_to_s3(
+        self,
+        s3_bucket: tuple[str, str],
+        nested_catalog_with_data: Path,
+        _aws_env: None,
+    ) -> None:
+        """Issue #547/#552: catalog-wide push lands intermediate catalog.json in the bucket.
+
+        The push->bucket round-trip is the guard against the silent-drop class:
+        a client walking child links from the root must find every intermediate
+        catalog.json, not just root catalog.json and leaf collection.json.
+        """
+        bucket_name, endpoint_url = s3_bucket
+
+        from portolan_cli.push import push_all_collections
+
+        result = push_all_collections(
+            catalog_root=nested_catalog_with_data,
+            destination=f"s3://{bucket_name}/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+        assert result.success is True, f"Push failed: {result}"
+
+        client = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id="testing",
+            aws_secret_access_key="testing",
+            region_name="us-east-1",
+        )
+        response = client.list_objects_v2(Bucket=bucket_name, Prefix="catalog/")
+        uploaded_keys = {obj["Key"] for obj in response.get("Contents", [])}
+
+        # The two intermediate catalogs that every prior code path dropped.
+        assert "catalog/tst/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/latest/catalog.json" in uploaded_keys, uploaded_keys
+        # Sanity: root and leaves still land too.
+        assert "catalog/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/latest/adm0/collection.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/latest/adm1/collection.json" in uploaded_keys, uploaded_keys
 
 
 # =============================================================================

--- a/tests/unit/test_nested_catalog_inference.py
+++ b/tests/unit/test_nested_catalog_inference.py
@@ -298,6 +298,45 @@ class TestCreateIntermediateCatalogs:
         assert links_by_rel["parent"]["href"] == "../catalog.json"
 
 
+class TestIntermediateCatalogIds:
+    """Test intermediate_catalog_ids() pure path-walk helper (shared by add + push)."""
+
+    def test_two_level_returns_single_ancestor(self) -> None:
+        """climate/hittekaart -> ['climate']."""
+        from portolan_cli.catalog import intermediate_catalog_ids
+
+        assert intermediate_catalog_ids("climate/hittekaart") == ["climate"]
+
+    def test_three_level_returns_ordered_ancestors(self) -> None:
+        """env/air/quality -> ['env', 'env/air'] (root-to-leaf order)."""
+        from portolan_cli.catalog import intermediate_catalog_ids
+
+        assert intermediate_catalog_ids("env/air/quality") == ["env", "env/air"]
+
+    def test_single_level_returns_empty(self) -> None:
+        """demographics -> [] (leaf holds collection.json, no intermediates)."""
+        from portolan_cli.catalog import intermediate_catalog_ids
+
+        assert intermediate_catalog_ids("demographics") == []
+
+    def test_matches_create_intermediate_catalogs(self, tmp_path: Path) -> None:
+        """The ids must be exactly the dirs create_intermediate_catalogs writes."""
+        from portolan_cli.catalog import (
+            create_intermediate_catalogs,
+            intermediate_catalog_ids,
+        )
+
+        (tmp_path / "catalog.json").write_text('{"type": "Catalog", "id": "test", "links": []}')
+        collection_id = "tst/latest/adm0"
+        create_intermediate_catalogs(collection_id, tmp_path)
+
+        expected_dirs = {
+            (tmp_path / sub / "catalog.json") for sub in intermediate_catalog_ids(collection_id)
+        }
+        written = set((tmp_path).glob("*/catalog.json")) | set((tmp_path).glob("*/*/catalog.json"))
+        assert written == expected_dirs
+
+
 class TestUpdateCatalogLinksNested:
     """Test that catalog links correctly reference intermediate catalogs."""
 

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -1057,6 +1057,141 @@ class TestForceFlag:
         # versions.json MUST be uploaded to force-overwrite remote state
         mock_upload_versions.assert_called_once()
 
+    @staticmethod
+    def _build_identical_version_catalog(tmp_path: Path) -> Path:
+        """Catalog whose local versions.json exactly matches the remote (Issue #496)."""
+        catalog_dir = tmp_path / "catalog"
+        versions_dir = catalog_dir / "test"
+        versions_dir.mkdir(parents=True)
+        versions_data = {
+            "spec_version": "1.0.0",
+            "current_version": "1.0.0",
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "created": "2024-01-01T00:00:00Z",
+                    "breaking": False,
+                    "message": "Initial version",
+                    "assets": {
+                        "data.parquet": {
+                            "sha256": "abc123",
+                            "size_bytes": 1024,
+                            "href": "test/data/data.parquet",
+                        }
+                    },
+                    "changes": ["data.parquet"],
+                },
+            ],
+        }
+        (versions_dir / "versions.json").write_text(json.dumps(versions_data, indent=2))
+        (versions_dir / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "test",
+                    "stac_version": "1.0.0",
+                    "description": "Test collection",
+                    "license": "proprietary",
+                    "extent": {
+                        "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                        "temporal": {"interval": [[None, None]]},
+                    },
+                    "links": [],
+                },
+                indent=2,
+            )
+        )
+        item_dir = versions_dir / "data"
+        item_dir.mkdir(parents=True)
+        (item_dir / "data.parquet").write_bytes(b"x" * 1024)
+        return catalog_dir
+
+    @pytest.mark.unit
+    def test_force_reuploads_metadata_when_versions_identical(self, tmp_path: Path) -> None:
+        """Issue #496: --force must re-upload metadata even with NO version delta.
+
+        Local and remote version lists are identical (no local_only, no
+        remote_only), but a regenerated collection.json needs re-uploading.
+        Before the fix, the "Nothing to push" gate returned early even with
+        --force, so the STAC upload phase never ran.
+        """
+        from portolan_cli.push import push
+
+        catalog_dir = self._build_identical_version_catalog(tmp_path)
+
+        with patch(
+            "portolan_cli.push._fetch_remote_versions_async", new_callable=AsyncMock
+        ) as mock_fetch:
+            # Remote has the EXACT same single version as local.
+            mock_fetch.return_value = (
+                {
+                    "spec_version": "1.0.0",
+                    "current_version": "1.0.0",
+                    "versions": [{"version": "1.0.0", "created": "2024-01-01T00:00:00Z"}],
+                },
+                "etag-123",
+            )
+            with patch(
+                "portolan_cli.push._upload_assets_async", new_callable=AsyncMock
+            ) as mock_upload_assets:
+                mock_upload_assets.return_value = (0, [], [], UploadMetrics())
+                with patch(
+                    "portolan_cli.push._upload_stac_files_async", new_callable=AsyncMock
+                ) as mock_upload_stac:
+                    mock_upload_stac.return_value = (1, [], ["stac/collection.json"])
+                    with patch(
+                        "portolan_cli.push._upload_versions_json_async", new_callable=AsyncMock
+                    ) as mock_upload_versions:
+                        mock_upload_versions.return_value = None
+
+                        result = push(
+                            catalog_root=catalog_dir,
+                            collection="test",
+                            destination="s3://mybucket/catalog",
+                            force=True,
+                        )
+
+        assert result.success is True
+        # The STAC upload phase MUST run so collection.json gets refreshed.
+        mock_upload_stac.assert_called_once()
+
+    @pytest.mark.unit
+    def test_no_force_skips_upload_when_versions_identical(self, tmp_path: Path) -> None:
+        """Without --force and no version delta, push is a no-op (regression guard).
+
+        This pins the other side of the Issue #496 gate: the "Nothing to push"
+        short-circuit must remain intact when force is not set.
+        """
+        from portolan_cli.push import push
+
+        catalog_dir = self._build_identical_version_catalog(tmp_path)
+
+        with patch(
+            "portolan_cli.push._fetch_remote_versions_async", new_callable=AsyncMock
+        ) as mock_fetch:
+            mock_fetch.return_value = (
+                {
+                    "spec_version": "1.0.0",
+                    "current_version": "1.0.0",
+                    "versions": [{"version": "1.0.0", "created": "2024-01-01T00:00:00Z"}],
+                },
+                "etag-123",
+            )
+            with patch(
+                "portolan_cli.push._upload_stac_files_async", new_callable=AsyncMock
+            ) as mock_upload_stac:
+                result = push(
+                    catalog_root=catalog_dir,
+                    collection="test",
+                    destination="s3://mybucket/catalog",
+                    force=False,
+                )
+
+        assert result.success is True
+        assert result.files_uploaded == 0
+        # No upload phase should run when nothing changed and force is off.
+        mock_upload_stac.assert_not_called()
+
 
 # =============================================================================
 # Orphan Cleanup Tests

--- a/tests/unit/test_push_intermediate_catalogs.py
+++ b/tests/unit/test_push_intermediate_catalogs.py
@@ -1,0 +1,229 @@
+"""Tests for intermediate catalog.json / README.md upload on push (Issue #547, #552).
+
+Per ADR-0032 (nested catalogs, flat collections), a nested collection like
+``tst/latest/adm0`` has a ``catalog.json`` at each intermediate level
+(``tst/`` and ``tst/latest/``) created by ``create_intermediate_catalogs``
+during ``add``. These files were never uploaded by ``push`` -- neither the
+single-collection path nor the catalog-wide path -- breaking STAC navigation for
+any client walking ``child`` links remotely. These tests pin the fix.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from portolan_cli.push import (
+    PushResult,
+    _discover_intermediate_catalog_files,
+    _discover_stac_files,
+    push,
+    push_all_collections,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _setup_valid_catalog(catalog_root: Path) -> None:
+    """Create the .portolan/config.yaml sentinel required by discover_collections."""
+    portolan_dir = catalog_root / ".portolan"
+    portolan_dir.mkdir(parents=True, exist_ok=True)
+    (portolan_dir / "config.yaml").write_text("version: '1.0'\n")
+
+
+def _write_catalog_json(path: Path, catalog_id: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "id": catalog_id,
+                "stac_version": "1.1.0",
+                "description": f"Catalog: {catalog_id}",
+                "links": [],
+            }
+        )
+    )
+
+
+def _write_leaf_collection(catalog_root: Path, collection_id: str) -> None:
+    collection_dir = catalog_root / collection_id
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    (collection_dir / "versions.json").write_text(
+        json.dumps({"versions": [{"version": "v1", "assets": {}}]})
+    )
+    (collection_dir / "collection.json").write_text(
+        json.dumps(
+            {
+                "type": "Collection",
+                "id": collection_id,
+                "stac_version": "1.1.0",
+                "description": f"Collection {collection_id}",
+                "license": "proprietary",
+                "extent": {
+                    "spatial": {"bbox": [[-180, -90, 180, 90]]},
+                    "temporal": {"interval": [[None, None]]},
+                },
+                "links": [],
+            }
+        )
+    )
+
+
+@pytest.fixture
+def nested_catalog(tmp_path: Path) -> Path:
+    """Two sibling leaf collections under a two-level nesting (structure from #552).
+
+    Layout::
+
+        catalog.json                    (root)
+        tst/catalog.json                (intermediate, level 1)
+        tst/README.md                   (intermediate authored readme)
+        tst/latest/catalog.json         (intermediate, level 2)
+        tst/latest/adm0/{collection,versions}.json
+        tst/latest/adm1/{collection,versions}.json
+    """
+    _setup_valid_catalog(tmp_path)
+    _write_catalog_json(tmp_path / "catalog.json", "root")
+    _write_catalog_json(tmp_path / "tst" / "catalog.json", "tst")
+    (tmp_path / "tst" / "README.md").write_text("# tst\n\nSub-catalog readme.\n")
+    _write_catalog_json(tmp_path / "tst" / "latest" / "catalog.json", "tst/latest")
+    _write_leaf_collection(tmp_path, "tst/latest/adm0")
+    _write_leaf_collection(tmp_path, "tst/latest/adm1")
+    return tmp_path
+
+
+class TestDiscoverIntermediateCatalogFiles:
+    """Unit tests for the discovery helper."""
+
+    def test_discovers_deduped_sorted_intermediate_files(self, nested_catalog: Path) -> None:
+        """Two sibling collections share ancestors; result is deduped + sorted."""
+        files = _discover_intermediate_catalog_files(
+            nested_catalog, ["tst/latest/adm0", "tst/latest/adm1"]
+        )
+        rel = [f.relative_to(nested_catalog).as_posix() for f in files]
+
+        # tst/ and tst/latest/ each appear once despite two sibling collections;
+        # the authored tst/README.md is included, and root catalog.json is NOT.
+        # Sorted by ancestor dir; within a dir, catalog.json precedes README.md.
+        assert rel == [
+            "tst/catalog.json",
+            "tst/README.md",
+            "tst/latest/catalog.json",
+        ]
+
+    def test_single_level_collection_has_no_intermediates(self, tmp_path: Path) -> None:
+        """A flat collection id yields no intermediate files."""
+        _setup_valid_catalog(tmp_path)
+        _write_catalog_json(tmp_path / "catalog.json", "root")
+        _write_leaf_collection(tmp_path, "demographics")
+        assert _discover_intermediate_catalog_files(tmp_path, ["demographics"]) == []
+
+
+class TestCatalogWidePushIntermediateCatalogs:
+    """push_all_collections must upload intermediate catalog.json (Issue #547, #552)."""
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_uploads_intermediate_catalogs(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, nested_catalog: Path
+    ) -> None:
+        mock_push.return_value = PushResult(
+            success=True, files_uploaded=1, versions_pushed=1, conflicts=[], errors=[]
+        )
+
+        result = push_all_collections(
+            catalog_root=nested_catalog,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        assert result.success is True
+        uploaded_keys = [c.args[1] for c in mock_obs_put.call_args_list]
+
+        assert "catalog/tst/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/latest/catalog.json" in uploaded_keys, uploaded_keys
+        assert "catalog/tst/README.md" in uploaded_keys, uploaded_keys
+
+    @patch("portolan_cli.push.obs.put")
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_versions_json_uploaded_after_intermediate_catalogs(
+        self, mock_push: MagicMock, mock_obs_put: MagicMock, nested_catalog: Path
+    ) -> None:
+        """Manifest-last: root versions.json uploads after intermediate catalogs."""
+        # Root versions.json is required for the manifest-last upload to fire.
+        (nested_catalog / "versions.json").write_text(
+            json.dumps({"schema_version": "1.0.0", "collections": {}})
+        )
+        mock_push.return_value = PushResult(
+            success=True, files_uploaded=1, versions_pushed=1, conflicts=[], errors=[]
+        )
+
+        push_all_collections(
+            catalog_root=nested_catalog,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=False,
+            profile=None,
+        )
+
+        uploaded_keys = [c.args[1] for c in mock_obs_put.call_args_list]
+        versions_idx = uploaded_keys.index("catalog/versions.json")
+        inter_idx = uploaded_keys.index("catalog/tst/latest/catalog.json")
+        assert versions_idx > inter_idx, uploaded_keys
+
+
+class TestCatalogWideDryRun:
+    """Dry-run must report the intermediate catalogs it would upload."""
+
+    @patch("portolan_cli.push.push_async", new_callable=AsyncMock)
+    def test_dry_run_lists_intermediate_catalogs(
+        self, mock_push: MagicMock, nested_catalog: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        mock_push.return_value = PushResult(
+            success=True, files_uploaded=0, versions_pushed=0, conflicts=[], errors=[], dry_run=True
+        )
+
+        push_all_collections(
+            catalog_root=nested_catalog,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=True,
+            profile=None,
+        )
+
+        out = capsys.readouterr().out
+        assert "tst/catalog.json" in out
+        assert "tst/latest/catalog.json" in out
+
+
+class TestSingleCollectionIntermediateCatalogs:
+    """Single-collection push (include_catalog=True) also covers its ancestors."""
+
+    def test_discover_stac_files_includes_intermediate_catalogs(self, nested_catalog: Path) -> None:
+        stac_files = _discover_stac_files(nested_catalog, "tst/latest/adm0", include_catalog=True)
+        catalog_rel = {p.relative_to(nested_catalog).as_posix() for p in stac_files["catalog"]}
+        readme_rel = {p.relative_to(nested_catalog).as_posix() for p in stac_files["readmes"]}
+
+        assert "catalog.json" in catalog_rel  # root
+        assert "tst/catalog.json" in catalog_rel
+        assert "tst/latest/catalog.json" in catalog_rel
+        assert "tst/README.md" in readme_rel
+
+    def test_dry_run_single_collection_lists_intermediates(
+        self, nested_catalog: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        push(
+            catalog_root=nested_catalog,
+            collection="tst/latest/adm0",
+            destination="s3://bucket/catalog",
+            dry_run=True,
+        )
+        out = capsys.readouterr().out
+        assert "tst/catalog.json" in out
+        assert "tst/latest/catalog.json" in out


### PR DESCRIPTION
## Summary

Fixes three related `portolan push` bugs, all in the "silently drops metadata it should sync" class called out in `.claude/rules/sync.md`.

- **#547 / #552 — intermediate `catalog.json` (and `README.md`) never uploaded.** Per ADR-0032, a nested collection `a/b/c` gets a `catalog.json` at each intermediate level (`a/`, `a/b/`). Push only uploaded the *root* `catalog.json` and each *leaf* `collection.json`, so a client walking `child` links from the root reached 404s remotely. Both push paths now discover and upload every ancestor `catalog.json`/`README.md`.
- **#496 — `push --force` did not refresh a stale `collection.json`.** When `add` regenerates `collection.json` in place without a version bump, the version diff is empty and push returned early at the "Nothing to push" gate — even with `--force`. `--force` now proceeds to the upload phase (unchanged data assets still skipped via the existing sha256 diff).

## Changes

- **`catalog.py`** — extract `intermediate_catalog_ids(collection_id)`, the pure ancestor-path walk; refactor `create_intermediate_catalogs()` to use it so `add` and `push` share one source of truth.
- **`push.py`**
  - add `_discover_intermediate_catalog_files()` (deduped, sorted; `README.md` only if present);
  - catalog-wide: thread `collections` into `_push_all_upload_root_files()`, upload intermediates after root `catalog.json` and **before** root `versions.json` (manifest-last preserved), guarded by the same "only after all collections succeed" check;
  - single-collection: extend `_discover_stac_files()`'s `include_catalog` branch;
  - report intermediates in both dry-run paths;
  - fix the `--force` gate and adjust the success message for metadata-only pushes.

## Tests

New tests fail before the fix, pass after:

- `test_nested_catalog_inference.py` — `intermediate_catalog_ids` + parity with `create_intermediate_catalogs`.
- `test_push_intermediate_catalogs.py` (new) — discovery dedup/sort, catalog-wide upload keys, manifest-last ordering, single-collection discovery, both dry-runs.
- `test_push.py` — two `#496` gate tests (force re-uploads on identical version lists; no-force stays a no-op).
- `test_s3_moto.py` — push→bucket round-trip asserting `catalog/tst/catalog.json` and `catalog/tst/latest/catalog.json` actually land.

## Verification

`ruff` ✓ · `mypy --strict` ✓ · `lint-imports` ✓ · `xenon` ✓ · full unit tier **4674 passed / 0 failed** ✓ · moto integration ✓

Closes #496
Closes #547
Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved nested catalog handling so push operations discover and upload intermediate `catalog.json` (and optional `README.md`) for ancestor levels, in both catalog-wide and single-collection flows.

* **Bug Fixes**
  * Fixed cases where intermediate catalog ancestors could be unintentionally skipped during push.
  * Adjusted forced metadata refresh so `--force` still re-uploads metadata even when there’s no `versions.json` delta.

* **Tests**
  * Added integration and unit tests covering intermediate catalog upload/discovery, dry-run reporting, and `--force` vs no-op behavior when versions are identical.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->