### PR TITLE
test: validate spec_compliance against the shipped STAC schemas, hermetically (#557)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: uv run lint-imports
 
       - name: Spell check
-        run: uv run codespell --skip "*.parquet,*.tif,.git,*.lock" portolan_cli tests docs
+        run: uv run codespell --skip "*.parquet,*.tif,.git,*.lock,portolan_cli/validation/_vendored" portolan_cli tests docs
 
   security:
     name: Security Scan

--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,10 @@ cython_debug/
 catalog.json
 !tests/fixtures/**/catalog.json
 versions.json
+# Vendored upstream STAC schemas are real source, not test artifacts. Their
+# filenames (catalog.json, item.json, ...) collide with the rules above, so
+# un-ignore the whole vendored tree. See portolan_cli/validation/schema_registry.py.
+!portolan_cli/validation/_vendored/**
 
 # PyPI configuration file
 .pypirc

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0053](context/shared/adr/0053-mandatory-human-readable-titles.md) | Mandatory human-readable titles/descriptions; auto-humanize slugs; title on child/item links |
 | [0054](context/shared/adr/0054-arcgis-folder-recursion-and-structure.md) | ArcGIS folder recursion (default-on), folder URLs, token auth pass-through, nested-folder subcatalogs |
 | [0055](context/shared/adr/0055-extension-registry-single-source.md) | Single-source the recognized-extension vocabulary via a typed in-package registry (derives the formats/constants/scan_classify/add maps; drops dead `.raquet`) |
+| [0056](context/shared/adr/0056-hermetic-shipped-schema-validation.md) | Validate compliance against the shipped STAC schemas via a vendored STAC v1.1.0 `$ref` closure + `referencing.Registry` (hermetic); `format` off pending href policy (#573); deletes inline stubs (#557) |
 
 ## Common Commands
 

--- a/context/shared/adr/0056-hermetic-shipped-schema-validation.md
+++ b/context/shared/adr/0056-hermetic-shipped-schema-validation.md
@@ -1,0 +1,80 @@
+# ADR-0056: Hermetic validation against the shipped STAC schemas
+
+## Status
+Accepted
+
+## Context
+
+`tests/spec_compliance/` is meant to prove that CLI output conforms to the
+schemas Portolan actually ships (`spec/schema/catalog.schema.json`,
+`collection.schema.json`). It did not. The compliance tests validated documents
+against hand-copied inline schema stubs in `conftest.py`
+(`portolan_catalog_schema` / `portolan_collection_schema`) that covered only the
+Portolan *extension* fields, never the STAC base. The shipped schemas were
+loaded by no validation test, so they could drift from CLI output silently
+(issue #557, pre-sprint audit finding C12; the stubs were already looser than
+the shipped schemas — obs 5023).
+
+The shipped schemas extend upstream STAC v1.1.0 via `allOf` + absolute-URL
+`$ref` (`https://schemas.stacspec.org/v1.1.0/...`). Those references cannot be
+resolved offline, which is why the stubs existed. Validating against the real
+schemas therefore requires resolving the STAC closure without network access,
+because the test suite is hermetic and this logic is the seed of `reis`, the
+validator being extracted from this repo (issue #563).
+
+Two forces complicate a naive "just load the schema":
+
+- **Relative hrefs.** Portolan emits relative hrefs by design (SELF_CONTAINED,
+  ADR-0051). The STAC schema marks href fields `format: iri`, which relative
+  paths fail. The href/"published" policy is unresolved (discussion #573).
+- **Mixed dialects and malformed upstream `$id`.** The Portolan wrappers are
+  JSON Schema 2020-12; the STAC base schemas are draft-07. Some STAC v1.1.0
+  schemas declare a broken `$id` (e.g. `common.json` → `.../commonjson`).
+
+## Decision
+
+1. **Vendor the STAC v1.1.0 `$ref` closure** (11 files) as package data under
+   `portolan_cli/validation/_vendored/stac/1.1.0/`, fetched by
+   `scripts/refresh_stac_schemas.py`. Files stay byte-identical to upstream.
+2. **Add `portolan_cli/validation/schema_registry.py`** (in the reis extraction
+   seam): builds a `referencing.Registry` from the vendored closure and exposes
+   `validate_document(instance, schema)`. It keys each resource by its canonical
+   retrieval URL and normalizes `$id` at load time, side-stepping the malformed
+   upstream ids. `jsonschema` resolves each referenced resource under its own
+   `$schema`, so a 2020-12 validator follows `$ref`s into draft-07 resources.
+3. **Run with `format` assertions OFF.** JSON Schema `format` is opt-in in
+   `jsonschema`, so `format: iri` is simply not enforced. This makes relative
+   hrefs pass without any special-casing and does **not** pre-judge #573. When
+   #573 settles the href policy, format enforcement is turned on in this one
+   module, consistently for tests and any runtime consumer.
+4. **Delete the inline stubs**; compliance tests validate against the shipped
+   schemas via the registry. `jsonschema` + `referencing` become explicit
+   runtime dependencies (previously transitive via `stac-check`).
+
+## Consequences
+
+- Compliance tests now exercise the STAC base plus Portolan extensions from the
+  real shipped files. A backward-incompatible edit to a shipped schema breaks
+  the suite (the missing guard #557 was about). Real `init`/`add` output already
+  conformed, so no CLI output changes were needed.
+- Validation is hermetic and works from an installed wheel (the vendored closure
+  ships as package data). Note: `.gitignore` had a bare `catalog.json` rule for
+  test artifacts that silently dropped the vendored STAC catalog base from the
+  wheel; the vendored tree is now explicitly un-ignored.
+- `format`-off means iri/datetime formats are not checked here. That is a
+  deliberate, documented gap owned by #573, not an oversight.
+- Vendored schemas can lag a future STAC version. STAC v1.1.0 is immutable, so
+  the copy does not drift; a version bump is a manual `refresh_stac_schemas.py`
+  run (with `--check` available for CI). No automated network-diff test, by
+  choice.
+
+## Alternatives considered
+
+- **Keep the inline stubs.** Rejected: that is the bug. They validate a fiction.
+- **Enforce `format: iri` and tolerate relative hrefs via an acceptable-error
+  filter** (mirroring `stac_rules.py`). Rejected for now: it re-introduces href
+  special-casing and pre-judges #573. `format`-off is simpler and neutral.
+- **Fetch STAC schemas over the network at test time.** Rejected: non-hermetic,
+  flaky, and unusable for the offline `reis` extraction.
+- **Depend on a package that ships STAC schemas.** None does cleanly; `pystac`
+  ships no JSON Schemas. Vendoring the closure is explicit and auditable.

--- a/portolan_cli/validation/_vendored/README.md
+++ b/portolan_cli/validation/_vendored/README.md
@@ -1,0 +1,31 @@
+# Vendored upstream schemas
+
+These files are **fetched from upstream, not hand-authored.** Do not edit them by
+hand.
+
+## `stac/1.1.0/`
+
+The transitive `$ref` closure of the STAC v1.1.0 catalog and collection JSON
+Schemas, fetched from `https://schemas.stacspec.org/v1.1.0/`. Portolan's shipped
+`spec/schema/catalog.schema.json` and `collection.schema.json` extend these via
+`allOf` + absolute-URL `$ref`. Vendoring the closure lets
+`portolan_cli.validation.schema_registry` resolve those references offline, so
+spec-compliance validation is hermetic (no network in tests or at runtime).
+
+Layout mirrors the upstream URL paths so relative `$ref`s line up. Each file is
+kept byte-identical to upstream; the registry normalizes the (occasionally
+malformed) `$id` at load time rather than editing the files, so the refresh
+check below stays a faithful diff against upstream.
+
+### Refreshing
+
+Run only when bumping the pinned STAC version (also update the `$ref`s in
+`spec/schema/*.json` and `STAC_VERSION` in `schema_registry.py`):
+
+```bash
+uv run python scripts/refresh_stac_schemas.py          # re-fetch + write
+uv run python scripts/refresh_stac_schemas.py --check   # verify current
+```
+
+STAC v1.1.0 is an immutable published version, so the vendored copy does not
+drift on its own. There is deliberately no automated network-diff test.

--- a/portolan_cli/validation/_vendored/stac/1.1.0/catalog-spec/json-schema/catalog.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/catalog-spec/json-schema/catalog.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json",
+  "title": "STAC Catalog Specification",
+  "description": "This object represents Catalogs in a SpatioTemporal Asset Catalog.",
+  "allOf": [
+    {
+      "$ref": "#/definitions/catalog"
+    },
+    {
+      "$ref": "../../item-spec/json-schema/common.json"
+    }
+  ],
+  "definitions": {
+    "catalog": {
+      "title": "STAC Catalog",
+      "type": "object",
+      "$comment": "title and description is validated through the common metadata.",
+      "required": [
+        "stac_version",
+        "type",
+        "id",
+        "description",
+        "links"
+      ],
+      "properties": {
+        "stac_version": {
+          "title": "STAC version",
+          "type": "string",
+          "const": "1.1.0"
+        },
+        "stac_extensions": {
+          "title": "STAC extensions",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "title": "Reference to a JSON Schema",
+            "type": "string",
+            "format": "iri"
+          }
+        },
+        "type": {
+          "title": "Type of STAC entity",
+          "const": "Catalog"
+        },
+        "id": {
+          "title": "Identifier",
+          "type": "string",
+          "minLength": 1
+        },
+        "links": {
+          "$ref": "../../item-spec/json-schema/item.json#/definitions/links"
+        }
+      }
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/collection-spec/json-schema/collection.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/collection-spec/json-schema/collection.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json",
+  "title": "STAC Collection Specification",
+  "description": "This object represents Collections in a SpatioTemporal Asset Catalog.",
+  "allOf": [
+    {
+      "$ref": "#/definitions/collection"
+    },
+    {
+      "$ref": "../../item-spec/json-schema/common.json"
+    }
+  ],
+  "definitions": {
+    "collection": {
+      "title": "STAC Collection",
+      "description": "These are the fields specific to a STAC Collection.",
+      "type": "object",
+      "$comment": "title, description, keywords, providers and license is validated through the common metadata.",
+      "required": [
+        "stac_version",
+        "type",
+        "id",
+        "description",
+        "license",
+        "extent",
+        "links"
+      ],
+      "properties": {
+        "stac_version": {
+          "title": "STAC version",
+          "type": "string",
+          "const": "1.1.0"
+        },
+        "stac_extensions": {
+          "title": "STAC extensions",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "title": "Reference to a JSON Schema",
+            "type": "string",
+            "format": "iri"
+          }
+        },
+        "type": {
+          "title": "Type of STAC entity",
+          "const": "Collection"
+        },
+        "id": {
+          "title": "Identifier",
+          "type": "string",
+          "minLength": 1
+        },
+        "extent": {
+          "title": "Extents",
+          "type": "object",
+          "required": [
+            "spatial",
+            "temporal"
+          ],
+          "properties": {
+            "spatial": {
+              "title": "Spatial extent object",
+              "type": "object",
+              "required": [
+                "bbox"
+              ],
+              "properties": {
+                "bbox": {
+                  "title": "Spatial extents",
+                  "type": "array",
+                  "oneOf": [
+                    {
+                      "minItems": 1,
+                      "maxItems": 1
+                    },
+                    {
+                      "minItems": 3
+                    }
+                  ],
+                  "items": {
+                    "title": "Spatial extent",
+                    "type": "array",
+                    "oneOf": [
+                      {
+                        "minItems": 4,
+                        "maxItems": 4
+                      },
+                      {
+                        "minItems": 6,
+                        "maxItems": 6
+                      }
+                    ],
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
+            "temporal": {
+              "title": "Temporal extent object",
+              "type": "object",
+              "required": [
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "title": "Temporal extents",
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "title": "Temporal extent",
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 2,
+                    "items": {
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "format": "date-time",
+                      "pattern": "(\\+00:00|Z)$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "assets": {
+          "$ref": "../../item-spec/json-schema/item.json#/definitions/assets"
+        },
+        "item_assets": {
+          "additionalProperties": {
+            "allOf": [
+              {
+                "type": "object",
+                "minProperties": 2,
+                "properties": {
+                  "href": {
+                    "title": "Disallow href",
+                    "not": {}
+                  },
+                  "title": {
+                    "title": "Asset title",
+                    "type": "string"
+                  },
+                  "description": {
+                    "title": "Asset description",
+                    "type": "string"
+                  },
+                  "type": {
+                    "title": "Asset type",
+                    "type": "string"
+                  },
+                  "roles": {
+                    "title": "Asset roles",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "$ref": "../../item-spec/json-schema/common.json"
+              }
+            ]
+          }
+        },
+        "links": {
+          "$ref": "../../item-spec/json-schema/item.json#/definitions/links"
+        },
+        "summaries": {
+          "$ref": "#/definitions/summaries"
+        }
+      }
+    },
+    "summaries": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "title": "JSON Schema",
+            "type": "object",
+            "minProperties": 1,
+            "allOf": [
+              {
+                "$ref": "http://json-schema.org/draft-07/schema"
+              }
+            ]
+          },
+          {
+            "title": "Range",
+            "type": "object",
+            "required": [
+              "minimum",
+              "maximum"
+            ],
+            "properties": {
+              "minimum": {
+                "title": "Minimum value",
+                "type": [
+                  "number",
+                  "string"
+                ]
+              },
+              "maximum": {
+                "title": "Maximum value",
+                "type": [
+                  "number",
+                  "string"
+                ]
+              }
+            }
+          },
+          {
+            "title": "Set of values",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "description": "For each field only the original data type of the property can occur (except for arrays), but we can't validate that in JSON Schema yet. See the sumamry description in the STAC specification for details."
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/bands.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/bands.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/bands.json",
+  "title": "Bands Field",
+  "type": "object",
+  "properties": {
+    "bands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "common.json"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/basics.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/basics.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/basics.json",
+  "title": "Basic Descriptive Fields",
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "description": "A human-readable title describing the entity.",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "description": "Detailed multi-line description to fully explain the entity.",
+      "type": "string",
+      "minLength": 1
+    },
+    "keywords": {
+      "title": "Keywords",
+      "description": "List of keywords describing the entity.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "roles": {
+      "title": "Roles",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/common.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/common.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/commonjson",
+  "title": "STAC Common Metadata",
+  "type": "object",
+  "description": "This schema includes all common metadata fields.",
+  "allOf": [
+    {
+      "$ref": "basics.json"
+    },
+    {
+      "$ref": "bands.json"
+    },
+    {
+      "$ref": "datetime.json"
+    },
+    {
+      "$ref": "data-values.json"
+    },
+    {
+      "$ref": "instrument.json"
+    },
+    {
+      "$ref": "licensing.json"
+    },
+    {
+      "$ref": "provider.json"
+    }
+  ]
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/data-values.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/data-values.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/data-values.json#",
+  "title": "Fields related to data values",
+  "type": "object",
+  "properties": {
+    "data_type": {
+      "title": "Data type of the values",
+      "type": "string",
+      "enum": [
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float16",
+        "float32",
+        "float64",
+        "cint16",
+        "cint32",
+        "cfloat32",
+        "cfloat64",
+        "other"
+      ]
+    },
+    "nodata": {
+      "title": "No data value",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "nan",
+            "inf",
+            "-inf"
+          ]
+        }
+      ]
+    },
+    "statistics": {
+      "title": "Statistics",
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "minimum": {
+          "title": "Minimum value of all the data values",
+          "type": "number"
+        },
+        "maximum": {
+          "title": "Maximum value of all the data values",
+          "type": "number"
+        },
+        "mean": {
+          "title": "Mean value of all the data values",
+          "type": "number"
+        },
+        "stddev": {
+          "title": "Standard deviation value of all the data values",
+          "type": "number"
+        },
+        "count": {
+          "title": "Total number of all data values",
+          "type": "integer",
+          "minimum": 0
+        },
+        "valid_percent": {
+          "title": "Percentage of valid (not nodata) values",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "unit": {
+      "title": "Unit denomination of the data value",
+      "type": "string"
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/datetime.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/datetime.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/datetime.json",
+  "title": "Date and Time Fields",
+  "type": "object",
+  "dependencies": {
+    "start_datetime": {
+      "required": [
+        "end_datetime"
+      ]
+    },
+    "end_datetime": {
+      "required": [
+        "start_datetime"
+      ]
+    }
+  },
+  "properties": {
+    "datetime": {
+      "title": "Date and Time",
+      "description": "The searchable date/time of the data, in UTC (Formatted in RFC 3339) ",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time",
+      "pattern": "(\\+00:00|Z)$"
+    },
+    "start_datetime": {
+      "title": "Start Date and Time",
+      "description": "The searchable start date/time of the data, in UTC (Formatted in RFC 3339) ",
+      "type": "string",
+      "format": "date-time",
+      "pattern": "(\\+00:00|Z)$"
+    },
+    "end_datetime": {
+      "title": "End Date and Time",
+      "description": "The searchable end date/time of the data, in UTC (Formatted in RFC 3339) ",
+      "type": "string",
+      "format": "date-time",
+      "pattern": "(\\+00:00|Z)$"
+    },
+    "created": {
+      "title": "Creation Time",
+      "type": "string",
+      "format": "date-time",
+      "pattern": "(\\+00:00|Z)$"
+    },
+    "updated": {
+      "title": "Last Update Time",
+      "type": "string",
+      "format": "date-time",
+      "pattern": "(\\+00:00|Z)$"
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/instrument.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/instrument.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/instrument.json",
+  "title": "Instrument Fields",
+  "type": "object",
+  "properties": {
+    "platform": {
+      "title": "Platform",
+      "type": "string"
+    },
+    "instruments": {
+      "title": "Instruments",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "constellation": {
+      "title": "Constellation",
+      "type": "string"
+    },
+    "mission": {
+      "title": "Mission",
+      "type": "string"
+    },
+    "gsd": {
+      "title": "Ground Sample Distance",
+      "type": "number",
+      "exclusiveMinimum": 0
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/item.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/item.json
@@ -1,0 +1,347 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/item.json",
+  "title": "STAC Item",
+  "type": "object",
+  "description": "This object represents the metadata for an item in a SpatioTemporal Asset Catalog.",
+  "allOf": [
+    {
+      "$ref": "#/definitions/core"
+    }
+  ],
+  "definitions": {
+    "core": {
+      "allOf": [
+        {
+          "$ref": "https://geojson.org/schema/Feature.json"
+        },
+        {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "geometry",
+                "bbox"
+              ],
+              "properties": {
+                "geometry": {
+                  "$ref": "https://geojson.org/schema/Geometry.json"
+                },
+                "bbox": {
+                  "type": "array",
+                  "oneOf": [
+                    {
+                      "minItems": 4,
+                      "maxItems": 4
+                    },
+                    {
+                      "minItems": 6,
+                      "maxItems": 6
+                    }
+                  ],
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "geometry"
+              ],
+              "properties": {
+                "geometry": {
+                  "type": "null"
+                },
+                "bbox": {
+                  "not": {}
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "object",
+          "required": [
+            "stac_version",
+            "id",
+            "links",
+            "assets",
+            "properties"
+          ],
+          "properties": {
+            "stac_version": {
+              "title": "STAC version",
+              "type": "string",
+              "const": "1.1.0"
+            },
+            "stac_extensions": {
+              "title": "STAC extensions",
+              "type": "array",
+              "uniqueItems": true,
+              "items": {
+                "title": "Reference to a JSON Schema",
+                "type": "string",
+                "format": "iri"
+              }
+            },
+            "id": {
+              "title": "Provider ID",
+              "description": "Provider item ID",
+              "type": "string",
+              "minLength": 1
+            },
+            "links": {
+              "$ref": "#/definitions/links"
+            },
+            "assets": {
+              "$ref": "#/definitions/assets"
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "$ref": "common.json"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "datetime"
+                      ],
+                      "properties": {
+                        "datetime": {
+                          "not": {
+                            "type": "null"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "required": [
+                        "datetime",
+                        "start_datetime",
+                        "end_datetime"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "$comment": "Rules enforcement for STAC Item",
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "links": {
+                    "contains": {
+                      "required": [
+                        "rel"
+                      ],
+                      "properties": {
+                        "rel": {
+                          "const": "collection"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "collection"
+                ],
+                "properties": {
+                  "collection": {
+                    "title": "Collection ID",
+                    "description": "The ID of the STAC Collection this Item references to.",
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "else": {
+                "properties": {
+                  "collection": {
+                    "not": {}
+                  }
+                }
+              }
+            },
+            {
+              "$comment": "The if-then-else below checks whether the bands field is given in assets or not. If not, allows bands in properties (then), otherwise, disallows bands in properties (else).",
+              "if": {
+                "$comment": "If there is no asset with bands...",
+                "required": [
+                  "assets"
+                ],
+                "properties": {
+                  "assets": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "properties": {
+                        "bands": false
+                      }
+                    }
+                  }
+                }
+              },
+              "then": {
+                "$comment": "... then bands are not allowed in properties...",
+                "properties": {
+                  "properties": {
+                    "properties": {
+                      "bands": false
+                    }
+                  }
+                }
+              },
+              "else": {
+                "$comment": "... otherwise bands are allowed in properties.",
+                "properties": {
+                  "properties": {
+                    "$ref": "bands.json"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "links": {
+      "title": "Item links",
+      "description": "Links to item relations",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/link"
+      }
+    },
+    "link": {
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "rel",
+            "href"
+          ],
+          "properties": {
+            "href": {
+              "title": "Link reference",
+              "type": "string",
+              "format": "iri-reference",
+              "minLength": 1
+            },
+            "rel": {
+              "title": "Link relation type",
+              "type": "string",
+              "minLength": 1
+            },
+            "type": {
+              "title": "Link type",
+              "type": "string"
+            },
+            "title": {
+              "title": "Link title",
+              "type": "string"
+            },
+            "method": {
+              "title": "Link method",
+              "type": "string",
+              "pattern": "^[A-Z]+$",
+              "default": "GET"
+            },
+            "headers": {
+              "title": "Link headers",
+              "type": "object",
+              "additionalProperties": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            },
+            "body": {
+              "title": "Link body",
+              "$comment": "Any type is allowed."
+            }
+          },
+          "$comment": "Link with relationship `self` must be absolute URI",
+          "if": {
+            "properties": {
+              "rel": {
+                "const": "self"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "href": {
+                "format": "iri"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "common.json"
+        }
+      ]
+    },
+    "assets": {
+      "title": "Asset links",
+      "description": "Links to assets",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/asset"
+      }
+    },
+    "asset": {
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "href"
+          ],
+          "properties": {
+            "href": {
+              "title": "Asset reference",
+              "type": "string",
+              "format": "iri-reference",
+              "minLength": 1
+            },
+            "title": {
+              "title": "Asset title",
+              "type": "string"
+            },
+            "description": {
+              "title": "Asset description",
+              "type": "string"
+            },
+            "type": {
+              "title": "Asset type",
+              "type": "string"
+            },
+            "roles": {
+              "title": "Asset roles",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "common.json"
+        }
+      ]
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/licensing.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/licensing.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/licensing.json",
+  "title": "Licensing Fields",
+  "type": "object",
+  "properties": {
+    "license": {
+      "type": "string",
+      "pattern": "^[\\w\\-\\.\\+]+$"
+    }
+  }
+}

--- a/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/provider.json
+++ b/portolan_cli/validation/_vendored/stac/1.1.0/item-spec/json-schema/provider.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.stacspec.org/v1.1.0/item-spec/json-schema/provider.json",
+  "title": "Provider Fields",
+  "type": "object",
+  "properties": {
+    "providers": {
+      "title": "Providers",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "title": "Organization name",
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "title": "Organization description",
+            "type": "string"
+          },
+          "roles": {
+            "title": "Organization roles",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "producer",
+                "licensor",
+                "processor",
+                "host"
+              ]
+            }
+          },
+          "url": {
+            "title": "Organization homepage",
+            "type": "string",
+            "format": "iri"
+          }
+        }
+      }
+    }
+  }
+}

--- a/portolan_cli/validation/schema_registry.py
+++ b/portolan_cli/validation/schema_registry.py
@@ -1,0 +1,105 @@
+"""Hermetic JSON Schema validation against the shipped Portolan spec schemas.
+
+The shipped ``spec/schema/catalog.schema.json`` and ``collection.schema.json``
+extend the upstream STAC v1.1.0 schemas via ``allOf`` + absolute-URL ``$ref``.
+To validate documents without network access, the transitive closure of those
+upstream schemas is vendored under ``_vendored/stac/<version>/`` (refresh with
+``scripts/refresh_stac_schemas.py``) and served from a ``referencing.Registry``.
+
+Two subtleties this module handles:
+
+* **Mixed dialects.** The Portolan wrapper schemas are JSON Schema 2020-12; the
+  vendored STAC schemas are draft-07. ``jsonschema`` resolves each referenced
+  resource under its own declared ``$schema``, so a 2020-12 validator can follow
+  a ``$ref`` into a draft-07 resource correctly.
+* **Malformed upstream ``$id``.** Some STAC v1.1.0 schemas declare a broken
+  ``$id`` (e.g. ``common.json`` → ``.../commonjson``). Relative ``$ref``s resolve
+  against a resource's base URI, so each resource's ``$id`` is normalized to its
+  canonical retrieval URL at load time. The vendored files on disk stay
+  byte-identical to upstream so the refresh script's ``--check`` stays honest.
+
+``format`` assertions are intentionally OFF. Portolan emits relative hrefs by
+design and the href/IRI policy is unresolved (discussion #573), so enforcing
+``format: iri`` here would reject valid Portolan output and pre-judge that
+decision. Validation is structural only.
+
+This module is part of the ``portolan_cli.validation`` extraction seam (the
+future ``reis`` package, issue #563): it imports no CLI, output, or config
+layer, and no application framework.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from importlib.resources import files
+from typing import TYPE_CHECKING, Any
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+if TYPE_CHECKING:
+    from importlib.abc import Traversable
+
+# Pinned STAC version. Must match the ``$ref``s in spec/schema/*.json and the
+# vendored directory name. Bump via scripts/refresh_stac_schemas.py.
+STAC_VERSION = "1.1.0"
+
+_STAC_BASE_URL = f"https://schemas.stacspec.org/v{STAC_VERSION}/"
+_VENDOR_ANCHOR = f"_vendored/stac/{STAC_VERSION}"
+
+
+def _iter_vendored(node: Traversable, prefix: str = "") -> list[tuple[str, str]]:
+    """Yield (url-relative-path, text) for every vendored ``.json`` under ``node``."""
+    out: list[tuple[str, str]] = []
+    for child in node.iterdir():
+        rel = f"{prefix}{child.name}"
+        if child.is_dir():
+            out.extend(_iter_vendored(child, prefix=f"{rel}/"))
+        elif child.name.endswith(".json"):
+            out.append((rel, child.read_text()))
+    return out
+
+
+@lru_cache(maxsize=1)
+def build_stac_registry() -> Registry:
+    """Build a ``referencing.Registry`` of the vendored STAC v1.1.0 closure.
+
+    Each resource is keyed by its canonical retrieval URL
+    (``https://schemas.stacspec.org/v{STAC_VERSION}/<path>``), which is what the
+    shipped Portolan schemas' ``$ref``s point at. Cached: the vendored schemas
+    never change at runtime.
+    """
+    root = files("portolan_cli.validation").joinpath(*_VENDOR_ANCHOR.split("/"))
+    registry: Registry = Registry()
+    for rel_path, text in _iter_vendored(root):
+        url = f"{_STAC_BASE_URL}{rel_path}"
+        contents: dict[str, Any] = json.loads(text)
+        # Normalize the base URI so relative $refs resolve against the canonical
+        # URL rather than a possibly-malformed upstream $id.
+        contents["$id"] = url
+        resource = Resource.from_contents(contents)
+        registry = registry.with_resource(uri=url, resource=resource)
+    return registry.crawl()
+
+
+def validate_document(
+    instance: dict[str, Any],
+    schema: dict[str, Any],
+    *,
+    registry: Registry | None = None,
+) -> list[str]:
+    """Validate ``instance`` against ``schema``, returning error strings.
+
+    ``schema`` is a Portolan spec schema (2020-12) that ``$ref``s the vendored
+    STAC schemas, resolved from ``registry`` (defaults to the shared vendored
+    registry). ``format`` assertions are off (see module docstring); validation
+    is structural. Returns ``[]`` when valid, else ``["<json_path>: <message>"]``
+    entries, sorted for stable output.
+    """
+    validator = Draft202012Validator(
+        schema,
+        registry=registry if registry is not None else build_stac_registry(),
+    )
+    errors = sorted(validator.iter_errors(instance), key=lambda e: list(e.absolute_path))
+    return [f"{e.json_path}: {e.message}" for e in errors]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dependencies = [
     "rich>=13.0.0",  # Terminal progress bars (transitive via geoparquet-io, but we import directly)
     "rio-cogeo>=5.0.0",  # COG creation/validation (includes rasterio)
     "stac-check>=1.4.0",  # STAC schema validation + best practices linting
+    "jsonschema>=4.18.0",  # Hermetic spec-schema validation in validation/ seam (registry API needs >=4.18); was transitive via stac-check
+    "referencing>=0.30.0",  # Offline $ref registry for vendored STAC schemas (validation/schema_registry.py)
     "typing_extensions>=4.0.0; python_version < '3.11'",
 ]
 
@@ -90,6 +92,7 @@ dev = [
     "radon>=6.0.1",
     "ruff>=0.14.11",
     "types-defusedxml>=0.7.0",  # Type stubs for defusedxml
+    "types-jsonschema>=4.18.0",  # Type stubs for jsonschema (validation/schema_registry.py)
     "types-PyYAML>=6.0",  # Type stubs for PyYAML
     "vulture>=2.14",
     "xenon>=0.9.3",
@@ -365,6 +368,7 @@ dev = [
     "pylint>=4.0.5",
     "pytest-asyncio>=1.3.0",
     "pytest-xdist>=3.8.0",
+    "types-jsonschema>=4.18.0",
     "types-pyyaml>=6.0.12.20250915",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,10 @@ skips = []  # Add specific checks to skip if needed, e.g., ["B101"]
 # "BU" is the INSPIRE theme code for Buildings (used in test fixtures)
 # "disjointness" is a real set-theory term (codespell wants "disjointedness")
 ignore-words-list = "nd,bu,ue,adresse,projet,environnement,copie,explicite,connexion,objets,visibles,issus,fonction,mesures,informations,disjointness"
+# Vendored upstream STAC schemas are byte-identical third-party data (they carry
+# upstream's own typos, e.g. "sumamry" in collection.json). Never spell-check them;
+# a refresh re-imports upstream text verbatim. Keep in sync with the ci.yml --skip.
+skip = "portolan_cli/validation/_vendored"
 
 # ---------- dead code ----------
 

--- a/scripts/refresh_stac_schemas.py
+++ b/scripts/refresh_stac_schemas.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Refresh the vendored upstream STAC JSON Schemas.
+
+Portolan's shipped ``spec/schema/catalog.schema.json`` and
+``collection.schema.json`` ``allOf``-reference the upstream STAC schemas by
+absolute URL. To validate CLI output hermetically (no network in tests), the
+transitive closure of those upstream schemas is vendored into the package at
+``portolan_cli/validation/_vendored/stac/<version>/`` and served from a
+``referencing.Registry`` (see ``portolan_cli.validation.schema_registry``).
+
+This script re-fetches that closure. Run it only when bumping the pinned STAC
+version (``STAC_VERSION`` below and the ``$ref``s in ``spec/schema/*.json``).
+STAC v1.1.0 is an immutable published version, so the vendored copy does not
+drift on its own; there is deliberately no automated network diff test.
+
+Usage::
+
+    uv run python scripts/refresh_stac_schemas.py
+    uv run python scripts/refresh_stac_schemas.py --check   # CI: fail if stale
+
+The closure is discovered by crawling ``$ref``s starting from the catalog and
+collection roots. References are resolved relative to each document's retrieval
+URL. Files are written under a path mirroring their URL so relative ``$ref``s
+line up; the registry keys each resource by its retrieval URL (NOT the embedded
+``$id``, which is malformed for some STAC v1.1.0 schemas, e.g. ``common.json``
+declares ``$id`` ``.../commonjson``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import sys
+import urllib.request
+from pathlib import Path
+from urllib.parse import urljoin, urlsplit
+
+STAC_VERSION = "1.1.0"
+_STAC_BASE = f"https://schemas.stacspec.org/v{STAC_VERSION}/"
+_ROOTS = (
+    f"{_STAC_BASE}catalog-spec/json-schema/catalog.json",
+    f"{_STAC_BASE}collection-spec/json-schema/collection.json",
+)
+
+# portolan_cli/validation/_vendored/stac/<version>/
+_VENDOR_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "portolan_cli"
+    / "validation"
+    / "_vendored"
+    / "stac"
+    / STAC_VERSION
+)
+
+
+def _refs(node: object) -> list[str]:
+    out: list[str] = []
+
+    def walk(o: object) -> None:
+        if isinstance(o, dict):
+            for key, value in o.items():
+                if key == "$ref" and isinstance(value, str):
+                    out.append(value)
+                else:
+                    walk(value)
+        elif isinstance(o, list):
+            for item in o:
+                walk(item)
+
+    walk(node)
+    return out
+
+
+def crawl() -> dict[str, dict[str, object]]:
+    """Fetch the transitive $ref closure of the STAC roots (STAC host only)."""
+    fetched: dict[str, dict[str, object]] = {}
+    queue: collections.deque[str] = collections.deque(_ROOTS)
+    while queue:
+        url = queue.popleft().split("#", 1)[0]
+        if url in fetched:
+            continue
+        with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310 (trusted host)
+            doc = json.loads(resp.read().decode())
+        fetched[url] = doc
+        for ref in set(_refs(doc)):
+            if ref.startswith("#") or ref.startswith("http://json-schema.org"):
+                continue
+            target = urljoin(url, ref).split("#", 1)[0]
+            if target.startswith(_STAC_BASE) and target not in fetched:
+                queue.append(target)
+    return fetched
+
+
+def _relpath(url: str) -> Path:
+    """Map a schemas.stacspec.org URL to a vendored path under _VENDOR_DIR."""
+    return Path(urlsplit(url).path.split(f"/v{STAC_VERSION}/", 1)[1])
+
+
+def write(fetched: dict[str, dict[str, object]]) -> None:
+    for url, doc in fetched.items():
+        dest = _VENDOR_DIR / _relpath(url)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(json.dumps(doc, indent=2) + "\n")
+
+
+def check(fetched: dict[str, dict[str, object]]) -> int:
+    stale: list[str] = []
+    for url, doc in fetched.items():
+        dest = _VENDOR_DIR / _relpath(url)
+        expected = json.dumps(doc, indent=2) + "\n"
+        if not dest.exists() or dest.read_text() != expected:
+            stale.append(str(_relpath(url)))
+    if stale:
+        print("Vendored STAC schemas are stale:", file=sys.stderr)
+        for name in sorted(stale):
+            print(f"  {name}", file=sys.stderr)
+        print("Run: uv run python scripts/refresh_stac_schemas.py", file=sys.stderr)
+        return 1
+    print(f"Vendored STAC v{STAC_VERSION} closure is current ({len(fetched)} files).")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail (exit 1) if the vendored copy differs from upstream; write nothing.",
+    )
+    args = parser.parse_args()
+
+    fetched = crawl()
+    if args.check:
+        return check(fetched)
+    write(fetched)
+    print(f"Vendored STAC v{STAC_VERSION} closure: {len(fetched)} files -> {_VENDOR_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/spec_compliance/conftest.py
+++ b/tests/spec_compliance/conftest.py
@@ -82,152 +82,29 @@ def validation_rules(schemas_dir: Path) -> list[dict[str, Any]]:
 
 
 # =============================================================================
-# Portolan-Only Schema Fixtures (without external STAC refs)
+# Shipped Schema Fixtures (load the real spec/schema/*.json)
 # =============================================================================
 
 
 @pytest.fixture(scope="session")
-def portolan_collection_schema() -> dict[str, Any]:
-    """Portolan-specific collection schema without external STAC reference.
+def catalog_schema(schemas_dir: Path) -> dict[str, Any]:
+    """Load the shipped STAC catalog schema (spec/schema/catalog.schema.json).
 
-    This validates only the Portolan extensions, not the base STAC schema.
-    Useful for compliance testing where we can't resolve external $refs.
+    This is the real schema published to users. It extends the upstream STAC
+    v1.1.0 schema via ``allOf`` + ``$ref``; those references resolve hermetically
+    from the vendored bundle (see ``portolan_cli.validation.schema_registry``).
+    Pair it with the ``validate_stac`` fixture, which supplies the resolving
+    registry.
     """
-    return {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "required": ["type", "stac_version", "id", "description", "license", "extent", "links"],
-        "properties": {
-            "type": {"const": "Collection"},
-            "stac_version": {
-                "type": "string",
-                "pattern": "^1\\.[0-9]+\\.[0-9]+$",
-            },
-            "id": {"type": "string", "minLength": 1},
-            "title": {"type": "string"},
-            "description": {"type": "string"},
-            "license": {"type": "string"},
-            "extent": {
-                "type": "object",
-                "required": ["spatial", "temporal"],
-                "properties": {
-                    "spatial": {
-                        "type": "object",
-                        "required": ["bbox"],
-                        "properties": {
-                            "bbox": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": {"type": "number"},
-                                },
-                            }
-                        },
-                    },
-                    "temporal": {
-                        "type": "object",
-                        "required": ["interval"],
-                        "properties": {
-                            "interval": {
-                                "type": "array",
-                                "items": {
-                                    "type": "array",
-                                    "items": {"type": ["string", "null"]},
-                                },
-                            }
-                        },
-                    },
-                },
-            },
-            "links": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": ["rel", "href"],
-                    "properties": {
-                        "rel": {"type": "string"},
-                        "href": {"type": "string", "minLength": 1},
-                        "type": {"type": "string"},
-                        "title": {"type": "string"},
-                    },
-                },
-            },
-            "assets": {
-                "type": "object",
-                "additionalProperties": {
-                    "type": "object",
-                    "required": ["href"],
-                    "properties": {
-                        "href": {"type": "string", "minLength": 1},
-                        "type": {"type": "string"},
-                        "title": {"type": "string"},
-                        "description": {"type": "string"},
-                        "roles": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                    },
-                },
-            },
-            "stac_extensions": {
-                "type": "array",
-                "items": {"type": "string"},
-            },
-            "summaries": {"type": "object"},
-            "providers": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": ["name"],
-                    "properties": {
-                        "name": {"type": "string"},
-                        "roles": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                        },
-                        "url": {"type": "string"},
-                        "description": {"type": "string"},
-                    },
-                },
-            },
-        },
-    }
+    result: dict[str, Any] = json.loads((schemas_dir / "catalog.schema.json").read_text())
+    return result
 
 
 @pytest.fixture(scope="session")
-def portolan_catalog_schema() -> dict[str, Any]:
-    """Portolan-specific catalog schema without external STAC reference.
-
-    This validates only the Portolan extensions, not the base STAC schema.
-    """
-    return {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "type": "object",
-        "required": ["type", "stac_version", "id", "description", "links"],
-        "properties": {
-            "type": {"const": "Catalog"},
-            "stac_version": {
-                "type": "string",
-                "pattern": "^1\\.[0-9]+\\.[0-9]+$",
-            },
-            "id": {"type": "string", "minLength": 1},
-            "title": {"type": "string"},
-            "description": {"type": "string"},
-            "links": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": ["rel", "href"],
-                    "properties": {
-                        "rel": {"type": "string"},
-                        "href": {"type": "string", "minLength": 1},
-                        "type": {"type": "string"},
-                        "title": {"type": "string"},
-                    },
-                },
-            },
-        },
-    }
+def collection_schema(schemas_dir: Path) -> dict[str, Any]:
+    """Load the shipped STAC collection schema (spec/schema/collection.schema.json)."""
+    result: dict[str, Any] = json.loads((schemas_dir / "collection.schema.json").read_text())
+    return result
 
 
 # =============================================================================
@@ -255,14 +132,16 @@ def validate_versions() -> Callable[[dict[str, Any], dict[str, Any]], list[str]]
 def validate_stac() -> Callable[[dict[str, Any], dict[str, Any]], list[str]]:
     """Return a validation function for STAC documents (catalog/collection).
 
-    Returns a list of validation error messages (empty if valid).
+    Delegates to ``portolan_cli.validation.schema_registry.validate_document``,
+    which resolves the shipped schemas' upstream STAC ``$ref``s from the vendored
+    bundle (hermetic, no network) and runs with ``format`` assertions off (href
+    policy is deferred; see discussion #573). Returns a list of validation error
+    messages (empty if valid).
     """
-    from jsonschema import Draft202012Validator
+    from portolan_cli.validation.schema_registry import validate_document
 
     def _validate(data: dict[str, Any], schema: dict[str, Any]) -> list[str]:
-        validator = Draft202012Validator(schema)
-        errors = list(validator.iter_errors(data))
-        return [f"{e.json_path}: {e.message}" for e in errors]
+        return validate_document(data, schema)
 
     return _validate
 

--- a/tests/spec_compliance/test_catalog_schema.py
+++ b/tests/spec_compliance/test_catalog_schema.py
@@ -30,7 +30,7 @@ class TestCatalogSchemaCompliance:
         self,
         runner: CliRunner,
         tmp_path: Path,
-        portolan_catalog_schema: dict[str, Any],
+        catalog_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """portolan init creates a schema-compliant catalog.json."""
@@ -42,7 +42,7 @@ class TestCatalogSchemaCompliance:
             assert catalog_path.exists(), "catalog.json not created"
 
             data = json.loads(catalog_path.read_text())
-            errors = validate_stac(data, portolan_catalog_schema)
+            errors = validate_stac(data, catalog_schema)
 
             assert not errors, "Schema validation failed:\n" + "\n".join(errors)
 
@@ -52,7 +52,7 @@ class TestCatalogSchemaCompliance:
         runner: CliRunner,
         tmp_path: Path,
         valid_points_geojson: Path,
-        portolan_catalog_schema: dict[str, Any],
+        catalog_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """catalog.json remains valid after adding a collection."""
@@ -70,7 +70,7 @@ class TestCatalogSchemaCompliance:
 
             catalog_path = Path("catalog.json")
             data = json.loads(catalog_path.read_text())
-            errors = validate_stac(data, portolan_catalog_schema)
+            errors = validate_stac(data, catalog_schema)
 
             assert not errors, "Schema validation failed:\n" + "\n".join(errors)
 
@@ -354,7 +354,7 @@ class TestCatalogMultipleCollections:
         tmp_path: Path,
         valid_points_geojson: Path,
         valid_polygons_geojson: Path,
-        portolan_catalog_schema: dict[str, Any],
+        catalog_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """Catalog with multiple collections should have multiple child links."""
@@ -380,7 +380,7 @@ class TestCatalogMultipleCollections:
             data = json.loads(catalog_path.read_text())
 
             # Validate schema
-            errors = validate_stac(data, portolan_catalog_schema)
+            errors = validate_stac(data, catalog_schema)
             assert not errors, "Schema validation failed:\n" + "\n".join(errors)
 
             # Check for multiple child links

--- a/tests/spec_compliance/test_collection_schema.py
+++ b/tests/spec_compliance/test_collection_schema.py
@@ -31,7 +31,7 @@ class TestCollectionSchemaCompliance:
         runner: CliRunner,
         tmp_path: Path,
         valid_points_geojson: Path,
-        portolan_collection_schema: dict[str, Any],
+        collection_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """portolan add creates a schema-compliant collection.json for GeoJSON."""
@@ -54,7 +54,7 @@ class TestCollectionSchemaCompliance:
             assert collection_path.exists(), f"collection.json not found at {collection_path}"
 
             data = json.loads(collection_path.read_text())
-            errors = validate_stac(data, portolan_collection_schema)
+            errors = validate_stac(data, collection_schema)
 
             assert not errors, "Schema validation failed:\n" + "\n".join(errors)
 
@@ -64,7 +64,7 @@ class TestCollectionSchemaCompliance:
         runner: CliRunner,
         tmp_path: Path,
         valid_points_parquet: Path,
-        portolan_collection_schema: dict[str, Any],
+        collection_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """portolan add creates a schema-compliant collection.json for GeoParquet."""
@@ -87,7 +87,7 @@ class TestCollectionSchemaCompliance:
             assert collection_path.exists(), "collection.json not found"
 
             data = json.loads(collection_path.read_text())
-            errors = validate_stac(data, portolan_collection_schema)
+            errors = validate_stac(data, collection_schema)
 
             assert not errors, "Schema validation failed:\n" + "\n".join(errors)
 

--- a/tests/spec_compliance/test_shipped_schema_hermetic.py
+++ b/tests/spec_compliance/test_shipped_schema_hermetic.py
@@ -28,6 +28,7 @@ from typing import Any
 
 import pytest
 from click.testing import CliRunner
+from referencing.exceptions import Unresolvable
 
 from portolan_cli.cli import cli
 from portolan_cli.validation.schema_registry import build_stac_registry, validate_document
@@ -163,7 +164,7 @@ class TestShippedSchemaEnforcesConstraints:
 
 
 class TestValidationIsHermetic:
-    """Validation must not reach the network even when sockets are unavailable."""
+    """Validation must resolve the STAC $refs offline and never fall back to the network."""
 
     @pytest.mark.unit
     def test_validation_works_with_sockets_blocked(
@@ -171,6 +172,11 @@ class TestValidationIsHermetic:
         monkeypatch: pytest.MonkeyPatch,
         catalog_schema: dict[str, Any],
     ) -> None:
+        # Drop the cached registry so it is rebuilt from the vendored bundle
+        # *under* the socket block. A warm lru_cache would otherwise let this
+        # pass without exercising offline construction at all.
+        build_stac_registry.cache_clear()
+
         def _no_network(*args: Any, **kwargs: Any) -> Any:
             raise AssertionError("validation attempted a network connection")
 
@@ -185,7 +191,21 @@ class TestValidationIsHermetic:
             "description": "d",
             "links": [],
         }
-        # Must complete (resolving the STAC $ref from the vendored bundle) with
-        # no network access.
+        # Resolves the STAC base $ref from the vendored bundle AND accepts a
+        # conformant catalog -- with no network access. Asserting == [] (not just
+        # "is a list") is what makes this a real conformance check.
         errors = validate_document(good_catalog, catalog_schema)
-        assert isinstance(errors, list)
+        assert errors == [], errors
+
+    @pytest.mark.unit
+    def test_unvendored_ref_raises_instead_of_fetching(self) -> None:
+        # The registry is built with no retrieval callable, so a $ref outside the
+        # vendored closure must raise Unresolvable rather than silently fetch it
+        # over the network. This is what gives the socket-blocked test teeth:
+        # an unresolved reference is a hard error, never a network round-trip.
+        schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [{"$ref": "https://schemas.stacspec.org/v1.1.0/not-vendored.json"}],
+        }
+        with pytest.raises(Unresolvable):
+            validate_document({"type": "Catalog"}, schema)

--- a/tests/spec_compliance/test_shipped_schema_hermetic.py
+++ b/tests/spec_compliance/test_shipped_schema_hermetic.py
@@ -1,0 +1,191 @@
+"""Spec compliance: validate CLI output against the SHIPPED schemas.
+
+Unlike the older tests that validated against hand-copied inline schema stubs
+(which only covered Portolan extensions, never the STAC base), these tests load
+the real ``spec/schema/catalog.schema.json`` and ``spec/schema/collection.schema.json``
+and validate CLI-generated output against them.
+
+The shipped schemas ``allOf``-reference the upstream STAC v1.1.0 draft-07
+schemas by URL. Those references are resolved from a vendored copy bundled with
+``portolan_cli.validation`` (see ``schema_registry``), so validation is
+hermetic: it never touches the network.
+
+Href/IRI format is intentionally NOT enforced here. Portolan emits relative
+hrefs by design and the href policy is unresolved (see discussion #573), so the
+validator runs with JSON Schema ``format`` assertions off. These tests check
+structural conformance only.
+
+See issue #557.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.validation.schema_registry import build_stac_registry, validate_document
+
+# STAC base schema URIs the shipped Portolan schemas reference. If the vendored
+# closure fails to register these, ``$ref`` resolution would fall back to the
+# network (or fail), so this is the canary for "the bundle is complete".
+_STAC_CATALOG_URI = "https://schemas.stacspec.org/v1.1.0/catalog-spec/json-schema/catalog.json"
+_STAC_COLLECTION_URI = (
+    "https://schemas.stacspec.org/v1.1.0/collection-spec/json-schema/collection.json"
+)
+
+
+# ``catalog_schema`` and ``collection_schema`` (the shipped schemas loaded from
+# disk) come from tests/spec_compliance/conftest.py.
+
+
+class TestVendoredClosureComplete:
+    """The vendored STAC closure must cover every reference the shipped schemas make."""
+
+    @pytest.mark.unit
+    def test_registry_resolves_stac_catalog_base_offline(self) -> None:
+        registry = build_stac_registry()
+        # crawl=False resolution: the resource is present without a fetch.
+        resource = registry.get_or_retrieve(_STAC_CATALOG_URI).value
+        assert resource.contents.get("$id", "").endswith("catalog.json")
+
+    @pytest.mark.unit
+    def test_registry_resolves_stac_collection_base_offline(self) -> None:
+        registry = build_stac_registry()
+        resource = registry.get_or_retrieve(_STAC_COLLECTION_URI).value
+        assert "collection" in json.dumps(resource.contents).lower()
+
+
+class TestShippedSchemaValidatesRealOutput:
+    """CLI-generated catalogs/collections conform to the SHIPPED schemas."""
+
+    @pytest.mark.integration
+    def test_init_catalog_conforms_to_shipped_catalog_schema(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        catalog_schema: dict[str, Any],
+    ) -> None:
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["init", "--auto"])
+            assert result.exit_code == 0, f"init failed: {result.output}"
+
+            data = json.loads(Path("catalog.json").read_text())
+            errors = validate_document(data, catalog_schema)
+            assert not errors, "shipped catalog schema rejected init output:\n" + "\n".join(errors)
+
+    @pytest.mark.integration
+    def test_add_collection_conforms_to_shipped_schemas(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        valid_points_geojson: Path,
+        catalog_schema: dict[str, Any],
+        collection_schema: dict[str, Any],
+    ) -> None:
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            assert runner.invoke(cli, ["init", "--auto"]).exit_code == 0
+
+            collection_dir = Path("points")
+            collection_dir.mkdir()
+            shutil.copy(valid_points_geojson, collection_dir / "points.geojson")
+            result = runner.invoke(cli, ["add", str(collection_dir / "points.geojson")])
+            assert result.exit_code == 0, f"add failed: {result.output}"
+
+            catalog = json.loads(Path("catalog.json").read_text())
+            cat_errors = validate_document(catalog, catalog_schema)
+            assert not cat_errors, "shipped catalog schema rejected add output:\n" + "\n".join(
+                cat_errors
+            )
+
+            collection_path = collection_dir / "collection.json"
+            assert collection_path.exists(), "collection.json not created"
+            collection = json.loads(collection_path.read_text())
+            col_errors = validate_document(collection, collection_schema)
+            assert not col_errors, "shipped collection schema rejected add output:\n" + "\n".join(
+                col_errors
+            )
+
+
+class TestShippedSchemaEnforcesConstraints:
+    """A schema edit that changes what is valid must change what the suite accepts.
+
+    These feed deliberately non-conformant documents through the SHIPPED schema
+    and require errors. If someone loosens a shipped schema incompatibly, the
+    corresponding assertion here flips, so the suite is a real guard (checkbox 4).
+    """
+
+    @pytest.mark.unit
+    def test_catalog_missing_title_is_rejected(self, catalog_schema: dict[str, Any]) -> None:
+        # Portolan extension requires human-readable title (RULE-0100).
+        bad_catalog = {
+            "type": "Catalog",
+            "stac_version": "1.1.0",
+            "id": "x",
+            "description": "d",
+            "links": [],
+        }
+        errors = validate_document(bad_catalog, catalog_schema)
+        assert errors, "shipped catalog schema accepted a catalog with no title"
+
+    @pytest.mark.unit
+    def test_stac_base_required_fields_enforced(self, catalog_schema: dict[str, Any]) -> None:
+        # stac_version/id/links are required by the STAC base schema (via $ref),
+        # NOT by the Portolan extension. Catching them proves the vendored STAC
+        # base is actually applied, not silently skipped -- the whole point of
+        # loading the shipped schema instead of an extension-only stub (#557).
+        base_only_violation = {"type": "Catalog", "title": "T", "description": "d"}
+        errors = validate_document(base_only_violation, catalog_schema)
+        joined = "\n".join(errors)
+        assert "'stac_version' is a required property" in joined
+        assert "'id' is a required property" in joined
+        assert "'links' is a required property" in joined
+
+    @pytest.mark.unit
+    def test_child_link_without_title_is_rejected(self, catalog_schema: dict[str, Any]) -> None:
+        # RULE-0102/0103: child/item links MUST carry a human-readable title.
+        bad_catalog = {
+            "type": "Catalog",
+            "stac_version": "1.1.0",
+            "id": "x",
+            "title": "Title",
+            "description": "d",
+            "links": [{"rel": "child", "href": "./points/collection.json"}],
+        }
+        errors = validate_document(bad_catalog, catalog_schema)
+        assert errors, "shipped catalog schema accepted a child link with no title"
+
+
+class TestValidationIsHermetic:
+    """Validation must not reach the network even when sockets are unavailable."""
+
+    @pytest.mark.unit
+    def test_validation_works_with_sockets_blocked(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        catalog_schema: dict[str, Any],
+    ) -> None:
+        def _no_network(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("validation attempted a network connection")
+
+        monkeypatch.setattr(socket, "socket", _no_network)
+        monkeypatch.setattr(socket, "create_connection", _no_network)
+
+        good_catalog = {
+            "type": "Catalog",
+            "stac_version": "1.1.0",
+            "id": "x",
+            "title": "Title",
+            "description": "d",
+            "links": [],
+        }
+        # Must complete (resolving the STAC $ref from the vendored bundle) with
+        # no network access.
+        errors = validate_document(good_catalog, catalog_schema)
+        assert isinstance(errors, list)

--- a/tests/spec_compliance/test_validators.py
+++ b/tests/spec_compliance/test_validators.py
@@ -112,7 +112,7 @@ class TestSchemaValidatorRejectsInvalid:
     @pytest.mark.integration
     def test_stac_validator_rejects_wrong_type(
         self,
-        portolan_catalog_schema: dict[str, Any],
+        catalog_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """STAC validator MUST reject wrong type field."""
@@ -124,14 +124,14 @@ class TestSchemaValidatorRejectsInvalid:
             "links": [],
         }
 
-        errors = validate_stac(invalid_data, portolan_catalog_schema)
+        errors = validate_stac(invalid_data, catalog_schema)
 
         assert errors, "Validator should reject wrong 'type' field"
 
     @pytest.mark.integration
     def test_stac_validator_rejects_invalid_stac_version(
         self,
-        portolan_collection_schema: dict[str, Any],
+        collection_schema: dict[str, Any],
         validate_stac: Callable[[dict[str, Any], dict[str, Any]], list[str]],
     ) -> None:
         """STAC validator MUST reject invalid stac_version pattern."""
@@ -148,7 +148,7 @@ class TestSchemaValidatorRejectsInvalid:
             "links": [],
         }
 
-        errors = validate_stac(invalid_data, portolan_collection_schema)
+        errors = validate_stac(invalid_data, collection_schema)
 
         assert errors, "Validator should reject stac_version that doesn't match 1.x.x"
 

--- a/uv.lock
+++ b/uv.lock
@@ -4610,6 +4610,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "geoparquet-io" },
     { name = "httpx" },
+    { name = "jsonschema" },
     { name = "lxml" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4626,6 +4627,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "rasterio", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "referencing" },
     { name = "requests" },
     { name = "rich" },
     { name = "rio-cogeo", version = "6.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -4654,6 +4656,7 @@ dev = [
     { name = "radon" },
     { name = "ruff" },
     { name = "types-defusedxml" },
+    { name = "types-jsonschema" },
     { name = "types-pyyaml" },
     { name = "vulture" },
     { name = "xenon" },
@@ -4693,6 +4696,7 @@ dev = [
     { name = "pylint" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
+    { name = "types-jsonschema" },
     { name = "types-pyyaml" },
 ]
 
@@ -4715,6 +4719,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.151.5" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },
+    { name = "jsonschema", specifier = ">=4.18.0" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mapbox-vector-tile", marker = "extra == 'thumbnails'", specifier = ">=2.0.0" },
     { name = "matplotlib", marker = "extra == 'thumbnails'", specifier = ">=3.8.0" },
@@ -4745,6 +4750,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0.1" },
     { name = "rasterio", specifier = ">=1.3.0" },
+    { name = "referencing", specifier = ">=0.30.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "rio-cogeo", specifier = ">=5.0.0" },
@@ -4753,6 +4759,7 @@ requires-dist = [
     { name = "stac-check", specifier = ">=1.4.0" },
     { name = "stac-geoparquet", specifier = ">=0.6.0" },
     { name = "types-defusedxml", marker = "extra == 'dev'", specifier = ">=0.7.0" },
+    { name = "types-jsonschema", marker = "extra == 'dev'", specifier = ">=4.18.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.14" },
@@ -4769,6 +4776,7 @@ dev = [
     { name = "pylint", specifier = ">=4.0.5" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "types-jsonschema", specifier = ">=4.18.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
@@ -7120,6 +7128,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/39/af/d324da5ffbf0af40477533a09ee6c902de335c445a8dcc88c58f62af6e5f/types_defusedxml-0.7.0.20260408.tar.gz", hash = "sha256:f35377d59344f98b57f9bf319cff2107aac35f9e4d42f9ed6cfeeafacffadb00", size = 10638, upload-time = "2026-04-08T04:26:12.239Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/68/7570cfb818d6a5b3ff964114527e28e360eccf18329b457f057a18596e64/types_defusedxml-0.7.0.20260408-py3-none-any.whl", hash = "sha256:2d68db82412170b91b3e490b7c118a4f4e5a27756a126e2453f629c8d514b106", size = 13435, upload-time = "2026-04-08T04:26:11.347Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/46/73b6a5d61a61015c4248030a8cb07e5bdddb4041430fae9e585a68692578/types_jsonschema-4.26.0.20260518.tar.gz", hash = "sha256:e1dd53dc97a64f5eccdd6fa9839666e09bb500a8ebba2db6fdaf1789faea81a6", size = 16638, upload-time = "2026-05-18T06:06:44.106Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/d5/134f8a147dcecda10db7f60cfc6af0578a25a5c53c87b3907a64385e0184/types_jsonschema-4.26.0.20260518-py3-none-any.whl", hash = "sha256:30b30a518c7fe335df85c919fcbcc631b69c03d4a4b5b632fa916bea03065307", size = 16072, upload-time = "2026-05-18T06:06:43.264Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #557.

## Problem

`tests/spec_compliance/` validated documents against hand-copied inline schema stubs (`portolan_catalog_schema` / `portolan_collection_schema` in `conftest.py`) that covered only the Portolan *extensions*, never the STAC base. The shipped `spec/schema/catalog.schema.json` and `collection.schema.json` were loaded by **no** validation test, so they could drift from real CLI output silently. The reason the shipped schemas weren't loaded: they `allOf`-`$ref` the upstream STAC v1.1.0 schemas by URL, which can't be resolved offline.

## Approach

Validate against the real shipped schemas, resolving the STAC `$ref`s from a vendored copy of the transitive closure. No network.

- **Vendor** the STAC v1.1.0 `$ref` closure (11 files, all draft-07) as package data under `portolan_cli/validation/_vendored/stac/1.1.0/`. `scripts/refresh_stac_schemas.py` fetches it (`--check` verifies currency). Files stay byte-identical to upstream.
- **`portolan_cli/validation/schema_registry.py`** (in the reis extraction seam, issue #563): `build_stac_registry()` + `validate_document()`. Keys resources by retrieval URL and normalizes the malformed upstream `$id`s (e.g. STAC's `common.json` declares `$id` `.../commonjson`); resolves cross-dialect 2020-12 → draft-07 `$ref`s.
- **Delete the inline stubs**; rewire `test_catalog_schema` / `test_collection_schema` / `test_validators` onto the shipped schemas.
- **`test_shipped_schema_hermetic.py`**: real `init`/`add` output conforms; the STAC **base** + Portolan-extension constraints are enforced (guards incompatible schema edits — checkbox 4); validation stays offline even with sockets blocked.

## Deliberate decisions (see ADR-0056)

- **`format` assertions off.** Portolan emits relative hrefs by design; the STAC schema marks href `format: iri`. The href/"published" policy is unresolved (discussion #573), so enforcing it here would reject valid output and pre-judge #573. Structural conformance only; format enforcement turns on in this one module when #573 lands.
- **No spec bump.** This changes how tests consume schemas, not schema content.
- **Pin-and-forget on staleness.** STAC v1.1.0 is immutable; refresh is a manual script run on a version bump. No automated network-diff test.

## Notable side-fix

`.gitignore` had a bare `catalog.json` rule (for dev test artifacts) that silently dropped the vendored STAC **catalog base** schema from the wheel. The vendored tree is now explicitly un-ignored; wheel build confirmed to ship all 11 files.

## Verification

Real `init`/`add` output already conformed to the stricter shipped schemas — no CLI output changes needed.

- `pytest tests/spec_compliance/` → 99 passed
- Full unit tier → 4757 passed, 5 skipped, 0 failed
- ruff, mypy (src + tests), deptry, vulture, xenon, pylint 10/10
- import-linter → 5/5 kept, including both validation-seam contracts (no CLI/Click/Rich leak)
- `refresh_stac_schemas.py --check` → current; wheel ships all 11 vendored files

## Dependencies

`jsonschema` + `referencing` promoted from transitive (via `stac-check`) to explicit runtime deps, since the shipped `validation/` module now imports them directly. `types-jsonschema` added for mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)