### PR TITLE
ci(mutation): fail loud on broken mutation testing + repair mutmut config (PR 3/5)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,21 +72,42 @@ jobs:
           echo "  Suspicious: $SUSPICIOUS"
           echo "  Total testable: $TESTABLE"
 
+          # Zero testable mutants means mutmut generated/parsed nothing — that
+          # is mutation testing being SILENTLY BROKEN, not a pass. This exact
+          # no-op shipped before (the old code `exit 0`d here), so treat it as a
+          # hard failure that demands investigation.
           if [ "$TESTABLE" -eq 0 ]; then
-            echo "No testable mutations generated - check if source code has test coverage"
-            exit 0
+            echo "::error::No testable mutants were generated/parsed — mutation testing is silently broken. See portolan-sdi/portolan-cli#612 (sandbox baseline + scalability)."
+            exit 1
           fi
 
           # Calculate kill rate (higher is better)
           KILL_RATE=$(echo "scale=2; $KILLED * 100 / $TESTABLE" | bc)
           echo "Mutation kill rate: $KILL_RATE% ($KILLED killed, $SURVIVED survived)"
 
-          # Fail if kill rate drops below 60%
-          # Start conservative; increase as test suite matures (see ci.md)
-          MIN_KILL_RATE=60
+          # Floor comes from .mutation-baseline (first non-comment, non-blank
+          # line) so it can be ratcheted in a reviewable, single-line diff.
+          MIN_KILL_RATE=$(grep -vE '^\s*#' .mutation-baseline | grep -vE '^\s*$' | head -1)
+          if ! [[ "$MIN_KILL_RATE" =~ ^[0-9]+$ ]]; then
+            echo "::error::.mutation-baseline floor is not an integer: '$MIN_KILL_RATE'"
+            exit 1
+          fi
+
+          {
+            echo "## Mutation Testing"
+            echo ""
+            echo "| Metric | Value |"
+            echo "| --- | --- |"
+            echo "| Kill rate | ${KILL_RATE}% |"
+            echo "| Floor | ${MIN_KILL_RATE}% |"
+            echo "| Killed | $KILLED |"
+            echo "| Survived | $SURVIVED |"
+            echo "| Total testable | $TESTABLE |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
           below_floor=$(echo "$KILL_RATE < $MIN_KILL_RATE" | bc)
           if [ "$below_floor" -eq 1 ]; then
-            echo "::error::Mutation kill rate ($KILL_RATE%) is below threshold ($MIN_KILL_RATE%)"
+            echo "::error::Mutation kill rate ($KILL_RATE%) is below the ${MIN_KILL_RATE}% floor from .mutation-baseline"
             echo "Tests are not catching enough bugs. Review survived mutants:"
             uv run mutmut results --all true | grep -E ': survived$' | head -20
             exit 1

--- a/.mutation-baseline
+++ b/.mutation-baseline
@@ -1,0 +1,6 @@
+# Minimum mutation kill rate (%) enforced by the nightly `mutation` job.
+# Rate = killed / (killed + survived) from mutmut's cicd-stats.
+#
+# Ratchet this UP as the test suite matures; LOWERING it requires an explicit
+# justification in the PR that does so. First non-comment, non-blank line wins.
+60

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -112,7 +112,23 @@ Runs at 4 AM UTC daily. Can be triggered manually.
 
 Uses `mutmut` to verify tests actually catch bugs.
 
-**Threshold:** Kill rate must be ≥ 60% (increase as codebase matures)
+**Threshold:** the floor lives in `.mutation-baseline` (a single integer, currently
+60). The job reads it rather than hardcoding the number, so it can be ratcheted up
+in a one-line, reviewable diff as the suite matures. **Lowering it requires a
+justification in the PR that does so.**
+
+**Fails loud, never silent.** If mutmut generates zero testable mutants — i.e.
+mutation testing is broken, not passing — the job hard-fails (it used to `exit 0`
+and report a green nightly, hiding a broken setup). `[tool.mutmut]` in
+`pyproject.toml` copies the `scripts/` package + data files into the mutants
+sandbox and scopes the stats run to the fast, offline suite with `--no-cov`.
+
+> **Status:** mutation testing is being repaired — the sandbox baseline still fails
+> on a test that passes normally, and the ~45k generated mutants exceed the nightly
+> window. Tracked in [#612](https://github.com/portolan-sdi/portolan-cli/issues/612).
+> Until it is resolved the nightly `mutation` job **correctly fails** rather than
+> silently passing. (The geoparquet-io #565 CWD guard was evaluated and is **not**
+> needed: `isolated_filesystem`/`chdir` tests do not crash the stats phase.)
 
 Why this matters: AI-generated tests can be tautological — they may pass but not actually verify behavior. Mutation testing injects bugs and checks if tests catch them.
 
@@ -234,7 +250,13 @@ Using `xenon` (based on radon cyclomatic complexity):
 
 ### "Mutation kill rate below threshold"
 
-Your tests aren't catching enough injected bugs. Review the mutation report artifact and add tests for survived mutants.
+Your tests aren't catching enough injected bugs. Review the mutation report artifact and add tests for survived mutants. The floor lives in `.mutation-baseline`.
+
+### "No testable mutants were generated"
+
+Mutation testing is broken, not passing — the job hard-fails on this. Usually the
+mutmut sandbox baseline failed (a test that passes normally but not in `mutants/`)
+or the `[tool.mutmut]` sandbox is missing a file. See [#612](https://github.com/portolan-sdi/portolan-cli/issues/612).
 
 ### "Complexity exceeds threshold"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,6 +255,27 @@ verbose = false
 [tool.mutmut]
 paths_to_mutate = ["portolan_cli/"]
 pytest_add_cli_args_test_selection = ["tests/"]
+# The `scripts/` package is imported by a few tests (test_scripts,
+# test_pip_audit_ignores, test_fetch_lib_docs_integration). mutmut runs the
+# suite from a copied `mutants/` sandbox, so scripts/ must be copied in too or
+# collection dies with `ModuleNotFoundError: No module named 'scripts'` — which
+# used to sink the whole stats phase silently (see nightly.yml's zero-mutant
+# guard).
+# scripts/ (imported by a few tests) and the data files those tests read must
+# be present in the sandbox, or collection/execution dies there.
+also_copy = ["scripts/", ".pip-audit-ignores", ".mutation-baseline"]
+# The stats/baseline run must mirror the fast CI test job, not the whole suite:
+# - --no-cov: pyproject's addopts inject --cov, whose instrumentation conflicts
+#   with mutmut's; without this the stats phase is unreliable.
+# - --tb=short: a stats-phase failure must show WHERE it broke.
+# - marker filter: exclude network/slow/benchmark/e2e (mutation of portolan_cli
+#   is validated by the fast, offline suite; e2e needs Docker, network needs a
+#   live server).
+pytest_add_cli_args = [
+    "--no-cov",
+    "--tb=short",
+    "-m", "not network and not slow and not benchmark and not e2e and not e2e_slow",
+]
 
 # ---------- architecture enforcement ----------
 # See ADR-0025 for rationale. These contracts enforce critical architectural boundaries.


### PR DESCRIPTION
## Description

**PR 3 of 5.** Stacked on #610. Running `mutmut` locally revealed mutation testing
has been **silently non-functional** — the old `nightly.yml` `exit 0`'d when zero
testable mutants were produced, so a broken stats phase reported a green nightly.

## What changed

**Safety net**
- `nightly.yml`: zero testable mutants → **hard fail** (was `exit 0`). Mutation
  testing being broken can no longer masquerade as a pass.
- Floor moved from a hardcoded `MIN_KILL_RATE=60` to **`.mutation-baseline`**
  (ratchetable; the job validates it's an integer and writes a step-summary table).

**mutmut config repair (`[tool.mutmut]`)**
- `also_copy = ["scripts/", ".pip-audit-ignores", ".mutation-baseline"]` — tests
  import the `scripts` package + read those data files; the sandbox lacked them,
  killing collection with `ModuleNotFoundError: scripts`.
- `--no-cov` — pyproject `addopts` inject `--cov`, which conflicts with mutmut.
- Marker filter scoping the stats run to the fast offline suite.

**CWD guard (geoparquet-io #565): evaluated, NOT needed.** Empirically, the ~390
`isolated_filesystem`/`chdir` test sites do **not** crash mutmut's stats phase
(Click restores CWD on `__exit__`). Documented in `ci.md` so the question isn't reopened.

## Scope note

Full repair — the remaining sandbox baseline failures (a test that passes normally
but not in `mutants/`) and the ~45k-mutant scalability for a nightly window — is a
larger, separate effort tracked in **#612**. Per the agreed scope, this PR ships the
safety net + config repair; the nightly `mutation` job now **fails honestly** until
#612 is done, replacing the previous silent-green.

## Verification

- `mutmut run` locally: `scripts` import + data-file errors resolved (stats now runs
  354 tests before the #612 baseline blocker, up from an immediate crash).
- CWD non-vulnerability confirmed by observing the stats phase run past all chdir sites.
- `actionlint` + `zizmor` clean; `.mutation-baseline` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)