### PR TITLE
docs: reconcile spec hierarchy model with ADR-0032 (#554, #555)

### DIFF
--- a/spec/core.md
+++ b/spec/core.md
@@ -88,13 +88,14 @@ Asset hrefs **MUST** be absolute S3 URLs:
 
 ## Link Paths
 
-STAC link relations (`root`, `self`, `child`, `parent`) **SHOULD** use relative paths within the catalog structure:
+STAC link relations (`root`, `self`, `child`, `parent`) **SHOULD** use relative paths within the catalog structure. Hierarchy is built from nested catalogs, so `child` links point from a catalog down to its intermediate catalogs or leaf collections, never from one collection to another (see [structure.md](structure.md#nested-catalogs-flat-collections)). This is an intermediate catalog linking to a leaf collection:
 
 ```json
 "links": [
-  {"rel": "root", "href": "./catalog.json", "type": "application/json"},
-  {"rel": "self", "href": "./collection.json", "type": "application/json"},
-  {"rel": "child", "href": "./2022/collection.json", "type": "application/json"}
+  {"rel": "root", "href": "../catalog.json", "type": "application/json"},
+  {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
+  {"rel": "self", "href": "./catalog.json", "type": "application/json"},
+  {"rel": "child", "href": "./air-quality/collection.json", "type": "application/json", "title": "Air Quality"}
 ]
 ```
 

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -242,15 +242,20 @@ rules:
   - id: RULE-0041
     level: error
     scope: catalog
-    description: Catalog MUST have flat hierarchy (no nested sub-collections)
+    description: Collections MUST be leaves; a collection MUST NOT contain a child collection
     rationale: |
-      Flat hierarchy simplifies tooling and versioning boundaries.
+      Hierarchy is built from nested catalogs, not nested collections (ADR-0032).
+      Intermediate levels are catalogs; collections are always leaves. Keeping
+      collections flat preserves STAC API compatibility (APIs index collections
+      flat) while catalogs above them provide thematic organization.
     validation: |
       For each collection in catalog:
-        assert collection has no child collections
-        # Collections contain items directly
+        for link in collection.links where link.rel == "child":
+          assert link points to a catalog.json, not a collection.json
+        # Collections hold assets or item subdirs directly, never child collections
     references:
-      - structure.md#flat-hierarchy
+      - structure.md#nested-catalogs-flat-collections
+      - ../context/shared/adr/0032-nested-catalogs-with-flat-collections.md
 
   - id: RULE-0042
     level: error

--- a/spec/structure.md
+++ b/spec/structure.md
@@ -37,7 +37,7 @@ Only Portolan-internal tooling configuration lives in `.portolan/`. STAC metadat
 
 ## Collection Level
 
-Each collection is a top-level subdirectory of the project root, named with the collection ID.
+Each collection lives in a subdirectory named with its collection ID. For a nested collection the ID is a POSIX path (e.g. `environment/air-quality`) and the directory sits under one or more intermediate catalog directories (see [Nested Catalogs, Flat Collections](#nested-catalogs-flat-collections)).
 
 | File | Required | Description |
 |------|----------|-------------|
@@ -81,20 +81,40 @@ Each item is a subdirectory of the collection named with the item ID.
 
 Item IDs are derived from the item directory name. By convention, item directories **SHOULD** be named after the primary data file's stem (e.g., source file `census.shp` goes into item directory `census/`).
 
-## Flat Hierarchy
+## Nested Catalogs, Flat Collections
 
-Portolan catalogs use a **flat hierarchy**: collections contain items directly, with no nested sub-collections.
+Portolan organizes hierarchy with **nested catalogs**, not nested collections ([ADR-0032](../context/shared/adr/0032-nested-catalogs-with-flat-collections.md)). Intermediate levels are catalogs (`catalog.json`); collections are always leaves. A collection **MUST NOT** contain a child collection. This keeps collections flat for STAC API compatibility while still allowing thematic organization above them.
+
+Directory mapping:
+
+| Directory | File | Role |
+|-----------|------|------|
+| Root | `catalog.json` | Root catalog |
+| Level above a collection | `catalog.json` | Intermediate (thematic) catalog |
+| Data directory | `collection.json` | Leaf collection (holds vector assets or item subdirs) |
+| Subdirectory within a collection | `catalog.json` | Organizes many items below a collection |
+
+A nested collection's ID is its POSIX path from the catalog root (e.g. `environment/air-quality`). `portolan add` writes a `catalog.json` at each intermediate level and links parent → child down to the leaf `collection.json`.
 
 ```
-# Correct (flat)
-census-2020/tracts/tracts.parquet
-census-2020/blocks/blocks.parquet
+# Correct: intermediate levels are catalogs, collections are leaves
+environment/
+├── catalog.json                 ← intermediate catalog
+├── air-quality/
+│   ├── collection.json          ← leaf collection (data)
+│   └── pm25.parquet
+└── water-quality/
+    ├── collection.json          ← leaf collection (data)
+    └── turbidity.parquet
 
-# Incorrect (nested)
-census/2020/tracts/tracts.parquet
+# Incorrect: a collection containing a child collection
+environment/
+├── collection.json              ← collection with a child collection (not allowed)
+└── air-quality/
+    └── collection.json
 ```
 
-This simplifies tooling and avoids ambiguity about where versioning boundaries lie.
+Deep nesting is allowed; each level above the leaf is a catalog. Catalogs may also appear *below* a collection to organize its items (for example, a raster collection grouping items by year).
 
 ## STAC Conventions
 


### PR DESCRIPTION
Reconciles the spec docs with the adopted nested-catalog model (ADR-0032, supersedes ADR-0012). `spec/structure.md` and `spec/schema/rules.yaml` still specified the superseded flat-hierarchy model, which forbids the layout the CLI actually ships (intermediate `catalog.json` files + nested collection IDs, `catalog.py:568-663`).

## Changes

**`spec/structure.md` (#554)**
- Renamed `## Flat Hierarchy` → `## Nested Catalogs, Flat Collections`. Intermediate levels are catalogs, collections are leaves, a collection MUST NOT contain a child collection. Added a directory-mapping table, a correct nested example (`environment/` catalog → `air-quality/collection.json`), and the wrong (nested-collection) counter-example.
- Fixed the Collection Level line that called collections *top-level* subdirs; nested IDs sit under intermediate catalog dirs.

**`spec/core.md` (#554)**
- Fixed the Link Paths example. As written it was a collection (`self: ./collection.json`) with `child: ./2022/collection.json`, a collection containing a child collection, which the corrected model forbids. Rewrote it as an intermediate catalog linking to a leaf collection, using the `root`/`parent`/`self`/`child` hrefs the code emits, plus a `title` (ADR-0053).

**`spec/schema/rules.yaml` (#555)**
- Rewrote RULE-0041 to assert the ADR-0032 invariant (collections are leaves; no collection contains a child collection) instead of forbidding nesting. Kept it ERROR. Updated the validation sketch to check `child` links resolve to `catalog.json`, not `collection.json`, and repointed the reference to the renamed anchor + ADR-0032.

## Why no code changes
No validator implements RULE-0041 (it's spec-only), and `init`/`add` already build the nested model.

## Verification
- `rules.yaml` parses; RULE-0041 loads; 45 rules, IDs unique.
- `tests/spec_compliance/test_rules_coverage.py` — 17 passed.
- No dangling `flat-hierarchy` references remain; no markdown-anchor checker exists to break. RULE-0041 has no `code_rule`, so spec/CLI parity tests don't touch it.

Closes #554
Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)