### PR TITLE
fix: lint linked collections/items, not just root catalog (#604)

### DIFF
--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from pathlib import Path, PurePath
 from typing import Any
 
@@ -22,6 +23,69 @@ from portolan_cli.validation.results import Severity, ValidationResult
 
 # Substring identifying the STAC Table extension in stac_extensions URLs.
 _TABLE_EXTENSION_MARKER = "stac-extensions.github.io/table"
+
+
+def _load_stac_json(path: Path) -> dict[str, Any] | None:
+    """Load a STAC JSON object; return None on malformed JSON or a non-object root.
+
+    Malformed files are reported by other rules (``catalog_json_valid``), so a
+    walker that consumes this helper simply skips them.
+    """
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _is_below_hidden_dir(path: Path, catalog_path: Path) -> bool:
+    """True if any directory between the root and ``path`` is hidden (e.g. .portolan)."""
+    return any(part.startswith(".") for part in path.relative_to(catalog_path).parts[:-1])
+
+
+def iter_stac_object_files(catalog_path: Path) -> Iterator[tuple[Path, dict[str, Any], str]]:
+    """Yield ``(path, data, kind)`` for every STAC object file under a catalog root.
+
+    Walks the root ``catalog.json``, nested sub-catalogs (ADR-0032), every
+    ``collection.json``, and every STAC **Item** — items are identified by
+    content (a GeoJSON ``Feature`` carrying a ``stac_version``), since they use
+    ``{id}.json`` names rather than a fixed filename, and the ``stac_version``
+    requirement keeps raw ``.json`` vector data from being mistaken for an item.
+    ``kind`` is ``"Catalog"``, ``"Collection"``, or ``"Item"``.
+
+    Objects are yielded root-first, then nested catalogs, collections, and items
+    (each group in sorted path order). Hidden directories (e.g. ``.portolan/``)
+    and malformed / non-object JSON are skipped. Shared by ``StacFieldsRule``
+    (field checks) and ``StacLintRule`` (best-practice linting) so both cover
+    the same below-root object set (issues #543, #604).
+    """
+    root = catalog_path / "catalog.json"
+    root_data = _load_stac_json(root)
+    if root_data is not None:
+        yield root, root_data, "Catalog"
+
+    for cat_json in sorted(catalog_path.rglob("catalog.json")):
+        if cat_json == root or _is_below_hidden_dir(cat_json, catalog_path):
+            continue
+        data = _load_stac_json(cat_json)
+        if data is not None:
+            yield cat_json, data, "Catalog"
+
+    for col_json in sorted(catalog_path.rglob("collection.json")):
+        if _is_below_hidden_dir(col_json, catalog_path):
+            continue
+        data = _load_stac_json(col_json)
+        if data is not None:
+            yield col_json, data, "Collection"
+
+    for item_json in sorted(catalog_path.rglob("*.json")):
+        if item_json.name in ("catalog.json", "collection.json"):
+            continue
+        if _is_below_hidden_dir(item_json, catalog_path):
+            continue
+        data = _load_stac_json(item_json)
+        if data is not None and data.get("type") == "Feature" and "stac_version" in data:
+            yield item_json, data, "Item"
 
 
 def _resolve_local_href(collection_dir: Path, href: str) -> Path | None:
@@ -291,7 +355,10 @@ class StacFieldsRule(ValidationRule):
         catalog_file = catalog_path / "catalog.json"
 
         # The root catalog.json must exist and parse; other rules report the
-        # specifics, but a missing/invalid root is a hard stop here too.
+        # specifics, but a missing/invalid root is a hard stop here too. The
+        # shared walker (``iter_stac_object_files``) silently skips a malformed
+        # or non-object root, so guard it explicitly here to keep the precise
+        # diagnostics below.
         try:
             root = json.loads(catalog_file.read_text())
         except (OSError, json.JSONDecodeError) as e:
@@ -302,47 +369,17 @@ class StacFieldsRule(ValidationRule):
 
         # A bare JSON scalar/array is valid JSON (CatalogJsonValidRule accepts it)
         # but not a STAC object; guard before _check_object calls data.get(...).
-        # The nested _load helper applies the same isinstance filter to children.
         if not isinstance(root, dict):
             return self._fail(
                 "catalog.json must be a JSON object",
                 fix_hint="Fix catalog.json first (see catalog_json_valid rule)",
             )
 
-        problems: list[str] = self._check_object(root, Path("catalog.json"), "Catalog")
-
-        # Nested sub-catalogs (ADR-0032). Skip the root (already checked).
-        for cat_json in sorted(catalog_path.rglob("catalog.json")):
-            if cat_json == catalog_file or self._is_hidden(cat_json, catalog_path):
-                continue
-            data = self._load(cat_json)
-            if data is not None:
-                problems.extend(
-                    self._check_object(data, cat_json.relative_to(catalog_path), "Catalog")
-                )
-
-        # Every collection.json in the tree.
-        for col_json in sorted(catalog_path.rglob("collection.json")):
-            if self._is_hidden(col_json, catalog_path):
-                continue
-            data = self._load(col_json)
-            if data is not None:
-                problems.extend(
-                    self._check_object(data, col_json.relative_to(catalog_path), "Collection")
-                )
-
-        # Every STAC Item in the tree. Items use ``{id}.json`` names (not a fixed
-        # ``item.json``), so they are identified by content rather than filename.
-        for item_json in sorted(catalog_path.rglob("*.json")):
-            if item_json.name in ("catalog.json", "collection.json"):
-                continue
-            if self._is_hidden(item_json, catalog_path):
-                continue
-            data = self._load(item_json)
-            if data is not None and self._is_item(data):
-                problems.extend(
-                    self._check_object(data, item_json.relative_to(catalog_path), "Item")
-                )
+        # Walk the root, nested sub-catalogs (ADR-0032), every collection, and
+        # every item (root-first, sorted) via the shared enumerator (issue #543).
+        problems: list[str] = []
+        for path, data, kind in iter_stac_object_files(catalog_path):
+            problems.extend(self._check_object(data, path.relative_to(catalog_path), kind))
 
         if problems:
             preview = "; ".join(problems[:5])
@@ -354,31 +391,6 @@ class StacFieldsRule(ValidationRule):
             )
 
         return self._pass("All required STAC fields present")
-
-    @staticmethod
-    def _is_hidden(path: Path, catalog_path: Path) -> bool:
-        """True if any directory between the root and ``path`` is hidden (e.g. .portolan)."""
-        return any(part.startswith(".") for part in path.relative_to(catalog_path).parts[:-1])
-
-    @staticmethod
-    def _load(path: Path) -> dict[str, Any] | None:
-        """Load a STAC JSON object; return None on malformed JSON (reported elsewhere)."""
-        try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return None
-        return data if isinstance(data, dict) else None
-
-    @staticmethod
-    def _is_item(data: dict[str, Any]) -> bool:
-        """True if a JSON object is a STAC Item.
-
-        A STAC Item is a GeoJSON ``Feature`` carrying a ``stac_version``. The
-        ``stac_version`` requirement distinguishes it from a plain GeoJSON
-        Feature stored as ``.json`` (which has no ``stac_version``), so raw
-        vector data is not misreported as a malformed item.
-        """
-        return data.get("type") == "Feature" and "stac_version" in data
 
     def _check_object(self, data: dict[str, Any], rel: Path, kind: str) -> list[str]:
         """Return required-field / type problems for one catalog, collection, or item."""

--- a/portolan_cli/validation/stac_rules.py
+++ b/portolan_cli/validation/stac_rules.py
@@ -10,14 +10,14 @@ from __future__ import annotations
 import json
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 from urllib.parse import urlsplit
 
 from stac_check.lint import Linter  # type: ignore[import-untyped]
 
 from portolan_cli.validation.results import Severity, ValidationResult
-from portolan_cli.validation.rules import ValidationRule
+from portolan_cli.validation.rules import ValidationRule, iter_stac_object_files
 
 # Phrase the schema validator emits when it cannot fetch a JSON Schema over the
 # network. stac-validator raises ``Could not resolve schema: <uri>. Reason:
@@ -209,6 +209,23 @@ class StacLintRule(ValidationRule):
 
     Uses stac-check's best practices checks. Each check can have
     configurable severity via .portolan/config.yaml.
+
+    stac-check's ``create_best_practices_dict()`` only lints the single object
+    the ``Linter`` was built from, so a recursive ``Linter(catalog.json)`` run
+    reported best-practice violations for the ROOT catalog only — missing
+    summaries, self links, non-searchable identifiers, etc. in linked
+    collections and items went unreported (issue #604). This rule instead walks
+    every STAC object (root, sub-catalogs, collections, items) via
+    :func:`iter_stac_object_files` and aggregates each object's best-practices
+    dict, prefixing every finding with the object's path.
+
+    Each object is linted from its already-parsed dict with ``fast=True`` so
+    stac-check skips schema validation (which fetches schemas over the network)
+    — best-practice checks read only the object's own data, so this makes the
+    rule deterministic offline and independent of the ``strict`` flag (which
+    never affected best-practice output). Filename-derived checks
+    (``check_catalog_id``, ``check_item_id``) do not fire on dict input; Portolan
+    controls those filenames, so the loss is immaterial.
     """
 
     name = "stac_lint"
@@ -253,47 +270,39 @@ class StacLintRule(ValidationRule):
         if not catalog_json.exists():
             return self._pass("No catalog.json found")
 
-        try:
-            linter = Linter(
-                item=str(catalog_json),
-                recursive=True,
-                fast=not self.strict,
-                fast_linting=True,  # Always run BP checks
-            )
-        except Exception as e:
-            # Best-practice linting can't run if an extension schema can't be
-            # fetched, but that is not a lint violation — pass rather than
-            # block the catalog on an unreachable/unpublished extension.
-            if not self.strict and _is_schema_resolution_error(str(e)):
-                return self._pass("Lint skipped (unresolved extension schema)")
-            return self._fail(f"STAC lint failed: {e}")
+        severity_map = self._get_severity_map()
+        skip_checks = self.SKIP_CHECKS | self._runtime_skip_checks
 
-        # Get best practices dict (not an attribute, must call method)
-        bp_dict = linter.create_best_practices_dict()
-
-        # Collect violations by severity
+        # Violations by severity, aggregated across every STAC object.
         errors: list[str] = []
         warnings: list[str] = []
         infos: list[str] = []
 
-        severity_map = self._get_severity_map()
-        skip_checks = self.SKIP_CHECKS | self._runtime_skip_checks
+        for path, data, _kind in iter_stac_object_files(catalog_path):
+            try:
+                # fast=True + a dict item makes stac-check skip schema
+                # validation (no network); best-practice checks read only `data`.
+                linter = Linter(item=data, fast=True, fast_linting=True)
+            except Exception as e:
+                # Best-practice linting can't run if an extension schema can't be
+                # fetched, but that is not a lint violation — skip the object
+                # rather than block the catalog on an unreachable/unpublished
+                # extension. A CORE schema failure is not tolerable (see
+                # _is_schema_resolution_error) and still fails the rule.
+                if not self.strict and _is_schema_resolution_error(str(e)):
+                    continue
+                return self._fail(f"STAC lint failed: {e}")
 
-        for check_name, messages in bp_dict.items():
-            if check_name in skip_checks:
-                continue
-            if not messages:
-                continue
-
-            severity = severity_map.get(check_name, Severity.WARNING)
-            message = messages[0] if isinstance(messages, list) else str(messages)
-
-            if severity == Severity.ERROR:
-                errors.append(f"{check_name}: {message}")
-            elif severity == Severity.WARNING:
-                warnings.append(f"{check_name}: {message}")
-            else:
-                infos.append(f"{check_name}: {message}")
+            rel = PurePath(path.relative_to(catalog_path)).as_posix()
+            self._classify_violations(
+                linter.create_best_practices_dict(),
+                rel,
+                severity_map,
+                skip_checks,
+                errors,
+                warnings,
+                infos,
+            )
 
         if not errors and not warnings:
             return self._pass("All best practice checks passed")
@@ -317,6 +326,37 @@ class StacLintRule(ValidationRule):
             message=f"Best practice issues: {', '.join(parts)}. {detail}",
             fix_hint="Run with --verbose to see all issues",
         )
+
+    def _classify_violations(
+        self,
+        bp_dict: dict[str, Any],
+        rel: str,
+        severity_map: dict[str, Severity],
+        skip_checks: frozenset[str],
+        errors: list[str],
+        warnings: list[str],
+        infos: list[str],
+    ) -> None:
+        """Sort one object's best-practice violations into the severity buckets.
+
+        Each finding is prefixed with ``rel`` (the object's catalog-relative
+        path) so the report names which collection/item is affected, not just
+        the root.
+        """
+        for check_name, messages in bp_dict.items():
+            if check_name in skip_checks or not messages:
+                continue
+
+            severity = severity_map.get(check_name, Severity.WARNING)
+            message = messages[0] if isinstance(messages, list) else str(messages)
+            entry = f"{rel}: {check_name}: {message}"
+
+            if severity == Severity.ERROR:
+                errors.append(entry)
+            elif severity == Severity.WARNING:
+                warnings.append(entry)
+            else:
+                infos.append(entry)
 
     def _compute_skip_checks(self) -> frozenset[str]:
         """Compute checks to skip based on config (called once at init)."""

--- a/tests/fixtures/validation/stac/README.md
+++ b/tests/fixtures/validation/stac/README.md
@@ -16,6 +16,18 @@ Test fixtures for `StacSchemaRule` and `StacLintRule` validation.
 | `self-contained-valid/` | SELF_CONTAINED 1.1.0 catalog (relative hrefs) → collection → item, all valid | Pass schema and fields (relative-href IRI errors must not be treated as failures) |
 | `self-contained-invalid-collection/` | SELF_CONTAINED 1.1.0 catalog whose collection is missing `extent` + `stac_version` | Fail schema and fields (issue #543 regression) |
 | `self-contained-invalid-item/` | SELF_CONTAINED 1.1.0 catalog whose nested item is missing `id` | Fail schema (issue #543 regression) |
+| `lint-below-root/` | SELF_CONTAINED 1.1.0 catalog with a CLEAN root, a collection missing `summaries` + a `rel='self'` link, and an item with a non-searchable id | Fail lint on below-root violations, each attributed to its object path (issue #604 regression) |
+
+### Issue #604 regression fixture (below-root best-practice linting)
+
+`lint-below-root/` pins the `StacLintRule` blind spot fixed in #604. stac-check's
+`create_best_practices_dict()` only lints the object its `Linter` was built from,
+so a recursive `Linter(catalog.json)` run reported best-practice violations for
+the ROOT catalog only. The root here is clean while the linked collection and
+item each carry violations — pre-fix `stac_lint` reported "All best practice
+checks passed"; post-fix it fails with `searchable_identifiers` (ERROR) plus
+`check_summaries` and `check_links_self` (WARNING), each prefixed with the
+offending object's relative path.
 
 ### Issue #543 regression fixtures (STAC 1.1.0, relative hrefs)
 

--- a/tests/fixtures/validation/stac/lint-below-root/catalog.json
+++ b/tests/fixtures/validation/stac/lint-below-root/catalog.json
@@ -1,0 +1,25 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.1.0",
+  "id": "lint-below-root",
+  "title": "Lint Below Root Catalog",
+  "description": "A SELF_CONTAINED catalog (relative hrefs, STAC 1.1.0) whose ROOT is clean but whose linked collection and item carry best-practice violations. Regression fixture for issue #604.",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "./demo-collection/collection.json",
+      "type": "application/json",
+      "title": "Demo Collection"
+    }
+  ]
+}

--- a/tests/fixtures/validation/stac/lint-below-root/demo-collection/Bad Item.json
+++ b/tests/fixtures/validation/stac/lint-below-root/demo-collection/Bad Item.json
@@ -1,0 +1,31 @@
+{
+  "type": "Feature",
+  "stac_version": "1.1.0",
+  "id": "Bad Item ID",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [0, 0]
+  },
+  "bbox": [0, 0, 0, 0],
+  "properties": {
+    "datetime": "2020-01-01T00:00:00Z"
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "./collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "./Bad Item.json",
+      "type": "application/geo+json"
+    }
+  ],
+  "assets": {}
+}

--- a/tests/fixtures/validation/stac/lint-below-root/demo-collection/collection.json
+++ b/tests/fixtures/validation/stac/lint-below-root/demo-collection/collection.json
@@ -1,0 +1,36 @@
+{
+  "type": "Collection",
+  "stac_version": "1.1.0",
+  "id": "demo-collection",
+  "title": "Demo Collection",
+  "description": "Schema-valid collection that violates two best practices below the root: it has no summaries field and no rel='self' link.",
+  "license": "CC0-1.0",
+  "extent": {
+    "spatial": {
+      "bbox": [[-180, -90, 180, 90]]
+    },
+    "temporal": {
+      "interval": [["2020-01-01T00:00:00Z", null]]
+    }
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "../catalog.json",
+      "type": "application/json",
+      "title": "Lint Below Root Catalog"
+    },
+    {
+      "rel": "parent",
+      "href": "../catalog.json",
+      "type": "application/json",
+      "title": "Lint Below Root Catalog"
+    },
+    {
+      "rel": "item",
+      "href": "./Bad Item.json",
+      "type": "application/geo+json",
+      "title": "Bad Item"
+    }
+  ]
+}

--- a/tests/unit/validation/test_stac_rules.py
+++ b/tests/unit/validation/test_stac_rules.py
@@ -71,6 +71,12 @@ def self_contained_invalid_item_catalog() -> Path:
 
 
 @pytest.fixture
+def lint_below_root_catalog() -> Path:
+    """SELF_CONTAINED 1.1.0 catalog: root clean, collection + item violate best practices."""
+    return FIXTURES_DIR / "lint-below-root"
+
+
+@pytest.fixture
 def catalog_invalid_json() -> Path:
     """Path to catalog with invalid JSON syntax."""
     return FIXTURES_DIR / "invalid-json"
@@ -663,6 +669,54 @@ class TestSelfContainedValidation:
         assert not result.passed
         assert result.severity == Severity.ERROR
         assert "id" in result.message
+
+
+@pytest.mark.unit
+class TestBelowRootLint:
+    """Regression tests for issue #604.
+
+    ``StacLintRule`` ran best-practice checks via a single recursive
+    ``Linter(catalog.json).create_best_practices_dict()`` call, but that method
+    only lints the object it was constructed from — the ROOT ``catalog.json``.
+    Best-practice violations in linked collections and items were never
+    surfaced, so ``check --metadata`` reported ``stac_lint`` clean while
+    below-root objects had missing summaries, missing self links,
+    non-searchable identifiers, etc.
+
+    The ``lint-below-root`` fixture has a CLEAN root catalog, a collection
+    missing both ``summaries`` and a ``rel='self'`` link, and an item whose id
+    (``"Bad Item ID"``) is not a searchable identifier. Pre-fix, all three go
+    undetected and the rule returns "All best practice checks passed".
+    """
+
+    def test_below_root_item_id_error_surfaced(self, lint_below_root_catalog: Path) -> None:
+        """An item's non-searchable id (ERROR) is detected below the root."""
+        from portolan_cli.validation.stac_rules import StacLintRule
+
+        result = StacLintRule().check(lint_below_root_catalog)
+        # searchable_identifiers is ERROR by default -> the whole rule fails.
+        assert not result.passed
+        assert result.severity == Severity.ERROR
+        assert "searchable_identifiers" in result.message
+        # The failing object is named so the user can find it.
+        assert "Bad Item" in result.message
+
+    def test_below_root_collection_warnings_surfaced(self, lint_below_root_catalog: Path) -> None:
+        """A collection's missing summaries + self link (WARNING) surface below the root."""
+        from portolan_cli.validation.stac_rules import StacLintRule
+
+        result = StacLintRule().check(lint_below_root_catalog)
+        assert "check_summaries" in result.message
+        assert "check_links_self" in result.message
+
+    def test_below_root_violation_names_collection_path(
+        self, lint_below_root_catalog: Path
+    ) -> None:
+        """Below-root violations carry the collection's path, not the root's."""
+        from portolan_cli.validation.stac_rules import StacLintRule
+
+        result = StacLintRule().check(lint_below_root_catalog)
+        assert "demo-collection" in result.message
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #604.

## Problem

`portolan check --metadata` reported `stac_lint` clean while best-practice violations in **linked collections and items** went unreported. stac-check's `create_best_practices_dict()` only lints the single object its `Linter` was built from, so a recursive `Linter(catalog.json)` run surfaced findings for the **root** `catalog.json` only — missing summaries, missing self links, non-searchable identifiers, etc. below the root were invisible.

This is the best-practices sibling of #543, which fixed the same root-only blind spot for **schema** and **required-field** checks and explicitly scoped `StacLintRule` out.

## Fix

- **`StacLintRule`**: walk every STAC object (root, sub-catalogs, collections, items) and aggregate each object's best-practices dict, prefixing every finding with the object's catalog-relative path so the report names the offending collection/item. Each object is linted from its already-parsed dict with `fast=True`, which makes stac-check skip schema validation (no per-object network fetch) — best-practice checks read only the object's own data, so the rule is now **deterministic offline** and no longer does wasteful recursive schema I/O. Filename-derived checks (`check_catalog_id`/`check_item_id`) don't fire on dict input; Portolan controls those filenames, so the loss is immaterial.
- Extracted the below-root object walk shared with `StacFieldsRule` into **`iter_stac_object_files`** (root-first, sorted, skips hidden dirs + malformed JSON); `StacFieldsRule` now consumes it too, removing the duplicated `rglob` walk.

## Verification

End-to-end on the new fixture, `check --metadata` now reports:

```
✗ stac_lint: Best practice issues: 1 error(s), 2 warning(s).
  demo-collection/Bad Item.json: searchable_identifiers: ...
  demo-collection/collection.json: check_summaries: ...
  demo-collection/collection.json: check_links_self: ...
```

## Tests

Regression fixture `lint-below-root/` (STAC 1.1.0, relative hrefs): clean root, a collection missing summaries + self link, and an item with a non-searchable id. Pre-fix the rule reported "All best practice checks passed"; post-fix it fails with `searchable_identifiers` (ERROR) plus `check_summaries` and `check_links_self` (WARNING), each attributed to its object. Three new tests in `TestBelowRootLint`; full unit tier (4775) + check/metadata integration suites green; all pre-commit gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)