### PR TITLE
refactor(cli): move post-add and check orchestration helpers into library modules (#620)

### DIFF
--- a/.claude/rules/conversion-and-visualization.md
+++ b/.claude/rules/conversion-and-visualization.md
@@ -121,7 +121,7 @@ render paths.
 - PMTiles is required for vector datasets > 100 MB and recommended > 10 MB
   (ADR-0050). Generate alongside the GeoParquet.
 - `pmtiles.src_crs` from `.portolan/config.yaml` must be threaded
-  `_get_pmtiles_settings()` (in `cli.py`) -> `generate_pmtiles_for_collection()`
+  `get_pmtiles_settings()` (in `pmtiles.py`) -> `generate_pmtiles_for_collection()`
   -> `gpio-pmtiles`, which reprojects to WGS84 before tippecanoe. Dropping it
   breaks PMTiles for any projected source.
 - A generated `.pmtiles` MUST be a **collection-level** asset AND have a

--- a/portolan_cli/check.py
+++ b/portolan_cli/check.py
@@ -19,7 +19,7 @@ import shutil
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from portolan_cli.constants import GEOSPATIAL_EXTENSIONS, PARQUET_EXTENSION, SIDECAR_PATTERNS
 from portolan_cli.conversion_config import ConversionOverrides, get_conversion_overrides
@@ -38,6 +38,9 @@ from portolan_cli.formats import (
     is_geoparquet,
 )
 from portolan_cli.scan_detect import is_filegdb
+
+if TYPE_CHECKING:
+    from portolan_cli.metadata.fix import FixReport
 
 logger = logging.getLogger(__name__)
 
@@ -522,3 +525,165 @@ def _get_relative_path(file_path: Path, root: Path) -> str:
         return file_path.relative_to(root).as_posix()
     except ValueError:
         return file_path.as_posix()
+
+
+# --- Check / fix workflow orchestration (ADR-0007: logic lives here) ---
+
+
+def resolve_catalog_root_for_check(path: Path) -> Path | None:
+    """Walk up from ``path`` to find the directory containing ``catalog.json``.
+
+    The metadata scanner only needs ``catalog.json`` to function, so this
+    deliberately does not require the ``.portolan/config.yaml`` sentinel that
+    ``find_catalog_root`` insists on. Returns None if no ``catalog.json`` is
+    found within the search depth.
+    """
+    from portolan_cli.constants import MAX_CATALOG_SEARCH_DEPTH
+
+    candidate = path.resolve() if path.exists() else path
+    for _ in range(MAX_CATALOG_SEARCH_DEPTH):
+        if (candidate / "catalog.json").exists():
+            return candidate
+        if candidate.parent == candidate:
+            break
+        candidate = candidate.parent
+    return None
+
+
+def build_check_rules(path: Path, *, strict: bool) -> tuple[Any, ...]:
+    """Build the validation rule set, honoring config severity overrides.
+
+    Loads ``.portolan/config.yaml`` (when present) for ``stac_lint.severity.*``
+    overrides and always routes through ``_build_rules`` so the ``strict`` flag
+    and config are respected.
+
+    Args:
+        path: Directory being checked (catalog root or a subdirectory).
+        strict: Whether ``--strict`` was passed (escalates warnings to errors).
+
+    Returns:
+        The ordered list of validation rule instances.
+    """
+    from portolan_cli.config import load_config
+    from portolan_cli.validation.runner import _build_rules
+
+    config = load_config(path) if (path / ".portolan" / "config.yaml").exists() else None
+    return _build_rules(strict=strict, config=config)
+
+
+@dataclass
+class FixWorkflowOutcome:
+    """Result of running the ``check --fix`` workflow.
+
+    Attributes:
+        metadata_fix_report: Metadata fix results (None when metadata not in scope
+            or skipped because no catalog root was found in mixed mode).
+        format_fix_report: Geo-asset conversion results (None when not in scope).
+        has_failures: True if any metadata fix failed.
+        fatal_error: Non-catalog message when a metadata-only fix found no
+            ``catalog.json``; the caller surfaces it and exits non-zero.
+    """
+
+    metadata_fix_report: FixReport | None = None
+    format_fix_report: Any = None
+    has_failures: bool = False
+    fatal_error: str | None = None
+
+
+def run_fix_workflow(
+    *,
+    path: Path,
+    run_metadata: bool,
+    run_geo_assets: bool,
+    dry_run: bool,
+    remove_legacy: bool,
+    force: bool = False,
+    workers: int | None = None,
+    on_progress: Callable[[ConversionResult], None] | None = None,
+) -> FixWorkflowOutcome:
+    """Run the metadata and/or geo-asset fix workflow and return the reports.
+
+    This owns the fix orchestration (ADR-0007): resolving the catalog root,
+    scanning metadata, applying fixes plus the title/tabular/PMTiles repairs, and
+    converting geo-assets. It performs no output rendering or process exit — the
+    caller renders the returned :class:`FixWorkflowOutcome` and decides exit codes.
+
+    Args:
+        path: Directory to check/fix.
+        run_metadata: Whether to fix metadata issues.
+        run_geo_assets: Whether to fix geo-asset format issues.
+        dry_run: Preview changes without applying them.
+        remove_legacy: Remove source files after successful conversion.
+        force: Re-optimize already-valid COGs (raster-scoped, issue #530).
+        workers: Parallel worker processes for conversion.
+        on_progress: Optional per-conversion progress callback.
+
+    Returns:
+        A :class:`FixWorkflowOutcome` with the fix reports and status flags.
+    """
+    outcome = FixWorkflowOutcome()
+
+    # Fix metadata if in scope
+    if run_metadata:
+        from portolan_cli.metadata import fix_metadata
+        from portolan_cli.metadata.fix import (
+            repair_pmtiles_links,
+            repair_tabular_flags,
+            repair_titles_and_links,
+        )
+        from portolan_cli.metadata.scan import scan_catalog_metadata
+
+        # Resolve to the catalog root before scanning. Without this the scanner
+        # returns an empty report whenever `path` points at a subdirectory below
+        # the root, causing --fix to silently no-op. The scanner's only
+        # structural requirement is catalog.json, so walk parents looking for it
+        # (tests and existing catalogs may not have a .portolan sentinel, so
+        # find_catalog_root is too strict here).
+        catalog_root = resolve_catalog_root_for_check(path)
+        if catalog_root is None:
+            # Metadata-only mode: user explicitly asked, fail loudly so the
+            # silent-no-op trap is closed. Mixed mode (--fix without flags):
+            # stay backwards-compatible — skip metadata so the geo-assets pass
+            # can still operate on the directory.
+            if not run_geo_assets:
+                outcome.fatal_error = (
+                    f"fatal: not a portolan catalog (or any parent of {path}): "
+                    "no catalog.json found, cannot run metadata fix"
+                )
+                return outcome
+        else:
+            metadata_check_report = scan_catalog_metadata(catalog_root)
+            metadata_fix_report = fix_metadata(catalog_root, metadata_check_report, dry_run=dry_run)
+
+            # Issue #502: populate human-readable titles/descriptions and
+            # backfill child/item link titles as part of the metadata fix.
+            metadata_fix_report.results.extend(
+                repair_titles_and_links(catalog_root, dry_run=dry_run)
+            )
+
+            # Issue #481: backfill portolan:geospatial: false on tabular
+            # collections (RULE-0090) as part of the metadata fix.
+            metadata_fix_report.results.extend(repair_tabular_flags(catalog_root, dry_run=dry_run))
+
+            # Issue #569: backfill the rel="pmtiles" web-map-links link on
+            # collections with a PMTiles asset but no link (RULE-0061).
+            metadata_fix_report.results.extend(repair_pmtiles_links(catalog_root, dry_run=dry_run))
+
+            outcome.metadata_fix_report = metadata_fix_report
+            if metadata_fix_report.failure_count > 0:
+                outcome.has_failures = True
+
+    # Fix geo-assets if in scope
+    if run_geo_assets:
+        outcome.format_fix_report = check_directory(
+            path,
+            fix=True,
+            dry_run=dry_run,
+            remove_legacy=remove_legacy,
+            force=force,
+            workers=workers,
+            on_progress=on_progress,
+            catalog_path=path,
+        )
+
+    return outcome

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -38,7 +38,6 @@ from portolan_cli.convert import ConversionResult
 from portolan_cli.discovery import get_sidecars
 from portolan_cli.emit import emit_error, emit_success
 from portolan_cli.json_output import ErrorDetail, error_envelope, success_envelope
-from portolan_cli.metadata import fix_metadata
 from portolan_cli.metadata.fix import FixReport
 from portolan_cli.output import detail, error, success, warn
 from portolan_cli.output import info as info_output
@@ -1401,14 +1400,10 @@ def _execute_check_workflow(
     - Without --fix: run validation and report issues
     - With --fix: run validation AND apply fixes for the selected scope
     """
-    from portolan_cli.config import load_config
-    from portolan_cli.validation.runner import _build_rules
+    from portolan_cli.check import build_check_rules
 
-    # Load config for severity overrides (stac_lint.severity.*)
-    config = load_config(path) if (path / ".portolan" / "config.yaml").exists() else None
-
-    # Always use _build_rules to respect config and strict flag
-    rules = _build_rules(strict=strict, config=config)
+    # Build rules (respects config severity overrides + strict flag)
+    rules = build_check_rules(path, strict=strict)
 
     # Handle fix workflows (may exit early)
     if fix:
@@ -1440,26 +1435,6 @@ def _execute_check_workflow(
         _output_combined(path, metadata_report, mode, use_json, verbose)
 
 
-def _resolve_catalog_root_for_check(path: Path) -> Path | None:
-    """Walk up from `path` to find the directory containing catalog.json.
-
-    The metadata scanner only needs `catalog.json` to function, so this
-    deliberately does not require the `.portolan/config.yaml` sentinel
-    that `find_catalog_root` insists on. Returns None if no catalog.json
-    is found within the search depth.
-    """
-    from portolan_cli.constants import MAX_CATALOG_SEARCH_DEPTH
-
-    candidate = path.resolve() if path.exists() else path
-    for _ in range(MAX_CATALOG_SEARCH_DEPTH):
-        if (candidate / "catalog.json").exists():
-            return candidate
-        if candidate.parent == candidate:
-            break
-        candidate = candidate.parent
-    return None
-
-
 def _run_fix_workflow(
     *,
     path: Path,
@@ -1473,7 +1448,10 @@ def _run_fix_workflow(
     force: bool = False,
     workers: int | None = None,
 ) -> None:
-    """Execute the fix workflow for selected scope.
+    """Run the check --fix workflow (library) and render its results.
+
+    Delegates the fix orchestration to ``check.run_fix_workflow`` and only wires
+    up the progress callback, output rendering, and exit codes here (ADR-0007).
 
     Args:
         path: Directory to check/fix.
@@ -1487,78 +1465,31 @@ def _run_fix_workflow(
         force: Re-optimize already-valid COGs (raster-scoped, issue #530).
         workers: Parallel worker processes for conversion.
     """
-    metadata_fix_report: FixReport | None = None
-    format_fix_report = None
-    has_failures = False
+    from portolan_cli.check import run_fix_workflow
 
-    # Fix metadata if in scope
-    if run_metadata:
-        from portolan_cli.metadata.scan import scan_catalog_metadata
+    # Progress callback for conversion (skip for JSON mode, per ADR-0040: per-file only in verbose)
+    def show_conversion_progress(result: ConversionResult) -> None:
+        if not use_json and verbose and result.source:
+            info_output(f"Converting: {result.source.name}")
 
-        # Resolve to the catalog root before scanning. Without this the
-        # scanner returns an empty report whenever `path` points at a
-        # subdirectory below the root, causing --fix to silently no-op.
-        # The scanner's only structural requirement is catalog.json, so
-        # walk parents looking for it (tests and existing catalogs may
-        # not have a .portolan sentinel, so find_catalog_root is too
-        # strict here).
-        catalog_root = _resolve_catalog_root_for_check(path)
-        if catalog_root is None:
-            # Metadata-only mode: user explicitly asked, fail loudly so the
-            # silent-no-op trap is closed. Mixed mode (--fix without flags):
-            # stay backwards-compatible — skip metadata so the geo-assets
-            # pass can still operate on the directory.
-            if not run_geo_assets:
-                msg = (
-                    f"fatal: not a portolan catalog (or any parent of {path}): "
-                    "no catalog.json found, cannot run metadata fix"
-                )
-                emit_error("check", "NotACatalogError", msg, use_json=use_json)
-                raise SystemExit(1)
-        else:
-            metadata_check_report = scan_catalog_metadata(catalog_root)
-            metadata_fix_report = fix_metadata(catalog_root, metadata_check_report, dry_run=dry_run)
+    outcome = run_fix_workflow(
+        path=path,
+        run_metadata=run_metadata,
+        run_geo_assets=run_geo_assets,
+        dry_run=dry_run,
+        remove_legacy=remove_legacy,
+        force=force,
+        workers=workers,
+        on_progress=show_conversion_progress,
+    )
 
-            # Issue #502: populate human-readable titles/descriptions and
-            # backfill child/item link titles as part of the metadata fix.
-            from portolan_cli.metadata.fix import (
-                repair_pmtiles_links,
-                repair_tabular_flags,
-                repair_titles_and_links,
-            )
+    # Metadata-only fix that found no catalog root: surface and exit (issue #384).
+    if outcome.fatal_error is not None:
+        emit_error("check", "NotACatalogError", outcome.fatal_error, use_json=use_json)
+        raise SystemExit(1)
 
-            metadata_fix_report.results.extend(
-                repair_titles_and_links(catalog_root, dry_run=dry_run)
-            )
-
-            # Issue #481: backfill portolan:geospatial: false on tabular
-            # collections (RULE-0090) as part of the metadata fix.
-            metadata_fix_report.results.extend(repair_tabular_flags(catalog_root, dry_run=dry_run))
-
-            # Issue #569: backfill the rel="pmtiles" web-map-links link on
-            # collections with a PMTiles asset but no link (RULE-0061).
-            metadata_fix_report.results.extend(repair_pmtiles_links(catalog_root, dry_run=dry_run))
-
-            if metadata_fix_report.failure_count > 0:
-                has_failures = True
-
-    # Fix geo-assets if in scope
-    if run_geo_assets:
-        # Progress callback for conversion (skip for JSON mode, per ADR-0040: per-file only in verbose)
-        def show_conversion_progress(result: ConversionResult) -> None:
-            if not use_json and verbose and result.source:
-                info_output(f"Converting: {result.source.name}")
-
-        format_fix_report = check_directory(
-            path,
-            fix=True,
-            dry_run=dry_run,
-            remove_legacy=remove_legacy,
-            force=force,
-            workers=workers,
-            on_progress=show_conversion_progress,
-            catalog_path=path,
-        )
+    metadata_fix_report = outcome.metadata_fix_report
+    format_fix_report = outcome.format_fix_report
 
     # Output results
     if use_json:
@@ -1566,7 +1497,7 @@ def _run_fix_workflow(
             mode=mode,
             metadata_fix_report=metadata_fix_report,
             format_fix_report=format_fix_report,
-            has_failures=has_failures,
+            has_failures=outcome.has_failures,
         )
     else:
         _output_fix_human(
@@ -1578,7 +1509,7 @@ def _run_fix_workflow(
         )
 
     # Exit with error if any failures
-    if has_failures:
+    if outcome.has_failures:
         raise SystemExit(1)
     # Also exit with error if format conversion had failures
     if (
@@ -2713,45 +2644,19 @@ def _check_partition_prompt(
     Returns:
         True if user declined partitioning, False otherwise.
     """
-    from portolan_cli.config import get_setting
-    from portolan_cli.partitioning import should_partition
+    from portolan_cli.partitioning import find_large_partition_candidates
 
-    part_enabled = get_setting("partitioning.enabled", catalog_path=catalog_root)
-    if part_enabled is None:
-        part_enabled = True  # Default: enabled (prompt before partitioning large files)
-    part_prompt = get_setting("partitioning.prompt", catalog_path=catalog_root)
-    if part_prompt is None:
-        part_prompt = True  # Default: prompt in interactive mode
-    threshold_gb = get_setting("partitioning.threshold_gb", catalog_path=catalog_root) or 2.0
-
-    if not (part_enabled and part_prompt and sys.stderr.isatty()):
+    # Prompting only makes sense interactively; skip the config read + scan
+    # entirely when not attached to a terminal.
+    if not sys.stderr.isatty():
         return False
 
-    # Pre-scan for large files that would trigger partitioning
-    large_files: list[tuple[Path, float]] = []
-    for p in resolved_paths:
-        try:
-            if p.is_file() and p.suffix.lower() == ".parquet":
-                if should_partition(p, threshold_gb=threshold_gb, enabled=True):
-                    size_gb = p.stat().st_size / (1024 * 1024 * 1024)
-                    large_files.append((p, size_gb))
-            elif p.is_dir():
-                for pq in p.rglob("*.parquet"):
-                    try:
-                        if should_partition(pq, threshold_gb=threshold_gb, enabled=True):
-                            size_gb = pq.stat().st_size / (1024 * 1024 * 1024)
-                            large_files.append((pq, size_gb))
-                    except OSError:
-                        # Skip files with permission errors or broken symlinks
-                        continue
-        except OSError:
-            # Skip paths with permission errors or broken symlinks
-            continue
-
+    decision = find_large_partition_candidates(resolved_paths, catalog_root)
+    large_files = decision.large_files
     if not large_files:
         return False
 
-    warn(f"Found {len(large_files)} file(s) exceeding {threshold_gb} GB threshold:")
+    warn(f"Found {len(large_files)} file(s) exceeding {decision.threshold_gb} GB threshold:")
     for lf, size in large_files[:5]:  # Show first 5
         detail(f"  {lf.name} ({size:.2f} GB)")
     if len(large_files) > 5:
@@ -2762,262 +2667,6 @@ def _check_partition_prompt(
         return True
 
     return False
-
-
-def _handle_parquet_after_add(
-    catalog_root: Path,
-    affected_collections: set[str],
-    generate_parquet: bool,
-    verbose: bool,
-    *,
-    show_hints: bool = True,
-) -> None:
-    """Handle stac-geoparquet generation/hints after add command.
-
-    If generate_parquet is True or parquet.enabled config is set, generates
-    items.parquet for affected collections. Otherwise, shows hints for
-    collections exceeding the threshold.
-
-    Args:
-        catalog_root: Path to catalog root.
-        affected_collections: Set of collection IDs that were modified.
-        generate_parquet: Whether --stac-geoparquet flag was passed.
-        verbose: Whether to show verbose output.
-        show_hints: Whether to show hints (disabled in JSON output mode).
-    """
-    if not affected_collections:
-        return
-
-    from portolan_cli.config import get_setting
-    from portolan_cli.stac_parquet import (
-        add_parquet_link_to_collection,
-        count_items,
-        generate_items_parquet,
-        should_suggest_parquet,
-        track_parquet_in_versions,
-    )
-
-    for coll_id in affected_collections:
-        coll_path = catalog_root / coll_id
-        if not (coll_path / "collection.json").exists():
-            continue
-
-        # Get settings per-collection with hierarchical lookup (ADR-0039)
-        parquet_enabled_raw = get_setting(
-            "parquet.enabled",
-            catalog_path=catalog_root,
-            collection=coll_id,
-            collection_path=coll_path,
-        )
-        threshold_raw = get_setting(
-            "parquet.threshold",
-            catalog_path=catalog_root,
-            collection=coll_id,
-            collection_path=coll_path,
-        )
-
-        # Type coercion: parquet.enabled can be string from env var
-        parquet_enabled = _coerce_bool(parquet_enabled_raw, default=False)
-        threshold = _coerce_int(threshold_raw, default=100)
-
-        # Count items first to apply threshold gate
-        item_count = count_items(coll_path)
-
-        # Generate when:
-        # - Explicit --stac-geoparquet flag (always generate), OR
-        # - Auto-generation enabled AND item count exceeds threshold
-        should_generate = generate_parquet or (parquet_enabled and item_count > threshold)
-
-        if should_generate and item_count > 0:
-            try:
-                generate_items_parquet(coll_path)
-                add_parquet_link_to_collection(coll_path)
-                track_parquet_in_versions(coll_path)
-                if verbose:
-                    info_output(f"Generated items.parquet for '{coll_id}'")
-            except Exception as e:
-                # Explicit --stac-geoparquet should fail the command
-                if generate_parquet:
-                    raise
-                # Auto-generation failures just warn
-                warn(f"Failed to generate parquet for '{coll_id}': {e}")
-        elif show_hints and should_suggest_parquet(coll_path, threshold=threshold):
-            info_output(
-                f"Hint: Collection '{coll_id}' has {item_count} items (>{threshold}). "
-                f"Consider running: portolan stac-geoparquet -c {coll_id}"
-            )
-
-
-@dataclass
-class PMTilesSettings:
-    """Settings for PMTiles generation."""
-
-    enabled: bool = False
-    min_zoom: int | None = None
-    max_zoom: int | None = None
-    layer: str | None = None
-    bbox: str | None = None
-    where: str | None = None
-    include_cols: str | None = None
-    precision: int = 6
-    attribution: str | None = None
-    src_crs: str | None = None
-
-
-def _get_pmtiles_settings(catalog_root: Path, coll_id: str, coll_path: Path) -> PMTilesSettings:
-    """Get PMTiles settings for a collection."""
-    from portolan_cli.config import get_setting
-
-    def get(key: str) -> Any:
-        return get_setting(
-            f"pmtiles.{key}",
-            catalog_path=catalog_root,
-            collection=coll_id,
-            collection_path=coll_path,
-        )
-
-    return PMTilesSettings(
-        enabled=_coerce_bool(get("enabled"), default=False),
-        min_zoom=None if get("min_zoom") is None else _coerce_int(get("min_zoom"), default=0),
-        max_zoom=None if get("max_zoom") is None else _coerce_int(get("max_zoom"), default=14),
-        layer=get("layer"),
-        bbox=get("bbox"),
-        where=get("where"),
-        include_cols=get("include_cols"),
-        precision=_coerce_int(get("precision"), default=6),
-        attribution=get("attribution"),
-        src_crs=get("src_crs"),
-    )
-
-
-def _handle_pmtiles_after_add(
-    catalog_root: Path,
-    affected_collections: set[str],
-    generate_pmtiles: bool,
-    force: bool,
-    verbose: bool,
-    *,
-    use_json: bool = False,
-) -> None:
-    """Handle PMTiles generation after add command."""
-    if not affected_collections:
-        return
-
-    from portolan_cli.pmtiles import (
-        PMTilesNotAvailableError,
-        TippecanoeNotFoundError,
-        generate_pmtiles_for_collection,
-    )
-
-    for coll_id in affected_collections:
-        coll_path = catalog_root / coll_id
-        if not (coll_path / "collection.json").exists():
-            continue
-
-        settings = _get_pmtiles_settings(catalog_root, coll_id, coll_path)
-        if not (generate_pmtiles or settings.enabled):
-            continue
-
-        try:
-            result = generate_pmtiles_for_collection(
-                coll_path,
-                catalog_root,
-                force=force,
-                min_zoom=settings.min_zoom,
-                max_zoom=settings.max_zoom,
-                layer=settings.layer,
-                bbox=settings.bbox,
-                where=settings.where,
-                include_cols=settings.include_cols,
-                precision=settings.precision,
-                attribution=settings.attribution,
-                src_crs=settings.src_crs,
-            )
-            _report_pmtiles_result(result, verbose, generate_pmtiles, use_json=use_json)
-        except PMTilesNotAvailableError as e:
-            _handle_pmtiles_unavailable(
-                e, generate_pmtiles, settings.enabled, verbose, coll_id, use_json=use_json
-            )
-        except TippecanoeNotFoundError as e:
-            _handle_tippecanoe_missing(e, generate_pmtiles, coll_id, use_json=use_json)
-
-
-def _report_pmtiles_result(
-    result: Any, verbose: bool, explicit_flag: bool, *, use_json: bool = False
-) -> None:
-    """Report PMTiles generation results."""
-    if not use_json:
-        for p in result.generated:
-            success(f"Generated PMTiles: {p.name}")
-        if result.skipped and verbose:
-            for p in result.skipped:
-                info_output(f"Skipped PMTiles (up-to-date): {p.name}")
-    for path, error_msg in result.failed:
-        if explicit_flag:
-            if not use_json:
-                error(f"PMTiles generation failed: {error_msg}")
-            raise SystemExit(1)
-        if not use_json:
-            warn(f"Failed to generate PMTiles for '{path}': {error_msg}")
-
-
-def _handle_pmtiles_unavailable(
-    e: Exception,
-    explicit_flag: bool,
-    config_enabled: bool,
-    verbose: bool,
-    coll_id: str,
-    *,
-    use_json: bool = False,
-) -> None:
-    """Handle PMTilesNotAvailableError."""
-    if explicit_flag:
-        if not use_json:
-            error(str(e))
-        raise SystemExit(1) from e
-    if use_json:
-        return
-    # Warn if pmtiles.enabled in config (user expectation), or info if just verbose
-    if config_enabled:
-        warn(f"PMTiles enabled for '{coll_id}' but gpio-pmtiles not installed")
-    elif verbose:
-        info_output(f"Skipping PMTiles for '{coll_id}': gpio-pmtiles not installed")
-
-
-def _handle_tippecanoe_missing(
-    e: Exception, explicit_flag: bool, coll_id: str, *, use_json: bool = False
-) -> None:
-    """Handle TippecanoeNotFoundError."""
-    if explicit_flag:
-        if not use_json:
-            error(str(e))
-        raise SystemExit(1) from e
-    if not use_json:
-        warn(f"Skipping PMTiles for '{coll_id}': tippecanoe not installed")
-
-
-def _coerce_bool(value: Any, *, default: bool = False) -> bool:
-    """Coerce a value to boolean.
-
-    Handles string values like "true", "1", "yes" from env vars.
-    """
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.lower() in ("true", "1", "yes", "on")
-    return bool(value)
-
-
-def _coerce_int(value: Any, *, default: int) -> int:
-    """Coerce a value to integer with safe fallback."""
-    if value is None:
-        return default
-    try:
-        return int(value)
-    except (ValueError, TypeError):
-        return default
 
 
 @cli.command("add")
@@ -3291,13 +2940,26 @@ def add_cmd(
     # Handle stac-geoparquet generation BEFORE output (so JSON reflects final state)
     # Always run parquet generation if --stac-geoparquet flag was passed, regardless of output mode
     # Only show hints in non-JSON mode
-    _handle_parquet_after_add(
-        catalog_root, affected, generate_parquet, verbose, show_hints=not use_json
+    from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+    generate_or_suggest_parquet(
+        catalog_root,
+        affected,
+        generate_parquet=generate_parquet,
+        verbose=verbose,
+        show_hints=not use_json,
     )
 
     # Handle PMTiles generation BEFORE output (so JSON reflects final state)
-    _handle_pmtiles_after_add(
-        catalog_root, affected, generate_pmtiles, force_pmtiles, verbose, use_json=use_json
+    from portolan_cli.pmtiles import generate_or_suggest_pmtiles
+
+    generate_or_suggest_pmtiles(
+        catalog_root,
+        affected,
+        generate_pmtiles=generate_pmtiles,
+        force=force_pmtiles,
+        verbose=verbose,
+        use_json=use_json,
     )
 
     # Output combined results (after all processing complete)
@@ -3636,11 +3298,10 @@ def _resolve_push_settings(
     Raises:
         SystemExit: If config.yaml contains stale sensitive settings
     """
+    from portolan_cli.config import resolve_push_settings
+
     try:
-        resolved_destination = resolve_remote(destination, catalog_path, collection)
-        resolved_profile = resolve_aws_profile(profile, catalog_path, collection)
-        resolved_region = resolve_aws_region(None, catalog_path, collection)
-        return resolved_destination, resolved_profile, resolved_region
+        return resolve_push_settings(destination, profile, catalog_path, collection)
     except ValueError as e:
         emit_error(command, "ConfigError", str(e), use_json=use_json)
         raise SystemExit(1) from None

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -883,3 +883,99 @@ def check_sensitive_settings_in_config(catalog_path: Path) -> list[str]:
                     found.append(f"collections.{collection_name}.{key}")
 
     return found
+
+
+def coerce_bool(value: Any, *, default: bool = False) -> bool:
+    """Coerce a config value to boolean.
+
+    Settings sourced from environment variables arrive as strings, so accept
+    the common truthy spellings ("true", "1", "yes", "on") in addition to real
+    booleans.
+
+    Args:
+        value: Raw setting value (bool, str, None, or other).
+        default: Value returned when ``value`` is None.
+
+    Returns:
+        The coerced boolean.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ("true", "1", "yes", "on")
+    return bool(value)
+
+
+def coerce_int(value: Any, *, default: int) -> int:
+    """Coerce a config value to integer with a safe fallback.
+
+    Args:
+        value: Raw setting value (int, str, None, or other).
+        default: Value returned when ``value`` is None or not parseable.
+
+    Returns:
+        The coerced integer, or ``default`` on failure.
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def resolve_push_settings(
+    destination: str | None,
+    profile: str | None,
+    catalog_path: Path,
+    collection: str | None,
+) -> tuple[str | None, str, str | None]:
+    """Resolve remote/profile/region for push/sync with CLI > env > config precedence.
+
+    Sensitive settings (remote, profile, region) come from CLI flags, env vars,
+    or ``.env`` — never from ``config.yaml`` (which gets pushed). ``get_setting``
+    raises ``ValueError`` when a stale sensitive value is found in ``config.yaml``;
+    this function lets that propagate so the caller can surface it.
+
+    Args:
+        destination: CLI-provided remote destination (None if not specified).
+        profile: CLI-provided AWS profile (None if not specified).
+        catalog_path: Resolved catalog root for config lookup.
+        collection: Optional collection name for collection-level config.
+
+    Returns:
+        Tuple of (resolved_destination, resolved_profile, resolved_region).
+        ``resolved_profile`` defaults to ``"default"`` when nothing is configured.
+
+    Raises:
+        ValueError: If ``config.yaml`` contains stale sensitive settings.
+    """
+    collection_path = catalog_path / collection if collection else None
+    resolved_destination = get_setting(
+        "remote",
+        cli_value=destination,
+        catalog_path=catalog_path,
+        collection=collection,
+        collection_path=collection_path,
+    )
+    resolved_profile = get_setting(
+        "aws_profile",
+        cli_value=profile,
+        catalog_path=catalog_path,
+        collection=collection,
+        collection_path=collection_path,
+    )
+    resolved_region = get_setting(
+        "region",
+        cli_value=None,
+        catalog_path=catalog_path,
+        collection=collection,
+        collection_path=collection_path,
+    )
+    return (
+        resolved_destination,
+        resolved_profile if resolved_profile is not None else "default",
+        resolved_region,
+    )

--- a/portolan_cli/partitioning.py
+++ b/portolan_cli/partitioning.py
@@ -91,6 +91,101 @@ def should_partition(
     return file_size > threshold_bytes
 
 
+@dataclass
+class PartitionPromptDecision:
+    """Config-driven decision inputs for the interactive partition prompt.
+
+    The library computes *whether* there is anything to prompt about (config
+    gating + which files exceed the threshold); the CLI owns the actual TTY
+    check and ``click.confirm`` prompt (ADR-0007).
+    """
+
+    enabled: bool
+    """Value of ``partitioning.enabled`` (default True)."""
+
+    prompt: bool
+    """Value of ``partitioning.prompt`` (default True)."""
+
+    threshold_gb: float
+    """Size threshold in GB (``partitioning.threshold_gb``, default 2.0)."""
+
+    large_files: list[tuple[Path, float]]
+    """(path, size_gb) for files exceeding the threshold. Empty when gating is
+    off, so the CLI can short-circuit without prompting."""
+
+
+def find_large_partition_candidates(
+    resolved_paths: list[Path],
+    catalog_root: Path,
+) -> PartitionPromptDecision:
+    """Read partition config and scan paths for files that would be partitioned.
+
+    Reads ``partitioning.{enabled,prompt,threshold_gb}`` (hierarchical config)
+    and, when both ``enabled`` and ``prompt`` are set, scans ``resolved_paths``
+    for ``.parquet`` files exceeding the threshold. Returns an empty
+    ``large_files`` list when gating is disabled so the caller can skip the
+    prompt. Does no terminal I/O — the TTY check and confirmation live in the CLI.
+
+    Args:
+        resolved_paths: Paths (files or directories) the add command will import.
+        catalog_root: Catalog root used for hierarchical config lookup.
+
+    Returns:
+        A :class:`PartitionPromptDecision` describing the gating and candidates.
+    """
+    from portolan_cli.config import get_setting
+
+    enabled = get_setting("partitioning.enabled", catalog_path=catalog_root)
+    if enabled is None:
+        enabled = True  # Default: enabled (prompt before partitioning large files)
+    prompt = get_setting("partitioning.prompt", catalog_path=catalog_root)
+    if prompt is None:
+        prompt = True  # Default: prompt in interactive mode
+    threshold_gb = get_setting("partitioning.threshold_gb", catalog_path=catalog_root) or 2.0
+
+    if not (enabled and prompt):
+        return PartitionPromptDecision(
+            enabled=bool(enabled),
+            prompt=bool(prompt),
+            threshold_gb=threshold_gb,
+            large_files=[],
+        )
+
+    large_files = _scan_partition_candidates(resolved_paths, threshold_gb)
+    return PartitionPromptDecision(
+        enabled=True,
+        prompt=True,
+        threshold_gb=threshold_gb,
+        large_files=large_files,
+    )
+
+
+def _scan_partition_candidates(
+    resolved_paths: list[Path], threshold_gb: float
+) -> list[tuple[Path, float]]:
+    """Collect ``.parquet`` files exceeding ``threshold_gb`` from paths/dirs."""
+    large_files: list[tuple[Path, float]] = []
+    for p in resolved_paths:
+        try:
+            if p.is_file() and p.suffix.lower() == ".parquet":
+                if should_partition(p, threshold_gb=threshold_gb, enabled=True):
+                    size_gb = p.stat().st_size / (1024 * 1024 * 1024)
+                    large_files.append((p, size_gb))
+            elif p.is_dir():
+                for pq_file in p.rglob("*.parquet"):
+                    try:
+                        if should_partition(pq_file, threshold_gb=threshold_gb, enabled=True):
+                            size_gb = pq_file.stat().st_size / (1024 * 1024 * 1024)
+                            large_files.append((pq_file, size_gb))
+                    except OSError:
+                        # Skip files with permission errors or broken symlinks
+                        continue
+        except OSError:
+            # Skip paths with permission errors or broken symlinks
+            continue
+    return large_files
+
+
 def partition_geoparquet(
     input_path: Path,
     output_dir: Path,

--- a/portolan_cli/pmtiles.py
+++ b/portolan_cli/pmtiles.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from portolan_cli.errors import PortolanError
-from portolan_cli.output import warn
+from portolan_cli.output import error, info, success, warn
 
 # The PMTiles constants and pure asset/link classifiers now live in the
 # framework-free leaf pmtiles_links.py so validation/ can reach them without
@@ -912,3 +912,159 @@ def generate_pmtiles_for_collection(
     register_style_assets(collection_path, styles)
 
     return result
+
+
+@dataclass
+class PMTilesSettings:
+    """Per-collection PMTiles generation settings resolved from config."""
+
+    enabled: bool = False
+    min_zoom: int | None = None
+    max_zoom: int | None = None
+    layer: str | None = None
+    bbox: str | None = None
+    where: str | None = None
+    include_cols: str | None = None
+    precision: int = 6
+    attribution: str | None = None
+    src_crs: str | None = None
+
+
+def get_pmtiles_settings(catalog_root: Path, coll_id: str, coll_path: Path) -> PMTilesSettings:
+    """Resolve PMTiles settings for a collection via hierarchical config (ADR-0039)."""
+    from portolan_cli.config import coerce_bool, coerce_int, get_setting
+
+    def get(key: str) -> Any:
+        return get_setting(
+            f"pmtiles.{key}",
+            catalog_path=catalog_root,
+            collection=coll_id,
+            collection_path=coll_path,
+        )
+
+    return PMTilesSettings(
+        enabled=coerce_bool(get("enabled"), default=False),
+        min_zoom=None if get("min_zoom") is None else coerce_int(get("min_zoom"), default=0),
+        max_zoom=None if get("max_zoom") is None else coerce_int(get("max_zoom"), default=14),
+        layer=get("layer"),
+        bbox=get("bbox"),
+        where=get("where"),
+        include_cols=get("include_cols"),
+        precision=coerce_int(get("precision"), default=6),
+        attribution=get("attribution"),
+        src_crs=get("src_crs"),
+    )
+
+
+def generate_or_suggest_pmtiles(
+    catalog_root: Path,
+    affected_collections: set[str],
+    *,
+    generate_pmtiles: bool,
+    force: bool,
+    verbose: bool,
+    use_json: bool = False,
+) -> None:
+    """Generate PMTiles for affected collections when requested or configured.
+
+    For each affected collection, resolves PMTiles settings and generates when
+    ``--pmtiles`` was passed or ``pmtiles.enabled`` is configured. Generation runs
+    regardless of output mode so the JSON envelope reflects the final state
+    (ADR-0030); an explicitly-requested generation that fails exits non-zero.
+
+    Args:
+        catalog_root: Catalog root directory.
+        affected_collections: Collection IDs modified by the add command.
+        generate_pmtiles: Whether ``--pmtiles`` was passed.
+        force: Whether to regenerate up-to-date PMTiles.
+        verbose: Whether to emit per-file detail.
+        use_json: Whether the command runs in JSON output mode.
+    """
+    if not affected_collections:
+        return
+
+    for coll_id in affected_collections:
+        coll_path = catalog_root / coll_id
+        if not (coll_path / "collection.json").exists():
+            continue
+
+        settings = get_pmtiles_settings(catalog_root, coll_id, coll_path)
+        if not (generate_pmtiles or settings.enabled):
+            continue
+
+        try:
+            result = generate_pmtiles_for_collection(
+                coll_path,
+                catalog_root,
+                force=force,
+                min_zoom=settings.min_zoom,
+                max_zoom=settings.max_zoom,
+                layer=settings.layer,
+                bbox=settings.bbox,
+                where=settings.where,
+                include_cols=settings.include_cols,
+                precision=settings.precision,
+                attribution=settings.attribution,
+                src_crs=settings.src_crs,
+            )
+            _report_pmtiles_result(result, verbose, generate_pmtiles, use_json=use_json)
+        except PMTilesNotAvailableError as e:
+            _report_pmtiles_unavailable(
+                e, generate_pmtiles, settings.enabled, verbose, coll_id, use_json=use_json
+            )
+        except TippecanoeNotFoundError as e:
+            _report_tippecanoe_missing(e, generate_pmtiles, coll_id, use_json=use_json)
+
+
+def _report_pmtiles_result(
+    result: PMTilesResult, verbose: bool, explicit_flag: bool, *, use_json: bool = False
+) -> None:
+    """Report PMTiles generation results; exit non-zero on explicit-flag failure."""
+    if not use_json:
+        for p in result.generated:
+            success(f"Generated PMTiles: {p.name}")
+        if result.skipped and verbose:
+            for p in result.skipped:
+                info(f"Skipped PMTiles (up-to-date): {p.name}")
+    for path, error_msg in result.failed:
+        if explicit_flag:
+            if not use_json:
+                error(f"PMTiles generation failed: {error_msg}")
+            raise SystemExit(1)
+        if not use_json:
+            warn(f"Failed to generate PMTiles for '{path}': {error_msg}")
+
+
+def _report_pmtiles_unavailable(
+    e: Exception,
+    explicit_flag: bool,
+    config_enabled: bool,
+    verbose: bool,
+    coll_id: str,
+    *,
+    use_json: bool = False,
+) -> None:
+    """Report a PMTilesNotAvailableError; exit non-zero when explicitly requested."""
+    if explicit_flag:
+        if not use_json:
+            error(str(e))
+        raise SystemExit(1) from e
+    if use_json:
+        return
+    # Warn if pmtiles.enabled in config (user expectation), or info if just verbose
+    if config_enabled:
+        warn(f"PMTiles enabled for '{coll_id}' but gpio-pmtiles not installed")
+    elif verbose:
+        info(f"Skipping PMTiles for '{coll_id}': gpio-pmtiles not installed")
+
+
+def _report_tippecanoe_missing(
+    e: Exception, explicit_flag: bool, coll_id: str, *, use_json: bool = False
+) -> None:
+    """Report a TippecanoeNotFoundError; exit non-zero when explicitly requested."""
+    if explicit_flag:
+        if not use_json:
+            error(str(e))
+        raise SystemExit(1) from e
+    if not use_json:
+        warn(f"Skipping PMTiles for '{coll_id}': tippecanoe not installed")

--- a/portolan_cli/stac_parquet.py
+++ b/portolan_cli/stac_parquet.py
@@ -30,6 +30,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from portolan_cli.output import info, warn
+
 # Constants
 PARQUET_FILENAME = "items.parquet"
 PARQUET_MEDIA_TYPE = "application/vnd.apache.parquet"
@@ -390,3 +392,90 @@ def track_parquet_in_versions(collection_path: Path) -> None:
     )
 
     write_versions(versions_path, updated)
+
+
+def generate_or_suggest_parquet(
+    catalog_root: Path,
+    affected_collections: set[str],
+    *,
+    generate_parquet: bool,
+    verbose: bool,
+    show_hints: bool = True,
+) -> None:
+    """Generate items.parquet for affected collections, or hint when suggested.
+
+    For each affected collection, reads ``parquet.{enabled,threshold}`` with a
+    hierarchical lookup (ADR-0039) and decides whether to generate:
+
+    - Generate when ``generate_parquet`` (explicit ``--stac-geoparquet``) is set,
+      or when auto-generation is enabled and the item count exceeds the threshold.
+    - Otherwise, when ``show_hints`` and the collection is over threshold, print a
+      hint suggesting ``portolan stac-geoparquet``.
+
+    Generation always runs regardless of output mode so the JSON envelope reflects
+    the final state (ADR-0030). An explicitly-requested generation that fails
+    re-raises; an auto-generation failure only warns.
+
+    Args:
+        catalog_root: Catalog root directory.
+        affected_collections: Collection IDs modified by the add command.
+        generate_parquet: Whether ``--stac-geoparquet`` was passed.
+        verbose: Whether to emit per-collection success detail.
+        show_hints: Whether to print suggestion hints (disabled in JSON mode).
+    """
+    if not affected_collections:
+        return
+
+    from portolan_cli.config import coerce_bool, coerce_int, get_setting
+
+    for coll_id in affected_collections:
+        coll_path = catalog_root / coll_id
+        if not (coll_path / "collection.json").exists():
+            continue
+
+        # Get settings per-collection with hierarchical lookup (ADR-0039)
+        parquet_enabled = coerce_bool(
+            get_setting(
+                "parquet.enabled",
+                catalog_path=catalog_root,
+                collection=coll_id,
+                collection_path=coll_path,
+            ),
+            default=False,
+        )
+        threshold = coerce_int(
+            get_setting(
+                "parquet.threshold",
+                catalog_path=catalog_root,
+                collection=coll_id,
+                collection_path=coll_path,
+            ),
+            default=100,
+        )
+
+        # Count items first to apply threshold gate
+        item_count = count_items(coll_path)
+
+        # Generate when:
+        # - Explicit --stac-geoparquet flag (always generate), OR
+        # - Auto-generation enabled AND item count exceeds threshold
+        should_generate = generate_parquet or (parquet_enabled and item_count > threshold)
+
+        if should_generate and item_count > 0:
+            try:
+                generate_items_parquet(coll_path)
+                add_parquet_link_to_collection(coll_path)
+                track_parquet_in_versions(coll_path)
+                if verbose:
+                    info(f"Generated items.parquet for '{coll_id}'")
+            except Exception as e:
+                # Explicit --stac-geoparquet should fail the command
+                if generate_parquet:
+                    raise
+                # Auto-generation failures just warn
+                warn(f"Failed to generate parquet for '{coll_id}': {e}")
+        elif show_hints and should_suggest_parquet(coll_path, threshold=threshold):
+            info(
+                f"Hint: Collection '{coll_id}' has {item_count} items (>{threshold}). "
+                f"Consider running: portolan stac-geoparquet -c {coll_id}"
+            )

--- a/tests/unit/test_check_workflow.py
+++ b/tests/unit/test_check_workflow.py
@@ -1,0 +1,205 @@
+"""Tests for the check/fix workflow orchestration in check.py (issue #620).
+
+These exercise the Click-free workflow layer extracted from cli.py:
+- resolve_catalog_root_for_check: walk up to catalog.json
+- build_check_rules: rule construction honoring config + strict
+- run_fix_workflow: metadata/geo-asset fix orchestration returning reports
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _init_catalog(path: Path) -> None:
+    """Create a minimal managed catalog (sentinel + catalog.json)."""
+    portolan_dir = path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("{}")
+    (path / "catalog.json").write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "stac_version": "1.0.0",
+                "id": "c",
+                "description": "d",
+                "links": [],
+            }
+        )
+    )
+
+
+class TestResolveCatalogRootForCheck:
+    """Tests for resolve_catalog_root_for_check."""
+
+    @pytest.mark.unit
+    def test_finds_catalog_json_in_parent(self, tmp_path: Path) -> None:
+        from portolan_cli.check import resolve_catalog_root_for_check
+
+        _init_catalog(tmp_path)
+        subdir = tmp_path / "collection" / "nested"
+        subdir.mkdir(parents=True)
+
+        assert resolve_catalog_root_for_check(subdir) == tmp_path.resolve()
+
+    @pytest.mark.unit
+    def test_returns_none_without_catalog_json(self, tmp_path: Path) -> None:
+        from portolan_cli.check import resolve_catalog_root_for_check
+
+        # No catalog.json anywhere under a private temp dir.
+        loose = tmp_path / "loose"
+        loose.mkdir()
+
+        assert resolve_catalog_root_for_check(loose) is None
+
+
+class TestBuildCheckRules:
+    """Tests for build_check_rules (extraction parity, #620)."""
+
+    @pytest.mark.unit
+    def test_matches_underlying_build_rules(self, tmp_path: Path) -> None:
+        """Without config, build_check_rules matches validation.runner._build_rules."""
+        from portolan_cli.check import build_check_rules
+        from portolan_cli.validation.runner import _build_rules
+
+        _init_catalog(tmp_path)
+        got = build_check_rules(tmp_path, strict=False)
+        expected = _build_rules(strict=False, config=None)
+
+        assert [type(r).__name__ for r in got] == [type(r).__name__ for r in expected]
+
+    @pytest.mark.unit
+    def test_returns_rules_without_portolan_dir(self, tmp_path: Path) -> None:
+        """A path with no .portolan/config.yaml still yields the default rules."""
+        from portolan_cli.check import build_check_rules
+        from portolan_cli.validation.runner import _build_rules
+
+        got = build_check_rules(tmp_path, strict=True)
+        expected = _build_rules(strict=True, config=None)
+
+        assert [type(r).__name__ for r in got] == [type(r).__name__ for r in expected]
+
+
+class TestRunFixWorkflow:
+    """Tests for run_fix_workflow returning a FixWorkflowOutcome (#620)."""
+
+    @pytest.mark.unit
+    def test_metadata_only_without_catalog_sets_fatal_error(self, tmp_path: Path) -> None:
+        """Metadata-only fix with no catalog.json returns a fatal_error message."""
+        from portolan_cli.check import run_fix_workflow
+
+        loose = tmp_path / "loose"
+        loose.mkdir()
+
+        outcome = run_fix_workflow(
+            path=loose,
+            run_metadata=True,
+            run_geo_assets=False,
+            dry_run=False,
+            remove_legacy=False,
+        )
+
+        assert outcome.fatal_error is not None
+        assert "not a portolan catalog" in outcome.fatal_error
+        assert outcome.metadata_fix_report is None
+
+    @pytest.mark.unit
+    def test_mixed_mode_without_catalog_skips_metadata(self, tmp_path: Path) -> None:
+        """Mixed mode with no catalog skips metadata (no fatal) and still runs geo fix."""
+        from portolan_cli.check import CheckReport, run_fix_workflow
+
+        loose = tmp_path / "loose"
+        loose.mkdir()
+
+        sentinel = CheckReport(root=loose, files=[], conversion_report=None)
+        with patch("portolan_cli.check.check_directory", return_value=sentinel) as mock_check:
+            outcome = run_fix_workflow(
+                path=loose,
+                run_metadata=True,
+                run_geo_assets=True,
+                dry_run=False,
+                remove_legacy=False,
+            )
+
+        assert outcome.fatal_error is None
+        assert outcome.metadata_fix_report is None
+        assert outcome.format_fix_report is sentinel
+        mock_check.assert_called_once()
+
+    @pytest.mark.unit
+    def test_geo_only_threads_force_and_workers(self, tmp_path: Path) -> None:
+        """Geo-only fix forwards force/workers to check_directory."""
+        from portolan_cli.check import CheckReport, run_fix_workflow
+
+        _init_catalog(tmp_path)
+        sentinel = CheckReport(root=tmp_path, files=[], conversion_report=None)
+        with patch("portolan_cli.check.check_directory", return_value=sentinel) as mock_check:
+            outcome = run_fix_workflow(
+                path=tmp_path,
+                run_metadata=False,
+                run_geo_assets=True,
+                dry_run=False,
+                remove_legacy=False,
+                force=True,
+                workers=3,
+            )
+
+        assert outcome.format_fix_report is sentinel
+        kwargs = mock_check.call_args.kwargs
+        assert kwargs.get("force") is True
+        assert kwargs.get("workers") == 3
+
+    @pytest.mark.unit
+    def test_metadata_fix_reports_failures(self, tmp_path: Path) -> None:
+        """A metadata fix with failures sets has_failures on the outcome."""
+        from portolan_cli.check import run_fix_workflow
+        from portolan_cli.metadata.fix import FixAction, FixReport, FixResult
+        from portolan_cli.metadata.models import (
+            MetadataCheckResult,
+            MetadataReport,
+            MetadataStatus,
+        )
+
+        _init_catalog(tmp_path)
+
+        check_report = MetadataReport(
+            results=[
+                MetadataCheckResult(
+                    file_path=tmp_path / "x.parquet",
+                    status=MetadataStatus.MISSING,
+                    message="missing",
+                )
+            ]
+        )
+        fix_report = FixReport(
+            results=[
+                FixResult(
+                    file_path=tmp_path / "x.parquet",
+                    action=FixAction.CREATED,
+                    success=False,
+                    message="failed",
+                )
+            ]
+        )
+
+        with (
+            patch(
+                "portolan_cli.metadata.scan.scan_catalog_metadata",
+                return_value=check_report,
+            ),
+            patch("portolan_cli.metadata.fix_metadata", return_value=fix_report),
+        ):
+            outcome = run_fix_workflow(
+                path=tmp_path,
+                run_metadata=True,
+                run_geo_assets=False,
+                dry_run=False,
+                remove_legacy=False,
+            )
+
+        assert outcome.has_failures is True
+        assert outcome.metadata_fix_report is fix_report

--- a/tests/unit/test_cli_check.py
+++ b/tests/unit/test_cli_check.py
@@ -677,7 +677,7 @@ class TestCheckMetadataFixFlag:
                 "portolan_cli.metadata.scan.scan_catalog_metadata",
                 return_value=metadata_report,
             ),
-            patch("portolan_cli.cli.fix_metadata") as mock_fix,
+            patch("portolan_cli.metadata.fix_metadata") as mock_fix,
         ):
             from portolan_cli.metadata.fix import FixReport
 
@@ -714,7 +714,7 @@ class TestCheckMetadataFixFlag:
                 "portolan_cli.metadata.scan.scan_catalog_metadata",
                 return_value=metadata_report,
             ),
-            patch("portolan_cli.cli.fix_metadata") as mock_fix,
+            patch("portolan_cli.metadata.fix_metadata") as mock_fix,
         ):
             from portolan_cli.metadata.fix import FixReport
 
@@ -762,7 +762,7 @@ class TestCheckMetadataFixFlag:
                 "portolan_cli.metadata.scan.scan_catalog_metadata",
                 return_value=metadata_report,
             ),
-            patch("portolan_cli.cli.fix_metadata") as mock_fix,
+            patch("portolan_cli.metadata.fix_metadata") as mock_fix,
         ):
             # Mock fix_metadata to return a successful report
             from portolan_cli.metadata.fix import FixReport
@@ -812,7 +812,7 @@ class TestCheckMetadataFixFlag:
                 "portolan_cli.metadata.scan.scan_catalog_metadata",
                 return_value=metadata_report,
             ),
-            patch("portolan_cli.cli.fix_metadata") as mock_fix,
+            patch("portolan_cli.metadata.fix_metadata") as mock_fix,
         ):
             from portolan_cli.metadata.fix import FixReport
 
@@ -845,9 +845,9 @@ class TestCheckMetadataFixFlag:
         # --fix without scope flags should run both metadata and geo-asset fixes
         with (
             patch("portolan_cli.cli.validate_catalog") as mock_validate,
-            patch("portolan_cli.cli.check_directory") as mock_check,
+            patch("portolan_cli.check.check_directory") as mock_check,
             patch("portolan_cli.metadata.scan.scan_catalog_metadata") as mock_md_check,
-            patch("portolan_cli.cli.fix_metadata") as mock_fix,
+            patch("portolan_cli.metadata.fix_metadata") as mock_fix,
         ):
             from portolan_cli.validation.results import ValidationReport
 
@@ -921,7 +921,7 @@ class TestCheckForceWorkers:
         """--fix --force --workers N reaches check_directory with those values."""
         from portolan_cli.check import CheckReport
 
-        with patch("portolan_cli.cli.check_directory") as mock_check:
+        with patch("portolan_cli.check.check_directory") as mock_check:
             mock_check.return_value = CheckReport(root=catalog, files=[], conversion_report=None)
             result = runner.invoke(
                 cli,
@@ -951,7 +951,7 @@ class TestCheckForceWorkers:
 
         from portolan_cli.check import CheckReport
 
-        with patch("portolan_cli.cli.check_directory") as mock_check:
+        with patch("portolan_cli.check.check_directory") as mock_check:
             mock_check.return_value = CheckReport(root=catalog, files=[], conversion_report=None)
             result = runner.invoke(
                 cli,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1228,3 +1228,90 @@ class TestPMTilesConfigSettings:
         assert get_setting("pmtiles.src_crs", catalog_path=tmp_path) == "EPSG:3035"
         assert get_setting("pmtiles.min_zoom", catalog_path=tmp_path) == 4
         assert get_setting("pmtiles.max_zoom", catalog_path=tmp_path) == 14
+
+
+class TestCoerceHelpers:
+    """Tests for coerce_bool / coerce_int (env values arrive as strings, #620)."""
+
+    @pytest.mark.unit
+    def test_coerce_bool_truthy_strings(self) -> None:
+        from portolan_cli.config import coerce_bool
+
+        for truthy in ("true", "True", "1", "yes", "on"):
+            assert coerce_bool(truthy) is True
+
+    @pytest.mark.unit
+    def test_coerce_bool_falsey_and_default(self) -> None:
+        from portolan_cli.config import coerce_bool
+
+        assert coerce_bool("false") is False
+        assert coerce_bool("no") is False
+        assert coerce_bool(None) is False
+        assert coerce_bool(None, default=True) is True
+        assert coerce_bool(True) is True
+
+    @pytest.mark.unit
+    def test_coerce_int_parses_and_falls_back(self) -> None:
+        from portolan_cli.config import coerce_int
+
+        assert coerce_int("42", default=0) == 42
+        assert coerce_int(7, default=0) == 7
+        assert coerce_int("not-an-int", default=100) == 100
+        assert coerce_int(None, default=5) == 5
+
+
+class TestResolvePushSettings:
+    """Tests for resolve_push_settings precedence (CLI > env > config, #620)."""
+
+    def _init_catalog(self, path: Path, config: str = "") -> None:
+        portolan_dir = path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text(config)
+        (path / "catalog.json").write_text("{}")
+
+    @pytest.mark.unit
+    def test_cli_value_wins_and_profile_defaults(self, tmp_path: Path) -> None:
+        from portolan_cli.config import resolve_push_settings
+
+        self._init_catalog(tmp_path)
+        with mock.patch.dict(os.environ, {}, clear=False):
+            for key in ("PORTOLAN_REMOTE", "PORTOLAN_AWS_PROFILE", "PORTOLAN_REGION"):
+                os.environ.pop(key, None)
+            destination, profile, region = resolve_push_settings(
+                "s3://cli-bucket/", None, tmp_path, None
+            )
+
+        assert destination == "s3://cli-bucket/"
+        assert profile == "default"  # nothing configured → default
+        assert region is None
+
+    @pytest.mark.unit
+    def test_env_remote_used_when_no_cli(self, tmp_path: Path) -> None:
+        from portolan_cli.config import resolve_push_settings
+
+        self._init_catalog(tmp_path)
+        with mock.patch.dict(os.environ, {"PORTOLAN_REMOTE": "s3://env-bucket/"}):
+            destination, profile, _ = resolve_push_settings(None, None, tmp_path, None)
+
+        assert destination == "s3://env-bucket/"
+
+    @pytest.mark.unit
+    def test_cli_profile_overrides_env(self, tmp_path: Path) -> None:
+        from portolan_cli.config import resolve_push_settings
+
+        self._init_catalog(tmp_path)
+        with mock.patch.dict(os.environ, {"PORTOLAN_AWS_PROFILE": "env-profile"}):
+            _, profile, _ = resolve_push_settings(None, "cli-profile", tmp_path, None)
+
+        assert profile == "cli-profile"
+
+    @pytest.mark.unit
+    def test_stale_sensitive_config_raises(self, tmp_path: Path) -> None:
+        """A sensitive setting in config.yaml is rejected (must live in .env)."""
+        from portolan_cli.config import resolve_push_settings
+
+        self._init_catalog(tmp_path, "remote: s3://stale-from-config/\n")
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("PORTOLAN_REMOTE", None)
+            with pytest.raises(ValueError):
+                resolve_push_settings(None, None, tmp_path, None)

--- a/tests/unit/test_partitioning.py
+++ b/tests/unit/test_partitioning.py
@@ -808,3 +808,107 @@ class TestGlobAssetKeyCollision:
         assert "partitioned_data" not in collection.assets
         assert "partitioned_data_glob" not in collection.assets
         assert "existing_glob" in collection.assets
+
+
+def _init_catalog(path: Path, config: str = "") -> None:
+    """Create a minimal catalog with an optional config.yaml body."""
+    portolan_dir = path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text(config)
+    (path / "catalog.json").write_text("{}")
+
+
+class TestFindLargePartitionCandidates:
+    """Tests for find_large_partition_candidates (config decision, issue #620).
+
+    These exercise the Click-free decision layer extracted from cli.py: config
+    gating plus the file scan. The TTY check and prompt stay in the CLI.
+    """
+
+    @pytest.mark.unit
+    def test_disabled_returns_no_candidates(self, tmp_path: Path) -> None:
+        """partitioning.enabled=false short-circuits: no scan, empty candidates."""
+        from portolan_cli.partitioning import find_large_partition_candidates
+
+        _init_catalog(tmp_path, "partitioning:\n  enabled: false\n")
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        with mock.patch("portolan_cli.partitioning.should_partition", return_value=True):
+            decision = find_large_partition_candidates([parquet_file], tmp_path)
+
+        assert decision.enabled is False
+        assert decision.large_files == []
+
+    @pytest.mark.unit
+    def test_prompt_disabled_returns_no_candidates(self, tmp_path: Path) -> None:
+        """partitioning.prompt=false short-circuits even when enabled."""
+        from portolan_cli.partitioning import find_large_partition_candidates
+
+        _init_catalog(tmp_path, "partitioning:\n  enabled: true\n  prompt: false\n")
+        parquet_file = tmp_path / "data.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        with mock.patch("portolan_cli.partitioning.should_partition", return_value=True):
+            decision = find_large_partition_candidates([parquet_file], tmp_path)
+
+        assert decision.prompt is False
+        assert decision.large_files == []
+
+    @pytest.mark.unit
+    def test_flags_large_file(self, tmp_path: Path) -> None:
+        """A file over threshold is returned as a candidate with its size."""
+        from portolan_cli.partitioning import find_large_partition_candidates
+
+        _init_catalog(tmp_path)
+        parquet_file = tmp_path / "big.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        with mock.patch("portolan_cli.partitioning.should_partition", return_value=True):
+            decision = find_large_partition_candidates([parquet_file], tmp_path)
+
+        assert decision.enabled is True
+        assert [p for p, _ in decision.large_files] == [parquet_file]
+
+    @pytest.mark.unit
+    def test_small_file_not_flagged(self, tmp_path: Path) -> None:
+        """A small real file (well under 2GB) is not a candidate."""
+        from portolan_cli.partitioning import find_large_partition_candidates
+
+        _init_catalog(tmp_path)
+        parquet_file = tmp_path / "small.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        decision = find_large_partition_candidates([parquet_file], tmp_path)
+
+        assert decision.large_files == []
+
+    @pytest.mark.unit
+    def test_scans_directories_recursively(self, tmp_path: Path) -> None:
+        """Directories are scanned recursively for parquet candidates."""
+        from portolan_cli.partitioning import find_large_partition_candidates
+
+        _init_catalog(tmp_path)
+        nested = tmp_path / "data" / "nested"
+        nested.mkdir(parents=True)
+        parquet_file = nested / "deep.parquet"
+        parquet_file.write_bytes(b"x" * 100)
+
+        with mock.patch("portolan_cli.partitioning.should_partition", return_value=True):
+            decision = find_large_partition_candidates([tmp_path / "data"], tmp_path)
+
+        assert [p for p, _ in decision.large_files] == [parquet_file]
+
+    @pytest.mark.unit
+    def test_non_parquet_file_ignored(self, tmp_path: Path) -> None:
+        """Non-parquet files are ignored even when should_partition is True."""
+        from portolan_cli.partitioning import find_large_partition_candidates
+
+        _init_catalog(tmp_path)
+        other = tmp_path / "data.csv"
+        other.write_bytes(b"x" * 100)
+
+        with mock.patch("portolan_cli.partitioning.should_partition", return_value=True):
+            decision = find_large_partition_candidates([other], tmp_path)
+
+        assert decision.large_files == []

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -1132,3 +1132,148 @@ class TestPMTilesIntegration:
         # This test would use a real fixture and verify the output
         # Skipped for now as it requires a real GeoParquet file
         pytest.skip("Requires real GeoParquet fixture")
+
+
+def _make_collection(catalog_root: Path, coll_id: str, config: str = "") -> Path:
+    """Create a catalog with one collection containing collection.json."""
+    portolan_dir = catalog_root / ".portolan"
+    portolan_dir.mkdir(exist_ok=True)
+    (portolan_dir / "config.yaml").write_text(config)
+    (catalog_root / "catalog.json").write_text("{}")
+    coll_path = catalog_root / coll_id
+    coll_path.mkdir()
+    (coll_path / "collection.json").write_text(json.dumps({"type": "Collection", "id": coll_id}))
+    return coll_path
+
+
+class TestGetPMTilesSettings:
+    """Tests for get_pmtiles_settings config resolution (#620)."""
+
+    @pytest.mark.unit
+    def test_defaults_when_no_config(self, tmp_path: Path) -> None:
+        from portolan_cli.pmtiles import get_pmtiles_settings
+
+        coll_path = _make_collection(tmp_path, "roads")
+        settings = get_pmtiles_settings(tmp_path, "roads", coll_path)
+
+        assert settings.enabled is False
+        assert settings.min_zoom is None
+        assert settings.max_zoom is None
+        assert settings.precision == 6
+
+    @pytest.mark.unit
+    def test_reads_config_values(self, tmp_path: Path) -> None:
+        from portolan_cli.pmtiles import get_pmtiles_settings
+
+        config = (
+            "pmtiles:\n"
+            "  enabled: true\n"
+            "  min_zoom: 3\n"
+            "  max_zoom: 12\n"
+            "  precision: 7\n"
+            "  layer: roads\n"
+        )
+        coll_path = _make_collection(tmp_path, "roads", config)
+        settings = get_pmtiles_settings(tmp_path, "roads", coll_path)
+
+        assert settings.enabled is True
+        assert settings.min_zoom == 3
+        assert settings.max_zoom == 12
+        assert settings.precision == 7
+        assert settings.layer == "roads"
+
+
+class TestGenerateOrSuggestPMTiles:
+    """Tests for the post-add PMTiles orchestration moved out of cli.py (#620)."""
+
+    @pytest.mark.unit
+    def test_skips_when_disabled_and_not_flagged(self, tmp_path: Path) -> None:
+        from portolan_cli.pmtiles import generate_or_suggest_pmtiles
+
+        _make_collection(tmp_path, "roads")
+        with patch("portolan_cli.pmtiles.generate_pmtiles_for_collection") as mock_gen:
+            generate_or_suggest_pmtiles(
+                tmp_path,
+                {"roads"},
+                generate_pmtiles=False,
+                force=False,
+                verbose=False,
+            )
+        mock_gen.assert_not_called()
+
+    @pytest.mark.unit
+    def test_generates_when_flagged(self, tmp_path: Path) -> None:
+        from portolan_cli.pmtiles import PMTilesResult, generate_or_suggest_pmtiles
+
+        coll_path = _make_collection(tmp_path, "roads")
+        with patch(
+            "portolan_cli.pmtiles.generate_pmtiles_for_collection",
+            return_value=PMTilesResult(),
+        ) as mock_gen:
+            generate_or_suggest_pmtiles(
+                tmp_path,
+                {"roads"},
+                generate_pmtiles=True,
+                force=False,
+                verbose=False,
+            )
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args.args[0] == coll_path
+
+    @pytest.mark.unit
+    def test_explicit_flag_unavailable_exits(self, tmp_path: Path) -> None:
+        from portolan_cli.pmtiles import (
+            PMTilesNotAvailableError,
+            generate_or_suggest_pmtiles,
+        )
+
+        _make_collection(tmp_path, "roads")
+        with patch(
+            "portolan_cli.pmtiles.generate_pmtiles_for_collection",
+            side_effect=PMTilesNotAvailableError(),
+        ):
+            with pytest.raises(SystemExit):
+                generate_or_suggest_pmtiles(
+                    tmp_path,
+                    {"roads"},
+                    generate_pmtiles=True,
+                    force=False,
+                    verbose=False,
+                )
+
+    @pytest.mark.unit
+    def test_auto_unavailable_does_not_exit(self, tmp_path: Path) -> None:
+        """pmtiles.enabled but package missing warns instead of exiting (auto path)."""
+        from portolan_cli.pmtiles import (
+            PMTilesNotAvailableError,
+            generate_or_suggest_pmtiles,
+        )
+
+        _make_collection(tmp_path, "roads", "pmtiles:\n  enabled: true\n")
+        with patch(
+            "portolan_cli.pmtiles.generate_pmtiles_for_collection",
+            side_effect=PMTilesNotAvailableError(),
+        ):
+            # Must not raise SystemExit on the auto path.
+            generate_or_suggest_pmtiles(
+                tmp_path,
+                {"roads"},
+                generate_pmtiles=False,
+                force=False,
+                verbose=False,
+            )
+
+    @pytest.mark.unit
+    def test_missing_collection_json_skipped(self, tmp_path: Path) -> None:
+        from portolan_cli.pmtiles import generate_or_suggest_pmtiles
+
+        (tmp_path / "catalog.json").write_text("{}")
+        with patch("portolan_cli.pmtiles.generate_pmtiles_for_collection") as mock_gen:
+            generate_or_suggest_pmtiles(
+                tmp_path,
+                {"ghost"},
+                generate_pmtiles=True,
+                force=False,
+                verbose=False,
+            )
+        mock_gen.assert_not_called()

--- a/tests/unit/test_stac_parquet.py
+++ b/tests/unit/test_stac_parquet.py
@@ -598,3 +598,113 @@ class TestCollectionLevelAsset:
         # Verify asset was removed
         collection_json = json.loads((collection_with_items / "collection.json").read_text())
         assert "geoparquet-items" not in collection_json.get("assets", {})
+
+
+# =============================================================================
+# Test: generate_or_suggest_parquet (post-add orchestration, issue #620)
+# =============================================================================
+
+
+class TestGenerateOrSuggestParquet:
+    """Tests for the post-add parquet orchestration moved out of cli.py (#620)."""
+
+    @pytest.mark.unit
+    def test_explicit_flag_generates_parquet(self, collection_with_items: Path) -> None:
+        """--stac-geoparquet (generate_parquet=True) generates items.parquet."""
+        from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+        catalog_root = collection_with_items.parent
+        generate_or_suggest_parquet(
+            catalog_root,
+            {"landsat"},
+            generate_parquet=True,
+            verbose=False,
+        )
+
+        assert (collection_with_items / "items.parquet").exists()
+
+    @pytest.mark.unit
+    def test_no_flag_no_config_does_not_generate(self, collection_with_items: Path) -> None:
+        """Below threshold and without the flag, no items.parquet is written."""
+        from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+        catalog_root = collection_with_items.parent
+        generate_or_suggest_parquet(
+            catalog_root,
+            {"landsat"},
+            generate_parquet=False,
+            verbose=False,
+            show_hints=False,
+        )
+
+        assert not (collection_with_items / "items.parquet").exists()
+
+    @pytest.mark.unit
+    def test_missing_collection_json_is_skipped(self, tmp_path: Path) -> None:
+        """An affected collection without collection.json is a no-op, not an error."""
+        from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+        (tmp_path / "catalog.json").write_text("{}")
+        # Should not raise even though 'ghost' has no collection.json
+        generate_or_suggest_parquet(
+            tmp_path,
+            {"ghost"},
+            generate_parquet=True,
+            verbose=False,
+        )
+        assert not (tmp_path / "ghost" / "items.parquet").exists()
+
+    @pytest.mark.unit
+    def test_empty_affected_is_noop(self, tmp_path: Path) -> None:
+        """No affected collections returns without touching the filesystem."""
+        from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+        # No exception, nothing created
+        generate_or_suggest_parquet(tmp_path, set(), generate_parquet=True, verbose=False)
+
+    @pytest.mark.unit
+    def test_explicit_failure_reraises(self, collection_with_items: Path) -> None:
+        """An explicit --stac-geoparquet generation failure propagates (fails the command)."""
+        from unittest.mock import patch
+
+        from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+        catalog_root = collection_with_items.parent
+        with patch(
+            "portolan_cli.stac_parquet.generate_items_parquet",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                generate_or_suggest_parquet(
+                    catalog_root,
+                    {"landsat"},
+                    generate_parquet=True,
+                    verbose=False,
+                )
+
+    @pytest.mark.unit
+    def test_auto_failure_warns_not_raises(self, collection_with_items: Path) -> None:
+        """An auto-generation failure (config-enabled) warns instead of raising."""
+        from unittest.mock import patch
+
+        from portolan_cli.stac_parquet import generate_or_suggest_parquet
+
+        catalog_root = collection_with_items.parent
+        # Enable auto-generation with threshold 0 so the 5-item collection qualifies.
+        (catalog_root / ".portolan").mkdir(exist_ok=True)
+        (catalog_root / ".portolan" / "config.yaml").write_text(
+            "parquet:\n  enabled: true\n  threshold: 0\n"
+        )
+
+        with patch(
+            "portolan_cli.stac_parquet.generate_items_parquet",
+            side_effect=RuntimeError("boom"),
+        ):
+            # generate_parquet=False → auto path → should NOT raise
+            generate_or_suggest_parquet(
+                catalog_root,
+                {"landsat"},
+                generate_parquet=False,
+                verbose=False,
+            )
+        assert not (collection_with_items / "items.parquet").exists()


### PR DESCRIPTION
Closes #620. Part of #618.

## What

Six private helpers in `cli.py` hid config-reading + decision logic that belongs in the library layer (ADR-0007). This moves the decision/orchestration into the named library modules and leaves thin call sites in `cli.py` that only wire flags → library call → output. **No behavior change.**

| Helper (was in `cli.py`) | New home | New public API |
|---|---|---|
| `_resolve_push_settings` | `config.py` | `resolve_push_settings()` (+ shared `coerce_bool`/`coerce_int`) |
| `_check_partition_prompt` | `partitioning.py` | `find_large_partition_candidates()` → `PartitionPromptDecision` |
| `_handle_parquet_after_add` | `stac_parquet.py` | `generate_or_suggest_parquet()` |
| `_handle_pmtiles_after_add` (+ `_get_pmtiles_settings`, `PMTilesSettings`) | `pmtiles.py` | `generate_or_suggest_pmtiles()`, `get_pmtiles_settings()` |
| `_execute_check_workflow` (rule building) | `check.py` | `build_check_rules()` |
| `_run_fix_workflow` (+ `_resolve_catalog_root_for_check`) | `check.py` | `run_fix_workflow()` → `FixWorkflowOutcome`, `resolve_catalog_root_for_check()` |

## Design notes

- **Decisions move; rendering/prompting/exit stay.** The library computes *whether* to act (thresholds, config reads, file scans) and returns plain results; `cli.py` owns the `click.confirm` prompt, the TTY check, JSON/human rendering, and `SystemExit` codes. Output via `output.py` (the library's user-facing channel) is kept intact.
- `run_fix_workflow` returns a `FixWorkflowOutcome` (reports + `fatal_error` for the metadata-only no-catalog case) instead of emitting/exiting itself, so `cli.py` renders and decides exit codes.
- ADR-0030 invariants preserved: post-add parquet/PMTiles generation still runs regardless of output mode, and an explicitly-requested step that fails still fails the command.

## Acceptance criteria

- [x] Each helper's logic lives in its library home with **Click-free unit tests** (`test_config.py`, `test_partitioning.py`, `test_stac_parquet.py`, `test_pmtiles.py`, `test_check_workflow.py`).
- [x] `cli.py` call sites are thin (parse → delegate → emit); `cli.py` drops ~340 lines (8150 → 7811).
- [x] import-linter contracts still pass (`uv run lint-imports`).
- [x] No behavior change — full unit tier (4830 passed) and add/check/push/pmtiles integration tests (124 passed) green; mypy strict + ruff clean.

Also updated the `cli.py` → `pmtiles.py` location reference for `get_pmtiles_settings` in `.claude/rules/conversion-and-visualization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)