### PR TITLE
Single-source the recognized-extension vocabulary (#558); drop dead .raquet (#487)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -107,9 +107,15 @@ subsystem table below and the path-scoped rules for each.
 
 Two enums in `formats.py`: `CloudNativeStatus` (`CLOUD_NATIVE` / `CONVERTIBLE` /
 `UNSUPPORTED`) and `FormatType` (`VECTOR` routes to geoparquet-io, `RASTER`
-routes to rio-cogeo, `UNKNOWN`). `CLOUD_NATIVE_EXTENSIONS` is the source of truth
-for "already cloud-native, skip conversion" (`.fgb`, `.pmtiles`, `.raquet`,
-while `.parquet`/`.tif` need content inspection). `convert.py` orchestrates only
+routes to rio-cogeo, `UNKNOWN`). The extension vocabulary (which set each
+extension belongs to, plus its media type / role / display name) is
+single-sourced in `extension_registry.py` and *derived* into `formats.py`,
+`constants.py`, `scan_classify.py`, and `add.py` (ADR-0055) — edit the
+registry rows, not the frozensets, and the parity test keeps `spec/extensions.md`
+in sync. `CLOUD_NATIVE_EXTENSIONS` is the derived source of truth for "already
+cloud-native, skip conversion" (`.fgb`, `.pmtiles`; `.parquet`/`.tif` need
+content inspection; `.zarr`/`.copc.laz` are cloud-native via dedicated branches).
+`convert.py` orchestrates only
 (ADR-0010): `CLOUD_NATIVE` -> SKIPPED, `UNSUPPORTED` -> returned with no error
 (ADR-0014, accept with a warning), else route by `detect_format` to
 geoparquet-io or rio-cogeo. Never put geometry or raster math in our layer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0052](context/shared/adr/0052-llms-txt-requirement.md) | Require llms.txt for AI/LLM integration at catalog and collection levels |
 | [0053](context/shared/adr/0053-mandatory-human-readable-titles.md) | Mandatory human-readable titles/descriptions; auto-humanize slugs; title on child/item links |
 | [0054](context/shared/adr/0054-arcgis-folder-recursion-and-structure.md) | ArcGIS folder recursion (default-on), folder URLs, token auth pass-through, nested-folder subcatalogs |
+| [0055](context/shared/adr/0055-extension-registry-single-source.md) | Single-source the recognized-extension vocabulary via a typed in-package registry (derives the formats/constants/scan_classify/add maps; drops dead `.raquet`) |
 
 ## Common Commands
 

--- a/context/shared/adr/0055-extension-registry-single-source.md
+++ b/context/shared/adr/0055-extension-registry-single-source.md
@@ -1,0 +1,76 @@
+# ADR-0055: Single-source the recognized-extension vocabulary via a typed registry
+
+## Status
+Accepted
+
+## Context
+
+Portolan classifies files by extension in many places. That vocabulary had
+drifted across five surfaces (issue #558, pre-sprint audit finding C6):
+
+- `spec/extensions.md` — the human-facing doc
+- `formats.py` — cloud-native / convertible / unsupported / routing frozensets,
+  display names, error messages
+- `constants.py` — geospatial / tabular sets, sidecar patterns
+- `scan_classify.py` — the ten scan-category frozensets
+- `add.py` — `_MEDIA_TYPE_MAP` and `_ROLE_MAP`
+
+Concrete drift symptoms: `.raquet` was cloud-native in code but matches no real
+file (RaQuet rasters are `.parquet`; issue #487); `.webp`/`.gif` were documented
+thumbnails but missing from the media-type/role maps, so those assets were typed
+as `application/octet-stream` / role `data`; `.svg`, `.qix`, `.tfw`, `.gdb`,
+`.tsv`, `.zarr`, `.copc.laz` were each recognized in some surfaces and absent
+from others. Nothing failed a test when the surfaces disagreed.
+
+The vocabulary is also the natural core of `reis`, the validator being extracted
+from this repo (issue #563), so it is worth single-sourcing now.
+
+## Decision
+
+Introduce `portolan_cli/extension_registry.py` as the single source of truth: a
+frozen-dataclass table (`EXTENSION_REGISTRY`) with one `ExtensionSpec` row per
+extension, plus companion structures (`SIDECAR_OF`, `JUNK_DIRS`,
+`STAC_FILENAMES`, `STYLE_FILENAMES`, `THUMBNAIL_MAX_SIZE`). Every frozenset and
+map in the four code modules is **derived** from it via small helpers; the
+public symbol names are unchanged, so consumers and tests are untouched.
+
+The registry lives **inside the package**, not in `spec/`, because `spec/` is
+not shipped in the wheel (the same reason `constants.PORTOLAN_SPEC_VERSION`
+mirrors `spec/schema/spec-version.json`). It is a stdlib-only leaf that imports
+nothing from `portolan_cli`, so — like `scan_classify`, `bbox`, and
+`metadata.scan` (see the validation-seam contract in `pyproject.toml`) — it
+moves cleanly into `reis` at extraction time.
+
+`spec/extensions.md` remains the human doc and is tied to the registry by
+`tests/spec_compliance/test_extensions_doc_parity.py`, which parses the markdown
+tables and fails on any disagreement.
+
+We chose a typed Python module over a shipped data file (YAML/JSON) because
+`reis` is Python: the module extracts by moving, gives `mypy --strict` coverage
+of every row, and needs no runtime parsing or `importlib.resources`.
+
+## Consequences
+
+- One place to add or reclassify an extension; the four modules and the doc stay
+  in lock-step, enforced by the parity test.
+- `.raquet` is dropped (issue #487); `.webp`/`.gif` are now correctly typed as
+  thumbnails; `.svg` is a scan image; unsupported formats carry media types so
+  companion assets stay well-typed; the doc gains `.gdb`, `.tsv`, `.zarr`,
+  `.copc.laz`, `.qix`, `.tfw`.
+- A new indirection: reading a frozenset now means reading a comprehension plus
+  the registry row. Mitigated by keeping the derivations one line each and
+  co-locating the rationale on each `ExtensionSpec` field.
+- Out of scope (documented follow-up): `scan.py`'s `RECOGNIZED_*` sets and
+  `scan.py`/`scan_fix.py`'s divergent `SHAPEFILE_*_SIDECARS` are additional drift
+  not named by #558; folding them in would change sidecar-detection behavior.
+
+## Alternatives considered
+
+- **Reconcile values in place + a drift test, no registry.** Lighter, and the
+  issue offered it as an option, but leaves the tables hand-written in four
+  places and does not give `reis` a format module. Rejected in favor of a real
+  single source.
+- **Canonical machine-readable data file (YAML/JSON) in `spec/schema/`.** Matches
+  the `rules.yaml` / `spec-version.json` precedent and is language-neutral, but
+  `spec/` is not shipped at runtime and `reis` is Python, so the file would need
+  a packaged copy or codegen. A typed module avoids both.

--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -28,6 +28,7 @@ import click
 import pystac
 from pystac.layout import AsIsLayoutStrategy
 
+from portolan_cli import extension_registry as _reg
 from portolan_cli.checksums import compute_checksum, compute_dir_checksum, compute_dir_size
 from portolan_cli.collection import (
     _compute_union_bbox,
@@ -156,29 +157,9 @@ IGNORED_FILES: frozenset[str] = frozenset(
     }
 )
 
-# Extension-to-MIME-type mapping for asset files.
-_MEDIA_TYPE_MAP: dict[str, str] = {
-    ".parquet": "application/vnd.apache.parquet",
-    ".tif": "image/tiff; application=geotiff; profile=cloud-optimized",
-    ".tiff": "image/tiff; application=geotiff; profile=cloud-optimized",
-    ".geojson": "application/geo+json",
-    ".json": "application/json",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".svg": "image/svg+xml",
-    ".xml": "application/xml",
-    ".csv": "text/csv",
-    ".gpkg": "application/geopackage+sqlite3",
-    ".fgb": "application/vnd.flatgeobuf",
-    ".flatgeobuf": "application/vnd.flatgeobuf",
-    ".pmtiles": "application/vnd.pmtiles",
-    ".shp": "application/x-shapefile",
-    ".pdf": "application/pdf",
-    ".txt": "text/plain",
-    ".md": "text/markdown",
-    ".html": "text/html",
-}
+# Extension-to-MIME-type mapping for asset files. Derived from the extension
+# registry (the single source, ADR-0055). Edit rows there, not this map.
+_MEDIA_TYPE_MAP: dict[str, str] = _reg.field_map("media_type")
 
 # Asset keys reserved for well-known roles. _scan_item_assets prefers these
 # keys over filename-derived stems so STAC consumers can find assets by role
@@ -192,30 +173,10 @@ _ROLE_KEYS: dict[str, str] = {
     "documentation": "documentation",
 }
 
-# Extension-to-role mapping for asset files.
-# Data formats get "data", images get "thumbnail", metadata gets "metadata".
-_ROLE_MAP: dict[str, str] = {
-    ".parquet": "data",
-    ".tif": "data",
-    ".tiff": "data",
-    ".geojson": "data",
-    ".gpkg": "data",
-    ".fgb": "data",
-    ".flatgeobuf": "data",
-    ".csv": "data",
-    ".shp": "data",
-    ".pmtiles": "data",
-    ".png": "thumbnail",
-    ".jpg": "thumbnail",
-    ".jpeg": "thumbnail",
-    ".svg": "thumbnail",
-    ".xml": "metadata",
-    ".json": "metadata",
-    ".pdf": "documentation",
-    ".txt": "documentation",
-    ".md": "documentation",
-    ".html": "documentation",
-}
+# Extension-to-role mapping for asset files (data / thumbnail / metadata /
+# documentation). Derived from the extension registry (ADR-0055). Unknown
+# extensions fall back to "data" in _get_asset_role().
+_ROLE_MAP: dict[str, str] = _reg.field_map("role")
 
 
 def _get_media_type(path: Path) -> str:

--- a/portolan_cli/constants.py
+++ b/portolan_cli/constants.py
@@ -6,6 +6,8 @@ to avoid duplication and ensure consistency.
 
 from __future__ import annotations
 
+from portolan_cli import extension_registry as _reg
+
 # Version of the Portolan specification this CLI validates against (issue #566).
 #
 # SemVer, pre-1.0: breaking spec changes bump the MINOR until 1.0 (see the
@@ -18,47 +20,24 @@ from __future__ import annotations
 # from versions.SPEC_VERSION, which versions the versions.json manifest schema.
 PORTOLAN_SPEC_VERSION: str = "0.1.0"
 
-# Extensions we recognize as geospatial files
-# Note: .gdb is a directory extension (FileGDB) - handled specially in detection code
-GEOSPATIAL_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".geojson",
-        ".parquet",
-        ".shp",
-        ".gpkg",
-        ".fgb",
-        ".gdb",  # FileGDB directory (ESRI File Geodatabase)
-        ".csv",
-        ".tsv",  # Tab-separated values (may or may not have geometry)
-        ".tif",
-        ".tiff",
-        ".jp2",
-        ".pmtiles",
-    }
-)
+# The extension vocabulary below is DERIVED from portolan_cli.extension_registry
+# (the single source, ADR-0055). Edit rows there, not these members.
 
-# Extensions for tabular data that may or may not have geometry columns.
-# When these files lack geometry, they should be tracked as non-geospatial assets
-# (per ADR-0028) rather than causing errors.
-# Includes .parquet per Issue #177: tabular parquet files without geometry
-# should be tracked as auxiliary assets when alongside a primary geo-asset.
-# Includes .xlsx/.xls per Issue #432: basic Excel support for tabular data.
-TABULAR_EXTENSIONS: frozenset[str] = frozenset({".csv", ".tsv", ".parquet", ".xlsx", ".xls"})
+# Extensions we recognize as geospatial files (.gdb is a FileGDB directory,
+# handled specially in detection code).
+GEOSPATIAL_EXTENSIONS: frozenset[str] = _reg.extensions_where(is_geospatial=True)
+
+# Tabular data that may or may not carry geometry columns (ADR-0028). Includes
+# .parquet (issue #177) and .xlsx/.xls (issue #432).
+TABULAR_EXTENSIONS: frozenset[str] = _reg.extensions_where(is_tabular=True)
 
 # Cloud-native parquet extension
 PARQUET_EXTENSION: str = ".parquet"
 
-# Sidecar file patterns by primary file extension
-# Shapefile sidecars include:
-#   Required: .dbf (attributes), .shx (index)
-#   Optional: .prj (projection), .cpg (code page),
-#             .sbn/.sbx (ESRI spatial index), .qix (QGIS spatial index),
-#             .xml (metadata), .shp.xml (ESRI shapefile metadata)
+# Sidecar file patterns by primary file extension. Matched by appending each
+# pattern to the primary's stem, so compound forms (.shp.xml, .aux.xml) resolve.
 SIDECAR_PATTERNS: dict[str, list[str]] = {
-    ".shp": [".dbf", ".shx", ".prj", ".cpg", ".sbn", ".sbx", ".qix", ".xml", ".shp.xml"],
-    ".tif": [".tfw", ".xml", ".aux.xml", ".ovr"],
-    ".tiff": [".tfw", ".xml", ".aux.xml", ".ovr"],
-    ".img": [".ige", ".rrd", ".rde", ".xml"],
+    primary: list(patterns) for primary, patterns in _reg.SIDECAR_OF.items()
 }
 
 # Change detection constants (per ADR-0017)

--- a/portolan_cli/extension_registry.py
+++ b/portolan_cli/extension_registry.py
@@ -1,0 +1,413 @@
+"""Single source of truth for Portolan's recognized-file-extension vocabulary.
+
+Historically the extension vocabulary was hand-maintained in four places that
+drifted apart (issue #558): ``formats.py`` (cloud-native / convertible /
+unsupported sets), ``constants.py`` (geospatial / tabular / sidecar tables),
+``scan_classify.py`` (the ten scan categories), and ``add.py`` (media-type
+and asset-role maps). Plus the human doc ``spec/extensions.md``.
+
+This module is the one place that vocabulary lives now. Every frozenset/dict in
+those modules is *derived* from :data:`EXTENSION_REGISTRY` (see the derivation
+helpers below), and ``spec/extensions.md`` is tied to it by a parity test
+(``tests/spec_compliance/test_extensions_doc_parity.py``). See ADR-0055.
+
+It is deliberately a stdlib-only leaf that imports nothing from ``portolan_cli``
+so it can be lifted wholesale into ``reis`` (the validator being extracted, see
+issue #563) without dragging the app layers along.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+CloudNative = Literal["yes", "inspect", "no"]
+"""Static cloud-native status. ``inspect`` means it depends on file content
+(a ``.parquet`` may or may not carry ``geo`` metadata; a ``.tif`` may or may not
+be a valid COG), so those extensions are deliberately excluded from the static
+``CLOUD_NATIVE_EXTENSIONS`` set and resolved by content inspection instead."""
+
+ConvertTarget = Literal["GeoParquet", "COG"]
+Routes = Literal["vector", "raster"]
+Role = Literal["data", "thumbnail", "metadata", "documentation"]
+
+
+@dataclass(frozen=True)
+class ExtensionSpec:
+    """One row of the extension vocabulary.
+
+    Every field feeds at least one derivation below. Defaults describe the most
+    common case (an unremarkable, non-geospatial, unsupported-by-omission file),
+    so each row only spells out what makes it special.
+    """
+
+    ext: str
+    """Lowercase, dot-prefixed extension. Compound (``.copc.laz``) and
+    directory (``.gdb``, ``.zarr``) forms are allowed and flagged below."""
+
+    display_name: str | None = None
+    """Human format label (feeds ``FORMAT_DISPLAY_NAMES``). Left ``None`` for
+    extensions whose display is produced elsewhere (e.g. the ``.zarr`` /
+    ``.copc.laz`` special-case branches in ``formats.py``)."""
+
+    media_type: str | None = None
+    role: Role | None = None
+
+    cloud_native: CloudNative = "no"
+    convert_target: ConvertTarget | None = None
+    routes_as: Routes | None = None
+
+    scan_category: str | None = None
+    """Which ``FileCategory`` the scanner assigns by extension alone. ``None``
+    means the scanner does not recognize it by extension (dirs, compound
+    extensions, and unsupported formats fall here and surface as UNKNOWN)."""
+
+    is_dir: bool = False
+    is_compound: bool = False
+    is_geospatial: bool = False
+    is_tabular: bool = False
+    is_multilayer: bool = False
+    unsupported_message: str | None = None
+
+
+# =============================================================================
+# The registry
+# =============================================================================
+
+_NETCDF_MSG = "NetCDF is not yet supported. Support coming soon."
+_HDF5_MSG = "HDF5 is not yet supported. Support coming soon."
+_LAS_MSG = "LAS/LAZ point clouds require COPC format. Use pdal or other tools to convert."
+
+EXTENSION_REGISTRY: tuple[ExtensionSpec, ...] = (
+    # ---- Primary geospatial / format-detected ------------------------------
+    ExtensionSpec(
+        ".parquet",
+        display_name="GeoParquet",
+        media_type="application/vnd.apache.parquet",
+        role="data",
+        cloud_native="inspect",  # GeoParquet iff it carries a 'geo' metadata key
+        routes_as="vector",
+        scan_category="tabular_data",  # GEO_ASSET only after is_geoparquet() peek
+        is_geospatial=True,
+        is_tabular=True,
+    ),
+    ExtensionSpec(
+        ".geojson",
+        display_name="GeoJSON",
+        media_type="application/geo+json",
+        role="data",
+        convert_target="GeoParquet",
+        routes_as="vector",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    ExtensionSpec(
+        ".json",
+        display_name="JSON",
+        media_type="application/json",
+        role="metadata",
+        # Content-inspected at runtime: GeoJSON -> convertible, STAC -> metadata,
+        # otherwise unknown. Handled by a dedicated branch, so it is NOT in the
+        # static convertible-vector set and carries no convert_target here.
+        scan_category=None,
+    ),
+    ExtensionSpec(
+        ".shp",
+        display_name="SHP",
+        media_type="application/x-shapefile",
+        role="data",
+        convert_target="GeoParquet",
+        routes_as="vector",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    ExtensionSpec(
+        ".gpkg",
+        display_name="GPKG",
+        media_type="application/geopackage+sqlite3",
+        role="data",
+        convert_target="GeoParquet",
+        routes_as="vector",
+        scan_category="geo_asset",
+        is_geospatial=True,
+        is_multilayer=True,
+    ),
+    ExtensionSpec(
+        ".gdb",
+        # FileGDB directory. Display falls back to the generic upper-cased stem
+        # in formats.py; no media type (a directory, not a file we type).
+        convert_target="GeoParquet",
+        routes_as="vector",
+        is_dir=True,
+        is_geospatial=True,
+        is_multilayer=True,
+    ),
+    ExtensionSpec(
+        ".fgb",
+        display_name="FlatGeobuf",
+        media_type="application/vnd.flatgeobuf",
+        role="data",
+        cloud_native="yes",
+        routes_as="vector",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    ExtensionSpec(
+        # Defensive alias for FlatGeobuf in the media-type/role maps only; real
+        # files use .fgb, so this participates in no format-detection set.
+        ".flatgeobuf",
+        media_type="application/vnd.flatgeobuf",
+        role="data",
+    ),
+    ExtensionSpec(
+        ".pmtiles",
+        display_name="PMTiles",
+        media_type="application/vnd.pmtiles",
+        role="data",
+        cloud_native="yes",
+        routes_as="vector",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    ExtensionSpec(
+        ".csv",
+        display_name="CSV",
+        media_type="text/csv",
+        role="data",
+        convert_target="GeoParquet",
+        routes_as="vector",
+        scan_category="tabular_data",  # geometry columns -> geo at a later stage
+        is_geospatial=True,
+        is_tabular=True,
+    ),
+    ExtensionSpec(
+        ".tsv",
+        display_name="TSV",
+        # Mirrors .csv: content-inspected, dual vector/tabular (issue #558).
+        convert_target="GeoParquet",
+        routes_as="vector",
+        scan_category="tabular_data",
+        is_geospatial=True,
+        is_tabular=True,
+    ),
+    ExtensionSpec(
+        ".tif",
+        display_name="COG",
+        media_type="image/tiff; application=geotiff; profile=cloud-optimized",
+        role="data",
+        cloud_native="inspect",  # cloud-native iff a valid COG
+        routes_as="raster",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    ExtensionSpec(
+        ".tiff",
+        display_name="COG",
+        media_type="image/tiff; application=geotiff; profile=cloud-optimized",
+        role="data",
+        cloud_native="inspect",
+        routes_as="raster",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    ExtensionSpec(
+        ".jp2",
+        display_name="JP2",
+        convert_target="COG",
+        routes_as="raster",
+        scan_category="geo_asset",
+        is_geospatial=True,
+    ),
+    # ---- Cloud-native, directory / compound (not static-set members) -------
+    ExtensionSpec(
+        # Zarr array store: a directory, handled by a dedicated branch, so it is
+        # cloud-native but excluded from the static CLOUD_NATIVE_EXTENSIONS set.
+        ".zarr",
+        cloud_native="yes",
+        is_dir=True,
+    ),
+    ExtensionSpec(
+        # COPC point cloud: compound extension, handled by an endswith() branch
+        # ahead of the plain-.laz unsupported check. A .copc.laz asset is typed
+        # via the .laz media type (a COPC file is a LAZ file).
+        ".copc.laz",
+        cloud_native="yes",
+        is_compound=True,
+    ),
+    # ---- Tabular-only ------------------------------------------------------
+    ExtensionSpec(".xlsx", scan_category="tabular_data", is_tabular=True),
+    ExtensionSpec(".xls", scan_category="tabular_data", is_tabular=True),
+    # ---- Unsupported (rejected, but still well-typed per Matthias review) ---
+    ExtensionSpec(
+        ".nc",
+        display_name="NetCDF",
+        media_type="application/x-netcdf",
+        unsupported_message=_NETCDF_MSG,
+    ),
+    ExtensionSpec(
+        ".netcdf",
+        display_name="NetCDF",
+        media_type="application/x-netcdf",
+        unsupported_message=_NETCDF_MSG,
+    ),
+    ExtensionSpec(
+        ".h5", display_name="HDF5", media_type="application/x-hdf5", unsupported_message=_HDF5_MSG
+    ),
+    ExtensionSpec(
+        ".hdf5", display_name="HDF5", media_type="application/x-hdf5", unsupported_message=_HDF5_MSG
+    ),
+    ExtensionSpec(
+        ".las", display_name="LAS", media_type="application/vnd.las", unsupported_message=_LAS_MSG
+    ),
+    ExtensionSpec(
+        ".laz",
+        display_name="LAZ",
+        media_type="application/vnd.laszip",
+        unsupported_message=_LAS_MSG,
+    ),
+    # ---- Shapefile / raster sidecars (scanner's flat known-sidecar set) -----
+    ExtensionSpec(".dbf", scan_category="known_sidecar"),
+    ExtensionSpec(".shx", scan_category="known_sidecar"),
+    ExtensionSpec(".prj", scan_category="known_sidecar"),
+    ExtensionSpec(".cpg", scan_category="known_sidecar"),
+    ExtensionSpec(".sbn", scan_category="known_sidecar"),
+    ExtensionSpec(".sbx", scan_category="known_sidecar"),
+    ExtensionSpec(".ovr", scan_category="known_sidecar"),
+    ExtensionSpec(
+        ".xml", media_type="application/xml", role="metadata", scan_category="known_sidecar"
+    ),
+    # ---- Documentation -----------------------------------------------------
+    ExtensionSpec(
+        ".md", media_type="text/markdown", role="documentation", scan_category="documentation"
+    ),
+    ExtensionSpec(
+        ".txt", media_type="text/plain", role="documentation", scan_category="documentation"
+    ),
+    ExtensionSpec(".rst", scan_category="documentation"),
+    ExtensionSpec(
+        ".html", media_type="text/html", role="documentation", scan_category="documentation"
+    ),
+    ExtensionSpec(".htm", scan_category="documentation"),
+    ExtensionSpec(".pdf", media_type="application/pdf", role="documentation"),
+    # ---- Visualization derivatives -----------------------------------------
+    ExtensionSpec(".mbtiles", scan_category="visualization"),
+    # ---- Thumbnail / preview images ----------------------------------------
+    ExtensionSpec(".png", media_type="image/png", role="thumbnail", scan_category="thumbnail"),
+    ExtensionSpec(".jpg", media_type="image/jpeg", role="thumbnail", scan_category="thumbnail"),
+    ExtensionSpec(".jpeg", media_type="image/jpeg", role="thumbnail", scan_category="thumbnail"),
+    ExtensionSpec(".webp", media_type="image/webp", role="thumbnail", scan_category="thumbnail"),
+    ExtensionSpec(".gif", media_type="image/gif", role="thumbnail", scan_category="thumbnail"),
+    ExtensionSpec(".svg", media_type="image/svg+xml", role="thumbnail", scan_category="thumbnail"),
+    # ---- Junk / ignored ----------------------------------------------------
+    ExtensionSpec(".exe", scan_category="junk"),
+    ExtensionSpec(".dll", scan_category="junk"),
+    ExtensionSpec(".so", scan_category="junk"),
+    ExtensionSpec(".dylib", scan_category="junk"),
+    ExtensionSpec(".pyc", scan_category="junk"),
+    ExtensionSpec(".pyo", scan_category="junk"),
+    ExtensionSpec(".class", scan_category="junk"),
+    ExtensionSpec(".o", scan_category="junk"),
+    ExtensionSpec(".obj", scan_category="junk"),
+)
+
+
+# =============================================================================
+# Non-extension vocabulary (single-sourced here too)
+# =============================================================================
+
+# Sidecar patterns keyed by the PRIMARY file's extension. Matched by appending
+# each pattern to the primary's stem (so compound forms like ".shp.xml" and
+# ".aux.xml" resolve correctly). This is a different projection than the flat
+# scanner set derived from scan_category == "known_sidecar" above: it answers
+# "given this primary, what sidecars might accompany it".
+SIDECAR_OF: dict[str, tuple[str, ...]] = {
+    ".shp": (".dbf", ".shx", ".prj", ".cpg", ".sbn", ".sbx", ".qix", ".xml", ".shp.xml"),
+    ".tif": (".tfw", ".xml", ".aux.xml", ".ovr"),
+    ".tiff": (".tfw", ".xml", ".aux.xml", ".ovr"),
+    ".img": (".ige", ".rrd", ".rde", ".xml"),
+}
+
+JUNK_DIRS: frozenset[str] = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        ".svn",
+        ".hg",
+        ".idea",
+        ".vscode",
+        "node_modules",
+        ".tox",
+        ".pytest_cache",
+    }
+)
+
+STAC_FILENAMES: frozenset[str] = frozenset({"catalog.json", "collection.json", "versions.json"})
+
+STYLE_FILENAMES: frozenset[str] = frozenset({"style.json"})
+
+# Max size (bytes) for an image to be treated as a thumbnail rather than raster.
+THUMBNAIL_MAX_SIZE: int = 1024 * 1024
+
+
+# =============================================================================
+# Derivation helpers
+# =============================================================================
+
+
+def extensions_where(**field_equals: object) -> frozenset[str]:
+    """Return the set of ``ext`` values whose row matches every ``field=value``.
+
+    Example: ``extensions_where(scan_category="geo_asset")``.
+    """
+    return frozenset(
+        spec.ext
+        for spec in EXTENSION_REGISTRY
+        if all(getattr(spec, field) == value for field, value in field_equals.items())
+    )
+
+
+def field_map(field: str) -> dict[str, str]:
+    """Map ``ext -> getattr(row, field)`` for rows where that field is not None.
+
+    Used to build ``FORMAT_DISPLAY_NAMES``, ``_MEDIA_TYPE_MAP``, ``_ROLE_MAP``,
+    and ``UNSUPPORTED_ERROR_MESSAGES``.
+    """
+    result: dict[str, str] = {}
+    for spec in EXTENSION_REGISTRY:
+        value = getattr(spec, field)
+        if value is not None:
+            result[spec.ext] = value
+    return result
+
+
+def cloud_native_extensions() -> frozenset[str]:
+    """Statically cloud-native, single-suffix files (skip conversion).
+
+    Excludes ``inspect`` extensions (``.parquet``/``.tif``, resolved by content)
+    and the directory/compound cloud-native forms (``.zarr``/``.copc.laz``,
+    resolved by dedicated branches).
+    """
+    return frozenset(
+        spec.ext
+        for spec in EXTENSION_REGISTRY
+        if spec.cloud_native == "yes" and not spec.is_dir and not spec.is_compound
+    )
+
+
+def convertible_extensions(target: ConvertTarget) -> frozenset[str]:
+    """Extensions that convert to the given cloud-native target."""
+    return frozenset(spec.ext for spec in EXTENSION_REGISTRY if spec.convert_target == target)
+
+
+def unsupported_extensions() -> frozenset[str]:
+    """Extensions explicitly rejected with a helpful message."""
+    return frozenset(
+        spec.ext for spec in EXTENSION_REGISTRY if spec.unsupported_message is not None
+    )
+
+
+def all_known_sidecar_extensions() -> frozenset[str]:
+    """Every sidecar suffix the system knows: the flat scanner set plus all
+    per-primary patterns in :data:`SIDECAR_OF`."""
+    from_patterns = {ext for patterns in SIDECAR_OF.values() for ext in patterns}
+    return extensions_where(scan_category="known_sidecar") | frozenset(from_patterns)

--- a/portolan_cli/formats.py
+++ b/portolan_cli/formats.py
@@ -18,6 +18,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from portolan_cli import extension_registry as _reg
+
 if TYPE_CHECKING:
     from portolan_cli.conversion_config import ConversionOverrides
 
@@ -65,86 +67,27 @@ class FormatInfo:
 # Cloud-Native Format Constants
 # =============================================================================
 
-# Extensions for cloud-native formats (pass through without conversion)
-CLOUD_NATIVE_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".fgb",  # FlatGeobuf
-        ".pmtiles",  # PMTiles
-        ".raquet",  # Raquet (raster parquet)
-        # Note: .parquet, .tif, .tiff require content inspection
-        # Note: .copc.laz is handled specially (compound extension)
-        # Note: .zarr is a directory, not a file extension
-    }
-)
+# The extension vocabulary below is DERIVED from portolan_cli.extension_registry
+# (the single source, ADR-0055). Edit rows there, not these frozensets.
 
-# Extensions for convertible vector formats
-# Note: .gdb is a directory extension (FileGDB) - handled specially in detection code
-CONVERTIBLE_VECTOR_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".shp",  # Shapefile
-        ".geojson",  # GeoJSON
-        ".gpkg",  # GeoPackage
-        ".gdb",  # FileGDB directory (ESRI File Geodatabase)
-        ".csv",  # CSV with geometry
-        ".tsv",  # TSV with geometry (tab-separated)
-    }
-)
+# Cloud-native formats that pass through without conversion. Statically
+# cloud-native single-suffix files only: .parquet/.tif are content-inspected
+# ("inspect"), and .zarr/.copc.laz are cloud-native but handled by the
+# directory / compound-extension branches in get_cloud_native_status().
+CLOUD_NATIVE_EXTENSIONS: frozenset[str] = _reg.cloud_native_extensions()
 
-# Extensions for convertible raster formats
-CONVERTIBLE_RASTER_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".jp2",  # JPEG2000
-    }
-)
+# Convertible vector formats (.gdb is a FileGDB directory, handled specially).
+CONVERTIBLE_VECTOR_EXTENSIONS: frozenset[str] = _reg.convertible_extensions("GeoParquet")
 
-# Extensions for unsupported formats
-UNSUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".nc",  # NetCDF
-        ".netcdf",  # NetCDF alternate
-        ".h5",  # HDF5
-        ".hdf5",  # HDF5 alternate
-        ".las",  # LAS (non-COPC)
-        ".laz",  # LAZ (non-COPC, unless .copc.laz)
-    }
-)
+# Convertible raster formats.
+CONVERTIBLE_RASTER_EXTENSIONS: frozenset[str] = _reg.convertible_extensions("COG")
 
-# Display names for formats
-FORMAT_DISPLAY_NAMES: dict[str, str] = {
-    # Cloud-native
-    ".parquet": "GeoParquet",
-    ".fgb": "FlatGeobuf",
-    ".pmtiles": "PMTiles",
-    ".raquet": "Raquet",
-    ".tif": "COG",
-    ".tiff": "COG",
-    # Convertible vector
-    ".shp": "SHP",
-    ".geojson": "GeoJSON",
-    ".gpkg": "GPKG",
-    ".csv": "CSV",
-    ".tsv": "TSV",
-    ".json": "JSON",  # Plain JSON; use content inspection to detect GeoJSON
-    # Convertible raster
-    ".jp2": "JP2",
-    # Unsupported
-    ".nc": "NetCDF",
-    ".netcdf": "NetCDF",
-    ".h5": "HDF5",
-    ".hdf5": "HDF5",
-    ".las": "LAS",
-    ".laz": "LAZ",
-}
+# Explicitly unsupported formats.
+UNSUPPORTED_EXTENSIONS: frozenset[str] = _reg.unsupported_extensions()
 
-# Error messages for unsupported formats
-UNSUPPORTED_ERROR_MESSAGES: dict[str, str] = {
-    ".nc": "NetCDF is not yet supported. Support coming soon.",
-    ".netcdf": "NetCDF is not yet supported. Support coming soon.",
-    ".h5": "HDF5 is not yet supported. Support coming soon.",
-    ".hdf5": "HDF5 is not yet supported. Support coming soon.",
-    ".las": "LAS/LAZ point clouds require COPC format. Use pdal or other tools to convert.",
-    ".laz": "LAS/LAZ point clouds require COPC format. Use pdal or other tools to convert.",
-}
+# Display names and unsupported error messages.
+FORMAT_DISPLAY_NAMES: dict[str, str] = _reg.field_map("display_name")
+UNSUPPORTED_ERROR_MESSAGES: dict[str, str] = _reg.field_map("unsupported_message")
 
 
 # =============================================================================
@@ -499,32 +442,14 @@ class FormatType(Enum):
     UNKNOWN = "unknown"  # Cannot determine format
 
 
-# Extensions that indicate vector formats (handled by geoparquet-io)
-# Note: .gdb is a directory extension (FileGDB) - handled specially in detect_format
-# Note: Cloud-native formats like .fgb and .pmtiles are included here so detect_format()
-# returns VECTOR, allowing convert_vector() to then check cloud-native status and skip.
-VECTOR_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".geojson",
-        ".parquet",
-        ".shp",
-        ".gpkg",
-        ".fgb",  # FlatGeobuf (cloud-native)
-        ".pmtiles",  # PMTiles (cloud-native vector tiles, issue #198)
-        ".gdb",  # FileGDB directory (ESRI File Geodatabase)
-        ".csv",
-        ".tsv",  # Tab-separated values (may or may not have geometry)
-    }
-)
+# Extensions that route to geoparquet-io (vector) / rio-cogeo (raster). Derived
+# from the registry (ADR-0055). Cloud-native vectors like .fgb/.pmtiles are
+# included in VECTOR_EXTENSIONS so detect_format() returns VECTOR, letting
+# convert_vector() then check cloud-native status and skip. .gdb is a FileGDB
+# directory handled specially in detect_format().
+VECTOR_EXTENSIONS: frozenset[str] = _reg.extensions_where(routes_as="vector")
 
-# Extensions that indicate raster formats (handled by rio-cogeo)
-RASTER_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".tif",
-        ".tiff",
-        ".jp2",  # JPEG2000
-    }
-)
+RASTER_EXTENSIONS: frozenset[str] = _reg.extensions_where(routes_as="raster")
 
 
 def detect_format(path: Path) -> FormatType:
@@ -572,13 +497,8 @@ def detect_format(path: Path) -> FormatType:
 # Multi-Layer Format Support (Issue #265)
 # =============================================================================
 
-# Formats that can contain multiple layers
-MULTILAYER_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".gpkg",  # GeoPackage
-        ".gdb",  # FileGDB directory
-    }
-)
+# Formats that can contain multiple layers (derived from the registry, ADR-0055).
+MULTILAYER_EXTENSIONS: frozenset[str] = _reg.extensions_where(is_multilayer=True)
 
 
 def list_layers(path: Path) -> list[str] | None:

--- a/portolan_cli/scan_classify.py
+++ b/portolan_cli/scan_classify.py
@@ -23,134 +23,49 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
+from portolan_cli import extension_registry as _reg
+
 # =============================================================================
-# Extension Mappings
+# Extension Mappings (DERIVED from extension_registry — the single source,
+# ADR-0055. Edit rows there, not these frozensets.)
 # =============================================================================
 
-# Primary geospatial formats (GEO_ASSET)
-# Note: .parquet is NOT here — it requires metadata peeking to distinguish
-# GeoParquet from plain Parquet. See is_geoparquet() and classify_file().
-GEO_ASSET_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".geojson",
-        ".shp",
-        ".gpkg",
-        ".fgb",
-        ".tif",
-        ".tiff",
-        ".jp2",
-        ".pmtiles",  # PMTiles: cloud-native vector tiles (issue #198)
-    }
-)
+# Primary geospatial formats (GEO_ASSET). .parquet is NOT here — it needs a
+# metadata peek to tell GeoParquet from plain Parquet (see is_geoparquet()).
+GEO_ASSET_EXTENSIONS: frozenset[str] = _reg.extensions_where(scan_category="geo_asset")
 
-# Shapefile sidecars (KNOWN_SIDECAR)
-# Note: .aux.xml removed - Path.suffix returns ".xml" not ".aux.xml",
-# so .xml already catches these files
-SIDECAR_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".dbf",
-        ".shx",
-        ".prj",
-        ".cpg",
-        ".sbn",
-        ".sbx",
-        ".ovr",
-        ".xml",
-    }
-)
+# Shapefile / raster sidecars (KNOWN_SIDECAR). Compound forms like .aux.xml are
+# caught by .xml here, since Path.suffix returns only the last extension.
+SIDECAR_EXTENSIONS: frozenset[str] = _reg.extensions_where(scan_category="known_sidecar")
 
-# Tabular data formats (TABULAR_DATA)
-# Note: .parquet is here because plain Parquet (no geo metadata) is tabular.
-# GeoParquet files are detected by is_geoparquet() which peeks at metadata.
-TABULAR_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".csv",
-        ".tsv",
-        ".xlsx",
-        ".xls",
-        ".parquet",  # Plain Parquet; GeoParquet detected via metadata peeking
-    }
-)
+# Tabular data (TABULAR_DATA). .parquet is here because plain Parquet is tabular;
+# GeoParquet is detected by is_geoparquet()'s metadata peek.
+TABULAR_EXTENSIONS: frozenset[str] = _reg.extensions_where(is_tabular=True)
 
-# Documentation formats (DOCUMENTATION)
-DOC_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".md",
-        ".txt",
-        ".rst",
-        ".html",
-        ".htm",
-    }
-)
+# Documentation (DOCUMENTATION).
+DOC_EXTENSIONS: frozenset[str] = _reg.extensions_where(scan_category="documentation")
 
-# Visualization formats (VISUALIZATION)
-# Note: .pmtiles is NOT here — it is a primary cloud-native format (GEO_ASSET).
-# See issue #198 and formats.py CLOUD_NATIVE_EXTENSIONS.
-VIZ_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".mbtiles",
-    }
-)
+# Visualization (VISUALIZATION). .pmtiles is NOT here — it is a primary
+# cloud-native format (GEO_ASSET). See issue #198.
+VIZ_EXTENSIONS: frozenset[str] = _reg.extensions_where(scan_category="visualization")
 
-# Thumbnail/image formats (THUMBNAIL) - checked with size
-IMAGE_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".png",
-        ".jpg",
-        ".jpeg",
-        ".webp",
-        ".gif",
-    }
-)
+# Thumbnail/image formats (THUMBNAIL) — checked with size.
+IMAGE_EXTENSIONS: frozenset[str] = _reg.extensions_where(scan_category="thumbnail")
 
-# Junk file extensions (JUNK)
-JUNK_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".exe",
-        ".dll",
-        ".so",
-        ".dylib",
-        ".pyc",
-        ".pyo",
-        ".class",
-        ".o",
-        ".obj",
-    }
-)
+# Junk file extensions (JUNK).
+JUNK_EXTENSIONS: frozenset[str] = _reg.extensions_where(scan_category="junk")
 
-# Junk directory names (JUNK)
-JUNK_DIRS: frozenset[str] = frozenset(
-    {
-        "__pycache__",
-        ".git",
-        ".svn",
-        ".hg",
-        ".idea",
-        ".vscode",
-        "node_modules",
-        ".tox",
-        ".pytest_cache",
-    }
-)
+# Junk directory names (JUNK).
+JUNK_DIRS: frozenset[str] = _reg.JUNK_DIRS
 
-# STAC/catalog metadata filenames (STAC_METADATA)
-STAC_FILENAMES: frozenset[str] = frozenset(
-    {
-        "catalog.json",
-        "collection.json",
-        "versions.json",  # Portolan version history
-    }
-)
+# STAC/catalog metadata filenames (STAC_METADATA).
+STAC_FILENAMES: frozenset[str] = _reg.STAC_FILENAMES
 
-# Style filenames (STYLE)
-STYLE_FILENAMES: frozenset[str] = frozenset(
-    {
-        "style.json",
-    }
-)
+# Style filenames (STYLE).
+STYLE_FILENAMES: frozenset[str] = _reg.STYLE_FILENAMES
 
-# Max size for thumbnail classification (1MB)
-THUMBNAIL_MAX_SIZE: int = 1024 * 1024
+# Max size for thumbnail classification (1MB).
+THUMBNAIL_MAX_SIZE: int = _reg.THUMBNAIL_MAX_SIZE
 
 
 def is_geoparquet(path: Path) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,7 +226,8 @@ skips = []  # Add specific checks to skip if needed, e.g., ["B101"]
 # "Nd" is a Unicode category code for "Number, decimal digit" used in Hypothesis tests
 # French words from Belgian ISO 19139 test fixture (tests/fixtures/csw/belgium_buildings_iso19139.xml)
 # "BU" is the INSPIRE theme code for Buildings (used in test fixtures)
-ignore-words-list = "nd,bu,ue,adresse,projet,environnement,copie,explicite,connexion,objets,visibles,issus,fonction,mesures,informations"
+# "disjointness" is a real set-theory term (codespell wants "disjointedness")
+ignore-words-list = "nd,bu,ue,adresse,projet,environnement,copie,explicite,connexion,objets,visibles,issus,fonction,mesures,informations,disjointness"
 
 # ---------- dead code ----------
 

--- a/spec/extensions.md
+++ b/spec/extensions.md
@@ -10,11 +10,13 @@ These extensions are recognized as importable geospatial data:
 |-----------|--------|------|--------------|-------|
 | `.parquet` | GeoParquet | Vector | Yes | Requires geo metadata (content inspection) |
 | `.geojson` | GeoJSON | Vector | No | Converts to GeoParquet |
-| `.json` | GeoJSON | Vector | No | Content inspected for GeoJSON structure |
+| `.json` | JSON | Vector | No | Content-inspected: GeoJSON → GeoParquet; STAC metadata and other JSON are skipped |
 | `.shp` | Shapefile | Vector | No | Converts to GeoParquet |
 | `.gpkg` | GeoPackage | Vector | No | Converts to GeoParquet |
+| `.gdb` | FileGDB (Esri) | Vector | No | Directory format; converts all layers to GeoParquet |
 | `.fgb` | FlatGeobuf | Vector | Yes | Cloud-native, passed through |
 | `.csv` | CSV | Vector/Tabular | No | Content inspected: geometry columns → GeoParquet; no geometry → tabular (if enabled) |
+| `.tsv` | TSV | Vector/Tabular | No | Content inspected: geometry columns → GeoParquet; no geometry → tabular (if enabled) |
 | `.tif`, `.tiff` | GeoTIFF/COG | Raster | Depends | Content inspected for COG compliance |
 | `.jp2` | JPEG2000 | Raster | No | Converts to COG |
 
@@ -43,10 +45,21 @@ Some formats require content inspection to determine type and cloud-native statu
 - **`.csv`**: Checked for geometry columns (lat/lon, WKT, WKB)
   - If geometry columns found → GeoParquet conversion
   - If no geometry columns → tabular (requires `tabular.enabled: true`)
-- **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry)
+- **`.json`**: Checked for GeoJSON structure (FeatureCollection, Feature, or geometry). STAC metadata (identified by `stac_version`) is **not** GeoJSON and is skipped.
 - **`.tif`/`.tiff`**: Validated against COG spec (internal tiling, overviews)
 
 Files that fail content inspection are treated as convertible (vector), tabular (if enabled), or rejected (raster without geo info).
+
+## Additional Cloud-Native Formats
+
+These are already cloud-native and passed through without conversion, but they
+are not plain single-suffix files, so they are recognized by dedicated handling
+rather than a simple extension lookup:
+
+| Extension | Format | Type | Notes |
+|-----------|--------|------|-------|
+| `.zarr` | Zarr | Raster/Array | Directory store; recognized as a directory, not a file extension |
+| `.copc.laz` | COPC | Point cloud | Compound extension; cloud-optimized point cloud. Distinct from plain `.las`/`.laz` (unsupported, see below) |
 
 ## Sidecar Files
 
@@ -58,11 +71,13 @@ These extensions are recognized as sidecar files belonging to a primary asset:
 | `.shx` | Shapefile index |
 | `.prj` | Shapefile projection |
 | `.cpg` | Shapefile code page |
-| `.sbn`, `.sbx` | Shapefile spatial index |
+| `.sbn`, `.sbx` | Shapefile spatial index (Esri) |
+| `.qix` | Shapefile spatial index (QGIS/GDAL) |
 | `.ovr` | Raster overview (pyramid) |
+| `.tfw` | Raster world file (georeferencing) |
 | `.xml` | Auxiliary metadata (aux.xml, etc.) |
 
-Sidecar files are **not** imported directly. When importing a `.shp` file, its sidecars are read automatically.
+Sidecar files are **not** imported directly. When importing a `.shp` file, its sidecars are read automatically. Compound sidecar names (e.g. `.shp.xml`, `.aux.xml`) are matched by appending the pattern to the primary file's stem; a bare `.xml` also catches them since `Path.suffix` returns only the last extension.
 
 ## Visualization Formats
 
@@ -88,19 +103,21 @@ These files have semantic meaning and are not imported as data.
 
 | Extension | Handling |
 |-----------|----------|
-| `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif` | Treated as thumbnails if < 1 MiB (1,048,576 bytes) |
+| `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`, `.svg` | Treated as thumbnails if < 1 MiB (1,048,576 bytes) |
 
 Small images are assumed to be previews, not raster data.
 
 ## Unsupported Formats
 
-These formats are explicitly rejected with informative error messages:
+These formats are explicitly rejected with informative error messages. They are
+still assigned a media type so that, if present as companion files, assets remain
+well-typed.
 
-| Extension | Format | Reason |
-|-----------|--------|--------|
-| `.nc`, `.netcdf` | NetCDF | Not yet supported |
-| `.h5`, `.hdf5` | HDF5 | Not yet supported |
-| `.las`, `.laz` | LAS/LAZ | Use COPC format instead |
+| Extension | Format | Media Type | Reason |
+|-----------|--------|------------|--------|
+| `.nc`, `.netcdf` | NetCDF | `application/x-netcdf` | Not yet supported |
+| `.h5`, `.hdf5` | HDF5 | `application/x-hdf5` | Not yet supported |
+| `.las`, `.laz` | LAS/LAZ | `application/vnd.las`, `application/vnd.laszip` | Plain point clouds; use COPC (`.copc.laz`) instead |
 
 ## Tabular Formats
 

--- a/tests/spec_compliance/test_extensions_doc_parity.py
+++ b/tests/spec_compliance/test_extensions_doc_parity.py
@@ -1,0 +1,109 @@
+"""Parity between spec/extensions.md and the code extension vocabulary (#558).
+
+`spec/extensions.md` is the human-facing canonical doc; the code frozensets are
+derived from `portolan_cli.extension_registry` (ADR-0055). This test parses the
+markdown tables and fails if the doc and the code disagree, so the two can never
+drift again.
+
+Parsing model: for each level-2 (`##`) section, collect the backtick-quoted
+tokens in the FIRST column of every markdown table row. That yields the set of
+extensions each section documents.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.constants import GEOSPATIAL_EXTENSIONS, TABULAR_EXTENSIONS
+from portolan_cli.extension_registry import EXTENSION_REGISTRY, all_known_sidecar_extensions
+from portolan_cli.formats import UNSUPPORTED_EXTENSIONS
+from portolan_cli.scan_classify import (
+    DOC_EXTENSIONS,
+    IMAGE_EXTENSIONS,
+    JUNK_DIRS,
+    JUNK_EXTENSIONS,
+    SIDECAR_EXTENSIONS,
+    VIZ_EXTENSIONS,
+)
+
+pytestmark = pytest.mark.unit
+
+_EXTENSIONS_MD = Path(__file__).resolve().parents[2] / "spec" / "extensions.md"
+_BACKTICK = re.compile(r"`([^`]+)`")
+
+
+def _section_first_column_tokens(text: str) -> dict[str, set[str]]:
+    """Map each ``## Section`` title to the set of backticked first-column tokens."""
+    sections: dict[str, set[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        if line.startswith("## "):
+            current = line[3:].strip()
+            sections.setdefault(current, set())
+            continue
+        if current is None or not line.lstrip().startswith("|"):
+            continue
+        first_cell = line.split("|")[1] if line.count("|") >= 2 else ""
+        sections[current].update(_BACKTICK.findall(first_cell))
+    return sections
+
+
+@pytest.fixture(scope="module")
+def doc_sections() -> dict[str, set[str]]:
+    return _section_first_column_tokens(_EXTENSIONS_MD.read_text(encoding="utf-8"))
+
+
+def test_extensions_md_exists() -> None:
+    assert _EXTENSIONS_MD.is_file()
+
+
+def test_primary_geospatial_matches_code(doc_sections: dict[str, set[str]]) -> None:
+    # Documented importable formats. `.pmtiles` is a geospatial format but is
+    # documented under Visualization; `.json` is content-inspected and not in
+    # GEOSPATIAL_EXTENSIONS. Both handled explicitly here.
+    expected = (GEOSPATIAL_EXTENSIONS - {".pmtiles"}) | {".json"}
+    assert doc_sections["Primary Geospatial Formats"] == expected
+
+
+def test_additional_cloud_native_matches_code(doc_sections: dict[str, set[str]]) -> None:
+    expected = {
+        spec.ext
+        for spec in EXTENSION_REGISTRY
+        if spec.cloud_native == "yes" and (spec.is_dir or spec.is_compound)
+    }
+    assert doc_sections["Additional Cloud-Native Formats"] == expected == {".zarr", ".copc.laz"}
+
+
+def test_visualization_matches_code(doc_sections: dict[str, set[str]]) -> None:
+    assert doc_sections["Visualization Formats"] == VIZ_EXTENSIONS | {".pmtiles"}
+
+
+def test_thumbnails_match_code(doc_sections: dict[str, set[str]]) -> None:
+    assert doc_sections["Thumbnail/Preview"] == IMAGE_EXTENSIONS
+
+
+def test_unsupported_matches_code(doc_sections: dict[str, set[str]]) -> None:
+    assert doc_sections["Unsupported Formats"] == UNSUPPORTED_EXTENSIONS
+
+
+def test_tabular_matches_code(doc_sections: dict[str, set[str]]) -> None:
+    assert doc_sections["Tabular Formats"] == TABULAR_EXTENSIONS
+
+
+def test_sidecars_are_documented_and_known(doc_sections: dict[str, set[str]]) -> None:
+    documented = doc_sections["Sidecar Files"]
+    # Every scanner-recognized sidecar must be documented, and every documented
+    # sidecar must be a real known sidecar (the doc may curate a subset, e.g. it
+    # omits obscure .img sidecars).
+    assert SIDECAR_EXTENSIONS <= documented <= all_known_sidecar_extensions()
+
+
+def test_ignored_files_match_code(doc_sections: dict[str, set[str]]) -> None:
+    tokens = doc_sections["Ignored Files"]
+    doc_dirs = {t[:-1] for t in tokens if t.endswith("/")}
+    doc_exts = {t for t in tokens if t.startswith(".") and not t.endswith("/")}
+    assert doc_exts == JUNK_EXTENSIONS | DOC_EXTENSIONS
+    assert doc_dirs == JUNK_DIRS

--- a/tests/unit/test_asset_role_media.py
+++ b/tests/unit/test_asset_role_media.py
@@ -1,0 +1,42 @@
+"""Regression tests for asset role/media-type assignment (issue #558).
+
+`.webp` and `.gif` were documented and scan-classified as thumbnails but were
+absent from add.py's `_ROLE_MAP` / `_MEDIA_TYPE_MAP`, so such assets were
+mis-typed as role "data" / "application/octet-stream". `.svg` was already a
+thumbnail in the role map but missing from the scan image set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.add import _get_asset_role, _get_media_type
+from portolan_cli.scan_classify import IMAGE_EXTENSIONS
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_media"),
+    [
+        ("preview.webp", "image/webp"),
+        ("preview.gif", "image/gif"),
+        ("preview.svg", "image/svg+xml"),
+    ],
+)
+def test_image_media_types(filename: str, expected_media: str) -> None:
+    # Pre-fix, .webp/.gif fell through to "application/octet-stream".
+    assert _get_media_type(Path(filename)) == expected_media
+
+
+@pytest.mark.parametrize("filename", ["preview.webp", "preview.gif", "preview.svg"])
+def test_image_role_is_thumbnail(filename: str) -> None:
+    # Pre-fix, .webp/.gif fell through to the "data" default.
+    assert _get_asset_role(Path(filename)) == "thumbnail"
+
+
+def test_svg_is_a_scan_image_extension() -> None:
+    # .svg now classified as an image by the scanner, matching the role map.
+    assert ".svg" in IMAGE_EXTENSIONS

--- a/tests/unit/test_extension_registry.py
+++ b/tests/unit/test_extension_registry.py
@@ -1,0 +1,258 @@
+"""Tests for the single-source extension registry (issue #558).
+
+These pin the *derived* vocabulary to explicit expected literals, so the test
+fails loudly if a registry row is added/removed/mis-typed. They also assert the
+structural invariants (disjointness, uniqueness) and that the four consuming
+modules expose exactly the registry-derived values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portolan_cli import extension_registry as reg
+
+pytestmark = pytest.mark.unit
+
+
+class TestDerivedSets:
+    """Registry derivations equal their expected post-reconciliation literals."""
+
+    def test_cloud_native_extensions(self) -> None:
+        # .raquet dropped (#487); .parquet/.tif are "inspect"; .zarr/.copc.laz
+        # are cloud-native but dir/compound so excluded from the static set.
+        assert reg.cloud_native_extensions() == {".fgb", ".pmtiles"}
+
+    def test_convertible_vector_extensions(self) -> None:
+        assert reg.convertible_extensions("GeoParquet") == {
+            ".shp",
+            ".geojson",
+            ".gpkg",
+            ".gdb",
+            ".csv",
+            ".tsv",
+        }
+
+    def test_convertible_raster_extensions(self) -> None:
+        assert reg.convertible_extensions("COG") == {".jp2"}
+
+    def test_unsupported_extensions(self) -> None:
+        assert reg.unsupported_extensions() == {
+            ".nc",
+            ".netcdf",
+            ".h5",
+            ".hdf5",
+            ".las",
+            ".laz",
+        }
+
+    def test_vector_routing_extensions(self) -> None:
+        assert reg.extensions_where(routes_as="vector") == {
+            ".geojson",
+            ".parquet",
+            ".shp",
+            ".gpkg",
+            ".fgb",
+            ".pmtiles",
+            ".gdb",
+            ".csv",
+            ".tsv",
+        }
+
+    def test_raster_routing_extensions(self) -> None:
+        assert reg.extensions_where(routes_as="raster") == {".tif", ".tiff", ".jp2"}
+
+    def test_multilayer_extensions(self) -> None:
+        assert reg.extensions_where(is_multilayer=True) == {".gpkg", ".gdb"}
+
+    def test_geospatial_extensions(self) -> None:
+        assert reg.extensions_where(is_geospatial=True) == {
+            ".geojson",
+            ".parquet",
+            ".shp",
+            ".gpkg",
+            ".fgb",
+            ".gdb",
+            ".csv",
+            ".tsv",
+            ".tif",
+            ".tiff",
+            ".jp2",
+            ".pmtiles",
+        }
+
+    def test_tabular_extensions(self) -> None:
+        assert reg.extensions_where(is_tabular=True) == {
+            ".csv",
+            ".tsv",
+            ".parquet",
+            ".xlsx",
+            ".xls",
+        }
+
+    def test_scan_geo_asset_extensions(self) -> None:
+        assert reg.extensions_where(scan_category="geo_asset") == {
+            ".geojson",
+            ".shp",
+            ".gpkg",
+            ".fgb",
+            ".tif",
+            ".tiff",
+            ".jp2",
+            ".pmtiles",
+        }
+
+    def test_scan_sidecar_extensions(self) -> None:
+        assert reg.extensions_where(scan_category="known_sidecar") == {
+            ".dbf",
+            ".shx",
+            ".prj",
+            ".cpg",
+            ".sbn",
+            ".sbx",
+            ".ovr",
+            ".xml",
+        }
+
+    def test_scan_image_extensions_include_svg(self) -> None:
+        # .svg added so scan agrees with add._ROLE_MAP (#558).
+        assert reg.extensions_where(scan_category="thumbnail") == {
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".webp",
+            ".gif",
+            ".svg",
+        }
+
+    def test_scan_junk_extensions(self) -> None:
+        assert reg.extensions_where(scan_category="junk") == {
+            ".exe",
+            ".dll",
+            ".so",
+            ".dylib",
+            ".pyc",
+            ".pyo",
+            ".class",
+            ".o",
+            ".obj",
+        }
+
+
+class TestDerivedMaps:
+    """Display-name / media-type / role maps."""
+
+    def test_format_display_names_drop_raquet(self) -> None:
+        names = reg.field_map("display_name")
+        assert ".raquet" not in names
+        assert names[".parquet"] == "GeoParquet"
+        assert names[".fgb"] == "FlatGeobuf"
+        # Exactly the 18 human-labelled formats, nothing more.
+        assert set(names) == {
+            ".parquet",
+            ".fgb",
+            ".pmtiles",
+            ".tif",
+            ".tiff",
+            ".shp",
+            ".geojson",
+            ".gpkg",
+            ".csv",
+            ".tsv",
+            ".json",
+            ".jp2",
+            ".nc",
+            ".netcdf",
+            ".h5",
+            ".hdf5",
+            ".las",
+            ".laz",
+        }
+
+    def test_media_types_include_webp_gif_and_unsupported(self) -> None:
+        media = reg.field_map("media_type")
+        assert media[".webp"] == "image/webp"
+        assert media[".gif"] == "image/gif"
+        assert media[".las"] == "application/vnd.laszip" or media[".las"] == "application/vnd.las"
+        assert media[".nc"] == "application/x-netcdf"
+
+    def test_roles_include_webp_gif(self) -> None:
+        roles = reg.field_map("role")
+        assert roles[".webp"] == "thumbnail"
+        assert roles[".gif"] == "thumbnail"
+        assert roles[".svg"] == "thumbnail"
+
+    def test_unsupported_error_messages(self) -> None:
+        messages = reg.field_map("unsupported_message")
+        assert set(messages) == {".nc", ".netcdf", ".h5", ".hdf5", ".las", ".laz"}
+        assert "COPC" in messages[".las"]
+
+
+class TestInvariants:
+    def test_no_duplicate_extensions(self) -> None:
+        exts = [spec.ext for spec in reg.EXTENSION_REGISTRY]
+        assert len(exts) == len(set(exts))
+
+    def test_all_extensions_lowercase_dotted(self) -> None:
+        for spec in reg.EXTENSION_REGISTRY:
+            assert spec.ext.startswith("."), spec.ext
+            assert spec.ext == spec.ext.lower(), spec.ext
+
+    def test_cloud_native_convertible_unsupported_disjoint(self) -> None:
+        cn = reg.cloud_native_extensions()
+        cv = reg.convertible_extensions("GeoParquet")
+        cr = reg.convertible_extensions("COG")
+        un = reg.unsupported_extensions()
+        assert cn.isdisjoint(cv)
+        assert cn.isdisjoint(cr)
+        assert cv.isdisjoint(un)
+        assert cn.isdisjoint(un)
+
+    def test_additional_cloud_native_are_dir_or_compound(self) -> None:
+        extras = {
+            spec.ext
+            for spec in reg.EXTENSION_REGISTRY
+            if spec.cloud_native == "yes" and (spec.is_dir or spec.is_compound)
+        }
+        assert extras == {".zarr", ".copc.laz"}
+
+
+class TestModulesUseRegistry:
+    """The four consuming modules expose exactly the registry-derived values."""
+
+    def test_formats_module(self) -> None:
+        from portolan_cli import formats
+
+        assert formats.CLOUD_NATIVE_EXTENSIONS == reg.cloud_native_extensions()
+        assert formats.CONVERTIBLE_VECTOR_EXTENSIONS == reg.convertible_extensions("GeoParquet")
+        assert formats.CONVERTIBLE_RASTER_EXTENSIONS == reg.convertible_extensions("COG")
+        assert formats.UNSUPPORTED_EXTENSIONS == reg.unsupported_extensions()
+        assert formats.VECTOR_EXTENSIONS == reg.extensions_where(routes_as="vector")
+        assert formats.RASTER_EXTENSIONS == reg.extensions_where(routes_as="raster")
+        assert formats.MULTILAYER_EXTENSIONS == reg.extensions_where(is_multilayer=True)
+        assert formats.FORMAT_DISPLAY_NAMES == reg.field_map("display_name")
+        assert formats.UNSUPPORTED_ERROR_MESSAGES == reg.field_map("unsupported_message")
+
+    def test_constants_module(self) -> None:
+        from portolan_cli import constants
+
+        assert constants.GEOSPATIAL_EXTENSIONS == reg.extensions_where(is_geospatial=True)
+        assert constants.TABULAR_EXTENSIONS == reg.extensions_where(is_tabular=True)
+        assert constants.SIDECAR_PATTERNS == {k: list(v) for k, v in reg.SIDECAR_OF.items()}
+
+    def test_scan_classify_module(self) -> None:
+        from portolan_cli import scan_classify
+
+        assert scan_classify.GEO_ASSET_EXTENSIONS == reg.extensions_where(scan_category="geo_asset")
+        assert scan_classify.SIDECAR_EXTENSIONS == reg.extensions_where(
+            scan_category="known_sidecar"
+        )
+        assert scan_classify.TABULAR_EXTENSIONS == reg.extensions_where(is_tabular=True)
+        assert scan_classify.IMAGE_EXTENSIONS == reg.extensions_where(scan_category="thumbnail")
+        assert scan_classify.JUNK_DIRS == reg.JUNK_DIRS
+
+    def test_add_module(self) -> None:
+        from portolan_cli import add
+
+        assert add._MEDIA_TYPE_MAP == reg.field_map("media_type")
+        assert add._ROLE_MAP == reg.field_map("role")

--- a/tests/unit/test_formats_cloud_native.py
+++ b/tests/unit/test_formats_cloud_native.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from portolan_cli.formats import (
+    FORMAT_DISPLAY_NAMES,
     CloudNativeStatus,
     get_cloud_native_status,
 )
@@ -87,15 +88,20 @@ class TestCloudNativeDetection:
         assert result.error_message is None
 
     @pytest.mark.unit
-    def test_raquet_returns_cloud_native(self, tmp_path: Path) -> None:
-        """Raquet files return CLOUD_NATIVE status."""
+    def test_raquet_extension_is_not_special(self, tmp_path: Path) -> None:
+        """`.raquet` is not a recognized extension (issue #487).
+
+        RaQuet rasters are real Parquet files written with a `.parquet`
+        extension (per raquet.io: `raquet-io convert … output.parquet`), so a
+        literal `.raquet` file matches nothing and is unsupported. Real RaQuet
+        files flow through the `.parquet` content-inspection branch instead.
+        """
         raquet_file = tmp_path / "test.raquet"
         raquet_file.write_bytes(b"\x00\x00\x00\x00")
         result = get_cloud_native_status(raquet_file)
-        assert result.status == CloudNativeStatus.CLOUD_NATIVE
-        assert result.display_name == "Raquet"
-        assert result.target_format is None
-        assert result.error_message is None
+        assert result.status == CloudNativeStatus.UNSUPPORTED
+        assert result.error_message is not None
+        assert ".raquet" not in FORMAT_DISPLAY_NAMES
 
 
 class TestIsGeoparquet:


### PR DESCRIPTION
## What

Closes #558. Closes #487.

The recognized-file-extension vocabulary had drifted across **five** surfaces — `spec/extensions.md` plus four code modules (`formats.py`, `constants.py`, `scan_classify.py`, `dataset.py`) — and nothing failed when they disagreed.

This adds `portolan_cli/extension_registry.py` as the single source of truth: a typed frozen-dataclass table with one row per extension. Every frozenset/map in the four modules is now **derived** from it. Public symbol names are unchanged, so all consumers and tests are untouched — the refactor is behavior-preserving except for the intended deltas below. `spec/extensions.md` stays the human doc and is tied to the registry by a new parity test. See [ADR-0055](context/shared/adr/0055-extension-registry-single-source.md).

The registry is a stdlib-only leaf that imports nothing from `portolan_cli`, so it lifts cleanly into `reis` (the validator extraction, #563) — it *is* reis's future format module.

## Reconciliation deltas (each paired with a test)

- **Drop `.raquet`** — dead code. Real RaQuet rasters use `.parquet` (per raquet.io: `raquet-io convert … output.parquet`), so `.raquet` matched no real files. RaQuet rasters keep flowing through the `.parquet` content-inspection branch. (#487)
- **Fix `.webp`/`.gif`** — documented + scan-classified as thumbnails but **missing from `dataset.py`'s `_ROLE_MAP`/`_MEDIA_TYPE_MAP`**, so they were mis-typed as `application/octet-stream` / role `data`. Now correctly `image/webp`·`image/gif` / role `thumbnail`.
- **`.svg`** now a scan image (matches the pre-existing role map).
- **Doc**: add `.gdb`, `.tsv`, `.zarr`, `.copc.laz`, `.qix`, `.tfw`; clarify `.json` as content-inspected; distinguish COPC from plain `.las`/`.laz`.
- **Unsupported media types** — `.nc`/`.h5`/`.las`/… now carry media types so companion assets stay well-typed (Matthias's external review).

## Why a typed Python registry (not a YAML data file)

`reis` is Python and extracts by *moving* the module; the typed table gives `mypy --strict` coverage of every row and needs no runtime parsing. It lives in-package (not `spec/`) because `spec/` isn't shipped in the wheel. Discussed in ADR-0055.

## Out of scope (follow-up)

`scan.py` (`RECOGNIZED_*`) and `scan.py`/`scan_fix.py` (divergent `SHAPEFILE_*_SIDECARS`) have additional drift **not named by #558**; folding them in would change sidecar-detection behavior. Noted for a follow-up issue.

## Testing

- New: `test_extension_registry.py` (derived sets pinned to explicit literals + invariants), `test_asset_role_media.py` (webp/gif/svg regressions), `test_extensions_doc_parity.py` (parses `extensions.md` ↔ code).
- Full unit tier green: **4746 passed, 5 skipped**. `ruff`, `mypy --strict`, `vulture`, `deptry`, `xenon`, CLAUDE.md validator all pass.
- Note: `lint-imports` reports a **pre-existing** `validation.rules → pmtiles → output/click` violation, unrelated to this change (present on `main`, latent in the #563 contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized extension registry to keep file-format classification, routing, and metadata lookups consistent across the app.
  * Improved support for additional formats and companions, including `.svg`, `.zarr`, `.copc.laz`, and more sidecar files.

* **Bug Fixes**
  * Corrected `.raquet` handling so it is now treated as unsupported.
  * Refined format detection for JSON, tabular, thumbnail, and cloud-native files.

* **Tests**
  * Added parity and unit tests to ensure documentation, classifications, and derived mappings stay in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->