### PR TITLE
ci(security): harden all workflows + add actionlint/zizmor gates (PR 1/5)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait 7 days before proposing a freshly-published version: fresh releases
+    # are where supply-chain compromises surface, and the delay lets advisories
+    # and yanks catch up before the update reaches a PR (zizmor dependabot-cooldown).
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"
@@ -18,6 +23,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # See the github-actions block above: 7-day delay before adopting a fresh
+    # release (zizmor dependabot-cooldown).
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "python"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@
 #
 # Philosophy: Starting from zero, all quality gates are STRICT.
 # Nothing passes with warnings - fix issues or they block the PR.
+#
+# Supply-chain hardening (see sync-spec.yml for the canonical pattern):
+# - Least-privilege GITHUB_TOKEN: read-only at the top level, widened per job.
+# - Third-party actions are SHA-pinned with a trailing version comment
+#   (Dependabot maintains the pins). actionlint + zizmor (prek.toml) guard this.
+# - persist-credentials: false on every checkout (no job pushes to the repo).
+# - Every job has a timeout so a hung step can't burn the runner budget.
 name: CI
 on:
   push:
@@ -11,16 +18,28 @@ on:
     branches: [main]
   workflow_dispatch:  # Allow manual triggering
 
+# Least-privilege default; no job here writes to the repo.
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (a new push to a PR obsoletes the old).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       iceberg: ${{ steps.filter.outputs.iceberg }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -32,11 +51,14 @@ jobs:
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
@@ -44,7 +66,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -69,11 +91,14 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
@@ -81,7 +106,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -122,6 +147,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }} / ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -138,15 +164,17 @@ jobs:
       # GitHub Actions runners aren't EC2 instances, so IMDS requests fail
       AWS_EC2_METADATA_DISABLED: "true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -162,7 +190,7 @@ jobs:
         run: brew install tippecanoe
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -174,7 +202,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: portolan-sdi/portolan-cli
@@ -184,6 +212,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.iceberg == 'true' || github.event_name == 'push'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -192,15 +221,17 @@ jobs:
     env:
       AWS_EC2_METADATA_DISABLED: "true"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -208,7 +239,7 @@ jobs:
           command: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -220,7 +251,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: portolan-sdi/portolan-cli
@@ -231,20 +262,23 @@ jobs:
     needs: changes
     if: needs.changes.outputs.iceberg == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -252,7 +286,7 @@ jobs:
           command: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -282,11 +316,14 @@ jobs:
   dead-code:
     name: Dead Code, Complexity & Duplication
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
@@ -294,7 +331,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -313,11 +350,14 @@ jobs:
   docs:
     name: Documentation Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
@@ -325,7 +365,7 @@ jobs:
         run: uv python install 3.11
 
       - name: Install dependencies
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -341,11 +381,14 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+# Least-privilege default; the deploy job widens for Pages/OIDC below.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -21,16 +20,19 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -41,7 +43,7 @@ jobs:
         run: uv run mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./site
 
@@ -49,10 +51,15 @@ jobs:
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write      # Deploy to GitHub Pages
+      id-token: write   # OIDC token for Pages deployment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,18 +9,26 @@ on:
     - cron: '0 4 * * *'  # 4 AM UTC daily
   workflow_dispatch:  # Allow manual triggering
 
+# Nightly jobs only read the repo. A job needing more (e.g. network-live opening
+# a tracking issue) widens its own permissions block.
+permissions:
+  contents: read
+
 jobs:
   mutation:
     name: Mutation Testing
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -76,7 +84,8 @@ jobs:
           # Fail if kill rate drops below 60%
           # Start conservative; increase as test suite matures (see ci.md)
           MIN_KILL_RATE=60
-          if [ $(echo "$KILL_RATE < $MIN_KILL_RATE" | bc) -eq 1 ]; then
+          below_floor=$(echo "$KILL_RATE < $MIN_KILL_RATE" | bc)
+          if [ "$below_floor" -eq 1 ]; then
             echo "::error::Mutation kill rate ($KILL_RATE%) is below threshold ($MIN_KILL_RATE%)"
             echo "Tests are not catching enough bugs. Review survived mutants:"
             uv run mutmut results --all true | grep -E ': survived$' | head -20
@@ -93,7 +102,7 @@ jobs:
           cp mutants/mutmut-cicd-stats.json .
 
       - name: Upload mutation report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-report
           path: |
@@ -105,16 +114,18 @@ jobs:
   benchmark:
     name: Performance Benchmarks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0  # Full history to compare with previous runs
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -148,7 +159,7 @@ jobs:
           fi
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results
           path: benchmark-results.json
@@ -158,14 +169,17 @@ jobs:
   network-live:
     name: Live Network Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -185,14 +199,17 @@ jobs:
   slow-tests:
     name: Slow Tests (Stress/Scale)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -212,16 +229,19 @@ jobs:
   dependency-check:
     name: Dependency Audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Note: Job-level continue-on-error removed. Only audit steps soft-fail.
     # Setup steps (checkout, uv, python) fail fast on errors.
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3
@@ -256,14 +276,17 @@ jobs:
   iceberg-e2e-full:
     name: Iceberg E2E Tests (Full Suite)
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
-        uses: nick-fields/retry@v4
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 5
           max_attempts: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,22 +20,33 @@ on:
     branches: [main]
   workflow_dispatch:  # Manual trigger for recovery scenarios
 
+# Least-privilege default; the release job widens to write tags/releases + OIDC.
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Run if: push with bump commit OR manual trigger (workflow_dispatch)
     if: startsWith(github.event.head_commit.message, 'bump:') || github.event_name == 'workflow_dispatch'
     permissions:
       contents: write  # Required for creating tags and releases
       id-token: write  # Required for trusted PyPI publishing
     steps:
-      - uses: actions/checkout@v7
+      # This is the ONE checkout that must keep credentials: the job pushes the
+      # release tag back to the repo (git push origin <tag>) using GITHUB_TOKEN.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0  # zizmor: ignore[artipacked] deliberate: tag push needs the persisted token
         with:
           fetch-depth: 0  # Full history for tag creation
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        # Cache disabled on the publish path: a poisoned cache could taint the
+        # artifact we push to PyPI (zizmor cache-poisoning).
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.11
@@ -57,7 +68,7 @@ jobs:
       - name: Check release status
         id: release_check
         run: |
-          TAG="v${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
 
           # Check if GitHub Release exists (the real indicator of a completed release)
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -77,14 +88,18 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pass step outputs through env, not a ${{ }} splice into the shell body.
+          VERSION: ${{ steps.version.outputs.version }}
 
       - name: Create git tag
         if: steps.release_check.outputs.tag_exists == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
 
       - name: Build package
         if: steps.release_check.outputs.release_exists == 'false'
@@ -92,16 +107,17 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.release_check.outputs.release_exists == 'false'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           print-hash: true
 
       - name: Create GitHub Release
         if: steps.release_check.outputs.release_exists == 'false'
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
-            --title "${{ steps.version.outputs.tag }}" \
-            --notes "See [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details." \
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "See [CHANGELOG](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md) for details." \
             dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -23,6 +23,7 @@ jobs:
   audit:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # No issues: write needed for this job
     permissions:
       contents: read
@@ -31,10 +32,12 @@ jobs:
       vuln_count: ${{ steps.audit.outputs.vuln_count }}
       vuln_packages: ${{ steps.audit.outputs.vuln_packages }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version: "0.6.14"
 
@@ -107,7 +110,7 @@ jobs:
           fi
 
       - name: Upload audit artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: security-audit-reports
           path: |
@@ -121,6 +124,7 @@ jobs:
     name: Manage Security Issue
     needs: audit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only this job needs issues: write (least privilege)
     permissions:
       contents: read
@@ -128,14 +132,14 @@ jobs:
     steps:
       - name: Download audit report
         if: needs.audit.outputs.has_vulnerabilities == 'true'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: security-audit-reports
           path: /tmp/audit
 
       - name: Find existing security issue
         id: find-issue
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const issues = await github.rest.issues.listForRepo({
@@ -161,13 +165,20 @@ jobs:
 
       - name: Create or update issue (vulnerabilities found)
         if: needs.audit.outputs.has_vulnerabilities == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        # Pass the prior step's output through env, not a ${{ }} splice into the
+        # script body (zizmor template-injection). Read it via process.env below.
+        env:
+          ISSUE_NUMBER: ${{ steps.find-issue.outputs.issue_number }}
+          ISSUE_EXISTS: ${{ steps.find-issue.outputs.issue_exists }}
+          VULN_COUNT: ${{ needs.audit.outputs.vuln_count }}
+          VULN_PACKAGES: ${{ needs.audit.outputs.vuln_packages }}
         with:
           script: |
             const fs = require('fs');
             const now = new Date().toISOString();
-            const vulnCount = '${{ needs.audit.outputs.vuln_count }}';
-            const vulnPackages = '${{ needs.audit.outputs.vuln_packages }}';
+            const vulnCount = process.env.VULN_COUNT || '';
+            const vulnPackages = process.env.VULN_PACKAGES || '';
             const runNumber = '${{ github.run_number }}';
             const serverUrl = '${{ github.server_url }}';
             const repo = '${{ github.repository }}';
@@ -227,8 +238,8 @@ jobs:
               '*This issue is automatically managed by the [Security Audit workflow](' + serverUrl + '/' + repo + '/actions/workflows/security-audit.yml). It will be auto-closed when all vulnerabilities are resolved.*'
             ].join('\n');
 
-            const issueExists = '${{ steps.find-issue.outputs.issue_exists }}' === 'true';
-            const issueNumber = parseInt('${{ steps.find-issue.outputs.issue_number }}') || 0;
+            const issueExists = (process.env.ISSUE_EXISTS || '') === 'true';
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER || '0', 10) || 0;
 
             if (issueExists) {
               await github.rest.issues.update({
@@ -251,10 +262,13 @@ jobs:
 
       - name: Close issue (no vulnerabilities)
         if: needs.audit.outputs.has_vulnerabilities == 'false' && steps.find-issue.outputs.issue_exists == 'true'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        # Step output via env, not a ${{ }} splice into the script (zizmor).
+        env:
+          ISSUE_NUMBER: ${{ steps.find-issue.outputs.issue_number }}
         with:
           script: |
-            const issueNumber = parseInt('${{ steps.find-issue.outputs.issue_number }}');
+            const issueNumber = parseInt(process.env.ISSUE_NUMBER || '0', 10);
             const now = new Date().toISOString();
             const runNumber = '${{ github.run_number }}';
             const serverUrl = '${{ github.server_url }}';

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -5,15 +5,25 @@ on:
     - cron: '0 0 * * 0'  # Weekly on Sunday
   workflow_dispatch:  # Manual trigger
 
+# Least-privilege default; the job widens to open its sync PR.
+permissions:
+  contents: read
+
 jobs:
   sync-skills:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write        # create-pull-request pushes the sync branch
+      pull-requests: write   # ...and opens the PR
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
@@ -21,8 +31,9 @@ jobs:
         run: python scripts/sync_skills_readme.py --update
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: sync/skills-install
           delete-branch: true
           title: "sync: Update skills install instructions"

--- a/.github/workflows/sync-spec.yml
+++ b/.github/workflows/sync-spec.yml
@@ -11,9 +11,15 @@ concurrency:
   group: sync-spec-to-mirror
   cancel-in-progress: true  # Latest spec state wins
 
+# Least-privilege default. Cross-repo writes use SPEC_REPO_PAT, not GITHUB_TOKEN,
+# so the workflow token only needs read access to check out this repo.
+permissions:
+  contents: read
+
 jobs:
   sync-spec:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout CLI repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/prek.toml
+++ b/prek.toml
@@ -81,6 +81,30 @@ hooks = [
 ]
 
 # =============================================================================
+# Workflow linting — keeps the supply-chain hardening in .github/workflows
+# from rotting (SHA pins, least-privilege permissions, no template injection).
+# =============================================================================
+[[repos]]
+repo = "https://github.com/rhysd/actionlint"
+rev = "v1.7.12"
+hooks = [
+  # -shellcheck= disables actionlint's embedded shellcheck: its presence varies
+  # by machine (it shells out to an optional binary), which would make results
+  # non-deterministic. actionlint's own workflow validation — action refs,
+  # expression syntax, needs/matrix graphs — is what we gate on here.
+  { id = "actionlint", args = ["-shellcheck="] },
+]
+
+[[repos]]
+repo = "https://github.com/woodruffw/zizmor-pre-commit"
+rev = "v1.26.1"
+hooks = [
+  # --no-online-audits: hermetic (no network calls to GitHub during the audit),
+  # so the hook is deterministic and works offline / in CI without a token.
+  { id = "zizmor", args = ["--no-online-audits"] },
+]
+
+# =============================================================================
 # Local hooks
 # =============================================================================
 [[repos]]


### PR DESCRIPTION
## Description

**PR 1 of 5** in a DevOps/CI hardening series that pulls the best of
geoparquet-io [#552](https://github.com/geoparquet/geoparquet-io/pull/552) /
[#557](https://github.com/geoparquet/geoparquet-io/pull/557) /
[#565](https://github.com/geoparquet/geoparquet-io/pull/565) into portolan-cli,
adapted to this repo's norms (prek not pre-commit; mutmut 3.x JSON; Codecov patch).

This PR makes supply-chain hardening a **uniform, lint-enforced** property across
every workflow, using `sync-spec.yml` (already SHA-pinned + `persist-credentials:
false` + `concurrency`) as the in-repo template.

## What changed

For **every** workflow (`ci`, `docs`, `nightly`, `release`, `security-audit`,
`sync-skills`, `sync-spec`):

- **Least-privilege `GITHUB_TOKEN`** — top-level `permissions: contents: read`,
  widened per job only where needed (`issues: write`, Pages `id-token`,
  `pull-requests: write`, release tag push).
- **`timeout-minutes` on every job** so a hung step can't burn the runner budget.
- **All third-party actions SHA-pinned** with a trailing version comment
  (Dependabot maintains the pins going forward).
- **`persist-credentials: false` on every checkout** except the release
  tag-push checkout (the one legitimate exception, inline-justified via
  `# zizmor: ignore[artipacked]`).
- **`concurrency` on `ci.yml`** to cancel superseded PR runs.
- **Template-injection removed** — `${{ }}` step/job-output expansions in
  `release.yml` and `security-audit.yml` moved out of `run:`/`github-script`
  bodies into `env:` indirection.
- **Cache disabled on the PyPI publish path** (cache-poisoning).

Enforcement so this can't rot:

- **New prek hooks**: `actionlint` (workflow validation) and
  `zizmor --no-online-audits` (hermetic). Both green.
- **7-day Dependabot cooldown** so fresh releases age before reaching a PR.
- Fixed an `SC2046` word-splitting warning in nightly's mutation check.

No job **semantics** changed — this is hardening + linting only. The diff is
mechanical (pins/permissions/timeouts/persist-credentials) plus the env
indirection.

## Post-merge

Nothing required for this PR. The required-check ruleset + Dependabot auto-merge
land in PR 4 of the series.

## Related

Series: hardening (this) → single rule source + pip-audit ignore file →
mutation robustness → self-healing automation → contributor guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened workflow permissions across CI, docs, release, and sync jobs.
  * Pinned third-party automation actions to fixed revisions and added run timeouts.
  * Added safeguards for dependency updates and security audits.

* **Chores**
  * Updated automated dependency and workflow settings to use a short release delay.
  * Added workflow linting checks for action and security configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->