### PR TITLE
fix: collection-level asset freshness — check reports STALE that --fix/add cannot clear (#512)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -1982,6 +1982,45 @@ def _finalize_with_backend(
         )
 
 
+_FRESHNESS_CHECKABLE_SUFFIXES = frozenset({".parquet", ".tif", ".tiff"})
+
+
+def _asset_freshness_fields(
+    file_path: Path,
+    *,
+    is_collection_level: bool,
+) -> tuple[float | None, int | None, str | None]:
+    """Compute (source_mtime, feature_count, schema_fingerprint) for tracking.
+
+    Only collection-level, freshness-checkable assets (GeoParquet / COG) get a
+    baseline: they have no companion item.json, so the metadata_fresh check
+    reads their freshness straight from versions.json (#512). Item-level assets
+    are left to their existing item.json / ``--fix`` path.
+
+    Best-effort: any extraction failure falls back to ``(None, None, None)`` so
+    tracking never blocks an otherwise successful ``add``. The asset's own mtime
+    doubles as ``source_mtime`` — mirroring ``update_versions_tracking`` — since
+    the freshness fast path compares the asset file's current mtime to it.
+    """
+    if not is_collection_level:
+        return (None, None, None)
+    if file_path.suffix.lower() not in _FRESHNESS_CHECKABLE_SUFFIXES:
+        return (None, None, None)
+
+    from portolan_cli.metadata.detection import get_current_metadata
+
+    try:
+        current = get_current_metadata(file_path)
+        return (
+            file_path.stat().st_mtime,
+            current.current_feature_count,
+            current.current_schema_fingerprint,
+        )
+    except (ValueError, OSError):
+        logger.debug("Could not extract freshness heuristics for %s", file_path, exc_info=True)
+        return (None, None, None)
+
+
 def _batch_update_versions(
     collection_dir: Path,
     collection_id: str,
@@ -2033,12 +2072,24 @@ def _batch_update_versions(
                 asset_key = f"{p.item_id}/{filename}"
 
             stat = file_path.stat()
+            # Collection-level assets (ADR-0031) have no companion item.json, so
+            # the freshness check reads their baseline straight from
+            # versions.json. Persist source_mtime + heuristics here so a plain
+            # `add` produces a FRESH asset instead of a perpetual STALE (#512),
+            # and so a touched-but-identical asset stays FRESH via the ADR-0017
+            # heuristic fallback rather than flipping to STALE/BREAKING.
+            source_mtime, feature_count, schema_fingerprint = _asset_freshness_fields(
+                file_path, is_collection_level=p.is_collection_level_asset
+            )
             # Use pre-computed file_size (handles directories like FileGDB correctly)
             all_assets[asset_key] = Asset(
                 sha256=file_checksum,
                 size_bytes=file_size,
                 href=href,
                 mtime=stat.st_mtime,
+                source_mtime=source_mtime,
+                feature_count=feature_count,
+                schema_fingerprint=schema_fingerprint,
             )
 
     # Add single version with all assets

--- a/portolan_cli/backends/iceberg/versioning.py
+++ b/portolan_cli/backends/iceberg/versioning.py
@@ -68,6 +68,10 @@ def version_to_snapshot_properties(
             asset_data["source_mtime"] = asset.source_mtime
         if asset.mtime is not None:
             asset_data["mtime"] = asset.mtime
+        if asset.feature_count is not None:
+            asset_data["feature_count"] = asset.feature_count
+        if asset.schema_fingerprint is not None:
+            asset_data["schema_fingerprint"] = asset.schema_fingerprint
         assets_dict[name] = asset_data
     props["portolake.assets"] = json.dumps(assets_dict)
     # Serialize schema
@@ -107,6 +111,8 @@ def snapshot_to_version(snapshot: Snapshot) -> Version:
             source_path=adata.get("source_path"),
             source_mtime=adata.get("source_mtime"),
             mtime=adata.get("mtime"),
+            feature_count=adata.get("feature_count"),
+            schema_fingerprint=adata.get("schema_fingerprint"),
         )
 
     # Deserialize schema

--- a/portolan_cli/metadata/scan.py
+++ b/portolan_cli/metadata/scan.py
@@ -307,10 +307,19 @@ def _check_collection_level_asset(
         return None
 
     current = get_current_metadata(asset_path)
+    # Freshness baseline is the asset's own mtime. `add` records it under the
+    # `mtime` field (ADR-0017 fast-path), while `--fix`'s
+    # `update_versions_tracking` records it under `source_mtime`; a single asset
+    # may carry either (or both). Prefer `source_mtime` but fall back to `mtime`
+    # so a plain `add` (which never wrote `source_mtime` for collection-level
+    # assets) is not perpetually STALE — the #512 regression.
+    stored_source_mtime = stored.get("source_mtime")
+    stored_mtime = stored_source_mtime if stored_source_mtime is not None else stored.get("mtime")
+    stored_schema_fingerprint = stored.get("schema_fingerprint")
     state = FileMetadataState(
         file_path=asset_path,
         current_mtime=current.current_mtime,
-        stored_mtime=stored.get("source_mtime"),
+        stored_mtime=stored_mtime,
         # Collection-level assets have no item.json bbox source. Heuristics
         # fall through to feature-count + schema fingerprint comparisons,
         # which is sufficient signal for STALE/BREAKING detection.
@@ -319,7 +328,7 @@ def _check_collection_level_asset(
         current_feature_count=current.current_feature_count,
         stored_feature_count=stored.get("feature_count"),
         current_schema_fingerprint=current.current_schema_fingerprint,
-        stored_schema_fingerprint=stored.get("schema_fingerprint"),
+        stored_schema_fingerprint=stored_schema_fingerprint,
     )
     stale, reason = is_stale(state)
     if not stale:
@@ -329,7 +338,11 @@ def _check_collection_level_asset(
             message=f"Metadata is up to date ({reason})",
         )
     changes = detect_changes(state)
-    if reason == "schema_changed":
+    # Only escalate to BREAKING when a stored schema fingerprint actually
+    # exists to compare against. Without a baseline (older catalogs, or entries
+    # written before heuristics were persisted) a mtime change cannot prove a
+    # schema break — report STALE rather than a blocking BREAKING error.
+    if reason == "schema_changed" and stored_schema_fingerprint is not None:
         return MetadataCheckResult(
             file_path=asset_path,
             status=MetadataStatus.BREAKING,

--- a/portolan_cli/metadata/scan.py
+++ b/portolan_cli/metadata/scan.py
@@ -23,6 +23,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
+from portolan_cli.checksums import compute_checksum
 from portolan_cli.metadata.detection import (
     check_file_metadata,
     detect_changes,
@@ -337,6 +338,25 @@ def _check_collection_level_asset(
             status=MetadataStatus.FRESH,
             message=f"Metadata is up to date ({reason})",
         )
+    # Older catalogs (and entries written before heuristics were persisted) carry
+    # no schema-fingerprint baseline, so `is_stale` treats any mtime change as an
+    # unprovable change and forces STALE. Before reporting that, fall back to the
+    # stored content hash — the same tiebreaker `add` uses to skip unchanged files
+    # (`is_current`, query.py). A byte-identical asset (e.g. after a `git clone`,
+    # which resets mtimes) then reads FRESH instead of a perpetual STALE that
+    # neither `--fix` nor a plain `add` can clear (#512). Newer catalogs carry
+    # heuristics and resolve touched-but-identical without hashing.
+    stored_sha256 = stored.get("sha256")
+    if (
+        stored_schema_fingerprint is None
+        and isinstance(stored_sha256, str)
+        and _content_hash_matches(asset_path, stored_sha256)
+    ):
+        return MetadataCheckResult(
+            file_path=asset_path,
+            status=MetadataStatus.FRESH,
+            message="Metadata is up to date (content unchanged)",
+        )
     changes = detect_changes(state)
     # Only escalate to BREAKING when a stored schema fingerprint actually
     # exists to compare against. Without a baseline (older catalogs, or entries
@@ -357,6 +377,24 @@ def _check_collection_level_asset(
         changes=changes,
         fix_hint="Run 'portolan add' to refresh the collection-level asset",
     )
+
+
+def _content_hash_matches(asset_path: Path, stored_sha256: str) -> bool:
+    """True if the asset file's SHA-256 equals the stored checksum.
+
+    Mirrors the slow-path tiebreaker in `is_current` (query.py) so `check`
+    agrees with `add`'s skip decision: a byte-identical asset is FRESH even
+    when its mtime moved (e.g. after `git clone`, which resets mtimes). Only
+    regular files are hashed — freshness-checkable collection-level assets are
+    always `.parquet`/`.tif`/`.tiff` files (see `_is_freshness_checkable`); a
+    directory asset falls through to the mtime path (and `add` can clear it).
+    """
+    if not asset_path.is_file():
+        return False
+    try:
+        return compute_checksum(asset_path) == stored_sha256
+    except (ValueError, OSError):
+        return False
 
 
 def _read_versions_entry(versions_path: Path, asset_filename: str) -> dict[str, Any] | None:

--- a/portolan_cli/metadata/update.py
+++ b/portolan_cli/metadata/update.py
@@ -291,9 +291,11 @@ def update_versions_tracking(file_path: Path, versions_path: Path) -> None:
     # Get current mtime from file
     current_mtime = file_path.stat().st_mtime
 
-    # Create updated asset with new mtime. Preserve all other tracking fields
-    # (mtime, feature_count, schema_fingerprint) so refreshing source_mtime does
-    # not wipe the freshness heuristics used by the metadata_fresh check (#512).
+    # Refresh both mtime fields to the current file so the entry stays
+    # internally consistent — carrying the current `source_mtime` next to a
+    # stale `mtime` would leave the two fields describing different on-disk
+    # states. Preserve the freshness heuristics (feature_count,
+    # schema_fingerprint) so refreshing mtime does not wipe them (#512).
     old_asset = current_version.assets[asset_name]
     updated_asset = Asset(
         sha256=old_asset.sha256,
@@ -301,7 +303,7 @@ def update_versions_tracking(file_path: Path, versions_path: Path) -> None:
         href=old_asset.href,
         source_path=old_asset.source_path,
         source_mtime=current_mtime,
-        mtime=old_asset.mtime,
+        mtime=current_mtime,
         feature_count=old_asset.feature_count,
         schema_fingerprint=old_asset.schema_fingerprint,
     )

--- a/portolan_cli/metadata/update.py
+++ b/portolan_cli/metadata/update.py
@@ -291,7 +291,9 @@ def update_versions_tracking(file_path: Path, versions_path: Path) -> None:
     # Get current mtime from file
     current_mtime = file_path.stat().st_mtime
 
-    # Create updated asset with new mtime
+    # Create updated asset with new mtime. Preserve all other tracking fields
+    # (mtime, feature_count, schema_fingerprint) so refreshing source_mtime does
+    # not wipe the freshness heuristics used by the metadata_fresh check (#512).
     old_asset = current_version.assets[asset_name]
     updated_asset = Asset(
         sha256=old_asset.sha256,
@@ -299,6 +301,9 @@ def update_versions_tracking(file_path: Path, versions_path: Path) -> None:
         href=old_asset.href,
         source_path=old_asset.source_path,
         source_mtime=current_mtime,
+        mtime=old_asset.mtime,
+        feature_count=old_asset.feature_count,
+        schema_fingerprint=old_asset.schema_fingerprint,
     )
 
     # Create updated assets dict

--- a/portolan_cli/versions.py
+++ b/portolan_cli/versions.py
@@ -76,6 +76,11 @@ class Asset:
             conversion occurred. Used to detect when source has changed.
         mtime: Optional Unix timestamp of the asset file itself.
             Used for fast-path change detection per ADR-0017.
+        feature_count: Optional feature/row count (pixel count for rasters)
+            captured when the asset was tracked. Lets a touched-but-identical
+            asset read FRESH instead of a spurious STALE (ADR-0017 heuristics).
+        schema_fingerprint: Optional hash of the asset schema captured when the
+            asset was tracked. Used to detect breaking schema changes.
     """
 
     sha256: str
@@ -84,6 +89,8 @@ class Asset:
     source_path: str | None = None
     source_mtime: float | None = None
     mtime: float | None = None
+    feature_count: int | None = None
+    schema_fingerprint: str | None = None
 
 
 @dataclass(frozen=True)
@@ -180,6 +187,9 @@ def _parse_versions_file(data: dict[str, Any]) -> VersionsFile:
                     source_mtime=asset_data.get("source_mtime"),
                     # Optional asset mtime for ADR-0017 fast-path
                     mtime=asset_data.get("mtime"),
+                    # Optional freshness heuristics (ADR-0017)
+                    feature_count=asset_data.get("feature_count"),
+                    schema_fingerprint=asset_data.get("schema_fingerprint"),
                 )
                 for name, asset_data in v["assets"].items()
             }
@@ -254,7 +264,8 @@ def write_versions(path: Path, versions_file: VersionsFile) -> None:
 def _serialize_asset(asset: Asset) -> dict[str, Any]:
     """Serialize an Asset to a JSON-compatible dictionary.
 
-    Only includes optional fields (source_path, source_mtime, mtime) when not None.
+    Only includes optional fields (source_path, source_mtime, mtime,
+    feature_count, schema_fingerprint) when not None.
 
     Args:
         asset: The Asset to serialize.
@@ -274,6 +285,10 @@ def _serialize_asset(asset: Asset) -> dict[str, Any]:
         data["source_mtime"] = asset.source_mtime
     if asset.mtime is not None:
         data["mtime"] = asset.mtime
+    if asset.feature_count is not None:
+        data["feature_count"] = asset.feature_count
+    if asset.schema_fingerprint is not None:
+        data["schema_fingerprint"] = asset.schema_fingerprint
     return data
 
 

--- a/spec/schema/versions.schema.json
+++ b/spec/schema/versions.schema.json
@@ -115,6 +115,16 @@
           "type": "number",
           "minimum": 0,
           "description": "Optional Unix timestamp of the asset file itself. Used for fast-path change detection (ADR-0017). NOTE: Accepts number (not just integer) because Python's os.stat().st_mtime returns floats. This relaxation should be upstreamed to portolan-spec."
+        },
+        "feature_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional feature/row count (pixel count for rasters) captured when the asset was tracked. Freshness heuristic (ADR-0017): lets a touched-but-identical asset read fresh instead of stale."
+        },
+        "schema_fingerprint": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional hash of the asset schema captured when the asset was tracked. Freshness heuristic (ADR-0017): a change indicates a breaking schema change."
         }
       }
     },

--- a/spec/versions.md
+++ b/spec/versions.md
@@ -87,6 +87,11 @@ The collection directory name **MUST NOT** appear in the asset key. The asset ke
 | `sha256` | string | **MUST** | SHA-256 checksum of the file content |
 | `size_bytes` | integer | **MUST** | File size in bytes |
 | `href` | string | **MUST** | Catalog-root-relative path to the asset (e.g., `"boundaries/districts/districts.parquet"`) |
+| `source_path` | string | *MAY* | Relative path to the original source file (e.g., the GeoJSON converted to this GeoParquet) |
+| `source_mtime` | number | *MAY* | Unix timestamp of the source file when conversion occurred; used to detect when the source has changed |
+| `mtime` | number | *MAY* | Unix timestamp of the asset file itself; fast-path change detection (ADR-0017) |
+| `feature_count` | integer | *MAY* | Feature/row count (pixel count for rasters) when tracked; freshness heuristic (ADR-0017) |
+| `schema_fingerprint` | string | *MAY* | Hash of the asset schema when tracked; a change indicates a breaking schema change (ADR-0017) |
 
 ## Versioning Rules
 

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -1175,3 +1175,184 @@ class TestVectorFormatOrphans:
         assert stray.name in orphan_names, (
             f"{ext} stray must be ORPHANED, got: {orphan_names}. full={report.to_dict()}"
         )
+
+
+# =============================================================================
+# #512: collection-level vector assets must not be perpetually STALE
+# =============================================================================
+
+
+def _write_versions_json_mtime_only(
+    collection_dir: Path,
+    *,
+    asset_filename: str,
+    file_path: Path,
+) -> None:
+    """Write a versions.json in the exact shape real ``add`` produces today.
+
+    Crucially this records ONLY the ``mtime`` field (the asset file's own
+    mtime) — no ``source_mtime`` and no ``feature_count`` /
+    ``schema_fingerprint`` heuristics. This is what
+    ``_batch_update_versions`` writes and what pre-fix / dogfooded catalogs
+    (e.g. the IGN Argentina port) contain on disk.
+    """
+    import hashlib
+
+    sha = hashlib.sha256(file_path.read_bytes()).hexdigest()
+    versions = {
+        "spec_version": "1.0.0",
+        "current_version": "1.0.0",
+        "versions": [
+            {
+                "version": "1.0.0",
+                "created": "2024-01-01T00:00:00Z",
+                "breaking": False,
+                "changes": [asset_filename],
+                "assets": {
+                    asset_filename: {
+                        "sha256": sha,
+                        "size_bytes": file_path.stat().st_size,
+                        "href": f"{collection_dir.name}/{asset_filename}",
+                        "mtime": file_path.stat().st_mtime,
+                    }
+                },
+            }
+        ],
+    }
+    (collection_dir / "versions.json").write_text(json.dumps(versions, indent=2))
+
+
+@pytest.mark.integration
+class TestIssue512CollectionFreshnessAfterAdd:
+    """#512: a collection-level vector asset added by `portolan add` must read
+    FRESH on the next scan.
+
+    Regression: `add` records only `mtime`, but the freshness check read
+    `source_mtime` (never written) → perpetual STALE that neither `--fix`
+    nor re-`add` could clear.
+    """
+
+    def test_add_then_scan_reports_fresh(
+        self,
+        fresh_catalog_no_versions: Path,
+        fixtures_dir: Path,
+    ) -> None:
+        """The true end-to-end #512 guard: real add → scan → FRESH.
+
+        Pre-fix this yields a STALE result for census.parquet because the
+        real `add` write path never records `source_mtime`.
+        """
+        from portolan_cli.add import add
+
+        collection_dir = fresh_catalog_no_versions / "demographics"
+        collection_dir.mkdir()
+        target_file = collection_dir / "census.parquet"
+        target_file.write_bytes((fixtures_dir / "simple.parquet").read_bytes())
+
+        add(
+            catalog_root=fresh_catalog_no_versions,
+            path=target_file,
+            collection_id="demographics",
+            item_id=None,
+            title="Census Data 2020",
+            description="Population demographics from 2020 census",
+        )
+
+        report = scan_catalog_metadata(fresh_catalog_no_versions)
+
+        asset_results = [r for r in report.results if r.file_path.name == "census.parquet"]
+        assert len(asset_results) == 1, f"expected one result, got: {report.to_dict()}"
+        assert asset_results[0].status == MetadataStatus.FRESH, (
+            f"freshly added collection-level asset must be FRESH, "
+            f"got {asset_results[0].status}: {report.to_dict()}"
+        )
+
+    def test_mtime_only_versions_entry_reads_fresh(
+        self,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+    ) -> None:
+        """An existing catalog whose versions.json has only `mtime` (no
+        `source_mtime`, no heuristics) reads FRESH when the file is
+        unchanged — heals the reporter's on-disk catalogs without re-add.
+        """
+        catalog_dir = tmp_path / "catalog"
+        catalog_dir.mkdir()
+        _write_catalog_json(catalog_dir)
+        collection_dir = catalog_dir / "boundaries"
+        collection_dir.mkdir()
+        data_path = collection_dir / "data.parquet"
+        shutil.copy(valid_points_parquet, data_path)
+        _write_collection_json(
+            collection_dir,
+            collection_id="boundaries",
+            extra_assets={
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "roles": ["data"],
+                }
+            },
+        )
+        _write_versions_json_mtime_only(
+            collection_dir, asset_filename="data.parquet", file_path=data_path
+        )
+
+        report = scan_catalog_metadata(catalog_dir)
+
+        results = [r for r in report.results if r.file_path.name == "data.parquet"]
+        assert len(results) == 1, f"expected one result, got: {report.to_dict()}"
+        assert results[0].status == MetadataStatus.FRESH, (
+            f"mtime-only entry with unchanged file must be FRESH, "
+            f"got {results[0].status}: {report.to_dict()}"
+        )
+
+    def test_mtime_only_entry_never_escalates_to_breaking(
+        self,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+    ) -> None:
+        """Without a stored `schema_fingerprint` we cannot prove a schema
+        break, so an mtime change on a heuristic-less entry must degrade to
+        STALE at worst — never a (blocking) BREAKING error.
+        """
+        import os
+
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        catalog_dir = tmp_path / "catalog"
+        catalog_dir.mkdir()
+        _write_catalog_json(catalog_dir)
+        collection_dir = catalog_dir / "boundaries"
+        collection_dir.mkdir()
+        data_path = collection_dir / "data.parquet"
+        shutil.copy(valid_points_parquet, data_path)
+        _write_collection_json(
+            collection_dir,
+            collection_id="boundaries",
+            extra_assets={
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "roles": ["data"],
+                }
+            },
+        )
+        _write_versions_json_mtime_only(
+            collection_dir, asset_filename="data.parquet", file_path=data_path
+        )
+
+        # Change the schema (new columns) and bump mtime past the fast path.
+        pq.write_table(pa.table({"a": [1, 2], "b": [3, 4]}), data_path)
+        bumped = data_path.stat().st_mtime + 120.0
+        os.utime(data_path, (bumped, bumped))
+
+        report = scan_catalog_metadata(catalog_dir)
+
+        results = [r for r in report.results if r.file_path.name == "data.parquet"]
+        assert len(results) == 1, f"expected one result, got: {report.to_dict()}"
+        assert results[0].status != MetadataStatus.BREAKING, (
+            f"mtime-only entry must not escalate to BREAKING, "
+            f"got {results[0].status}: {report.to_dict()}"
+        )

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -1356,3 +1356,109 @@ class TestIssue512CollectionFreshnessAfterAdd:
             f"mtime-only entry must not escalate to BREAKING, "
             f"got {results[0].status}: {report.to_dict()}"
         )
+
+    def test_mtime_only_entry_touched_but_identical_reads_fresh(
+        self,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+    ) -> None:
+        """A heuristic-less entry whose asset was touched (mtime moved) but is
+        byte-identical must read FRESH — the `git clone` case.
+
+        Cloning/copying a catalog resets asset mtimes, so a pre-fix (mtime-only)
+        entry's stored mtime no longer matches the file. Without a stored
+        schema-fingerprint baseline, `is_stale` cannot prove the change and
+        forces STALE — a perpetual STALE that `--fix` skips and a plain `add`
+        skips too (its content hash is unchanged). The content-hash fallback
+        must recognise the file as unchanged.
+
+        Regression: RED before the sha256 fallback (STALE), GREEN after.
+        """
+        import os
+
+        catalog_dir = tmp_path / "catalog"
+        catalog_dir.mkdir()
+        _write_catalog_json(catalog_dir)
+        collection_dir = catalog_dir / "boundaries"
+        collection_dir.mkdir()
+        data_path = collection_dir / "data.parquet"
+        shutil.copy(valid_points_parquet, data_path)
+        _write_collection_json(
+            collection_dir,
+            collection_id="boundaries",
+            extra_assets={
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "roles": ["data"],
+                }
+            },
+        )
+        _write_versions_json_mtime_only(
+            collection_dir, asset_filename="data.parquet", file_path=data_path
+        )
+
+        # Simulate a clone/checkout: mtime moves well past the fast-path
+        # tolerance, but the bytes are untouched.
+        bumped = data_path.stat().st_mtime + 120.0
+        os.utime(data_path, (bumped, bumped))
+
+        report = scan_catalog_metadata(catalog_dir)
+
+        results = [r for r in report.results if r.file_path.name == "data.parquet"]
+        assert len(results) == 1, f"expected one result, got: {report.to_dict()}"
+        assert results[0].status == MetadataStatus.FRESH, (
+            f"touched-but-identical mtime-only entry must be FRESH via the "
+            f"content-hash fallback, got {results[0].status}: {report.to_dict()}"
+        )
+
+    def test_mtime_only_entry_with_changed_content_is_not_masked(
+        self,
+        tmp_path: Path,
+        valid_points_parquet: Path,
+    ) -> None:
+        """The content-hash fallback must not mask a genuine change: an entry
+        whose asset actually changed (different bytes) must not read FRESH.
+
+        Guards against the fallback degenerating into an always-FRESH shortcut.
+        """
+        import os
+
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        catalog_dir = tmp_path / "catalog"
+        catalog_dir.mkdir()
+        _write_catalog_json(catalog_dir)
+        collection_dir = catalog_dir / "boundaries"
+        collection_dir.mkdir()
+        data_path = collection_dir / "data.parquet"
+        shutil.copy(valid_points_parquet, data_path)
+        _write_collection_json(
+            collection_dir,
+            collection_id="boundaries",
+            extra_assets={
+                "data": {
+                    "href": "./data.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "roles": ["data"],
+                }
+            },
+        )
+        _write_versions_json_mtime_only(
+            collection_dir, asset_filename="data.parquet", file_path=data_path
+        )
+
+        # Genuinely change the bytes (and bump mtime past the fast path).
+        pq.write_table(pa.table({"a": [1, 2, 3], "b": [4, 5, 6]}), data_path)
+        bumped = data_path.stat().st_mtime + 120.0
+        os.utime(data_path, (bumped, bumped))
+
+        report = scan_catalog_metadata(catalog_dir)
+
+        results = [r for r in report.results if r.file_path.name == "data.parquet"]
+        assert len(results) == 1, f"expected one result, got: {report.to_dict()}"
+        assert results[0].status != MetadataStatus.FRESH, (
+            f"a genuinely changed asset must not be masked as FRESH, "
+            f"got {results[0].status}: {report.to_dict()}"
+        )

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -218,6 +218,64 @@ class TestWriteVersions:
         assert loaded.versions[0].assets["test.parquet"].sha256 == "roundtrip"
 
     @pytest.mark.unit
+    def test_freshness_heuristic_fields_roundtrip(self, tmp_path: Path) -> None:
+        """#512: feature_count + schema_fingerprint survive write→read.
+
+        These per-asset freshness heuristics let a touched-but-identical
+        asset read FRESH instead of a spurious STALE/BREAKING.
+        """
+        asset = Asset(
+            sha256="fp",
+            size_bytes=512,
+            href="test.parquet",
+            source_mtime=1700000000.0,
+            mtime=1700000000.0,
+            feature_count=1000,
+            schema_fingerprint="deadbeefcafef00d",
+        )
+        version = Version(
+            version="1.0.0",
+            created=datetime(2024, 3, 15, 8, 0, 0, tzinfo=timezone.utc),
+            breaking=False,
+            assets={"test.parquet": asset},
+            changes=["test.parquet"],
+        )
+        vf = VersionsFile(spec_version="1.0.0", current_version="1.0.0", versions=[version])
+        versions_path = tmp_path / "versions.json"
+
+        write_versions(versions_path, vf)
+        loaded = read_versions(versions_path).versions[0].assets["test.parquet"]
+
+        assert loaded.feature_count == 1000
+        assert loaded.schema_fingerprint == "deadbeefcafef00d"
+        assert loaded.source_mtime == 1700000000.0
+
+    @pytest.mark.unit
+    def test_heuristic_fields_default_to_none(self, tmp_path: Path) -> None:
+        """An asset written without heuristics reads them back as None and
+        omits them from the JSON (backward-compatible)."""
+        asset = Asset(sha256="none", size_bytes=1, href="d.parquet")
+        version = Version(
+            version="1.0.0",
+            created=datetime(2024, 3, 15, 8, 0, 0, tzinfo=timezone.utc),
+            breaking=False,
+            assets={"d.parquet": asset},
+            changes=["d.parquet"],
+        )
+        vf = VersionsFile(spec_version="1.0.0", current_version="1.0.0", versions=[version])
+        versions_path = tmp_path / "versions.json"
+
+        write_versions(versions_path, vf)
+        raw = json.loads(versions_path.read_text())
+        entry = raw["versions"][0]["assets"]["d.parquet"]
+        assert "feature_count" not in entry
+        assert "schema_fingerprint" not in entry
+
+        loaded = read_versions(versions_path).versions[0].assets["d.parquet"]
+        assert loaded.feature_count is None
+        assert loaded.schema_fingerprint is None
+
+    @pytest.mark.unit
     def test_write_creates_parent_directories(self, tmp_path: Path) -> None:
         """write_versions creates parent directories if they don't exist."""
         vf = VersionsFile(spec_version="1.0.0", current_version=None, versions=[])


### PR DESCRIPTION
Fixes #512.

## Problem

`portolan check` perpetually reports `metadata_fresh: N stale` for collection-level vector assets (single GeoParquet per ADR-0031), and **neither `check --metadata --fix` nor `portolan add .` can clear it** — violating the invariant in `.claude/rules/scan-check.md`: *"check must never report an issue that `--fix` cannot resolve."* Found by @nlebovits dogfooding the IGN Argentina port (192 collections perpetually stale). The published STAC is correct; this is a freshness-tracking bug.

## Root cause (reproduced)

`add`'s `_batch_update_versions` writes only the `mtime` field to a collection-level asset's `versions.json` entry, but the freshness check `_check_collection_level_asset` reads **`source_mtime`** as its baseline — which is never written for these assets. So `stored_mtime` is `None` → `is_stale` returns `new_file` → **perpetual STALE**. `--fix` skips collection-level assets by design, and re-`add` sees the file unchanged and skips it, so nothing backfills it.

Additional finding: the heuristic fields the check *also* reads (`feature_count`, `schema_fingerprint`) were written by **no code path** and were even forbidden by `versions.schema.json` (`AssetEntry` had `additionalProperties: false`) — the ADR-0017 heuristic fallback was dormant.

## Fix (both halves)

**Read side** (`metadata/scan.py`): use `source_mtime ?? mtime` as the freshness baseline so existing catalogs (which already carry `mtime`) read FRESH with no re-add or backfill. Only escalate to BREAKING when a stored `schema_fingerprint` actually exists to compare against — a mtime-only entry degrades to STALE, never a blocking BREAKING.

**Write side**: add optional `feature_count` + `schema_fingerprint` to the `Asset` model (serialize/parse + both backends), and persist `source_mtime` + heuristics for collection-level freshness-checkable assets in `_batch_update_versions`. Newly-added catalogs then survive clone/touch (touched-but-identical → FRESH via the heuristic fallback). `update_versions_tracking` preserves these on `--fix`.

**Spec** (ADR-0048, CLI repo is spec source of truth): `versions.schema.json` gains the two optional `AssetEntry` fields (`additionalProperties: false` retained); `versions.md` documents them.

## Verification

- End-to-end repro: `init` + `add transport/roads.parquet` + `check --metadata` → no `metadata_fresh` stale (was `1 stale`); versions.json now carries `source_mtime` + `feature_count` + `schema_fingerprint`.
- Tests (TDD, red before / green after): real `add` → scan → FRESH (true regression guard); an existing-catalog `mtime`-only entry reads FRESH; a heuristic-less entry never escalates to BREAKING; `Asset` heuristic round-trip.
- Full unit tier **4765 passed, 5 skipped, 0 failed**; spec-compliance **101 passed**; iceberg unit **37 passed**; `mypy` clean; `ruff` clean; `lint-imports` 5 contracts kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking extra asset metadata in version history, improving freshness and schema-change detection.
  * Collection-level assets created or updated by `add` now preserve freshness-related details more accurately.

* **Bug Fixes**
  * Fixed cases where unchanged assets could be marked stale after a scan.
  * Reduced false breaking-change results when schema history isn’t available.
  * Preserved existing asset tracking info during version updates instead of overwriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->