### PR TITLE
spec/code: standardize on STAC 1.1.0 everywhere (schemas, docs, license default)

### DIFF
--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -496,7 +496,6 @@ class Catalog:
 
     PORTOLAN_DIR = ".portolan"
     CATALOG_FILE = "catalog.json"
-    STAC_VERSION = "1.1.0"
 
     def __init__(self, root: Path) -> None:
         """Initialize a Catalog instance.

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -496,7 +496,7 @@ class Catalog:
 
     PORTOLAN_DIR = ".portolan"
     CATALOG_FILE = "catalog.json"
-    STAC_VERSION = "1.0.0"
+    STAC_VERSION = "1.1.0"
 
     def __init__(self, root: Path) -> None:
         """Initialize a Catalog instance.

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3417,8 +3417,8 @@ def add_cmd(
 @click.option(
     "--license",
     "license_id",
-    default="proprietary",
-    help="SPDX license identifier (default: proprietary).",
+    default="other",
+    help="SPDX license expression, or 'other' for a non-SPDX license (default: other).",
 )
 @click.option(
     "--via",

--- a/portolan_cli/external.py
+++ b/portolan_cli/external.py
@@ -33,7 +33,12 @@ from portolan_cli.dataset import (
     _save_collection_with_links,
     _validate_collection_id,
 )
-from portolan_cli.stac import add_asset_to_collection, add_via_link, create_collection
+from portolan_cli.stac import (
+    DEFAULT_LICENSE,
+    add_asset_to_collection,
+    add_via_link,
+    create_collection,
+)
 from portolan_cli.validation import InputValidationError, validate_remote_url
 
 # Marks an asset as referenced in place rather than managed (downloaded/
@@ -168,7 +173,7 @@ def add_external_dataset(
     title: str | None = None,
     description: str | None = None,
     media_type: str | None = None,
-    license: str = "proprietary",
+    license: str = DEFAULT_LICENSE,
     via_url: str | None = None,
     bbox: list[float] | None = None,
     asset_key: str = "data",
@@ -188,7 +193,8 @@ def add_external_dataset(
         title: Optional human-readable collection title.
         description: Optional description (defaults to a generated one).
         media_type: Asset media type. Inferred from the URL when omitted.
-        license: SPDX license identifier (default: "proprietary").
+        license: SPDX license expression, or "other" for a non-SPDX license
+            (default: "other"). STAC 1.1 no longer accepts "proprietary".
         via_url: Provenance URL for the ``rel:"via"`` link. Defaults to ``url``.
         bbox: Optional WGS84 bbox [min_x, min_y, max_x, max_y]. Global if omitted.
         asset_key: Key for the asset entry in collection.json (default "data").

--- a/portolan_cli/extract/arcgis/imageserver/metadata.py
+++ b/portolan_cli/extract/arcgis/imageserver/metadata.py
@@ -51,7 +51,7 @@ def create_collection_metadata(
         - extent: spatial from fullExtent (WGS84), temporal open interval
         - summaries: band count, pixel type
         - links: source link to ImageServer, self link
-        - license: "proprietary" (default for unknown sources)
+        - license: "other" (STAC 1.1 default for unknown/non-SPDX sources)
     """
     collection_id = _sanitize_id(service_metadata.name)
 
@@ -103,7 +103,7 @@ def create_collection_metadata(
         "id": collection_id,
         "title": service_metadata.name,
         "description": description,
-        "license": "proprietary",
+        "license": "other",  # STAC 1.1: non-SPDX / unknown license (issue #568)
         "extent": {
             "spatial": {
                 "bbox": [list(wgs84_bbox)],

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -321,7 +321,10 @@ def _validate_contact(metadata: dict[str, Any]) -> list[str]:
 def _validate_license(metadata: dict[str, Any]) -> list[str]:
     """Validate the required 'license' field.
 
-    License must be a valid SPDX identifier or LicenseRef-* custom identifier.
+    License must be a valid SPDX identifier, a LicenseRef-* custom identifier,
+    or the STAC 1.1 keyword ``other`` (a license not covered by SPDX; a
+    rel="license" link is expected alongside it). STAC 1.1 no longer accepts
+    the deprecated ``proprietary`` value (issue #568).
 
     Args:
         metadata: The full metadata dictionary.
@@ -339,15 +342,17 @@ def _validate_license(metadata: dict[str, Any]) -> list[str]:
         errors.append("Field 'license' cannot be empty")
         return errors
 
-    # Validate license is SPDX identifier or valid LicenseRef-* custom identifier
+    # Validate license is an SPDX identifier, the STAC 1.1 "other" keyword,
+    # or a valid LicenseRef-* custom identifier.
     license_id = str(metadata.get("license"))
     is_standard_license = license_id in COMMON_SPDX_LICENSES
+    is_other_license = license_id == "other"
     is_custom_license = LICENSEREF_PATTERN.match(license_id) is not None
-    if not is_standard_license and not is_custom_license:
+    if not (is_standard_license or is_other_license or is_custom_license):
         errors.append(
             f"Invalid SPDX license identifier: '{license_id}'. "
-            f"Use a standard license (MIT, Apache-2.0, CC-BY-4.0, CC0-1.0) "
-            f"or custom format LicenseRef-YourLicense"
+            f"Use a standard license (MIT, Apache-2.0, CC-BY-4.0, CC0-1.0), "
+            f"'other' for a non-SPDX license, or custom format LicenseRef-YourLicense"
         )
 
     return errors

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -71,8 +71,11 @@ MACHINE_DERIVABLE_EXTRA_FIELDS = frozenset(
 # STAC version we generate (v1.1.0 has unified bands array, superseding eo:bands/raster:bands)
 STAC_VERSION = "1.1.0"
 
-# Default license when not specified
-DEFAULT_LICENSE = "proprietary"
+# Default license when not specified.
+# STAC 1.1 deprecates "proprietary" (it is not an SPDX identifier); "other" is
+# the spec keyword for a license not covered by an SPDX expression. A rel="license"
+# link SHOULD be added by the user once the concrete license is known (issue #568).
+DEFAULT_LICENSE = "other"
 
 # Sentinel datetime values for provisional items (ADR-0035, STAC 1.1.0 compliance)
 # STAC 1.1.0 and pystac require start_datetime/end_datetime to be valid ISO 8601 strings
@@ -98,7 +101,8 @@ def create_collection(
         description: Human-readable description.
         title: Optional display title. Defaults to a human-readable title
             derived from ``collection_id`` (Issue #502: titles are mandatory).
-        license: SPDX license identifier (default: "proprietary").
+        license: SPDX license expression, or "other" for a non-SPDX license
+            (default: "other"). STAC 1.1 no longer accepts "proprietary".
         bbox: Spatial extent as [min_x, min_y, max_x, max_y] in WGS84.
               Defaults to global extent if not specified.
         temporal_extent: Temporal extent as (start, end) datetimes.

--- a/spec/core.md
+++ b/spec/core.md
@@ -24,7 +24,7 @@ project/
 ## STAC Compliance
 
 - **MUST** be a valid STAC Catalog or Collection
-- **MUST** follow STAC specification version 1.0.0 or later
+- **MUST** follow STAC specification version 1.1.0
 - **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
 
 ### Spatial Extent for Tabular Collections

--- a/spec/examples/tabular-collection.json
+++ b/spec/examples/tabular-collection.json
@@ -1,6 +1,6 @@
 {
   "type": "Collection",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "id": "eurostat-electricity-prices",
   "title": "Industrial electricity prices by country",
   "description": "Half-yearly industrial electricity prices (EUR/kWh, including taxes) by European country. Non-geospatial tabular dataset. Source: Eurostat nrg_pc_205.",

--- a/spec/formats/tabular.md
+++ b/spec/formats/tabular.md
@@ -173,7 +173,7 @@ No item directory or item JSON is needed.
 ```json
 {
   "type": "Collection",
-  "stac_version": "1.0.0",
+  "stac_version": "1.1.0",
   "id": "eurostat-electricity-prices",
   "title": "Industrial electricity prices by country",
   "description": "Half-yearly industrial electricity prices (EUR/kWh) by European country. Source: Eurostat nrg_pc_205.",

--- a/spec/schema/README.md
+++ b/spec/schema/README.md
@@ -50,8 +50,8 @@ uv run pytest tests/spec_compliance/ -v
 ## Schema Notes
 
 The collection and catalog schemas reference external STAC schemas:
-- `https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json`
-- `https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json`
+- `https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json`
+- `https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json`
 
 For compliance testing, we use "Portolan-only" schemas (defined in `conftest.py`)
 that validate Portolan-specific requirements without requiring external $ref resolution.

--- a/spec/schema/catalog.schema.json
+++ b/spec/schema/catalog.schema.json
@@ -5,7 +5,7 @@
   "description": "Schema for Portolan-compliant STAC Catalogs. Extends the STAC Catalog schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [
     {
-      "$ref": "https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json"
+      "$ref": "https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json"
     },
     {
       "$ref": "#/$defs/PortolanCatalogExtensions"

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -5,7 +5,7 @@
   "description": "Schema for Portolan-compliant STAC Collections. Extends the STAC Collection schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [
     {
-      "$ref": "https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json"
+      "$ref": "https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json"
     },
     {
       "$ref": "#/$defs/PortolanCollectionExtensions"

--- a/spec/structure.md
+++ b/spec/structure.md
@@ -107,9 +107,9 @@ Portolan catalogs **MUST** be saved as `SELF_CONTAINED` (pystac terminology), me
 
 | Property | Default Value |
 |----------|---------------|
-| STAC version | `1.0.0` |
+| STAC version | `1.1.0` |
 | Catalog ID | `portolan-catalog` |
-| Collection license | `proprietary` (SPDX identifier) |
+| Collection license | `other` (STAC 1.1 keyword for a license not covered by SPDX; add a `rel="license"` link when the concrete license is known) |
 
 These defaults can be overridden during catalog creation or dataset import.
 

--- a/tests/spec_compliance/test_stac_version_1_1_0.py
+++ b/tests/spec_compliance/test_stac_version_1_1_0.py
@@ -1,0 +1,80 @@
+"""Spec compliance tests pinning STAC 1.1.0 standardization (issue #568).
+
+Portolan standardizes on STAC 1.1.0 everywhere: the shipped schemas reference
+the upstream v1.1.0 STAC schemas, generated STAC documents emit ``1.1.0``, and
+the default collection license is the STAC 1.1 ``other`` keyword (the deprecated
+``proprietary`` value is no longer emitted).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+class TestShippedSchemasReferenceStac110:
+    """The shipped Portolan schemas must $ref the upstream STAC 1.1.0 schemas."""
+
+    @pytest.mark.integration
+    def test_collection_schema_refs_stac_110(self, schemas_dir: Path) -> None:
+        """collection.schema.json references the STAC v1.1.0 collection schema."""
+        schema = json.loads((schemas_dir / "collection.schema.json").read_text())
+        refs = [entry.get("$ref", "") for entry in schema["allOf"]]
+        stac_refs = [ref for ref in refs if "schemas.stacspec.org" in ref]
+
+        assert stac_refs, "collection.schema.json must reference an upstream STAC schema"
+        assert all("/v1.1.0/" in ref for ref in stac_refs), (
+            f"collection.schema.json must reference STAC v1.1.0, got: {stac_refs}"
+        )
+
+    @pytest.mark.integration
+    def test_catalog_schema_refs_stac_110(self, schemas_dir: Path) -> None:
+        """catalog.schema.json references the STAC v1.1.0 catalog schema."""
+        schema = json.loads((schemas_dir / "catalog.schema.json").read_text())
+        refs = [entry.get("$ref", "") for entry in schema["allOf"]]
+        stac_refs = [ref for ref in refs if "schemas.stacspec.org" in ref]
+
+        assert stac_refs, "catalog.schema.json must reference an upstream STAC schema"
+        assert all("/v1.1.0/" in ref for ref in stac_refs), (
+            f"catalog.schema.json must reference STAC v1.1.0, got: {stac_refs}"
+        )
+
+
+class TestGeneratedOutputIsStac110:
+    """CLI-generated STAC documents must declare stac_version 1.1.0."""
+
+    @pytest.mark.integration
+    def test_init_catalog_json_is_stac_110(self, runner: CliRunner, tmp_path: Path) -> None:
+        """portolan init writes catalog.json with stac_version 1.1.0."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            data = json.loads(Path("catalog.json").read_text())
+            assert data.get("stac_version") == "1.1.0"
+
+    @pytest.mark.integration
+    def test_add_collection_json_is_stac_110_and_license_other(
+        self, runner: CliRunner, tmp_path: Path, valid_points_geojson: Path
+    ) -> None:
+        """portolan add writes collection.json with stac_version 1.1.0 and license 'other'."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            data = json.loads((collection_dir / "collection.json").read_text())
+            assert data.get("stac_version") == "1.1.0"
+            # STAC 1.1 deprecates "proprietary"; the default is now "other" (issue #568).
+            assert data.get("license") == "other"

--- a/tests/unit/extract/arcgis/imageserver/test_metadata.py
+++ b/tests/unit/extract/arcgis/imageserver/test_metadata.py
@@ -214,10 +214,10 @@ class TestCreateCollectionMetadata:
         assert len(source_links) >= 1
         assert source_links[0]["href"] == url
 
-    def test_license_defaults_to_proprietary(self, sample_metadata: ImageServerMetadata) -> None:
-        """License defaults to proprietary for unknown sources."""
+    def test_license_defaults_to_other(self, sample_metadata: ImageServerMetadata) -> None:
+        """License defaults to the STAC 1.1 'other' keyword for unknown sources (issue #568)."""
         result = create_collection_metadata(sample_metadata, "https://example.com")
-        assert result.get("license") == "proprietary"
+        assert result.get("license") == "other"
 
     def test_providers_from_copyright(self, sample_metadata: ImageServerMetadata) -> None:
         """Providers list is populated from copyright text."""

--- a/tests/unit/test_metadata_yaml.py
+++ b/tests/unit/test_metadata_yaml.py
@@ -167,6 +167,21 @@ class TestMetadataValidation:
             assert license_errors == [], f"License {license_id} should be valid"
 
     @pytest.mark.unit
+    def test_stac_other_license_passes(self) -> None:
+        """validate_metadata accepts the STAC 1.1 'other' license keyword (issue #568)."""
+        from portolan_cli.metadata_yaml import validate_metadata
+
+        metadata = {
+            "contact": {"name": "Data Team", "email": "data@example.org"},
+            "license": "other",
+        }
+
+        errors = validate_metadata(metadata)
+
+        license_errors = [e for e in errors if "license" in e.lower()]
+        assert license_errors == [], "STAC 1.1 'other' license should be valid"
+
+    @pytest.mark.unit
     def test_licenseref_custom_identifiers_pass(self) -> None:
         """validate_metadata accepts LicenseRef-* custom license identifiers (SPDX spec).
 

--- a/tests/unit/test_stac.py
+++ b/tests/unit/test_stac.py
@@ -36,7 +36,7 @@ class TestCreateCollection:
 
         assert collection.id == "test-collection"
         assert collection.description == "A test collection"
-        assert collection.license == "proprietary"  # default
+        assert collection.license == "other"  # default (STAC 1.1, issue #568)
         assert isinstance(collection, pystac.Collection)
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary

Standardizes the codebase and spec on **STAC 1.1.0** (issue #568). Previously the
version was split: the code already emitted `1.1.0`, but the shipped schemas and
docs still referenced `1.0.0`, and the default collection license was
`proprietary` — a value STAC 1.1 deprecates (it is not an SPDX identifier).

## Changes

**Schemas & spec docs**
- Bump external STAC `$ref`s in `spec/schema/catalog.schema.json` and
  `spec/schema/collection.schema.json` from `v1.0.0` → `v1.1.0` (and the schema
  `README.md` notes).
- `spec/structure.md` Defaults table: STAC version `1.0.0` → `1.1.0`; collection
  license `proprietary (SPDX identifier)` → `other` with a note that a
  `rel="license"` link should be added when the concrete license is known
  (fixes the incorrect "SPDX identifier" claim).
- `spec/core.md`: "STAC specification version 1.0.0 or later" → "1.1.0".
- Bump `stac_version` in the tabular example (`spec/examples/tabular-collection.json`
  and `spec/formats/tabular.md`) to `1.1.0`.

**License default (`proprietary` → `other`)**
- `portolan_cli/stac.py`: `DEFAULT_LICENSE = "other"` (STAC 1.1 keyword for a
  non-SPDX license).
- `portolan_cli/cli.py` `--license` default, `portolan_cli/external.py` (now
  references `DEFAULT_LICENSE`), and the ArcGIS ImageServer metadata default all
  updated, with docstrings/help clarified to "SPDX expression, or 'other'".
- `portolan_cli/metadata_yaml.py`: `_validate_license` now accepts the STAC 1.1
  `other` keyword alongside SPDX identifiers and `LicenseRef-*`.

**Consistency**
- `portolan_cli/catalog.py`: legacy `Catalog.STAC_VERSION` constant `1.0.0` →
  `1.1.0` (removes the last hardcoded `1.0.0` in serialization-adjacent code).

## Testing

- New `tests/spec_compliance/test_stac_version_1_1_0.py` pins the standardization:
  the shipped schemas `$ref` STAC `v1.1.0`, generated `catalog.json` /
  `collection.json` declare `1.1.0`, and the default collection license is
  `other` (issue task 4 — compliance tests validate against the 1.1 schemas).
- Added a `metadata_yaml` unit test asserting `other` validates.
- Updated existing default-license assertions in `tests/unit/test_stac.py` and the
  ArcGIS ImageServer metadata test.
- Full local gate green: `ruff format --check`, `ruff check`, `mypy portolan_cli`,
  and `pytest tests/ --ignore=tests/iceberg/ -m 'not network and not slow and not benchmark'`.

Closes #568

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default STAC output now uses version **1.1.0** for generated catalogs and collections.
  * Default collection license handling now uses **`other`** for non-SPDX licenses.

* **Bug Fixes**
  * Updated license validation to accept STAC 1.1-compatible license values.
  * Improved generated metadata and schema references to match STAC 1.1 requirements.

* **Documentation**
  * Refreshed examples and spec notes to reflect the newer STAC version and license guidance.

* **Tests**
  * Added coverage for STAC 1.1 schema references and generated output defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->