### PR TITLE
fix: catalog-versions.json writer conforms to its own schema (#561)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions require an ADR in `context/shared/adr/`
 - **NO** new dependencies without discussion (document in ADR)
 
-<!-- freshness: last-verified: 2026-06-02 -->
+<!-- freshness: last-verified: 2026-07-07 -->
 ## Design Principles
 
 | Principle | Meaning | ADR |

--- a/portolan_cli/constants.py
+++ b/portolan_cli/constants.py
@@ -18,7 +18,7 @@ from portolan_cli import extension_registry as _reg
 #
 # NOTE: This is the version of the *specification as a whole*. It is distinct
 # from versions.SPEC_VERSION, which versions the versions.json manifest schema.
-PORTOLAN_SPEC_VERSION: str = "0.1.0"
+PORTOLAN_SPEC_VERSION: str = "0.1.1"
 
 # The extension vocabulary below is DERIVED from portolan_cli.extension_registry
 # (the single source, ADR-0055). Edit rows there, not these members.

--- a/spec/README.md
+++ b/spec/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the canonical Portolan specification.
 
-**Spec version: `0.1.0`** ([SemVer](https://semver.org/), pre-1.0). The
+**Spec version: `0.1.1`** ([SemVer](https://semver.org/), pre-1.0). The
 canonical machine-readable home is
 [`schema/spec-version.json`](schema/spec-version.json). See
 [Versioning](#versioning) below for the bump policy.

--- a/spec/schema/catalog-versions.schema.json
+++ b/spec/schema/catalog-versions.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/catalog-versions.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan Catalog Versions Index",
   "description": "Schema for the root-level versions.json that indexes collection sync state. Different from collection-level versions.json.",
   "type": "object",
@@ -24,21 +24,41 @@
       "description": "ISO 8601 timestamp when catalog was initialized",
       "format": "date-time"
     },
+    "updated": {
+      "type": "string",
+      "description": "ISO 8601 timestamp when catalog data was last updated (i.e. the last `add`). Distinct from per-collection `synced_at`, which tracks the last push to cloud storage.",
+      "format": "date-time"
+    },
     "collections": {
       "type": "object",
-      "description": "Map of collection IDs to their sync state",
+      "description": "Map of collection IDs to their state",
       "additionalProperties": {
         "type": "object",
-        "description": "Collection sync state",
+        "description": "Per-collection state",
         "properties": {
           "current_version": {
             "type": ["string", "null"],
             "description": "Current version of this collection"
           },
+          "updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this collection's data was last updated locally (i.e. the last `add`)"
+          },
           "synced_at": {
             "type": "string",
             "format": "date-time",
-            "description": "When this collection was last synced"
+            "description": "When this collection was last synced to cloud storage (i.e. the last `push`)"
+          },
+          "asset_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of assets in the current version of this collection"
+          },
+          "total_size_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total size in bytes of the assets in the current version of this collection"
           }
         }
       }

--- a/spec/schema/catalog.schema.json
+++ b/spec/schema/catalog.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/catalog.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan STAC Catalog",
   "description": "Schema for Portolan-compliant STAC Catalogs. Extends the STAC Catalog schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/collection.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan STAC Collection",
   "description": "Schema for Portolan-compliant STAC Collections. Extends the STAC Collection schema with Portolan-specific requirements. See https://github.com/portolan-sdi/portolan-spec",
   "allOf": [

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -19,7 +19,7 @@
 # spec/schema/spec-version.json; see spec/README.md#versioning for the bump
 # policy (e.g. raising a rule's level from warning to error is a breaking
 # change and bumps the spec version).
-spec_version: "0.1.0"
+spec_version: "0.1.1"
 
 rules:
   # =============================================================================

--- a/spec/schema/spec-version.json
+++ b/spec/schema/spec-version.json
@@ -2,7 +2,7 @@
   "$id": "https://portolan.dev/schema/spec-version.json",
   "title": "Portolan Specification Version",
   "description": "Canonical machine-readable home for the Portolan specification version. Tools (the CLI, the read-only mirror, reis, and external conformance checkers) read spec_version from this file to claim or verify conformance against a specific version of the Portolan spec. See spec/README.md#versioning for the bump policy. This is distinct from the versions.json manifest schema version (versions.schema.json).",
-  "spec_version": "0.1.0",
+  "spec_version": "0.1.1",
   "versioning": "semver",
   "stability": "pre-release",
   "policy": "https://github.com/portolan-sdi/portolan-cli/blob/main/spec/README.md#versioning"

--- a/spec/schema/versions.schema.json
+++ b/spec/schema/versions.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://portolan.dev/schema/versions.schema.json",
-  "$comment": "Part of Portolan spec 0.1.0 (see spec/schema/spec-version.json).",
+  "$comment": "Part of Portolan spec 0.1.1 (see spec/schema/spec-version.json).",
   "title": "Portolan Versions Manifest",
   "description": "Schema for versions.json - tracks version history, asset checksums, and sync state per collection. See https://github.com/portolan-sdi/portolan-spec/blob/main/versions.md",
   "type": "object",

--- a/tests/spec_compliance/test_versions_schema.py
+++ b/tests/spec_compliance/test_versions_schema.py
@@ -53,6 +53,44 @@ class TestCatalogVersionsSchemaCompliance:
 
             assert not errors, "Schema validation failed:\n" + "\n".join(errors)
 
+    @pytest.mark.integration
+    def test_add_keeps_catalog_versions_json_valid(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        catalog_versions_schema: dict[str, Any],
+        validate_versions: Callable[[dict[str, Any], dict[str, Any]], list[str]],
+    ) -> None:
+        """portolan add keeps the catalog-level versions.json schema-compliant.
+
+        Regression for #561: ``update_catalog_versions`` wrote a top-level
+        ``updated`` key (plus per-collection ``updated`` / ``asset_count`` /
+        ``total_size_bytes``) that the shipped schema rejected. ``init`` alone
+        never exercised this write path, so the drift went uncaught.
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            versions_path = Path("versions.json")
+            assert versions_path.exists(), "catalog-level versions.json not found"
+
+            data = json.loads(versions_path.read_text())
+            assert "points" in data.get("collections", {}), (
+                "collection entry missing from catalog versions.json — add path did not run"
+            )
+            errors = validate_versions(data, catalog_versions_schema)
+
+            assert not errors, "Schema validation failed:\n" + "\n".join(errors)
+
 
 class TestCollectionVersionsSchemaCompliance:
     """Test that collection-level versions.json complies with the spec schema."""


### PR DESCRIPTION
Fixes #561.

## Problem

`update_catalog_versions` (`catalog.py:895-903`) writes a top-level `updated` key plus per-collection `updated` / `asset_count` / `total_size_bytes`, but `catalog-versions.schema.json` rejected them — the top level had `additionalProperties: false` and only knew `current_version` / `synced_at`. The catalog-level `versions.json` therefore violated its own shipped schema after any `add`.

The bug slipped through because the only compliance test validated `portolan init` output (empty `collections`, no `updated`) and never exercised the `add` write-path.

## Fix

Reconcile **toward the writer** — the emitted fields are useful and mirror the existing `portolan:asset_count` / `portolan:total_size_bytes` on collections. The schema now blesses them, keeping two distinct timestamps:

- `updated` — last time the collection's data changed (last `add`)
- `synced_at` — last time it was pushed to cloud storage (last `push`)

Purely additive (per-collection object stays lenient), so this is a non-breaking **PATCH** spec bump `0.1.0 → 0.1.1` across all mirror sites (`spec-version.json`, `constants.py`, `spec/README.md`, the four schema `$comment`s, `rules.yaml`).

## Regression test

`test_add_keeps_catalog_versions_json_valid` drives `init → add` and validates the root `versions.json` against the shipped schema. It fails before this change (`'updated' was unexpected`) and passes after — closing the `init`-only gap that let the drift through.

## Verification

- `tests/spec_compliance/` — 92 passed
- ruff + mypy + import-linter + all pre-commit gates green

## Scope note

This is the tight bug-fix half. The separate, larger job of loading the shipped **STAC** `catalog.schema.json` / `collection.schema.json` in the compliance suite (which needs offline `$ref` bundling) stays tracked in #557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app and spec to version 0.1.1.
  * Added new catalog metadata to track recent updates, item counts, and total size.

* **Bug Fixes**
  * Improved catalog updates so added items keep the catalog file valid and compatible with the latest schema.

* **Tests**
  * Added coverage for catalog update behavior to help prevent schema regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->