### PR TITLE
arch: import-linter contracts to hold the validation seam for reis extraction (#563)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,11 @@ pytest_add_cli_args_test_selection = ["tests/"]
 
 [tool.importlinter]
 root_packages = ["portolan_cli"]
-include_external_packages = false
+# Required so the validation-no-framework-leakage contract can forbid the
+# external `click`/`rich` packages (import-linter needs external nodes in the
+# graph at the top level). Only adds external nodes; internal contracts are
+# unaffected.
+include_external_packages = true
 
 [[tool.importlinter.contracts]]
 id = "cli-no-storage"
@@ -279,6 +283,40 @@ name = "Iceberg backend must not import CLI layer directly"
 type = "forbidden"
 source_modules = ["portolan_cli.backends.iceberg"]
 forbidden_modules = ["portolan_cli.cli"]
+
+[[tool.importlinter.contracts]]
+id = "validation-seam-for-reis"
+name = "Validation must not import CLI/output/config layers (reis extraction seam)"
+type = "forbidden"
+# portolan_cli.validation is nearly extraction-ready as the future `reis`
+# package (see issue #563). It stays free of the app-framework layers so the
+# seam is cheap to protect now, ahead of the post-sprint extraction.
+source_modules = ["portolan_cli.validation"]
+forbidden_modules = [
+    "portolan_cli.cli",
+    "portolan_cli.output",
+    "portolan_cli.config",
+]
+# Intentional extraction-time couplings: validation reaches into these
+# pure-logic/data modules for classification, bbox checks, and metadata scan.
+# They are leaves (or a self-contained subtree) that carry no CLI/output/config
+# dependency, so they move with `reis` or vendor trivially at extraction time.
+# Documented per the second checkbox on #563 (which listed only scan_classify;
+# metadata.scan and bbox are the same kind of coupling, added since).
+#   portolan_cli.validation -> portolan_cli.scan_classify
+#   portolan_cli.validation -> portolan_cli.metadata.scan
+#   portolan_cli.validation -> portolan_cli.bbox
+
+[[tool.importlinter.contracts]]
+id = "validation-no-framework-leakage"
+name = "Validation must not import Click or Rich (reis extraction seam)"
+type = "forbidden"
+# Framework tripwire: Click/Rich only ever reach validation *through* the
+# cli/output layers forbidden above. Guarding the external packages directly
+# catches a regression even if a new intermediate module were introduced.
+# (External-node analysis is enabled by the top-level include_external_packages.)
+source_modules = ["portolan_cli.validation"]
+forbidden_modules = ["click", "rich"]
 
 [[tool.importlinter.contracts]]
 id = "utilities-are-foundational"


### PR DESCRIPTION
Closes #563.

## What

Two import-linter contracts (per ADR-0025) protecting `portolan_cli.validation` as the future `reis` package, ahead of the post-sprint extraction (2026-07 spec sprint, audit §7).

1. **`validation-seam-for-reis`** (`forbidden`) — `validation` must not import the `cli` / `output` / `config` app-framework layers. These are the real extraction blockers (they carry the Click/Rich surface). Verified to pass for both **direct and indirect** import chains — nothing in validation's dependency cone reaches them.

2. **`validation-no-framework-leakage`** (`forbidden`) — a tripwire forbidding the external `click` / `rich` packages directly, so a regression is caught even if a new intermediate module were introduced. This is the "cheap upgrade" beyond the literal ticket; it needs top-level `include_external_packages = true` (adds external graph nodes only — the three pre-existing internal contracts still pass unchanged).

## Correction to the ticket premise

The issue described a *"single coupling to `scan_classify`"*. That's now stale — `validation/rules.py` also lazily imports `portolan_cli.metadata.scan` and `portolan_cli.bbox`. All three are the same kind of coupling: pure-logic leaves (or a self-contained subtree) with no cli/output/config dependency, so they move with `reis` or vendor trivially at extraction time. All three are documented in the contract comment, satisfying the second checkbox with the accurate count.

## Verification

- `uv run lint-imports` → **5 kept, 0 broken**.
- Negative test: injecting `import click` into a validation module flips `validation-no-framework-leakage` to **BROKEN**, confirming the tripwire actually bites.
- Pre-commit `architecture rules` + `dependency checker` hooks pass.

## Task checklist (from #563)

- [x] Add import-linter contract: `validation` must not import `cli` / `output` / `config`
- [x] Document the intentional `scan_classify` exception (+ `metadata.scan`, `bbox`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)