### PR TITLE
spec: rules.yaml is missing rules the CLI already enforces at ERROR severity (titles, bbox, partition, provisional datetime)

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -27,6 +27,27 @@ project/
 - **MUST** follow STAC specification version 1.0.0 or later
 - **MUST** use `SELF_CONTAINED` catalog type (relative links, portable)
 
+## Human-Readable Titles
+
+STAC Browser and other clients render `child`/`item` link titles directly; without them a client must fetch every child just to display its name. Portolan therefore requires human-readable titles throughout the catalog (see [ADR-0053](../context/shared/adr/0053-mandatory-human-readable-titles.md)):
+
+- Every `catalog.json` and `collection.json` **MUST** have a non-empty `title` and `description`
+- Titles **MUST** be human-readable — a raw slug (e.g. `snake_case`) or a technical namespace prefix (e.g. `ns:LayerName`) is not acceptable
+- Every `child` and `item` link **MUST** include a `title`
+
+`portolan check` enforces these at ERROR severity, and `portolan check --fix` auto-populates human-readable titles by humanizing slugs.
+
+## Bounding Box Validity
+
+Bounding boxes carry the spatial footprint that drives extent unions and map-UI browsing. Garbage coordinates poison the catalog-level extent and break viewers, so every `bbox` (catalog extent, collection extent, and item) **MUST**:
+
+- Contain no `NaN` or infinite values (including 3D elevation coordinates)
+- Contain no sentinel "effectively infinite" values (e.g. `±1.79e308`)
+- Have WGS84 coordinates within range (longitude in `[-180, 180]`, latitude in `[-90, 90]`)
+- Have `south <= north`
+
+`portolan check` enforces bbox validity at ERROR severity.
+
 ### Spatial Extent for Tabular Collections
 
 STAC requires `extent.spatial.bbox` for Collections. For **tabular (non-geospatial) collections** (`portolan:geospatial: false`):

--- a/spec/core.md
+++ b/spec/core.md
@@ -58,6 +58,16 @@ STAC requires `extent.spatial.bbox` for Collections. For **tabular (non-geospati
 
 See [formats/tabular.md](formats/tabular.md) for full tabular collection requirements.
 
+## Temporal Metadata
+
+Items **SHOULD** carry an explicit `datetime` (or `start_datetime`/`end_datetime` interval) describing when the data applies. Items added without a datetime receive a null temporal extent (an open interval) and are marked `portolan:datetime_provisional: true` (see [ADR-0035](../context/shared/adr/0035-temporal-extent-handling.md)).
+
+Provisional items are valid STAC but temporally incomplete:
+
+- They are accepted so ingestion is never blocked on unknown dates
+- `portolan check` flags them at WARNING severity
+- Enriching the datetime enables time-based browsing and clears the provisional flag
+
 ## Data Storage
 
 Portolan catalogs assume data is hosted in S3-compatible object storage. This is the ground truth for all assets.

--- a/spec/schema/catalog.schema.json
+++ b/spec/schema/catalog.schema.json
@@ -14,6 +14,7 @@
   "$defs": {
     "PortolanCatalogExtensions": {
       "type": "object",
+      "required": ["title", "description"],
       "properties": {
         "type": {
           "const": "Catalog"
@@ -27,6 +28,16 @@
           "type": "string",
           "description": "Catalog identifier. Defaults to 'portolan-catalog' if not specified.",
           "default": "portolan-catalog"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable catalog title. MUST be present and human-readable (not a raw slug). See RULE-0100 in rules.yaml and core.md#human-readable-titles."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable catalog description. MUST be non-empty. See RULE-0100 in rules.yaml."
         },
         "links": {
           "type": "array",
@@ -79,6 +90,26 @@
                 "not": {
                   "pattern": "^[a-zA-Z][a-zA-Z0-9+.-]*://"
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "rel": {
+                "enum": ["child", "item"]
+              }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "Child/item links MUST carry a human-readable title so clients can render them without dereferencing. See RULE-0102/RULE-0103 in rules.yaml.",
+            "required": ["title"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 1
               }
             }
           }

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -14,9 +14,20 @@
   "$defs": {
     "PortolanCollectionExtensions": {
       "type": "object",
+      "required": ["title", "description"],
       "properties": {
         "type": {
           "const": "Collection"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable collection title. MUST be present and human-readable (not a raw slug). See RULE-0101 in rules.yaml and core.md#human-readable-titles."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable collection description. MUST be non-empty. See RULE-0101 in rules.yaml."
         },
         "portolan:geospatial": {
           "type": "boolean",
@@ -82,6 +93,26 @@
         }
       },
       "allOf": [
+        {
+          "if": {
+            "properties": {
+              "rel": {
+                "enum": ["child", "item"]
+              }
+            },
+            "required": ["rel"]
+          },
+          "then": {
+            "description": "Child/item links MUST carry a human-readable title so clients can render them without dereferencing. See RULE-0102/RULE-0103 in rules.yaml.",
+            "required": ["title"],
+            "properties": {
+              "title": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
         {
           "if": {
             "properties": {

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -5,12 +5,15 @@
 #
 # Rule structure:
 #   id: Unique identifier (RULE-XXXX)
-#   level: error | warning
-#   scope: Where the rule applies (catalog, collection, item, asset, versions)
+#   level: error | warning | info
+#   scope: Where the rule applies (catalog, collection, item, asset, versions, config)
 #   description: Human-readable description
 #   rationale: Why this rule exists
 #   validation: How to validate (pseudo-code or description)
 #   references: Links to spec documentation
+#   code_rule: (optional) The `name` of the portolan_cli ValidationRule that
+#     enforces this rule, linking the spec entry to its CLI implementation.
+#     Feeds the rule-coverage matrix and lets tests assert spec/code parity.
 
 rules:
   # =============================================================================
@@ -582,3 +585,187 @@ rules:
           reject with message explaining how to enable
     references:
       - formats/tabular.md#enabling-tabular-support
+
+  # =============================================================================
+  # Metadata Quality Rules (human-readable titles/descriptions)
+  # =============================================================================
+  #
+  # Enforced by MandatoryTitlesRule (ERROR). STAC Browser renders child/item
+  # link titles directly, so missing or raw-slug titles force it to fetch every
+  # child just to display a name. See ADR-0053 and Issue #502.
+
+  - id: RULE-0100
+    level: error
+    scope: catalog
+    description: Catalogs MUST have a human-readable title and description
+    rationale: |
+      Titles and descriptions are the primary handle humans and agents use to
+      understand a catalog. A missing or raw-slug title (e.g. snake_case or a
+      "ns:Layer" namespace prefix) is not human-readable and degrades browsing.
+    validation: |
+      For catalog.json:
+        assert title is a non-empty string
+        assert title is human-readable (no underscores, no "prefix:Name" form)
+        assert description is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  - id: RULE-0101
+    level: error
+    scope: collection
+    description: Collections MUST have a human-readable title and description
+    rationale: |
+      Same as RULE-0100 at the collection level: a collection's title and
+      description are what map viewers and agents surface first.
+    validation: |
+      For each collection.json:
+        assert title is a non-empty string
+        assert title is human-readable (no underscores, no "prefix:Name" form)
+        assert description is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  - id: RULE-0102
+    level: error
+    scope: catalog
+    description: Child links MUST include a human-readable title
+    rationale: |
+      STAC Browser renders child link titles without dereferencing the target.
+      An untitled child link forces a fetch of every collection to show a name.
+    validation: |
+      For each link in catalog.json (or sub-catalog) with rel == "child":
+        assert link.title is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  - id: RULE-0103
+    level: error
+    scope: collection
+    description: Item links MUST include a human-readable title
+    rationale: |
+      As with child links, item link titles let clients render an item list
+      without fetching each item.json.
+    validation: |
+      For each link in collection.json with rel == "item":
+        assert link.title is a non-empty string
+    references:
+      - core.md#human-readable-titles
+    code_rule: mandatory_titles
+
+  # =============================================================================
+  # Bounding Box Validity Rules
+  # =============================================================================
+  #
+  # Enforced by BboxValidRule (ERROR). Garbage coordinates (inf/nan, sentinel
+  # values like ±1.79e308, or out-of-range lon/lat) poison catalog-level extent
+  # unions and break map-UI browsing. See Issue #516.
+
+  - id: RULE-0110
+    level: error
+    scope: catalog
+    description: Catalog extent bboxes MUST be valid
+    rationale: |
+      The catalog extent is the union of its collections; a single poisoned
+      coordinate makes the whole catalog un-browsable in a map UI.
+    validation: |
+      For each bbox in catalog.extent.spatial.bbox:
+        assert no coordinate is NaN or infinite
+        assert no coordinate exceeds a sane magnitude (sentinel poison)
+        assert lon in [-180, 180] and lat in [-90, 90]
+        assert south <= north
+    references:
+      - core.md#bounding-box-validity
+    code_rule: bbox_valid
+
+  - id: RULE-0111
+    level: error
+    scope: collection
+    description: Collection extent bboxes MUST be valid
+    rationale: |
+      Same validity constraints as RULE-0110 at the collection level.
+    validation: |
+      For each bbox in collection.extent.spatial.bbox:
+        assert no coordinate is NaN or infinite
+        assert no coordinate exceeds a sane magnitude (sentinel poison)
+        assert lon in [-180, 180] and lat in [-90, 90]
+        assert south <= north
+    references:
+      - core.md#bounding-box-validity
+    code_rule: bbox_valid
+
+  - id: RULE-0112
+    level: error
+    scope: item
+    description: Item bboxes MUST be valid
+    rationale: |
+      Invalid item bboxes propagate into the collection and catalog extents.
+    validation: |
+      For each item.json with a bbox:
+        assert no coordinate is NaN or infinite
+        assert no coordinate exceeds a sane magnitude (sentinel poison)
+        assert lon in [-180, 180] and lat in [-90, 90]
+        assert south <= north
+    references:
+      - core.md#bounding-box-validity
+    code_rule: bbox_valid
+
+  # =============================================================================
+  # Temporal Metadata Rules
+  # =============================================================================
+
+  - id: RULE-0120
+    level: warning
+    scope: item
+    description: Items SHOULD have an explicit datetime, not a provisional one
+    rationale: |
+      Items added without an explicit datetime get a null temporal extent and
+      are marked portolan:datetime_provisional=true (ADR-0035). They are valid
+      STAC but incomplete; enriching the datetime enables time-based browsing.
+    validation: |
+      For each item.json:
+        warn if properties["portolan:datetime_provisional"] is true
+    references:
+      - core.md#temporal-metadata
+    code_rule: provisional_datetime
+
+  # =============================================================================
+  # Partition Structure Rules (Hive-style partitioned collections)
+  # =============================================================================
+  #
+  # Enforced by PartitionStructureRule (WARNING) and
+  # PartitionSchemaConsistencyRule (ERROR). See ADR-0042 and ADR-0054.
+
+  - id: RULE-0130
+    level: warning
+    scope: collection
+    description: Partitioned collections SHOULD have consistent Hive-style structure
+    rationale: |
+      Mixed partition keys, orphan data files at the collection root, or a
+      missing partition:scheme make a partitioned dataset ambiguous to query
+      engines that rely on the Hive key=value convention.
+    validation: |
+      For each collection with key=value partition directories:
+        warn if partition directories use more than one partition key
+        warn if there are orphan .parquet files at the collection root
+        warn if collection.json is missing the partition:scheme field
+    references:
+      - formats/vector.md#partitioned-datasets
+    code_rule: partition_structure
+
+  - id: RULE-0131
+    level: error
+    scope: collection
+    description: All partition files in a collection MUST share the same schema
+    rationale: |
+      A partitioned collection is a single logical table split across files.
+      Divergent Parquet schemas across partitions break unified reads.
+    validation: |
+      For each collection with key=value partition directories:
+        read the Parquet schema (footer) of every partition file
+        assert all files share the same set of column names
+    references:
+      - formats/vector.md#partitioned-datasets
+    code_rule: partition_schema_consistency

--- a/tests/spec_compliance/test_rules_coverage.py
+++ b/tests/spec_compliance/test_rules_coverage.py
@@ -1,0 +1,189 @@
+"""Spec/code coverage tests for spec/schema/rules.yaml.
+
+These guard the invariant from Issue #562: the spec MUST be a superset of what
+the CLI enforces, never the reverse. Concretely:
+
+- Every ERROR-severity rule the CLI runs (``DEFAULT_RULES``) has a rules.yaml
+  entry, linked via the ``code_rule`` field (or is explicitly exempted because
+  its coverage lives in prose / JSON Schema).
+- Each entry's ``level`` matches the CLI rule's actual declared severity, so the
+  spec and code cannot silently drift apart.
+- The catalog/collection JSON Schemas require the mandatory human-readable
+  ``title``/``description`` (ADR-0053) and titles on ``child``/``item`` links.
+
+See ADR-0048 (CLI repo is the spec source of truth).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from portolan_cli.validation.results import Severity
+from portolan_cli.validation.runner import DEFAULT_RULES
+
+pytestmark = pytest.mark.integration
+
+# Declared severity of every CLI rule, keyed by its ``name``.
+_CLI_SEVERITY_BY_NAME: dict[str, str] = {rule.name: rule.severity.value for rule in DEFAULT_RULES}
+
+# ERROR-severity CLI rules whose spec coverage lives in prose / JSON Schema or a
+# pre-existing rules.yaml entry rather than a ``code_rule`` link. Keeping this
+# list explicit turns "add an ERROR rule without documenting it" into a test
+# failure: any new error rule must either add a ``code_rule`` mapping in
+# rules.yaml or be consciously exempted here.
+_EXEMPT_ERROR_RULES: frozenset[str] = frozenset(
+    {
+        "catalog_exists",  # RULE-0050 (required files)
+        "catalog_json_valid",  # RULE-0050 (required files)
+        "stac_fields",  # core STAC schema (catalog.schema.json)
+        "stac_schema",  # core STAC schema validation
+        "tabular_geospatial_flag",  # RULE-0090
+        "tabular_collection_level_assets",  # RULE-0094
+    }
+)
+
+# The rules added for Issue #562, with their expected (level, scope, code_rule).
+_NEW_RULES: dict[str, tuple[str, str, str]] = {
+    "RULE-0100": ("error", "catalog", "mandatory_titles"),
+    "RULE-0101": ("error", "collection", "mandatory_titles"),
+    "RULE-0102": ("error", "catalog", "mandatory_titles"),
+    "RULE-0103": ("error", "collection", "mandatory_titles"),
+    "RULE-0110": ("error", "catalog", "bbox_valid"),
+    "RULE-0111": ("error", "collection", "bbox_valid"),
+    "RULE-0112": ("error", "item", "bbox_valid"),
+    "RULE-0120": ("warning", "item", "provisional_datetime"),
+    "RULE-0130": ("warning", "collection", "partition_structure"),
+    "RULE-0131": ("error", "collection", "partition_schema_consistency"),
+}
+
+
+class TestNewRuleEntries:
+    """The Issue #562 rules exist in rules.yaml with the expected metadata."""
+
+    @pytest.mark.parametrize(("rule_id", "expected"), sorted(_NEW_RULES.items()))
+    def test_new_rule_present_with_expected_fields(
+        self,
+        validation_rules: list[dict[str, Any]],
+        rule_id: str,
+        expected: tuple[str, str, str],
+    ) -> None:
+        level, scope, code_rule = expected
+        by_id = {r["id"]: r for r in validation_rules}
+
+        assert rule_id in by_id, f"{rule_id} missing from rules.yaml"
+        entry = by_id[rule_id]
+        assert entry["level"] == level, f"{rule_id} level should be {level}"
+        assert entry["scope"] == scope, f"{rule_id} scope should be {scope}"
+        assert entry.get("code_rule") == code_rule, f"{rule_id} code_rule should be {code_rule}"
+
+    def test_rule_ids_are_unique(self, validation_rules: list[dict[str, Any]]) -> None:
+        ids = [r["id"] for r in validation_rules]
+        assert len(ids) == len(set(ids)), "Duplicate rule IDs in rules.yaml"
+
+
+class TestSpecCodeParity:
+    """rules.yaml and the CLI rules cannot silently drift apart."""
+
+    def test_code_rule_level_matches_cli_severity(
+        self, validation_rules: list[dict[str, Any]]
+    ) -> None:
+        for entry in validation_rules:
+            code_rule = entry.get("code_rule")
+            if code_rule is None:
+                continue
+            assert code_rule in _CLI_SEVERITY_BY_NAME, (
+                f"{entry['id']} references unknown code_rule '{code_rule}'"
+            )
+            assert entry["level"] == _CLI_SEVERITY_BY_NAME[code_rule], (
+                f"{entry['id']} level '{entry['level']}' does not match CLI severity "
+                f"'{_CLI_SEVERITY_BY_NAME[code_rule]}' for rule '{code_rule}'"
+            )
+
+    def test_spec_is_superset_of_cli_error_rules(
+        self, validation_rules: list[dict[str, Any]]
+    ) -> None:
+        """Every ERROR rule the CLI enforces is documented in rules.yaml."""
+        covered = {e["code_rule"] for e in validation_rules if e.get("code_rule")}
+
+        undocumented = [
+            rule.name
+            for rule in DEFAULT_RULES
+            if rule.severity is Severity.ERROR
+            and rule.name not in _EXEMPT_ERROR_RULES
+            and rule.name not in covered
+        ]
+
+        assert not undocumented, (
+            "ERROR-severity CLI rules missing a rules.yaml entry "
+            f"(add a code_rule mapping or exempt them): {undocumented}"
+        )
+
+
+class TestSchemaRequiresTitles:
+    """The published JSON Schemas enforce the mandatory-title rules (ADR-0053)."""
+
+    @pytest.fixture
+    def catalog_schema(self, schemas_dir: Path) -> dict[str, Any]:
+        result: dict[str, Any] = json.loads((schemas_dir / "catalog.schema.json").read_text())
+        return result
+
+    @pytest.fixture
+    def collection_schema(self, schemas_dir: Path) -> dict[str, Any]:
+        result: dict[str, Any] = json.loads((schemas_dir / "collection.schema.json").read_text())
+        return result
+
+    def test_catalog_extensions_require_title_and_description(
+        self, catalog_schema: dict[str, Any]
+    ) -> None:
+        ext = catalog_schema["$defs"]["PortolanCatalogExtensions"]
+        assert set(ext["required"]) >= {"title", "description"}
+
+        validator = Draft202012Validator(ext)
+        assert list(validator.iter_errors({"type": "Catalog", "description": "x"})), (
+            "catalog extension schema should reject a document missing title"
+        )
+        assert not list(validator.iter_errors({"title": "Roads", "description": "x"})), (
+            "catalog extension schema should accept a titled, described document"
+        )
+
+    def test_collection_extensions_require_title_and_description(
+        self, collection_schema: dict[str, Any]
+    ) -> None:
+        ext = collection_schema["$defs"]["PortolanCollectionExtensions"]
+        assert set(ext["required"]) >= {"title", "description"}
+
+        validator = Draft202012Validator(ext)
+        assert list(validator.iter_errors({"type": "Collection", "description": "x"})), (
+            "collection extension schema should reject a document missing title"
+        )
+
+    def test_catalog_child_links_require_title(self, catalog_schema: dict[str, Any]) -> None:
+        validator = Draft202012Validator(catalog_schema["$defs"]["CatalogLink"])
+
+        untitled_child = {"rel": "child", "href": "./roads/collection.json"}
+        assert list(validator.iter_errors(untitled_child)), (
+            "child link without a title should fail (RULE-0102)"
+        )
+
+        titled_child = {"rel": "child", "href": "./roads/collection.json", "title": "Roads"}
+        assert not list(validator.iter_errors(titled_child))
+
+        # Non-structural links are unaffected by the title requirement.
+        license_link = {"rel": "license", "href": "https://example.com/license"}
+        assert not list(validator.iter_errors(license_link))
+
+    def test_collection_item_links_require_title(self, collection_schema: dict[str, Any]) -> None:
+        validator = Draft202012Validator(collection_schema["$defs"]["CollectionLink"])
+
+        untitled_item = {"rel": "item", "href": "./census-2020/item.json"}
+        assert list(validator.iter_errors(untitled_item)), (
+            "item link without a title should fail (RULE-0103)"
+        )
+
+        titled_item = {"rel": "item", "href": "./census-2020/item.json", "title": "Census 2020"}
+        assert not list(validator.iter_errors(titled_item))


### PR DESCRIPTION
## Summary

Closes #562. The CLI enforced several ERROR-severity validation rules that
appeared nowhere in the spec (`rules.yaml`, `core.md`, or the JSON Schemas). The
spec is supposed to be a **superset** of what the CLI enforces, never the
reverse — this PR closes that gap for the rules flagged in the pre-sprint spec
audit (finding C11): mandatory titles, bbox validity, provisional datetime, and
partition structure.

## What changed

### `spec/schema/rules.yaml`
Added entries for every code-enforced rule that was undocumented, matching the
implemented semantics and severity (read from the rule classes in
`portolan_cli/validation/rules.py` and `stac_rules.py`):

- **RULE-0100–0103** (`error`) — mandatory human-readable titles/descriptions on
  catalogs & collections, and titles on `child`/`item` links (`MandatoryTitlesRule`, ADR-0053)
- **RULE-0110–0112** (`error`) — catalog/collection/item bbox validity, no
  inf/nan/sentinel/out-of-range coordinates (`BboxValidRule`, #516)
- **RULE-0120** (`warning`) — provisional datetime items (`ProvisionalDatetimeRule`, ADR-0035)
- **RULE-0130** (`warning`) — Hive-style partition structure consistency (`PartitionStructureRule`)
- **RULE-0131** (`error`) — partition schema consistency (`PartitionSchemaConsistencyRule`)

Each new entry carries a new optional **`code_rule`** field (documented in the
file header) linking it to the enforcing `ValidationRule.name`. This feeds the
rule-coverage matrix (Workstream D) and lets tests assert spec/code parity.

### `spec/core.md`
Added normative **MUST** clauses: a *Human-Readable Titles* section (ADR-0053)
and a *Bounding Box Validity* section, matching what `portolan check` already
enforces at ERROR severity.

### `spec/schema/catalog.schema.json` / `collection.schema.json`
- `title` and `description` are now `required` on the Portolan catalog/collection
  extension objects (with `minLength: 1`)
- `child`/`item` links now require a non-empty `title` via conditional subschemas

## How it was tested

New `tests/spec_compliance/test_rules_coverage.py` (17 tests, `integration`):

- Each new rule ID is present with the expected `level`, `scope`, and `code_rule`
- **Spec/code parity**: every `code_rule` entry's `level` matches the CLI rule's
  actual declared severity, so the two cannot silently drift
- **Superset guard**: every ERROR-severity rule in `DEFAULT_RULES` is either
  documented via `code_rule` or in an explicit, commented exemption list — so any
  future ERROR rule added without a spec entry fails CI
- The JSON Schemas reject documents missing `title`/`description` and reject
  untitled `child`/`item` links, while leaving non-structural links unaffected

Full local gate is green: `ruff format --check`, `ruff check`, `mypy portolan_cli`,
and `pytest tests/ --ignore=tests/iceberg/ -m 'not network and not slow and not benchmark'`
(5740 passed, 9 skipped).

Closes #562

---
*Automated by agent-farm.*