### PR TITLE
fix(add): scan collection-level assets in O(n), not O(n²) (#465)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -205,11 +205,35 @@ def _get_asset_role(path: Path) -> str:
     return _ROLE_MAP.get(path.suffix.lower(), "data")
 
 
+def _batch_sibling_names(sources: list[Path]) -> frozenset[str]:
+    """Base filenames of a batch's source files plus their converted outputs.
+
+    Used to prune cross-item re-scanning of collection-level assets (issue #465).
+    For each source we include its filename and its deterministic converted
+    output ``{stem}.parquet`` (which equals the source for cloud-native parquet).
+
+    Names, not paths, so the per-sibling membership check in ``_scan_item_assets``
+    is a plain set lookup — no ``resolve()``/``stat`` syscall per (file × sibling),
+    which would reintroduce O(n²) I/O. This is collision-safe: siblings only ever
+    share the one collection directory, every batch name carries a geospatial or
+    ``.parquet`` extension, and any real file with such a name is itself tracked
+    by its own ``prepare_item`` (or the deferred non-geo pass). Loose companions
+    that rely solely on the scan (``.txt``/``.png``/``.xml`` …) can never match.
+    """
+    names: set[str] = set()
+    for src in sources:
+        names.add(src.name)
+        names.add(f"{src.stem}.parquet")
+    return frozenset(names)
+
+
 def _scan_item_assets(
     item_dir: Path,
     item_id: str,
     primary_file: Path,
     collection_dir: Path,
+    *,
+    exclude_names: frozenset[str] = frozenset(),
 ) -> tuple[dict[str, pystac.Asset], dict[str, tuple[Path, str, int]], list[str]]:
     """Scan an item directory for all trackable assets.
 
@@ -222,6 +246,14 @@ def _scan_item_assets(
         item_id: Item identifier (for skipping item.json).
         primary_file: Path to the primary data file (gets "data" key).
         collection_dir: Path to the collection directory.
+        exclude_names: Base filenames of OTHER items being added in the same
+            batch (their sources and converted outputs). For a collection-level
+            asset (``item_dir == collection_dir``) the flat collection directory
+            also holds every sibling asset, so without this the scan re-checksums
+            all siblings on every file — O(n²) (issue #465). Files here that do
+            not share the primary's stem are skipped; each is tracked by its own
+            ``prepare_item``. Loose companions (not in this set) are kept per
+            ADR-0028. Ignored for item-level (subdirectory) scans.
 
     Returns:
         Tuple of (stac_assets, asset_files, asset_paths):
@@ -233,9 +265,28 @@ def _scan_item_assets(
     asset_files: dict[str, tuple[Path, str, int]] = {}
     asset_paths: list[str] = []
 
+    # Resolve directory paths once, not per file (these are O(n) scans; a
+    # per-file resolve() would be an O(n²) syscall storm for flat collections).
+    item_dir_resolved = item_dir.resolve()
+    # Issue #465: only prune cross-item siblings for collection-level (flat) scans.
+    is_collection_level = bool(exclude_names) and item_dir_resolved == collection_dir.resolve()
+    # Whether assets and the item.json will be co-located (affects href prefix).
+    assets_colocated = item_dir_resolved == (collection_dir / item_id).resolve()
+    primary_stem = primary_file.stem
+
     for file_path in item_dir.iterdir():
         # Skip symlinks and hidden files unconditionally
         if file_path.name.startswith("."):
+            continue
+
+        # Issue #465: skip siblings that belong to OTHER items in this batch.
+        # Keep the primary and its own same-stem source/sidecars; keep loose
+        # companions (not in exclude_names) so ADR-0028 tracking is preserved.
+        if (
+            is_collection_level
+            and file_path.stem != primary_stem
+            and file_path.name in exclude_names
+        ):
             continue
         if file_path.name in IGNORED_FILES:
             continue
@@ -294,8 +345,7 @@ def _scan_item_assets(
         # and we need ../ to reach the files. Otherwise, files are already in
         # the item subdirectory.
         #
-        item_json_dir = collection_dir / item_id
-        if item_dir.resolve() == item_json_dir.resolve():
+        if assets_colocated:
             # Assets and item JSON are in the same directory
             asset_href = file_path.name
         else:
@@ -1252,6 +1302,7 @@ def prepare_item(
     item_datetime: datetime | None = None,
     force: bool = False,
     reconvert: bool = False,
+    exclude_sibling_names: frozenset[str] = frozenset(),
 ) -> PreparedItem:
     """Prepare files for addition (convert, extract metadata, create STAC item).
 
@@ -1272,6 +1323,9 @@ def prepare_item(
         item_datetime: Optional acquisition/creation datetime (per ADR-0035).
         force: If True, bypass change detection (Issue #386).
         reconvert: If True, re-convert from source (requires force=True).
+        exclude_sibling_names: Base filenames of other batch items (sources +
+            converted outputs) to prune from a collection-level asset scan
+            (issue #465). Forwarded to _scan_item_assets; see its docstring.
 
     Returns:
         PreparedItem with all metadata needed for finalization.
@@ -1344,6 +1398,7 @@ def prepare_item(
         item_id=item_id_resolved,
         primary_file=output_path,
         collection_dir=collection_dir,
+        exclude_names=exclude_sibling_names,
     )
 
     # Enrich COG assets with render extension properties (Issue #13)
@@ -2555,7 +2610,11 @@ def add_directory(
     Returns:
         List of ItemInfo for each added item.
     """
-    files = iter_geospatial_files(path, recursive=recursive)
+    files = list(iter_geospatial_files(path, recursive=recursive))
+
+    # Issue #465: skip cross-item siblings when scanning collection-level assets
+    # so per-file work stays O(n) instead of O(n²).
+    batch_exclude_names = _batch_sibling_names(files)
 
     # Phase 1: Prepare all items (GDAL work, parallelizable)
     prepared: list[PreparedItem] = []
@@ -2566,6 +2625,7 @@ def add_directory(
             collection_id=collection_id,
             force=force,
             reconvert=reconvert,
+            exclude_sibling_names=batch_exclude_names,
         )
         prepared.append(result)
 
@@ -2804,6 +2864,11 @@ def add_files(
     if not files_to_process:
         return added, skipped, failures
 
+    # Issue #465: filenames of every batch item (sources + converted outputs) so a
+    # collection-level asset scan can skip siblings that are tracked as their own
+    # items instead of re-scanning the whole flat collection dir (O(n²) → O(n)).
+    batch_exclude_names = _batch_sibling_names([fp for fp, _ in files_to_process])
+
     # Import here to avoid circular imports
 
     # Accumulate prepared items for batch finalization (Issue #281)
@@ -2853,6 +2918,7 @@ def add_files(
                                 item_datetime=item_datetime,
                                 force=force,
                                 reconvert=reconvert,
+                                exclude_sibling_names=batch_exclude_names,
                             )
                             # Apply partitioning to each layer (Issue #352)
                             partitioned = _maybe_partition_large_file(
@@ -2892,6 +2958,7 @@ def add_files(
                 item_datetime=item_datetime,
                 force=force,
                 reconvert=reconvert,
+                exclude_sibling_names=batch_exclude_names,
             )
             # Check if file should be partitioned (Issue #352)
             # Returns multiple PreparedItems if partitioned, else [prepared]

--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -56,6 +56,7 @@ from portolan_cli.formats import (
     detect_format,
     is_cloud_optimized_geotiff,
     is_multilayer,
+    list_layers,
 )
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.metadata import (
@@ -219,11 +220,27 @@ def _batch_sibling_names(sources: list[Path]) -> frozenset[str]:
     ``.parquet`` extension, and any real file with such a name is itself tracked
     by its own ``prepare_item`` (or the deferred non-geo pass). Loose companions
     that rely solely on the scan (``.txt``/``.png``/``.xml`` …) can never match.
+
+    Multi-layer sources (GeoPackage/FileGDB) expand to one
+    ``{stem}_{layer}.parquet`` output per layer (``convert_multilayer_file``),
+    each tracked as its own layer item; their names are included so sibling
+    layers skip each other too. ``list_layers`` is cheap for single-layer
+    formats (extension check, no GDAL open) and reuses the exact naming
+    ``convert_multilayer_file`` applies.
     """
     names: set[str] = set()
     for src in sources:
         names.add(src.name)
         names.add(f"{src.stem}.parquet")
+        try:
+            layers = list_layers(src)
+        except Exception:
+            # Pruning is a best-effort optimization; a listing failure only
+            # means a few extra sibling scans, never incorrect output.
+            layers = None
+        if layers:
+            for layer in layers:
+                names.add(f"{src.stem}_{layer}.parquet")
     return frozenset(names)
 
 

--- a/tests/unit/test_add_continue_on_errors.py
+++ b/tests/unit/test_add_continue_on_errors.py
@@ -112,6 +112,7 @@ class TestAddFilesContinuesOnErrors:
             item_datetime: datetime | None = None,
             force: bool = False,
             reconvert: bool = False,
+            exclude_sibling_names: frozenset[str] = frozenset(),
         ) -> MagicMock:
             nonlocal call_count
             call_count += 1
@@ -173,6 +174,7 @@ class TestAddFilesContinuesOnErrors:
             item_datetime: datetime | None = None,
             force: bool = False,
             reconvert: bool = False,
+            exclude_sibling_names: frozenset[str] = frozenset(),
         ) -> MagicMock:
             if "file1" in path.name:
                 raise FileNotFoundError("Source file disappeared")
@@ -224,6 +226,7 @@ class TestAddFilesContinuesOnErrors:
             item_datetime: datetime | None = None,
             force: bool = False,
             reconvert: bool = False,
+            exclude_sibling_names: frozenset[str] = frozenset(),
         ) -> ItemInfo:
             raise ValueError(f"Error processing {path.name}")
 

--- a/tests/unit/test_csv_skip.py
+++ b/tests/unit/test_csv_skip.py
@@ -1389,6 +1389,7 @@ class TestAddFilesCodePaths:
             item_datetime=None,
             force=False,
             reconvert=False,
+            exclude_sibling_names=frozenset(),
         ):
             """Simulate add: success for geojson, geometry error for csv."""
             if path.suffix.lower() == ".geojson":

--- a/tests/unit/test_scan_bounded_465.py
+++ b/tests/unit/test_scan_bounded_465.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 import pytest
 
 import portolan_cli.add as add_mod
-from portolan_cli.add import add_files
+from portolan_cli.add import _batch_sibling_names, add_files
 
 pytestmark = [pytest.mark.unit]
 
@@ -131,3 +131,23 @@ def test_loose_non_geo_companions_are_not_dropped(
     assert any(h.endswith("preview.png") for h in hrefs), (
         f"non-geo companion preview.png was dropped: {hrefs}"
     )
+
+
+def test_batch_sibling_names_includes_multilayer_outputs(fixtures_dir: Path) -> None:
+    """Multi-layer sources contribute their per-layer `{stem}_{layer}.parquet`
+    output names so sibling layer items skip each other in a flat collection
+    scan (issue #465). Without these, each layer's scan re-checksums the other
+    layers' outputs — O(n²) in the layer count.
+    """
+    gpkg = fixtures_dir / "multilayer" / "multilayer.gpkg"
+    names = _batch_sibling_names([gpkg])
+
+    # Source + its single-file output form (always added).
+    assert "multilayer.gpkg" in names
+    assert "multilayer.parquet" in names
+    # Per-layer outputs, matching convert_multilayer_file's `{stem}_{layer}.parquet`.
+    assert {
+        "multilayer_lines.parquet",
+        "multilayer_points.parquet",
+        "multilayer_polygons.parquet",
+    } <= names

--- a/tests/unit/test_scan_bounded_465.py
+++ b/tests/unit/test_scan_bounded_465.py
@@ -1,0 +1,133 @@
+"""Regression tests for issue #465: O(n²) add on collection-level vector assets.
+
+`_scan_item_assets` scans the whole collection directory for every file added.
+For collection-level single-file vector assets (ADR-0031) `item_dir` IS the
+collection dir, so adding N files re-checksums every sibling → O(n²) work. This
+made the 1000-file stress tests exceed the 300s nightly timeout.
+
+These are fast unit tests (copies of the cloud-native `simple.parquet` fixture,
+no GDAL conversion). Test 1 bounds the redundant scan; Test 2 guards against the
+fix over-skipping and dropping legitimate non-geo companion assets (ADR-0028).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import portolan_cli.add as add_mod
+from portolan_cli.add import add_files
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def initialized_catalog(tmp_path: Path) -> Path:
+    """Minimal initialized catalog (ADR-0023/0029)."""
+    portolan_dir = tmp_path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
+    catalog_data = {
+        "type": "Catalog",
+        "stac_version": "1.0.0",
+        "id": "test-catalog",
+        "description": "Test catalog for issue #465",
+        "links": [],
+    }
+    (tmp_path / "catalog.json").write_text(json.dumps(catalog_data, indent=2))
+    return tmp_path
+
+
+def _collection_assets(collection_dir: Path) -> dict[str, dict]:
+    data = json.loads((collection_dir / "collection.json").read_text())
+    return data.get("assets", {})
+
+
+def test_collection_level_scan_is_bounded_not_quadratic(
+    initialized_catalog: Path, fixtures_dir: Path
+) -> None:
+    """Adding N collection-level vectors must NOT re-checksum every sibling.
+
+    Pre-fix, each file's scan re-checksums all N siblings, so `compute_checksum`
+    is called on the order of N·(N+1)/2 times (≈820 for N=40). Post-fix each file
+    checksums only itself (+ its own sidecars), so the count is O(N). The bound
+    3*N (120) sits far below the quadratic value and above the true linear count.
+    """
+    n = 40
+    collection_dir = initialized_catalog / "many"
+    collection_dir.mkdir()
+    fixture_bytes = (fixtures_dir / "simple.parquet").read_bytes()
+    for i in range(n):
+        (collection_dir / f"f{i:04d}.parquet").write_bytes(fixture_bytes)
+
+    real_compute_checksum = add_mod.compute_checksum
+    call_count = 0
+
+    def counting_checksum(path: Path) -> str:
+        nonlocal call_count
+        call_count += 1
+        return real_compute_checksum(path)
+
+    with patch.object(add_mod, "compute_checksum", side_effect=counting_checksum):
+        added, _skipped, failures = add_files(
+            paths=[collection_dir],
+            catalog_root=initialized_catalog,
+            collection_id="many",
+        )
+
+    assert not failures, f"unexpected failures: {failures}"
+
+    # Bound: linear, not quadratic. Pre-fix ≈ n*(n+1)/2 = 820 ≫ 120.
+    assert call_count <= 3 * n, (
+        f"compute_checksum called {call_count} times for {n} files "
+        f"(expected O(n) <= {3 * n}; quadratic would be ~{n * (n + 1) // 2}). "
+        "The collection-level scan is re-checksumming siblings (issue #465)."
+    )
+
+    # Correctness: the bound must not be met by dropping assets. All N must be
+    # tracked in collection.json and in the single versions.json version entry.
+    assets = _collection_assets(collection_dir)
+    assert len(assets) == n, f"expected {n} assets, got {len(assets)}: {sorted(assets)}"
+
+    versions_data = json.loads((collection_dir / "versions.json").read_text())
+    assert len(versions_data["versions"]) == 1
+    version_assets = versions_data["versions"][0]["assets"]
+    assert len(version_assets) == n, (
+        f"expected {n} assets in versions.json, got {len(version_assets)}"
+    )
+
+
+def test_loose_non_geo_companions_are_not_dropped(
+    initialized_catalog: Path, fixtures_dir: Path
+) -> None:
+    """Non-geo companions (not in GEOSPATIAL_EXTENSIONS) must stay tracked.
+
+    Files like `.txt`/`.png` are filtered out of `files_to_process` and are never
+    deferred, so at collection level they are tracked ONLY by the sibling scan.
+    The O(n²) fix must skip only *other items'* geo files, never these companions
+    (ADR-0028). Guards against an over-aggressive skip rule.
+    """
+    collection_dir = initialized_catalog / "with-companions"
+    collection_dir.mkdir()
+    (collection_dir / "data.parquet").write_bytes((fixtures_dir / "simple.parquet").read_bytes())
+    (collection_dir / "notes.txt").write_text("field notes for this dataset\n")
+    (collection_dir / "preview.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+
+    added, _skipped, failures = add_files(
+        paths=[collection_dir],
+        catalog_root=initialized_catalog,
+        collection_id="with-companions",
+    )
+    assert not failures, f"unexpected failures: {failures}"
+
+    hrefs = {a.get("href", "") for a in _collection_assets(collection_dir).values()}
+    assert any(h.endswith("data.parquet") for h in hrefs), f"geo asset missing: {hrefs}"
+    assert any(h.endswith("notes.txt") for h in hrefs), (
+        f"non-geo companion notes.txt was dropped: {hrefs}"
+    )
+    assert any(h.endswith("preview.png") for h in hrefs), (
+        f"non-geo companion preview.png was dropped: {hrefs}"
+    )


### PR DESCRIPTION
## Summary

Fixes #465 — the 1000-file stress tests (`TestScaleAt1000Files`) time out at the
300s nightly `pytest-timeout` because `portolan add` on a collection of
single-file vector assets is **O(n²)**, not linear.

The earlier issue comment ("~145 ms/file, linear, ~2.4 min for 1000 files; 300s
is enough") measured only geoparquet-io's conversion in isolation and missed the
superlinear STAC-assembly work. Benchmarking the real `add` CLI on *fresh*
catalogs shows per-file cost **growing** with n:

| files | total | ms/file | cost of doubling |
|------:|------:|--------:|-----------------:|
| 50  | 13.8s | 277 | — |
| 100 | 27.1s | 271 | ×1.96 |
| 200 | 66.0s | 330 | ×2.44 |
| 400 | 203.3s | 508 | ×3.08 |

Each doubling costs progressively more than 2× → O(n²). Even the naive linear
extrapolation from n=400 is 508s > 300s.

## Root cause

`_scan_item_assets` does `for file_path in item_dir.iterdir()`. For
collection-level single-file vector assets (ADR-0031), `prepare_item` sets
`item_dir = path.parent`, which **is the collection directory**. So every file's
`prepare_item` re-scans and re-checksums **every sibling** in the flat collection
dir. cProfile at n=150 confirms it: `compute_checksum` called 33,825 times and
`get_current_metadata` called exactly `150·151/2 = 11,325` (a triangular number).
The bloated live-object graph also made geoparquet-io's per-file `gc.collect()`
scan an O(n²) heap — which is where the original timeout traceback landed.

Output was always correct (versions.json / collection.json dedupe by key), so
this was pure wasted work — safe to remove.

## Fix

Build the set of other batch items' base filenames (sources + deterministic
converted outputs) once per `add`, and skip them in the **collection-level** scan
(`item_dir == collection_dir`) while keeping the primary's own same-stem
source/sidecars and any loose companion not in the set. Item-level (subdir)
scans are untouched. Non-geo companions (issue #383) are unaffected — they are
tracked in the separate deferred Phase 3, not by the sibling scan.

Membership is by **filename**, not resolved path, so the per-sibling check is a
plain set lookup with no `resolve()`/`stat` syscall — a path-based set would
reintroduce an O(n²) syscall storm (one `lstat` per file × sibling). This is
collision-safe: siblings share the one collection dir, every batch name carries a
geospatial/`.parquet` extension, and any real file with such a name is tracked by
its own `prepare_item`/the deferred pass; loose companions (`.txt`/`.png`/…) can
never match. The two directory `resolve()` calls in the scan are also hoisted out
of the per-file loop.

`portolan_cli/add.py` only: new `exclude_sibling_names` keyword threaded through
`add_files`/`add_directory` → `prepare_item` → `_scan_item_assets`, plus a
`_batch_sibling_names` helper. No change to `stac.py` or the dedupe backstops.

## Result

Per-file cost is now flat and scaling is linear (each doubling ×2.0):

| files | before | after | ms/file after |
|------:|-------:|------:|--------------:|
| 50  | 13.8s | 11.9s | 237 |
| 100 | 27.1s | 23.2s | 232 |
| 200 | 66.0s | 47.3s | 237 |
| 400 | 203.3s | 96.2s | 240 |

The 1000-file stress test now completes well under the 300s timeout (verified
locally). The remaining per-file cost is geoparquet-io conversion (linear).

## Tests

New fast unit regression tests (`tests/unit/test_scan_bounded_465.py`):
- **bounded scan** — 40 flat collection-level parquet assets; asserts
  `compute_checksum` is called O(n) (≤ 3N), and that all 40 assets are still
  tracked. Pre-fix this is ~1600 calls → red; post-fix ~80 → green.
- **companions not dropped** — `.txt`/`.png` companions beside a collection-level
  vector stay in `collection.json` (guards against over-skipping, ADR-0028).

Guard suites pass unchanged (collection-level workflow incl. #383, asset
key/href shape, batch versioning, snapshot accumulation, cloud-native vectors).
Two test mocks of `prepare_item` were updated for the new keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved add performance for large collections by avoiding repeated asset re-scans, reducing checksum work and preventing slow batch processing.
  * Preserved collection assets more reliably, including companion files alongside geo and non-geo Parquet files.
  * Fixed handling for batch imports so sibling items are no longer unnecessarily skipped during scans.
* **Tests**
  * Added regression coverage for performance bounds and asset retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->