### PR TITLE
docs(contributing): AI-era contributor guide + PR bar + CI reality (PR 5/5)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,12 @@ Examples: "Add `portolan publish` command for S3 sync" or "Fix collection asset 
 - #
 
 ## Checklist
-- [ ] Tests added/updated
-- [ ] All tests pass (`uv run pytest`)
-- [ ] Documentation updated (README, guides, CLI reference)
+See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).
+
+- [ ] Tests written **first** and exercise real behavior (TDD)
+- [ ] Integration coverage where the change crosses layers
+- [ ] `prek run --all-files` is green locally; all required CI checks pass
+- [ ] Changed lines are covered (`codecov/patch`)
+- [ ] At least one adversarial review (actively tried to break it)
+- [ ] CodeRabbit comments addressed
+- [ ] Docs updated and, for non-obvious decisions, an ADR added

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -29,16 +29,22 @@ Install with: `uv tool install prek && prek install`
 
 **Checks (all blocking):**
 
-- `ruff` — Linting with auto-fix
-- `ruff format` — Code formatting
-- `vulture` — Dead code detection
-- `xenon` — Complexity monitoring
+- `ruff` / `ruff format` — Linting with auto-fix + formatting
 - `mypy` — Type checking (strict)
-- `pytest -m unit` — Fast unit tests only
-- `menard check` — Documentation freshness (requires Python 3.11+)
-- `menard check-protected` — Protected content validation
+- `import-linter` — Architecture contracts (ADR-0025)
+- `codespell` — Spell checking
+- `vulture` / `xenon` / `pylint` — Dead code, complexity, duplicate code (R0801)
+- `bandit` — Static security analysis
+- `deptry` — Dependency hygiene
+- `actionlint` / `zizmor` — GitHub Actions workflow linting + supply-chain audit
+- `menard check` / `check-protected` — Documentation freshness + protected content
+- `validate-claude-md` — ADR index / reference validation
+- `pytest -m unit` — Fast unit tests (pre-push stage)
 - `commitizen` — Commit message validation (commit-msg stage)
-- Builtin hooks: trailing whitespace, YAML validation, large file detection
+- Builtin hooks: trailing whitespace, YAML/TOML validation, large file detection
+
+**This is the single rule source.** Tier 2 CI runs the exact same hooks via
+`prek run --all-files` (see below), so a green local `prek` run previews CI.
 
 **Philosophy:** All hooks block. No `--no-verify`. Fix issues before committing.
 
@@ -50,30 +56,32 @@ Workflow: `.github/workflows/ci.yml`
 
 ### Jobs
 
-#### `lint` — Lint & Format
+#### `quality` — Quality Gates (single rule source)
 
-- `ruff format --check` — Formatting verification
-- `ruff check` — Linting
-- `mypy` — Type checking (strict)
-- `codespell` — Spell checking
+Runs `prek run --all-files` — the *same* hooks developers run locally (see Tier 1),
+so CI and local hooks can't drift. Covers ruff, mypy, import-linter, codespell,
+vulture, xenon, pylint-duplicate, bandit, deptry, menard, actionlint, zizmor, and
+the builtin file hooks. Replaces the old separate `lint` and `dead-code` jobs.
 
-#### `security` — Security Scan
+CI skips three hooks: `no-commit-to-branch` (fails on push-to-main), `fast-tests`
+(the `test` job covers them), and `update-freshness` (stamps today's date, so it's
+non-deterministic in CI — drift is still caught by the non-mutating `menard-check`
+and `validate-claude-md`).
 
-- `bandit` — Static security analysis
-- `pip-audit` — Dependency vulnerability scanning
+#### `security` — Dependency Audit
+
+- `pip-audit` — dependency vulnerability scanning. Ignores come from the
+  single-source `.pip-audit-ignores` file (each entry has an expiry + reason;
+  expired entries drop automatically). The same file feeds `nightly.yml` and
+  `security-audit.yml`. (`bandit` moved into the `quality` job.)
 
 #### `test` — Test Matrix
 
 - Python versions: 3.10, 3.11, 3.12, 3.13
 - Operating systems: Ubuntu, macOS, Windows
 - Excludes network, slow, and benchmark tests
-- Coverage reporting to Codecov
-
-#### `dead-code` — Dead Code, Complexity & Duplication
-
-- `vulture` — Unused code detection (min confidence 80%)
-- `xenon` — Complexity thresholds (max C absolute, B modules, A average)
-- `pylint` — Duplicate code detection (R0801 only, `--fail-under=9.5`)
+- Coverage reporting to Codecov (the `codecov/patch` changed-line gate is a
+  required check — see [Branch protection](#branch-protection))
 
 #### `docs` — Documentation Build
 
@@ -143,6 +151,9 @@ Why this matters: AI-generated tests can be tautological — they may pass but n
 - Runs tests marked with `@pytest.mark.network`
 - Tests against real external services
 - 120-second timeout per test
+- **Non-blocking:** live third-party flakiness isn't a contributor's to fix, so a
+  failure does not fail the workflow — it opens/updates a single self-closing
+  tracking issue instead (mirrors the `security-audit` pattern)
 
 #### `dependency-check` — Dependency Audit
 
@@ -154,6 +165,34 @@ Why this matters: AI-generated tests can be tautological — they may pass but n
 - Python 3.11 on Ubuntu
 - Spins up `docker-compose` (REST Iceberg catalog + MinIO), runs `-m e2e` (includes `e2e_slow`: concurrency stress and large datasets)
 - 120s per-test timeout; Docker logs on failure; always tears down
+
+---
+
+## Branch Protection
+
+`main` protection is defined **as code** in `scripts/apply_branch_protection.sh`
+(idempotent, admin one-shot). It creates two rulesets:
+
+- **PR + green checks** (no bypass — binds admins too): every push goes through a
+  PR and the required status checks must pass.
+- **Review required** (repo admins may bypass): 1 approving review.
+
+**Required checks** are three stable contexts: `CI Success` (the `ci.yml`
+aggregation job that gates on quality/security/test/iceberg/docs/build — requiring
+this one context means adding a Python/OS never drops a required check),
+`codecov/patch`, and `codecov/project`.
+
+## Self-Healing Automation
+
+- **Supply-chain hardening is lint-enforced.** All workflows are SHA-pinned,
+  least-privilege (`permissions: contents: read` widened per job), and
+  `persist-credentials: false`; `actionlint` + `zizmor` (Tier 1 + the `quality`
+  job) keep it that way.
+- **Dependabot auto-merge** (`dependabot-automerge.yml`): patch/minor bumps are
+  approved and auto-merged once the full green check set passes; majors stay human.
+  A 7-day cooldown ages fresh releases before they reach a PR.
+- **Security issue automation** (`security-audit.yml`): opens/updates/closes a
+  single dependency-vulnerability tracking issue as CVEs appear and resolve.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,37 @@
 
 Thank you for your interest in contributing to portolan-cli!
 
+Most of the code here is written by AI agents, so the bar is set by **automation,
+not by reviewer attention**: every quality gate is enforced in CI, and a PR is
+trustable exactly to the degree it turns those gates green. AI-assisted
+contributions are welcome and encouraged — the strict CI is what makes them safe
+to merge.
+
+## What a finished PR looks like
+
+Before you ask for review, a PR should clear this bar:
+
+- [ ] **Tests first, and they exercise real behavior.** New/changed product code
+      ships with tests written before the implementation (TDD is required, see
+      [Testing](#testing)). Prefer a reproducible failing test as the starting
+      point.
+- [ ] **Integration coverage across boundaries.** If the change spans layers
+      (CLI → API → format handlers → backend), there is a test that crosses them,
+      not only unit tests.
+- [ ] **All CI is green.** Every required check passes — see
+      [What CI checks](#what-ci-checks). "Green means green": nothing merges red.
+- [ ] **Changed lines are covered.** The `codecov/patch` gate (changed-line
+      coverage) is satisfied by the fast test suite.
+- [ ] **At least one adversarial review.** A human or agent has actively tried to
+      break the change (edge cases, failure modes), not just skimmed it.
+- [ ] **CodeRabbit comments addressed.** The automated reviewer's findings are
+      resolved or explicitly answered.
+- [ ] **Docs and ADRs updated.** User-facing behavior is documented; non-obvious
+      decisions have an ADR (`context/shared/adr/`); `menard` doc-freshness passes.
+
+If you run `prek run --all-files` locally and it is green, you have cleared most of
+this bar before pushing.
+
 ## Development Setup
 
 1. **Clone the repository**
@@ -53,30 +84,62 @@ refactor(scope): restructure code
 test(scope): add tests
 ```
 
-Use `uv run cz commit` for interactive commit creation.
+Use `uv run cz commit` for interactive commit creation. PRs are **squash-merged**,
+so the PR title becomes the commit message — write it in conventional form.
 
 ### Pull Request Process
 
 1. Create a branch from `main`
-2. Write tests first, then implement (TDD is required — see Testing section)
+2. Write tests first, then implement (TDD is required — see [Testing](#testing))
 3. Run `prek run --all-files` to check everything locally
 4. Push and open a PR — CI runs automatically
 5. Fill in the PR template and link related issues
 
-### What CI Checks
+## What CI checks
 
-All PRs must pass:
+There is **one rule source**: CI runs the *same* hooks you run locally via
+`prek run --all-files` (see `prek.toml`), rather than re-listing each tool with its
+own arguments. So a green local `prek` run is a faithful preview of the CI `quality`
+job. That single job covers:
 
-- **ruff** — Linting and formatting
-- **mypy** — Type checking (strict mode)
-- **bandit** — Security scanning
-- **pip-audit** — Dependency vulnerabilities
-- **vulture** — Dead code detection
-- **xenon** — Complexity limits
-- **pytest** — Full test suite with coverage
-- **mkdocs** — Documentation build
+- **ruff** — lint + format
+- **mypy** — type checking (strict)
+- **import-linter** — architecture contracts ([ADR-0025](https://github.com/portolan-sdi/portolan-cli/blob/main/context/shared/adr/0025-architecture-as-code.md))
+- **codespell** — spelling
+- **vulture** / **xenon** / **pylint** — dead code, complexity, duplication
+- **bandit** — security scanning
+- **deptry** — dependency hygiene
+- **menard** — code↔doc freshness
+- **actionlint** / **zizmor** — GitHub Actions workflow linting + supply-chain audit
 
-All checks are strict — none allow failures.
+Alongside `quality`, CI runs the **test matrix** (Python 3.10–3.13 × Linux/macOS/
+Windows), **pip-audit** (dependency CVEs, ignores tracked in `.pip-audit-ignores`
+with expiry dates), the **docs build**, and the **package build**.
+
+**Required checks** (enforced by branch-protection rulesets, applied via
+`scripts/apply_branch_protection.sh`): `CI Success` (a single job that aggregates
+every gate above — so adding a Python/OS never drops a required check),
+`codecov/patch`, and `codecov/project`. All checks are strict; none allow failures.
+
+### Heavier gates run nightly, not per-PR
+
+To keep PR feedback fast, the expensive gates run on a schedule and don't block
+your PR:
+
+- **Mutation testing** (`mutmut`) — verifies tests actually catch injected bugs
+  (currently being repaired, see
+  [#612](https://github.com/portolan-sdi/portolan-cli/issues/612)).
+- **Benchmark regression** — flags performance regressions.
+- **Live-network tests** — hit real third-party services; because those can be
+  flaky, this job is **non-blocking** and a failure opens a single self-closing
+  tracking issue instead of turning the nightly red.
+
+### Self-healing automation
+
+- **Dependency vulnerabilities** — the security-audit workflow opens/updates/closes
+  a single tracking issue automatically as CVEs appear and get resolved.
+- **Dependabot auto-merge** — patch/minor dependency bumps are approved and
+  auto-merged once the full green check set passes; majors stay for a human.
 
 ## Testing
 
@@ -107,7 +170,9 @@ uv run pytest --cov=portolan_cli --cov-report=html
 
 ## Release Process
 
-Portolan uses a tag-based release workflow driven by conventional commits:
+Releases are **bump-commit-triggered**, not tag-triggered: pushing a `bump:` commit
+to `main` drives the release workflow, which creates the tag itself. Version bumps
+follow conventional commits:
 
 | Commit type | Version bump |
 |-------------|--------------|
@@ -116,12 +181,14 @@ Portolan uses a tag-based release workflow driven by conventional commits:
 | `BREAKING CHANGE:` | Major (x.0.0) |
 | `docs:`, `refactor:`, `test:`, `chore:` | No release |
 
-To cut a release, create a PR that runs:
+To cut a release, open a PR that runs:
 ```bash
 uv run cz bump --changelog
 ```
 
-Merging that PR triggers the release workflow: it creates a git tag, builds the package, publishes to PyPI, and creates a GitHub Release.
+When that PR merges, the release workflow detects the `bump:` commit, creates the
+git tag, builds the package, publishes to PyPI (trusted publishing), and creates a
+GitHub Release.
 
 ## Code Standards
 


### PR DESCRIPTION
## Description

**PR 5 of 5.** Stacked on #614. Brings the contributor-facing docs in line with the
hardened CI from PRs 1-4, in the spirit of geoparquet-io #557.

## What changed

**`docs/contributing.md`**
- New **"What a finished PR looks like"** checklist up top: tests-first (TDD),
  integration coverage across boundaries, all CI green, changed-line coverage,
  ≥1 adversarial review, CodeRabbit addressed, docs/ADR updated.
- **AI-assisted posture** — strict CI is what makes autonomous contributions
  trustable.
- Rewrote **"What CI checks"** around: the single rule source (CI runs the same
  `prek` hooks you run locally), the required checks (`CI Success` +
  `codecov/patch` + `codecov/project`), the nightly-only heavy gates (mutation
  [#612], benchmark, non-blocking live-network), and the self-healing bots.
- Fixed a stale fact: releases are **bump-commit-triggered**, not tag-triggered.

**`.github/pull_request_template.md`** — checklist mirrors the finished-PR bar and
links the guide.

**`context/shared/documentation/ci.md`** — Tier 1 hook list, the `quality` job
(single rule source), pip-audit via `.pip-audit-ignores`, and new **Branch
Protection** + **Self-Healing Automation** sections.

## Verification

- `mkdocs build --strict` passes (exit 0).
- Doc quality hooks (spelling, protected-content, menard) green.

---

### Series recap (stacked)

1. #609 — supply-chain hardening + actionlint/zizmor
2. #610 — single rule source + pip-audit ignore file
3. #613 — mutation robustness (+ tracking issue #612)
4. #614 — branch protection + Dependabot auto-merge + network issue
5. #611-this — contributor guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)