### PR TITLE
fix(push): report returned push failures as errors in JSON mode

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3904,6 +3904,21 @@ def push(
             )
         )
 
+        if not result.success:
+            # Route returned failures through the error path so JSON mode reports
+            # success=false and exits non-zero (never a success envelope).
+            err_msgs = result.errors or ["Push failed"]
+            if use_json:
+                envelope = error_envelope(
+                    "push",
+                    [ErrorDetail(type="PushError", message=msg) for msg in err_msgs],
+                )
+                output_json_envelope(envelope)
+            else:
+                for err_msg in err_msgs:
+                    error(err_msg)
+            raise SystemExit(1)
+
         if not emit_success(
             "push",
             {
@@ -3914,20 +3929,15 @@ def push(
             },
             use_json=use_json,
         ):
-            if result.success:
-                if result.versions_pushed > 0:
-                    success(
-                        f"Pushed {result.versions_pushed} version(s), {result.files_uploaded} file(s)"
-                    )
-                elif dry_run:
-                    # Dry-run mode: push.py already printed what would be done
-                    info_output("[DRY RUN] Complete - no files were uploaded")
-                else:
-                    info_output("Nothing to push - local and remote are in sync")
+            if result.versions_pushed > 0:
+                success(
+                    f"Pushed {result.versions_pushed} version(s), {result.files_uploaded} file(s)"
+                )
+            elif dry_run:
+                # Dry-run mode: push.py already printed what would be done
+                info_output("[DRY RUN] Complete - no files were uploaded")
             else:
-                for err_msg in result.errors:
-                    error(err_msg)
-                raise SystemExit(1)
+                info_output("Nothing to push - local and remote are in sync")
 
     except PushConflictError as err:
         if use_json:

--- a/tests/integration/test_push_integration.py
+++ b/tests/integration/test_push_integration.py
@@ -581,6 +581,49 @@ class TestPushJSONOutput:
             assert output_data["success"] is False
             assert "errors" in output_data
 
+    @pytest.mark.integration
+    def test_push_json_returned_failure_is_not_reported_as_success(
+        self, catalog_with_versions: Path
+    ) -> None:
+        """A returned PushResult(success=False) must yield success=False and exit 1.
+
+        Regression: the handler emitted the success envelope unconditionally, so a
+        failed push was reported as ``success: true`` with exit 0 in JSON mode.
+        """
+        from portolan_cli.cli import cli
+        from portolan_cli.push import PushResult
+
+        runner = CliRunner()
+
+        with patch("portolan_cli.push.push_async", new_callable=AsyncMock) as mock_push:
+            mock_push.return_value = PushResult(
+                success=False,
+                files_uploaded=0,
+                versions_pushed=0,
+                conflicts=[],
+                errors=["Upload failed: connection reset"],
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "push",
+                    "s3://mybucket/catalog",
+                    "--collection",
+                    "demographics",
+                    "--catalog",
+                    str(catalog_with_versions),
+                ],
+            )
+
+            assert result.exit_code == 1
+            output_data = json.loads(result.output)
+            assert output_data["success"] is False
+            assert output_data["command"] == "push"
+            assert output_data["errors"][0]["message"] == "Upload failed: connection reset"
+
 
 # =============================================================================
 # Dry-run Behavior Tests


### PR DESCRIPTION
## Problem

The single-collection `push` handler called `emit_success(...)` **unconditionally**. In JSON mode that:
1. emits a `success: true` envelope regardless of `result.success`, and
2. returns `True`, which skips the human branch — including the `else: … raise SystemExit(1)` failure path.

Net effect: a returned `PushResult(success=False, errors=[…])` was reported to agents as **`success: true` with exit code 0**. This violates the agent-native contract (a failed operation must return a non-zero exit and an error envelope — see `.claude/rules/cli-and-output.md` / `sync.md`).

This is a **pre-existing** bug (predates the #619 emit refactor, which preserved the behavior byte-for-byte). The existing `test_push_json_error` only covered the *raised* `PushConflictError`, not a *returned* failure — so the gap was untested.

## Fix

Check `result.success` **first**:
- **Failure** → build an `error_envelope("push", [ErrorDetail(type="PushError", …)])` in JSON mode / print each error in text mode, then `raise SystemExit(1)`.
- **Success** → unchanged: `emit_success(...)` guarding the existing human output branch, byte-identical.

Text-mode behavior is preserved (same errors printed, same exit 1); only the missing JSON failure path is added. Empty `errors` on failure fall back to a single `"Push failed"` detail so the envelope never claims `success: false` with an empty `errors` array.

## Test

New regression test `test_push_json_returned_failure_is_not_reported_as_success` — **red before, green after** — asserts exit `1`, `success: false`, `command == "push"`, and the exact error message for a returned `PushResult(success=False)`.

## Validation

- `test_push_integration.py::TestPushJSONOutput`: 3 passed
- `ruff check` + `mypy --strict` on `cli.py`: clean

## Scope note

The multi-collection path (`all_result`, ~cli.py:3864) similarly emits a success envelope in JSON mode on failure, but it *does* still exit 1 afterward. Left untouched here to keep this fix minimal; flagging as a possible follow-up to make its envelope `success: false` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)