### PR TITLE
docs: fix stale ADR headers, ADR-0009 command table, dangling rules.yaml anchors (#559)

### DIFF
--- a/context/shared/adr/0009-output-dry-run-and-verbose-modes.md
+++ b/context/shared/adr/0009-output-dry-run-and-verbose-modes.md
@@ -5,7 +5,7 @@ Accepted
 
 ## Context
 
-Portolan CLI performs destructive operations like file deletion (`prune`), remote sync (`sync`), and data transformation (`dataset add`). Users need confidence before executing these operations, especially in production environments or when operating on cloud storage.
+Portolan CLI performs destructive operations like removing tracked files (`rm`), remote sync (`push` / `sync`), and format conversion during import (`add`). Users need confidence before executing these operations, especially in production environments or when operating on cloud storage.
 
 Additionally, debugging and troubleshooting benefit from detailed technical output showing internal decisions, file paths, and library calls. However, this detail should not clutter normal usage.
 
@@ -64,30 +64,37 @@ Add **per-call** `dry_run` and `verbose` parameters to all output functions (`su
 
 ### Command Coverage
 
-Dry-run mode applies to commands that modify state:
+Dry-run mode applies to commands that modify filesystem or network state. The
+table below reflects the flags actually exposed by each command today:
 
 | Command | `--dry-run` | `--verbose` |
 |---------|-------------|-------------|
-| `dataset add` | ✅ | ✅ |
-| `dataset remove` | ✅ | ✅ |
-| `sync` | ✅ | ✅ |
-| `repair` | ✅ | ✅ |
-| `prune` | ✅ | ✅ |
-| `init` | ✅ | ✅ |
-| `check` | ❌ | ✅ |
-| `check --remote` | ❌ | ✅ |
-| `dataset list` | ❌ | ✅ |
-| `dataset info` | ❌ | ✅ |
-| `remote add` | ❌ | ✅ |
-| `remote list` | ❌ | ✅ |
+| `add` | ❌ | ✅ |
+| `add-external` | ❌ | ❌ |
+| `rm` | ✅ | ✅ |
+| `push` | ✅ | ✅ |
+| `pull` | ✅ | ❌ |
+| `sync` | ✅ | ❌ |
+| `clean` | ✅ | ❌ |
+| `scan` | ✅ | ❌ |
+| `check` | ✅ | ✅ |
+| `stac-geoparquet` | ✅ | ❌ |
+| `version prune` | ✅ | ❌ |
+| `extract arcgis` / `wfs` / `carto` | ✅ | ❌ |
+| `init` | ❌ | ❌ |
+| `list` | ❌ | ❌ |
+| `status` | ❌ | ❌ |
+| `info` | ❌ | ❌ |
 
-**Rule:** If it modifies filesystem or network state → support `--dry-run`.
+**Rule:** If it modifies filesystem or network state → it *should* support
+`--dry-run`. `add` and `add-external` are the current gap: they mutate state but
+do not yet expose `--dry-run` (tracked as follow-up work).
 
 ## Consequences
 
 ### What becomes easier
 
-- **Safe exploration:** Users can preview `prune`, `sync`, and `repair` before executing
+- **Safe exploration:** Users can preview `rm`, `sync`, and `clean` before executing
 - **AI integration:** Agents can run tools with `--dry-run` to understand behavior before committing
 - **Debugging:** Future verbose mode will expose technical details without cluttering normal output
 - **Testing:** Per-call parameters are straightforward to test with mutation testing

--- a/context/shared/adr/0021-catalog-json-root-level.md
+++ b/context/shared/adr/0021-catalog-json-root-level.md
@@ -1,8 +1,7 @@
 # ADR-0021: catalog.json at Root Level
 
 ## Status
-Accepted
-Superseded-By: ADR-0023
+Superseded by [ADR-0023](0023-stac-structure-separation.md)
 
 > Note: Subsumed by ADR-0023 which provides complete structure specification.
 

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -114,7 +114,7 @@ rules:
       else:
         assert versions is empty
     references:
-      - versions.md#current-version
+      - versions.md#root-level
 
   - id: RULE-0013
     level: error
@@ -387,7 +387,7 @@ rules:
         for style_key in collection["portolan:styles"]:
           assert style_key in collection.assets
     references:
-      - best-practices.md#portolan-styles-manifest
+      - best-practices.md#portolanstyles-manifest
 
   - id: RULE-0068
     level: error
@@ -447,7 +447,7 @@ rules:
           assert file exists at link.href
     references:
       - ai-integration.md
-      - core.md#ai-llm-integration
+      - core.md#ai--llm-integration
 
   - id: RULE-0081
     level: error
@@ -465,7 +465,7 @@ rules:
           assert file exists at link.href
     references:
       - ai-integration.md
-      - core.md#ai-llm-integration
+      - core.md#ai--llm-integration
 
   - id: RULE-0082
     level: warning


### PR DESCRIPTION
Fixes #559 — batched medium-severity findings from the 2026-07-03 pre-sprint spec audit.

## Changes

**1. ADR-0021 status was self-contradictory** — declared both `Accepted` and `Superseded-By: ADR-0023`. Now a single `Superseded by [ADR-0023](...)` line, matching the ADR-0004 convention.

**2. ADR-0009 command table named commands that never existed** (`dataset add`, `dataset remove`, `repair`, `prune`, `remote add`, `remote list`, `check --remote`, `dataset list/info`) and violated the STAC terminology rule (`dataset …`). Rebuilt the `--dry-run`/`--verbose` support matrix directly from the live Click command tree (introspected via `cli.commands`), and fixed the same fake command names in the Context and Consequences prose.

The table now reflects reality, including the honest gap: `add` / `add-external` mutate state but do **not** yet expose `--dry-run` (noted as follow-up under the Rule).

**3. Four dangling `references` anchors in `rules.yaml`** repointed to headings that actually exist (verified by simulating GitHub's slugifier against each target doc — `spec/` is GitHub-rendered, not part of the mkdocs site):

| Rule | Old anchor | New anchor |
|------|-----------|-----------|
| RULE-0012 | `versions.md#current-version` | `versions.md#root-level` |
| RULE-0067 | `best-practices.md#portolan-styles-manifest` | `best-practices.md#portolanstyles-manifest` |
| RULE-0080/0081 | `core.md#ai-llm-integration` | `core.md#ai--llm-integration` |

**4. Declared `level`/`scope` value lists** — already resolved in #587, which added `info` to the `level` list and `config` to the `scope` list in the rules.yaml header. All current usages match the declared vocabularies; no change needed. (Called out here so the checklist item is accounted for.)

## Verification

- `rules.yaml` parses; all four repointed anchors resolve against real headings.
- `uv run pytest tests/spec_compliance/test_rules_coverage.py` → 17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI guidance in the architecture notes to reflect current dry-run and verbose support across more commands, with refreshed examples for safer previewing.
  * Revised an older design note to show it has been superseded by a newer decision.
  * Fixed several specification reference links so they point to the correct documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->