### PR TITLE
refactor(extract): add common orchestrator base for arcgis/wfs/carto lifecycle (#622)

### DIFF
--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -45,6 +45,12 @@ from portolan_cli.extract.arcgis.url_parser import (
     parse_arcgis_url,
 )
 from portolan_cli.extract.common.filters import filter_layers
+from portolan_cli.extract.common.orchestrator_base import (
+    add_source_links,
+    init_extracted_catalog,
+    register_collection_styles,
+    seed_catalog_metadata,
+)
 from portolan_cli.extract.common.progress import (
     ExtractionProgress,
     emit_progress,
@@ -595,68 +601,32 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
     Per Issue #369: Propagates rich metadata from ArcGIS service to STAC files,
     avoiding generic placeholders.
     """
-    from portolan_cli.add import add_files
-    from portolan_cli.catalog import init_catalog
-    from portolan_cli.stac import update_stac_metadata
+    from portolan_cli.stac import is_technical_name, update_stac_metadata
 
-    # Get list of successfully extracted parquet files
-    parquet_files = [
-        output_dir / result.output_path
-        for result in report.layers
-        if result.status == "success" and result.output_path
-    ]
-
-    if not parquet_files:
-        return  # Nothing to add
-
-    # Initialize the catalog
-    # Extract title from service metadata if available (Issue #369)
-    title = None
-    description = None
-    if report.metadata_extracted:
-        # Use description from service metadata
-        description = report.metadata_extracted.description
-
-        # Use service name from URL as title
-        if report.metadata_extracted.source_url:
-            from portolan_cli.extract.arcgis.url_parser import parse_arcgis_url
-
-            try:
-                parsed = parse_arcgis_url(report.metadata_extracted.source_url)
-                title = parsed.service_name
-            except ValueError:
-                pass
+    title, description = _derive_catalog_titles(report)
 
     # Filter technical names BEFORE init_catalog to avoid writing them
-    # (update_stac_metadata can't overwrite if init_catalog already wrote them)
-    from portolan_cli.stac import is_technical_name
-
+    # (update_stac_metadata can't overwrite if init_catalog already wrote them).
     filtered_title = None if is_technical_name(title) else title
     filtered_description = None if is_technical_name(description) else description
 
-    init_catalog(output_dir, title=filtered_title, description=filtered_description)
+    def _post_init(out: Path, _files: list[Path]) -> None:
+        # Per Issue #369: overwrite init_catalog defaults with the rich
+        # (unfiltered) service metadata now that catalog.json exists.
+        update_stac_metadata(out / "catalog.json", title=title, description=description)
 
-    # Per Issue #369: Update catalog.json with rich metadata
-    # This handles cases where init_catalog used defaults
-    catalog_path = output_dir / "catalog.json"
-    update_stac_metadata(catalog_path, title=title, description=description)
-
-    # Add all extracted parquet files
-    add_files(
-        paths=parquet_files,
-        catalog_root=output_dir,
+    added = init_extracted_catalog(
+        output_dir,
+        report,
+        title=filtered_title,
+        description=filtered_description,
+        post_init=_post_init,
     )
+    if added is None:
+        return  # Nothing to add
 
     # Register extracted styles as STAC assets (Issue #490)
-    from portolan_cli.style import discover_styles, register_style_assets
-
-    for result in report.layers:
-        if result.status == "success" and result.output_path:
-            collection_dir = output_dir / Path(result.output_path).parent
-            styles = discover_styles(collection_dir)
-            if styles:
-                register_style_assets(collection_dir, styles)
-                logger.debug("Registered %d style(s) for %s", len(styles), result.name)
+    register_collection_styles(output_dir, report)
 
     # Seed metadata.yaml from extracted service metadata
     _seed_metadata_from_extraction(output_dir, report)
@@ -667,6 +637,27 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
     # Seed collection-level metadata.yaml with layer details
     # and update collection.json with rich metadata (Issue #369)
     _seed_collection_metadata_arcgis(output_dir, report)
+
+
+def _derive_catalog_titles(report: ExtractionReport) -> tuple[str | None, str | None]:
+    """Derive catalog title/description from harvested ArcGIS service metadata.
+
+    The service name (parsed from the source URL) becomes the title and the
+    service description becomes the catalog description (Issue #369). Both may be
+    None when no metadata was harvested.
+    """
+    if not report.metadata_extracted:
+        return None, None
+
+    description = report.metadata_extracted.description
+    title = None
+    if report.metadata_extracted.source_url:
+        try:
+            parsed = parse_arcgis_url(report.metadata_extracted.source_url)
+            title = parsed.service_name
+        except ValueError:
+            pass
+    return title, description
 
 
 def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
@@ -680,20 +671,13 @@ def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -
         output_dir: The catalog output directory.
         report: The extraction report containing metadata.
     """
-    from portolan_cli.metadata_seeding import seed_metadata_yaml
-    from portolan_cli.output import info
-
     if not report.metadata_extracted:
         return
 
-    # Convert MetadataExtracted from report to ArcGISMetadata, then to ExtractedMetadata
-    # We need to reconstruct ArcGISMetadata from the report data
+    # Reconstruct ArcGISMetadata from the report data, then serialize to the
+    # source-agnostic ExtractedMetadata the shared seeder expects.
     arcgis_metadata = _report_metadata_to_arcgis_metadata(report.metadata_extracted)
-    extracted = arcgis_metadata.to_extracted()
-
-    metadata_path = output_dir / ".portolan" / "metadata.yaml"
-    if seed_metadata_yaml(extracted, metadata_path):
-        info(f"Seeded metadata.yaml from {extracted.source_type}")
+    seed_catalog_metadata(output_dir, arcgis_metadata.to_extracted())
 
 
 def _report_metadata_to_arcgis_metadata(
@@ -729,37 +713,20 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
     """Add via provenance links to each extracted collection.
 
     Per Issue #353: Each collection should have a `via` link pointing to
-    the original data source (ArcGIS layer URL).
+    the original data source (ArcGIS layer URL). The layer-specific URL
+    (service URL + "/" + layer id) gives more precise provenance than the
+    bare service URL.
 
     Args:
         output_dir: The catalog output directory.
         report: The extraction report with layer info and source URL.
     """
-    from portolan_cli.stac import add_via_link
-
-    source_url = report.source_url
-
-    for layer in report.layers:
-        if layer.status != "success" or not layer.output_path:
-            continue
-
-        # Derive collection directory from output_path's parent
-        # Handles nested paths like "service/layer/layer.parquet"
-        collection_dir = output_dir / Path(layer.output_path).parent
-        collection_path = collection_dir / "collection.json"
-
-        if not collection_path.exists():
-            continue
-
-        # Build layer-specific URL: service_url + "/" + layer_id
-        # This gives more specific provenance than just the service URL
-        layer_url = f"{source_url.rstrip('/')}/{layer.id}"
-
-        add_via_link(
-            collection_path,
-            layer_url,
-            title=f"Source ArcGIS layer: {layer.name}",
-        )
+    add_source_links(
+        output_dir,
+        report,
+        url_builder=lambda source_url, layer: f"{source_url.rstrip('/')}/{layer.id}",
+        title_builder=lambda layer: f"Source ArcGIS layer: {layer.name}",
+    )
 
 
 def _seed_collection_metadata_arcgis(

--- a/portolan_cli/extract/carto/orchestrator.py
+++ b/portolan_cli/extract/carto/orchestrator.py
@@ -39,6 +39,11 @@ from portolan_cli.extract.carto.discovery import (
     tables_from_names,
 )
 from portolan_cli.extract.common.filters import filter_layers
+from portolan_cli.extract.common.orchestrator_base import (
+    add_source_links,
+    init_extracted_catalog,
+    seed_catalog_metadata,
+)
 from portolan_cli.extract.common.progress import (
     ExtractionProgress,
     emit_progress,
@@ -503,26 +508,27 @@ def _auto_init_catalog(
     Creates catalog.json/config.yaml/collection.json, adds provenance via-links,
     and seeds metadata.yaml at catalog and collection level.
     """
-    from portolan_cli.catalog import add_files, init_catalog
-    from portolan_cli.config import set_setting
-    from portolan_cli.formats import is_geoparquet
 
-    parquet_files = [
-        output_dir / r.output_path for r in report.layers if r.status == "success" and r.output_path
-    ]
-    if not parquet_files:
+    def _post_init(out: Path, parquet_files: list[Path]) -> None:
+        # Non-geo (tabular) outputs carry no `geo` metadata key; add_files only
+        # accepts them as standalone collection-level assets when tabular support
+        # is enabled (ADR-0047). Enable it before add_files when any output is
+        # non-geo.
+        from portolan_cli.config import set_setting
+        from portolan_cli.formats import is_geoparquet
+
+        if any(not is_geoparquet(path) for path in parquet_files):
+            set_setting(out, "tabular.enabled", True)
+
+    added = init_extracted_catalog(
+        output_dir,
+        report,
+        title=discovery.account_name,
+        description=None,
+        post_init=_post_init,
+    )
+    if added is None:
         return
-
-    title = discovery.account_name
-    init_catalog(output_dir, title=title, description=None)
-
-    # Non-geo (tabular) outputs carry no `geo` metadata key; add_files only
-    # accepts them as standalone collection-level assets when tabular support is
-    # enabled (ADR-0047). Enable it before add_files when any output is non-geo.
-    if any(not is_geoparquet(path) for path in parquet_files):
-        set_setting(output_dir, "tabular.enabled", True)
-
-    add_files(paths=parquet_files, catalog_root=output_dir)
 
     _add_via_links_to_collections(output_dir, report)
     _seed_metadata_from_extraction(output_dir, report, discovery.account_name)
@@ -531,19 +537,12 @@ def _auto_init_catalog(
 
 def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) -> None:
     """Add a `via` provenance link (a Carto SQL query URL) to each collection."""
-    from portolan_cli.stac import add_via_link
-
-    for layer in report.layers:
-        if layer.status != "success" or not layer.output_path:
-            continue
-        collection_path = output_dir / Path(layer.output_path).parent / "collection.json"
-        if not collection_path.exists():
-            continue
-        add_via_link(
-            collection_path,
-            _build_table_query_url(report.source_url, layer.name),
-            title=f"Source Carto table: {layer.name}",
-        )
+    add_source_links(
+        output_dir,
+        report,
+        url_builder=lambda source_url, layer: _build_table_query_url(source_url, layer.name),
+        title_builder=lambda layer: f"Source Carto table: {layer.name}",
+    )
 
 
 def _seed_metadata_from_extraction(
@@ -551,13 +550,9 @@ def _seed_metadata_from_extraction(
 ) -> None:
     """Seed catalog-level metadata.yaml from Carto account metadata."""
     from portolan_cli.extract.carto.metadata import extract_carto_metadata
-    from portolan_cli.metadata_seeding import seed_metadata_yaml
-    from portolan_cli.output import info
 
     extracted = extract_carto_metadata(report.source_url, account_name).to_extracted()
-    metadata_path = output_dir / ".portolan" / "metadata.yaml"
-    if seed_metadata_yaml(extracted, metadata_path):
-        info(f"Seeded metadata.yaml from {extracted.source_type}")
+    seed_catalog_metadata(output_dir, extracted)
 
 
 def _seed_collection_metadata_carto(output_dir: Path, report: ExtractionReport) -> None:

--- a/portolan_cli/extract/common/__init__.py
+++ b/portolan_cli/extract/common/__init__.py
@@ -5,6 +5,7 @@ backends (ArcGIS, WFS, etc.):
 
 - filters: Glob-based filtering for services/layers
 - metadata_seeding: Collection-level metadata seeding
+- orchestrator_base: Shared post-extraction catalog lifecycle
 - report: Extraction report models (LayerResult, ExtractionReport)
 - retry: Retry logic with exponential backoff
 - resume: Resume state for interrupted extractions
@@ -17,6 +18,13 @@ from portolan_cli.extract.common.filters import (
 )
 from portolan_cli.extract.common.metadata_seeding import (
     seed_collection_metadata,
+)
+from portolan_cli.extract.common.orchestrator_base import (
+    add_source_links,
+    collect_successful_parquet_files,
+    init_extracted_catalog,
+    register_collection_styles,
+    seed_catalog_metadata,
 )
 from portolan_cli.extract.common.report import (
     ExtractionReport,
@@ -45,6 +53,12 @@ __all__ = [
     "filter_services",
     # metadata_seeding
     "seed_collection_metadata",
+    # orchestrator_base
+    "add_source_links",
+    "collect_successful_parquet_files",
+    "init_extracted_catalog",
+    "register_collection_styles",
+    "seed_catalog_metadata",
     # report
     "ExtractionReport",
     "ExtractionSummary",

--- a/portolan_cli/extract/common/orchestrator_base.py
+++ b/portolan_cli/extract/common/orchestrator_base.py
@@ -1,0 +1,209 @@
+"""Shared post-extraction catalog lifecycle for extraction orchestrators.
+
+The ArcGIS, WFS, and Carto orchestrators each run the same lifecycle after their
+(genuinely source-specific) layer extraction finishes:
+
+1. Collect the successfully-extracted assets.
+2. Initialize a Portolan catalog and add those assets.
+3. Register any discovered style/legend sidecars as STAC assets.
+4. Add a provenance ``via`` link to each collection.
+5. Seed the catalog-level ``metadata.yaml`` from harvested service metadata.
+
+Only three things actually differ between the sources: the per-source title used
+for a ``via`` link, the source-URL that link points at, and the metadata
+serializer that produces the catalog-level ``ExtractedMetadata``. This module
+provides the shared skeleton and parametrizes those pieces via small callables,
+so each orchestrator keeps only its source-specific glue (see ADR-0007: all logic
+lives in the library layer).
+
+All library imports are function-local, matching the orchestrators' existing
+pattern, to keep import time low and sidestep import cycles through ``add.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from portolan_cli.extract.common.report import ExtractionReport, LayerResult
+    from portolan_cli.metadata_extraction import ExtractedMetadata
+
+logger = logging.getLogger(__name__)
+
+
+def collect_successful_parquet_files(
+    output_dir: Path,
+    report: ExtractionReport,
+) -> list[Path]:
+    """Return absolute paths of every successfully-extracted asset in the report.
+
+    Layers that failed, were skipped, or produced no output are excluded. The
+    returned list is what gets handed to ``add_files``; an empty list means there
+    is nothing to build a catalog around.
+
+    Args:
+        output_dir: The catalog output directory (asset paths are relative to it).
+        report: The extraction report.
+
+    Returns:
+        Absolute paths to successfully-extracted parquet files.
+    """
+    return [
+        output_dir / result.output_path
+        for result in report.layers
+        if result.status == "success" and result.output_path
+    ]
+
+
+def init_extracted_catalog(
+    output_dir: Path,
+    report: ExtractionReport,
+    *,
+    title: str | None,
+    description: str | None,
+    post_init: Callable[[Path, list[Path]], None] | None = None,
+) -> list[Path] | None:
+    """Initialize a catalog and add the extracted assets.
+
+    Shared core of every orchestrator's ``_auto_init_catalog``: collect assets,
+    bail out if there are none, initialize the catalog, run an optional
+    ``post_init`` hook (used for source-specific work that must happen *after*
+    ``init_catalog`` but *before* ``add_files`` — e.g. re-applying richer catalog
+    metadata, or enabling tabular support for non-geo outputs), then add the
+    assets.
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report.
+        title: Catalog title for ``init_catalog`` (already filtered by caller).
+        description: Catalog description for ``init_catalog``.
+        post_init: Optional hook called as ``post_init(output_dir, parquet_files)``
+            between ``init_catalog`` and ``add_files``.
+
+    Returns:
+        The list of added parquet files, or ``None`` when there was nothing to
+        add (the caller should then stop — no catalog was created).
+    """
+    from portolan_cli.catalog import add_files, init_catalog
+
+    parquet_files = collect_successful_parquet_files(output_dir, report)
+    if not parquet_files:
+        return None
+
+    init_catalog(output_dir, title=title, description=description)
+
+    if post_init is not None:
+        post_init(output_dir, parquet_files)
+
+    add_files(paths=parquet_files, catalog_root=output_dir)
+    return parquet_files
+
+
+def register_collection_styles(
+    output_dir: Path,
+    report: ExtractionReport,
+    *,
+    include_legends: bool = False,
+) -> None:
+    """Register discovered style (and optionally legend) sidecars as STAC assets.
+
+    Extraction writes style/legend files next to each collection's data; this
+    scans every successful collection and registers whatever it finds (Issue
+    #490 styles, Issue #498 legends).
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report.
+        include_legends: Also discover and register legend sidecars (WFS/WMS).
+    """
+    from portolan_cli.style import (
+        discover_legends,
+        discover_styles,
+        register_legend_assets,
+        register_style_assets,
+    )
+
+    for result in report.layers:
+        if result.status != "success" or not result.output_path:
+            continue
+        collection_dir = output_dir / Path(result.output_path).parent
+
+        styles = discover_styles(collection_dir)
+        if styles:
+            register_style_assets(collection_dir, styles)
+            logger.debug("Registered %d style(s) for %s", len(styles), result.name)
+
+        if include_legends:
+            legends = discover_legends(collection_dir)
+            if legends:
+                register_legend_assets(collection_dir, legends)
+                logger.debug("Registered %d legend(s) for %s", len(legends), result.name)
+
+
+def add_source_links(
+    output_dir: Path,
+    report: ExtractionReport,
+    *,
+    url_builder: Callable[[str, LayerResult], str],
+    title_builder: Callable[[LayerResult], str],
+) -> None:
+    """Add a provenance ``via`` link to each successfully-extracted collection.
+
+    Per Issue #353 every collection points back at the source it came from. The
+    href and title are source-specific, so they are supplied as callables.
+
+    Args:
+        output_dir: The catalog output directory.
+        report: The extraction report (its ``source_url`` is passed to
+            ``url_builder``).
+        url_builder: Builds the ``via`` href from ``(source_url, layer)``.
+        title_builder: Builds the ``via`` link title from ``layer``.
+    """
+    from portolan_cli.stac import add_via_link
+
+    source_url = report.source_url
+
+    for layer in report.layers:
+        if layer.status != "success" or not layer.output_path:
+            continue
+
+        # Derive the collection directory from the asset's parent so nested
+        # layouts like "service/layer/layer.parquet" resolve correctly.
+        collection_path = output_dir / Path(layer.output_path).parent / "collection.json"
+        if not collection_path.exists():
+            continue
+
+        add_via_link(
+            collection_path,
+            url_builder(source_url, layer),
+            title=title_builder(layer),
+        )
+
+
+def seed_catalog_metadata(
+    output_dir: Path,
+    extracted: ExtractedMetadata | None,
+) -> None:
+    """Seed the catalog-level ``metadata.yaml`` from harvested service metadata.
+
+    Writes ``{output_dir}/.portolan/metadata.yaml`` from the given serialized
+    metadata, emitting a user-facing confirmation when a file is created. A
+    ``None`` argument (no metadata harvested) is a no-op.
+
+    Args:
+        output_dir: The catalog output directory.
+        extracted: Source-agnostic metadata to seed, or ``None`` to skip.
+    """
+    from portolan_cli.metadata_seeding import seed_metadata_yaml
+    from portolan_cli.output import info
+
+    if extracted is None:
+        return
+
+    metadata_path = output_dir / ".portolan" / "metadata.yaml"
+    if seed_metadata_yaml(extracted, metadata_path):
+        info(f"Seeded metadata.yaml from {extracted.source_type}")

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -31,6 +31,12 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 from portolan_cli.extract.common.filters import filter_layers
+from portolan_cli.extract.common.orchestrator_base import (
+    add_source_links,
+    init_extracted_catalog,
+    register_collection_styles,
+    seed_catalog_metadata,
+)
 from portolan_cli.extract.common.progress import (
     ExtractionProgress,
     emit_progress,
@@ -774,64 +780,30 @@ def _auto_init_catalog(
     Per Issue #369: Propagates rich metadata from WFS service to STAC files,
     avoiding generic placeholders.
     """
-    from portolan_cli.catalog import add_files, init_catalog
     from portolan_cli.stac import update_stac_metadata
 
-    parquet_files = [
-        output_dir / result.output_path
-        for result in report.layers
-        if result.status == "success" and result.output_path
-    ]
+    # Extract and filter service title/description (Issue #369, #376)
+    filtered_title, filtered_description = _derive_catalog_titles(discovery_result)
 
-    if not parquet_files:
+    def _post_init(out: Path, _files: list[Path]) -> None:
+        # Per Issue #369/#376: overwrite init_catalog defaults with the filtered
+        # service metadata (filtered values avoid overwriting with boilerplate).
+        update_stac_metadata(
+            out / "catalog.json", title=filtered_title, description=filtered_description
+        )
+
+    added = init_extracted_catalog(
+        output_dir,
+        report,
+        title=filtered_title,
+        description=filtered_description,
+        post_init=_post_init,
+    )
+    if added is None:
         return
 
-    # Extract service title and description from discovery result (Issue #369)
-    service_title = discovery_result.service_title if discovery_result else None
-    service_description = discovery_result.service_abstract if discovery_result else None
-
-    # Filter technical names AND boilerplate (Issue #376)
-    from portolan_cli.extract.wfs.metadata import is_boilerplate_description
-    from portolan_cli.stac import is_technical_name
-
-    def _should_filter(text: str | None) -> bool:
-        return is_technical_name(text) or is_boilerplate_description(text)
-
-    filtered_title = None if _should_filter(service_title) else service_title
-    filtered_description = None if _should_filter(service_description) else service_description
-
-    init_catalog(output_dir, title=filtered_title, description=filtered_description)
-
-    # Per Issue #369: Update catalog.json with rich metadata
-    # Per Issue #376: Use filtered values to avoid overwriting with boilerplate
-    catalog_path = output_dir / "catalog.json"
-    update_stac_metadata(catalog_path, title=filtered_title, description=filtered_description)
-
-    add_files(
-        paths=parquet_files,
-        catalog_root=output_dir,
-    )
-
     # Register extracted styles and legends as STAC assets (Issue #490, #498)
-    from portolan_cli.style import (
-        discover_legends,
-        discover_styles,
-        register_legend_assets,
-        register_style_assets,
-    )
-
-    for result in report.layers:
-        if result.status == "success" and result.output_path:
-            collection_dir = output_dir / Path(result.output_path).parent
-            styles = discover_styles(collection_dir)
-            if styles:
-                register_style_assets(collection_dir, styles)
-                logger.debug("Registered %d style(s) for %s", len(styles), result.name)
-
-            legends = discover_legends(collection_dir)
-            if legends:
-                register_legend_assets(collection_dir, legends)
-                logger.debug("Registered %d legend(s) for %s", len(legends), result.name)
+    register_collection_styles(output_dir, report, include_legends=True)
 
     # Add via links for provenance tracking
     _add_via_links_to_collections(output_dir, report)
@@ -845,39 +817,47 @@ def _auto_init_catalog(
         _seed_collection_metadata_wfs(output_dir, report, discovery_result)
 
 
+def _derive_catalog_titles(
+    discovery_result: WFSDiscoveryResult | None,
+) -> tuple[str | None, str | None]:
+    """Derive filtered catalog title/description from the WFS discovery result.
+
+    Technical names and boilerplate descriptions are dropped (Issue #376) so the
+    catalog is not populated with service-generated placeholders.
+    """
+    from portolan_cli.extract.wfs.metadata import is_boilerplate_description
+    from portolan_cli.stac import is_technical_name
+
+    service_title = discovery_result.service_title if discovery_result else None
+    service_description = discovery_result.service_abstract if discovery_result else None
+
+    def _should_filter(text: str | None) -> bool:
+        return is_technical_name(text) or is_boilerplate_description(text)
+
+    filtered_title = None if _should_filter(service_title) else service_title
+    filtered_description = None if _should_filter(service_description) else service_description
+    return filtered_title, filtered_description
+
+
 def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) -> None:
     """Add via provenance links to each extracted collection.
 
     Each collection gets a `via` link pointing to a GetFeature-style URL
-    for the original WFS layer.
+    (``service_url?service=WFS&request=GetFeature&typename=X``) for the original
+    WFS layer.
     """
-    from portolan_cli.stac import add_via_link
 
-    source_url = report.source_url
-
-    for layer in report.layers:
-        if layer.status != "success" or not layer.output_path:
-            continue
-
-        # Derive collection directory from output_path's parent
-        # Handles nested paths like "service/layer/layer.parquet"
-        collection_dir = output_dir / Path(layer.output_path).parent
-        collection_path = collection_dir / "collection.json"
-
-        if not collection_path.exists():
-            continue
-
-        # Build GetFeature-style URL for provenance
-        # WFS GetFeature URL pattern: service_url?service=WFS&request=GetFeature&typename=X
-        layer_url = _build_wfs_url(
+    def _url(source_url: str, layer: LayerResult) -> str:
+        return _build_wfs_url(
             source_url, {"service": "WFS", "request": "GetFeature", "typename": layer.name}
         )
 
-        add_via_link(
-            collection_path,
-            layer_url,
-            title=f"Source WFS layer: {layer.name}",
-        )
+    add_source_links(
+        output_dir,
+        report,
+        url_builder=_url,
+        title_builder=lambda layer: f"Source WFS layer: {layer.name}",
+    )
 
 
 def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
@@ -891,18 +871,11 @@ def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -
         output_dir: The catalog output directory.
         report: The extraction report containing metadata.
     """
-    from portolan_cli.metadata_seeding import seed_metadata_yaml
-    from portolan_cli.output import info
-
     if not report.metadata_extracted:
         return
 
     wfs_metadata = _report_metadata_to_wfs_metadata(report.metadata_extracted)
-    extracted = wfs_metadata.to_extracted()
-
-    metadata_path = output_dir / ".portolan" / "metadata.yaml"
-    if seed_metadata_yaml(extracted, metadata_path):
-        info(f"Seeded metadata.yaml from {extracted.source_type}")
+    seed_catalog_metadata(output_dir, wfs_metadata.to_extracted())
 
 
 def _report_metadata_to_wfs_metadata(

--- a/tests/unit/extract/common/test_orchestrator_base.py
+++ b/tests/unit/extract/common/test_orchestrator_base.py
@@ -1,0 +1,253 @@
+"""Tests for the shared post-extraction catalog lifecycle.
+
+These cover the helpers in ``extract/common/orchestrator_base.py`` that the
+ArcGIS, WFS, and Carto orchestrators delegate to. The source-specific pieces
+(URL/title builders, metadata serializers) are exercised via the orchestrators'
+own suites; here we verify the shared skeleton in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.extract.common.orchestrator_base import (
+    add_source_links,
+    collect_successful_parquet_files,
+    init_extracted_catalog,
+    register_collection_styles,
+    seed_catalog_metadata,
+)
+from portolan_cli.extract.common.report import (
+    ExtractionReport,
+    ExtractionSummary,
+    LayerResult,
+)
+from portolan_cli.metadata_extraction import ExtractedMetadata
+
+pytestmark = pytest.mark.unit
+
+
+def _layer(
+    layer_id: int,
+    name: str,
+    *,
+    status: str = "success",
+    output_path: str | None = None,
+) -> LayerResult:
+    return LayerResult(
+        id=layer_id,
+        name=name,
+        status=status,
+        features=1,
+        size_bytes=1,
+        duration_seconds=0.0,
+        output_path=output_path,
+        warnings=[],
+        error=None,
+        attempts=1,
+    )
+
+
+def _report(
+    layers: list[LayerResult], *, source_url: str = "https://example.com/svc"
+) -> ExtractionReport:
+    return ExtractionReport(
+        extraction_date="2026-07-09T00:00:00+00:00",
+        source_url=source_url,
+        portolan_version="test",
+        gpio_version="test",
+        metadata_extracted=None,
+        layers=layers,
+        summary=ExtractionSummary(
+            total_layers=len(layers),
+            succeeded=sum(1 for r in layers if r.status == "success"),
+            failed=0,
+            skipped=0,
+            empty=0,
+            total_features=0,
+            total_size_bytes=0,
+            total_duration_seconds=0.0,
+        ),
+    )
+
+
+class TestCollectSuccessfulParquetFiles:
+    def test_includes_only_successful_with_output(self) -> None:
+        report = _report(
+            [
+                _layer(0, "a", output_path="a/a.parquet"),
+                _layer(1, "b", status="failed"),
+                _layer(2, "c", status="empty"),
+                _layer(3, "d", status="success", output_path=None),
+                _layer(4, "e", output_path="e/e.parquet"),
+            ]
+        )
+        files = collect_successful_parquet_files(Path("/out"), report)
+        assert files == [Path("/out/a/a.parquet"), Path("/out/e/e.parquet")]
+
+    def test_empty_when_nothing_succeeded(self) -> None:
+        report = _report([_layer(0, "a", status="failed")])
+        assert collect_successful_parquet_files(Path("/out"), report) == []
+
+
+class TestInitExtractedCatalog:
+    def test_returns_none_and_skips_hooks_when_no_assets(self, tmp_path: Path) -> None:
+        report = _report([_layer(0, "a", status="failed")])
+        called = {"post_init": False}
+
+        def _post_init(_out: Path, _files: list[Path]) -> None:
+            called["post_init"] = True
+
+        result = init_extracted_catalog(
+            tmp_path, report, title="t", description="d", post_init=_post_init
+        )
+
+        assert result is None
+        assert called["post_init"] is False
+        # No catalog was created.
+        assert not (tmp_path / "catalog.json").exists()
+
+    def test_runs_post_init_between_init_and_add(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+        events: list[str] = []
+
+        import portolan_cli.catalog as catalog_mod
+
+        def _fake_init(output_dir: Path, *, title: str | None, description: str | None) -> None:
+            events.append("init")
+
+        def _fake_add(*, paths: list[Path], catalog_root: Path) -> None:
+            events.append("add")
+
+        def _post_init(_out: Path, files: list[Path]) -> None:
+            events.append("post_init")
+            assert files == [tmp_path / "a/a.parquet"]
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
+        monkeypatch.setattr(catalog_mod, "add_files", _fake_add)
+
+        result = init_extracted_catalog(
+            tmp_path, report, title="t", description="d", post_init=_post_init
+        )
+
+        assert result == [tmp_path / "a/a.parquet"]
+        assert events == ["init", "post_init", "add"]
+
+    def test_post_init_optional(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+        import portolan_cli.catalog as catalog_mod
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: None)
+        monkeypatch.setattr(catalog_mod, "add_files", lambda *a, **k: None)
+
+        result = init_extracted_catalog(tmp_path, report, title=None, description=None)
+        assert result == [tmp_path / "a/a.parquet"]
+
+
+class TestAddSourceLinks:
+    def test_adds_link_only_for_successful_with_collection_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Two successful layers, but only one has a collection.json on disk.
+        (tmp_path / "a").mkdir()
+        (tmp_path / "a" / "collection.json").write_text("{}")
+        # layer b's collection.json is missing -> skipped.
+        (tmp_path / "b").mkdir()
+
+        report = _report(
+            [
+                _layer(0, "a", output_path="a/a.parquet"),
+                _layer(1, "b", output_path="b/b.parquet"),
+                _layer(2, "c", status="failed"),
+            ]
+        )
+
+        calls: list[tuple[Path, str, str]] = []
+
+        import portolan_cli.stac as stac_mod
+
+        def _fake_add_via_link(path: Path, url: str, *, title: str) -> None:
+            calls.append((path, url, title))
+
+        monkeypatch.setattr(stac_mod, "add_via_link", _fake_add_via_link)
+
+        add_source_links(
+            tmp_path,
+            report,
+            url_builder=lambda source_url, layer: f"{source_url}/{layer.id}",
+            title_builder=lambda layer: f"Source: {layer.name}",
+        )
+
+        assert calls == [
+            (
+                tmp_path / "a" / "collection.json",
+                "https://example.com/svc/0",
+                "Source: a",
+            )
+        ]
+
+
+class TestRegisterCollectionStyles:
+    def test_registers_styles_and_optional_legends(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+
+        import portolan_cli.style as style_mod
+
+        style_calls: list[Path] = []
+        legend_calls: list[Path] = []
+
+        monkeypatch.setattr(style_mod, "discover_styles", lambda d: ["style"])
+        monkeypatch.setattr(style_mod, "register_style_assets", lambda d, s: style_calls.append(d))
+        monkeypatch.setattr(style_mod, "discover_legends", lambda d: ["legend"])
+        monkeypatch.setattr(
+            style_mod, "register_legend_assets", lambda d, s: legend_calls.append(d)
+        )
+
+        # Without legends
+        register_collection_styles(tmp_path, report)
+        assert style_calls == [tmp_path / "a"]
+        assert legend_calls == []
+
+        # With legends
+        register_collection_styles(tmp_path, report, include_legends=True)
+        assert legend_calls == [tmp_path / "a"]
+
+    def test_skips_unsuccessful_layers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        report = _report([_layer(0, "a", status="failed")])
+        import portolan_cli.style as style_mod
+
+        called = {"discover": False}
+
+        def _discover(_d: Path) -> list[str]:
+            called["discover"] = True
+            return []
+
+        monkeypatch.setattr(style_mod, "discover_styles", _discover)
+        monkeypatch.setattr(style_mod, "register_style_assets", lambda d, s: None)
+
+        register_collection_styles(tmp_path, report)
+        assert called["discover"] is False
+
+
+class TestSeedCatalogMetadata:
+    def test_none_is_noop(self, tmp_path: Path) -> None:
+        seed_catalog_metadata(tmp_path, None)
+        assert not (tmp_path / ".portolan" / "metadata.yaml").exists()
+
+    def test_writes_metadata_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / ".portolan").mkdir()
+        extracted = ExtractedMetadata(
+            source_type="test_source",
+            source_url="https://example.com/svc",
+            description="A test service",
+        )
+        seed_catalog_metadata(tmp_path, extracted)
+        assert (tmp_path / ".portolan" / "metadata.yaml").exists()


### PR DESCRIPTION
Closes #622. Part of #618.

## What

40–50% of the arcgis / wfs / carto orchestrator lifecycle was duplicated. This hoists the shared post-extraction catalog lifecycle into a new `extract/common/orchestrator_base.py` and rewires all three orchestrators to use it.

The three already share `extract/common/` (retry, resume, filters, report, progress), so this follows the proven pattern.

## New shared module: `extract/common/orchestrator_base.py`

| Helper | Shared responsibility |
|---|---|
| `collect_successful_parquet_files` | The `status == "success" and output_path` asset filter |
| `init_extracted_catalog` | collect → `init_catalog` → optional `post_init` hook → `add_files`; returns `None` when there is nothing to add |
| `register_collection_styles` | Style + optional legend sidecar registration (arcgis/wfs) |
| `add_source_links` | The provenance `via`-link loop, parametrized on a source-URL builder and per-source link title |
| `seed_catalog_metadata` | Write the catalog-level `metadata.yaml` from a source-agnostic `ExtractedMetadata` |

Source-specific pieces stay local in each orchestrator: title derivation, the metadata serializer (`_report_metadata_to_*`), the `via`-link URL/title builders, carto's tabular-enable, and each `_extract_single_*`.

The `post_init` hook cleanly captures the one interleaved difference between the sources — arcgis/wfs re-apply richer metadata to `catalog.json` via `update_stac_metadata`, carto enables tabular support for non-geo outputs — all of which must run *after* `init_catalog` but *before* `add_files`.

## Compatibility

The test-referenced local wrappers (`_auto_init_catalog`, `_seed_metadata_from_extraction`, `_add_via_links_to_collections`) keep their existing signatures and become thin delegators, so behavior and the test surface are preserved.

## Acceptance criteria

- [x] Shared lifecycle lives once in `common/`.
- [x] All three orchestrators use it; the duplicated lifecycle blocks are removed.
- [x] pylint duplicate-code no longer flags those bodies (the three `_auto_init_catalog` / `_seed_metadata_from_extraction` / `_add_via_links_to_collections` ranges). Score holds at 9.96/10 (fail-under 9.5). Remaining flags are the pre-existing `_extract_*`/`_build_*` similarities (out of scope) plus the minimal shared call-site.
- [x] Extract integration/network tests green for all three sources.

## Testing

- New unit suite: `tests/unit/extract/common/test_orchestrator_base.py` (10 tests) covering asset collection, `init_extracted_catalog` ordering/early-return, `add_source_links` filtering, style/legend registration, and metadata seeding.
- `uv run pytest tests/unit/extract tests/integration/extract tests/unit/test_issue_353_via_link.py` → 764 passed.
- Full unit tier → 4781 passed, 5 skipped.
- Gates: ruff, `mypy`, `lint-imports`, `xenon --max-absolute=C`, `vulture`, `deptry`, pylint duplicate-code — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)