### PR TITLE
spec: remove state.json from structure.md and core.md — deleted from code long ago

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -4,7 +4,7 @@ These requirements apply to all Portolan catalogs, regardless of data format.
 
 ## Catalog Structure
 
-A Portolan catalog is a directory with STAC metadata at the project root and internal tooling state in `.portolan/`. See [structure.md](structure.md) for the full directory layout.
+A Portolan catalog is a directory with STAC metadata at the project root and internal tooling configuration in `.portolan/`. See [structure.md](structure.md) for the full directory layout.
 
 ```
 project/

--- a/spec/core.md
+++ b/spec/core.md
@@ -9,8 +9,7 @@ A Portolan catalog is a directory with STAC metadata at the project root and int
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml
-│   └── state.json
+│   └── config.yaml
 ├── catalog.json
 ├── llms.txt
 ├── versions.json

--- a/spec/structure.md
+++ b/spec/structure.md
@@ -1,6 +1,6 @@
 # Catalog Structure
 
-A Portolan catalog is a directory with STAC metadata and cloud-native geospatial data. Internal tooling state lives in `.portolan/`; all STAC-visible files live at the project root.
+A Portolan catalog is a directory with STAC metadata and cloud-native geospatial data. Internal tooling configuration lives in `.portolan/`; all STAC-visible files live at the project root.
 
 ## Directory Layout
 
@@ -33,7 +33,7 @@ The `.portolan` directory **MUST** exist at the project root. Tools **SHOULD** c
 |------|----------|-------------|
 | `config.yaml` | **MUST** | Catalog configuration (sentinel file) |
 
-Only Portolan-internal tooling state lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
+Only Portolan-internal tooling configuration lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
 
 ## Collection Level
 

--- a/spec/structure.md
+++ b/spec/structure.md
@@ -7,8 +7,7 @@ A Portolan catalog is a directory with STAC metadata and cloud-native geospatial
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml                    # Internal: catalog configuration
-│   └── state.json                     # Internal: local sync state
+│   └── config.yaml                    # Internal: catalog configuration
 ├── catalog.json                       # STAC Catalog (root metadata)
 ├── versions.json                      # Catalog-level versioning
 └── {collection_id}/
@@ -22,7 +21,7 @@ project/
 
 | File | Required | Description |
 |------|----------|-------------|
-| `.portolan/` | **MUST** | Internal tooling directory (config, state) |
+| `.portolan/` | **MUST** | Internal tooling directory (config) |
 | `catalog.json` | **MUST** | STAC Catalog (root metadata) |
 | `versions.json` | **MUST** | Catalog-level version tracking |
 
@@ -33,7 +32,6 @@ The `.portolan` directory **MUST** exist at the project root. Tools **SHOULD** c
 | File | Required | Description |
 |------|----------|-------------|
 | `config.yaml` | **MUST** | Catalog configuration (sentinel file) |
-| `state.json` | **SHOULD** | Local sync state |
 
 Only Portolan-internal tooling state lives in `.portolan/`. STAC metadata and version manifests live at the project root alongside the data they describe, making catalogs compatible with standard STAC tooling (STAC Browser, PySTAC, stac-validator).
 
@@ -122,8 +120,7 @@ A catalog with a single-file vector collection:
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml
-│   └── state.json
+│   └── config.yaml
 ├── catalog.json
 ├── versions.json
 └── districts/
@@ -139,8 +136,7 @@ A catalog with a partitioned vector collection (data > 2 GB):
 ```
 project/
 ├── .portolan/
-│   ├── config.yaml
-│   └── state.json
+│   └── config.yaml
 ├── catalog.json
 ├── versions.json
 └── buildings/


### PR DESCRIPTION
## Summary

Removes stale references to `state.json` from the spec. `state.json` was deleted
from the code long ago (issue #290, ADR-0027) — `config.yaml` is now the sole
sentinel in `.portolan/` — but the spec still documented it as a `SHOULD` file in
the directory layout, file tables, and examples.

Closes #556 (spec-sprint reconciliation, finding C5).

## Changes

- **`spec/structure.md`**
  - Dropped `state.json` from the directory-layout tree.
  - Removed the `state.json` row from the `.portolan/` contents table.
  - Updated the root-level table description from "Internal tooling directory
    (config, state)" to "(config)".
  - Removed `state.json` from both catalog examples (single-file and partitioned).
- **`spec/core.md`**
  - Removed `state.json` from the directory tree.

## Verification

- Grepped `spec/` and `docs/` for `state.json` — no remaining mentions.
- Confirmed the remaining "sync state" references all correctly describe
  `versions.json` (the current source of truth), not `state.json`.
- Existing tests already assert `.portolan/state.json` is never created
  (per issue #290), so the spec now matches the code.
- Local gate: `ruff format --check`, `ruff check`, and `mypy portolan_cli` all pass.

Closes #556

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the product specs to reflect a simplified `.portolan/` directory layout.
  * Removed references to a separate `state.json` file from example structures and directory requirements.
  * Clarified that the expected contents of `.portolan/` now center on `config.yaml` only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->