### PR TITLE
ci(automation): branch protection + Dependabot auto-merge + network issue (PR 4/5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,3 +361,33 @@ jobs:
       - name: Check package contents
         run: |
           uv run python -c "import tarfile; t = tarfile.open(list(__import__('pathlib').Path('dist').glob('*.tar.gz'))[0]); print('\n'.join(t.getnames()))"
+
+  ci-success:
+    name: CI Success
+    # Single aggregated status check for branch protection. Requiring THIS one
+    # context (see scripts/apply_branch_protection.sh) instead of every matrix
+    # cell means adding a Python version or OS never silently drops a required
+    # check, and the conditionally-skipped iceberg jobs don't block PRs that
+    # don't touch iceberg.
+    if: always()
+    needs: [quality, security, test, iceberg-test, iceberg-e2e, docs, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          # Trusted github context (success|failure|skipped|cancelled), passed
+          # through env rather than spliced into the script body (zizmor).
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "Dependency results: $RESULTS"
+          # A skipped job (e.g. iceberg on a non-iceberg PR) is fine; a failed or
+          # cancelled one is not.
+          IFS=','
+          for r in $RESULTS; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::A required CI job did not succeed (result: $r)"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed (or were legitimately skipped)."

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,40 @@
+# Auto-merge Dependabot PRs for patch and minor updates.
+#
+# Safe because the `main` rulesets (scripts/apply_branch_protection.sh) require
+# the full green check set before any merge. Auto-merge only *queues* the PR;
+# GitHub still blocks it until every required status check passes. Majors are
+# deliberately left for a human.
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  dependabot:
+    # Gate on the PR author, not github.actor: the actor context is spoofable
+    # via re-runs; the author of a Dependabot PR is not (zizmor bot-conditions).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      - name: Approve and enable auto-merge for patch/minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        # `gh pr review --approve` satisfies the "review required" ruleset; the
+        # subsequent auto-merge then waits for the required status checks.
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,6 +191,12 @@ jobs:
     name: Live Network Tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Non-blocking: live third-party servers (ArcGIS, WFS, ...) being flaky is not
+    # something a contributor can fix, so a failure does NOT fail the workflow —
+    # it opens/updates a single tracking issue instead (mirrors security-audit.yml).
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -211,11 +217,70 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run network tests against live services
+        id: nettests
+        # Keep the workflow green; the tracking-issue step below is the signal.
+        continue-on-error: true
         run: |
           uv run pytest tests/ \
             -m network \
             --timeout=120 \
             -v
+
+      - name: Track live-network status as a single issue
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # Trusted github context, via env not a ${{ }} splice into JS (zizmor).
+          TESTS_OUTCOME: ${{ steps.nettests.outcome }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const outcome = process.env.TESTS_OUTCOME;
+            const runUrl = process.env.RUN_URL;
+            const label = 'nightly-network-failure';
+            const title = 'Nightly live-network tests are failing';
+
+            // Ensure the tracking label exists (idempotent).
+            try {
+              await github.rest.issues.getLabel({owner, repo, name: label});
+            } catch {
+              await github.rest.issues.createLabel({
+                owner, repo, name: label, color: 'd73a4a',
+                description: 'Auto-managed: nightly live-network test failures',
+              });
+            }
+
+            const {data: open} = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: label,
+            });
+            const existing = open[0];
+
+            if (outcome === 'failure') {
+              const body = [
+                'The nightly **live-network** test job failed against third-party',
+                'services. This job is non-blocking (live servers can be flaky), but a',
+                'persistent failure may indicate a real regression in an extractor.',
+                '',
+                `Latest failing run: ${runUrl}`,
+                '',
+                '_Managed automatically — closes when the next nightly run passes._',
+              ].join('\n');
+              if (existing) {
+                await github.rest.issues.update({owner, repo, issue_number: existing.number, body});
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: existing.number,
+                  body: `Still failing — ${runUrl}`,
+                });
+              } else {
+                await github.rest.issues.create({owner, repo, title, labels: [label], body});
+              }
+            } else if (existing) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number,
+                body: `Live-network tests recovered — closing. ${runUrl}`,
+              });
+              await github.rest.issues.update({owner, repo, issue_number: existing.number, state: 'closed'});
+            }
 
   slow-tests:
     name: Slow Tests (Stress/Scale)

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# =============================================================================
+# apply_branch_protection.sh
+#
+# WHAT IT DOES
+#   Codifies portolan-cli's `main` branch protection as GitHub repository
+#   rulesets and enables repo-level auto-merge. This is the anchor that makes
+#   "green means green" enforceable and Dependabot auto-merge (see
+#   .github/workflows/dependabot-automerge.yml) safe.
+#
+#   Concretely:
+#     1. Enables repository auto-merge.
+#     2. Deletes the legacy classic branch-protection rule on `main` (if any).
+#     3. Creates-or-updates TWO rulesets on `main`:
+#        A. "main: PR + green checks" — every push goes through a PR and every
+#           required status check must pass. NO bypass actors: this applies to
+#           admins too, so nobody merges red.
+#        B. "main: review required" — 1 approving review, but repository admins
+#           may bypass (so an admin can land a green, bot-approved Dependabot PR,
+#           and admins are never hard-blocked on review).
+#     4. Prints a verification summary.
+#
+#   Splitting into two rulesets is deliberate: the strict checks (A) bind
+#   everyone, while only the softer review rule (B) grants admin bypass.
+#
+# REQUIRED STATUS CHECKS
+#   Just three contexts, on purpose:
+#     - "CI Success"      — the ci.yml aggregation job that gates on quality,
+#                           security, the test matrix, iceberg, docs, and build.
+#                           Requiring this one context (not each matrix cell)
+#                           means adding a Python/OS never drops a required check.
+#     - "codecov/patch"   — changed-line coverage (target in codecov.yml).
+#     - "codecov/project" — overall coverage floor.
+#
+# REQUIREMENTS
+#   - `gh` authenticated as a user with ADMIN on the repo.
+#   - `jq` on PATH.
+#
+# SAFE TO RE-RUN
+#   Idempotent. Rulesets are matched by name (GET), updated (PUT) if present, or
+#   created (POST) if not. Enabling auto-merge and deleting classic protection
+#   both no-op on a second run.
+#
+# RELATED MANUAL STEP (not done here)
+#   The Dependabot auto-merge workflow approves + queues bot PRs using the
+#   built-in GITHUB_TOKEN, which is sufficient. If you later want security
+#   auto-fix PRs to trigger CI (GITHUB_TOKEN-created PRs do not), create a
+#   fine-grained PAT (contents + pull-requests: write) and store it as the
+#   BOT_PR_TOKEN repository secret:
+#       gh secret set BOT_PR_TOKEN --repo <owner>/<repo>
+# =============================================================================
+set -euo pipefail
+
+REPO="${1:-portolan-sdi/portolan-cli}"
+BRANCH="main"
+
+# Repository role id 5 == "admin" (GitHub built-in role). Used as a bypass actor
+# for the review ruleset only.
+ADMIN_ROLE_ID=5
+
+command -v jq >/dev/null || { echo "error: jq is required" >&2; exit 1; }
+
+echo ">> Target repository: ${REPO}"
+
+# -----------------------------------------------------------------------------
+# 1. Enable repository auto-merge.
+# -----------------------------------------------------------------------------
+echo ">> Enabling auto-merge ..."
+gh api -X PATCH "repos/${REPO}" -F allow_auto_merge=true >/dev/null
+echo "   auto-merge enabled."
+
+# -----------------------------------------------------------------------------
+# 2. Delete classic branch protection on main (tolerate 404 = already gone).
+# -----------------------------------------------------------------------------
+echo ">> Removing classic branch protection on ${BRANCH} (if present) ..."
+if gh api "repos/${REPO}/branches/${BRANCH}/protection" >/dev/null 2>&1; then
+  gh api -X DELETE "repos/${REPO}/branches/${BRANCH}/protection" >/dev/null
+  echo "   classic protection deleted."
+else
+  echo "   no classic protection found (nothing to delete)."
+fi
+
+# -----------------------------------------------------------------------------
+# Helper: create-or-update a ruleset by name.
+#   $1 = ruleset name   $2 = full ruleset JSON payload (its "name" must match $1)
+# -----------------------------------------------------------------------------
+upsert_ruleset() {
+  local name="$1" payload="$2" existing_id
+  existing_id=$(
+    gh api "repos/${REPO}/rulesets?includes_parents=false" \
+      --jq ".[] | select(.name == \"${name}\") | .id" 2>/dev/null | head -1
+  )
+  if [ -n "${existing_id}" ]; then
+    echo ">> Updating ruleset '${name}' (id ${existing_id}) ..."
+    gh api -X PUT "repos/${REPO}/rulesets/${existing_id}" \
+      --input - <<<"${payload}" >/dev/null
+  else
+    echo ">> Creating ruleset '${name}' ..."
+    gh api -X POST "repos/${REPO}/rulesets" \
+      --input - <<<"${payload}" >/dev/null
+  fi
+  echo "   '${name}' applied."
+}
+
+# -----------------------------------------------------------------------------
+# 3A. Ruleset: PR required + required status checks (no bypass — binds admins).
+# -----------------------------------------------------------------------------
+CHECKS_RULESET=$(jq -n '
+{
+  name: "main: PR + green checks",
+  target: "branch",
+  enforcement: "active",
+  conditions: { ref_name: { include: ["refs/heads/main"], exclude: [] } },
+  bypass_actors: [],
+  rules: [
+    { type: "deletion" },
+    { type: "non_fast_forward" },
+    { type: "pull_request",
+      parameters: {
+        required_approving_review_count: 0,
+        dismiss_stale_reviews_on_push: false,
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_review_thread_resolution: false
+      }
+    },
+    { type: "required_status_checks",
+      parameters: {
+        strict_required_status_checks_policy: true,
+        do_not_enforce_on_create: false,
+        required_status_checks: [
+          { context: "CI Success" },
+          { context: "codecov/patch" },
+          { context: "codecov/project" }
+        ]
+      }
+    }
+  ]
+}')
+
+# -----------------------------------------------------------------------------
+# 3B. Ruleset: 1 approving review, bypassable by repository admins.
+# -----------------------------------------------------------------------------
+REVIEW_RULESET=$(jq -n --argjson admin "${ADMIN_ROLE_ID}" '
+{
+  name: "main: review required",
+  target: "branch",
+  enforcement: "active",
+  conditions: { ref_name: { include: ["refs/heads/main"], exclude: [] } },
+  bypass_actors: [
+    { actor_id: $admin, actor_type: "RepositoryRole", bypass_mode: "always" }
+  ],
+  rules: [
+    { type: "pull_request",
+      parameters: {
+        required_approving_review_count: 1,
+        dismiss_stale_reviews_on_push: false,
+        require_code_owner_review: false,
+        require_last_push_approval: false,
+        required_review_thread_resolution: false
+      }
+    }
+  ]
+}')
+
+upsert_ruleset "main: PR + green checks" "${CHECKS_RULESET}"
+upsert_ruleset "main: review required" "${REVIEW_RULESET}"
+
+# -----------------------------------------------------------------------------
+# 4. Verification summary.
+# -----------------------------------------------------------------------------
+echo
+echo ">> Current rulesets on ${REPO}:"
+gh api "repos/${REPO}/rulesets?includes_parents=false" \
+  --jq '.[] | "   - \(.name) [\(.enforcement)]"'
+echo ">> Done. Required checks: CI Success, codecov/patch, codecov/project."


### PR DESCRIPTION
## Description

**PR 4 of 5.** Stacked on #613. Makes "green means green" enforceable and lets
low-risk work heal itself.

## What changed

**Branch protection as code**
- `scripts/apply_branch_protection.sh` — idempotent, admin one-shot: enables repo
  auto-merge, drops legacy classic protection, and creates two rulesets on `main`:
  - **A. PR + green checks** — required status checks, **no bypass** (binds admins
    too; nobody merges red).
  - **B. review required** — 1 approval, bypassable by repo admins (so an admin can
    land a green, bot-approved Dependabot PR).
- New **`ci-success`** aggregation job in `ci.yml` (`if: always()`, treats skipped
  conditional iceberg jobs as OK). Branch protection requires just three stable
  contexts: **`CI Success`**, **`codecov/patch`**, **`codecov/project`** — so adding
  a Python/OS to the matrix never silently drops a required check.

**Dependabot auto-merge**
- `dependabot-automerge.yml` — approves + auto-merges (squash) patch/minor bumps;
  majors stay human. Gated on the **non-spoofable PR author**. Safe because the
  rulesets still require the full green matrix before the queued merge fires.

**Network-live tracking issue**
- `nightly.yml` live-network tests are now non-blocking; a github-script step
  opens/updates/closes **one** tracking issue on failure/recovery (reusing the
  security-audit pattern). Flaky third-party servers surface as a self-closing
  issue instead of a silently-red nightly.

## Post-merge (once, needs admin)

1. `bash scripts/apply_branch_protection.sh` — applies the rulesets + auto-merge.
2. (Optional) create the `BOT_PR_TOKEN` secret if you want security auto-fix PRs to
   trigger CI — see the script header.

Note: `codecov.yml`'s patch target stays at 80% (now enforced as a required gate);
it can be ratcheted to 90% later without touching this machinery.

## Verification

- `bash -n scripts/apply_branch_protection.sh` clean; jq payloads validated.
- `actionlint` + `zizmor` clean across all workflows (incl. the new aggregation
  job, auto-merge workflow, and github-script issue management).

🤖 Generated with [Claude Code](https://claude.com/claude-code)