### PR TITLE
feat(spec): mandate AGENTS.md (rel=agents) — enforce + generate it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ AI agents will write most of the code. Human review does not scale to match AI o
 | [0049](context/shared/adr/0049-stac-geoparquet-scalability.md) | STAC-GeoParquet required for collections >1000 items |
 | [0050](context/shared/adr/0050-pmtiles-visualization-requirement.md) | PMTiles required for vector datasets >100 MB |
 | [0051](context/shared/adr/0051-self-contained-catalog-type.md) | SELF_CONTAINED catalog type (relative links, portable) |
-| [0052](context/shared/adr/0052-llms-txt-requirement.md) | Require llms.txt for AI/LLM integration at catalog and collection levels |
+| [0052](context/shared/adr/0052-llms-txt-requirement.md) | Require AGENTS.md for AI/LLM integration at catalog and collection levels (supersedes llms.txt); schema-required link + RULE-0080/0081 enforcement + generation |
 | [0053](context/shared/adr/0053-mandatory-human-readable-titles.md) | Mandatory human-readable titles/descriptions; auto-humanize slugs; title on child/item links |
 | [0054](context/shared/adr/0054-arcgis-folder-recursion-and-structure.md) | ArcGIS folder recursion (default-on), folder URLs, token auth pass-through, nested-folder subcatalogs |
 | [0055](context/shared/adr/0055-extension-registry-single-source.md) | Single-source the recognized-extension vocabulary via a typed in-package registry (derives the formats/constants/scan_classify/add maps; drops dead `.raquet`) |

--- a/context/shared/adr/0052-llms-txt-requirement.md
+++ b/context/shared/adr/0052-llms-txt-requirement.md
@@ -1,35 +1,40 @@
-# ADR-0052: Require llms.txt for AI/LLM Integration
+# ADR-0052: Require AGENTS.md for AI/LLM Integration
 
-**Date**: 2026-06-05
+**Date**: 2026-06-05 (revised 2026-07-09: `llms.txt` → `AGENTS.md`)
 **Status**: Accepted
 
 ## Decision
 
-Every Portolan catalog and collection **MUST** include an `llms.txt` file linked via `rel: "llms"` in the STAC JSON.
+Every Portolan catalog and collection **MUST** include an `AGENTS.md` file linked via `rel: "agents"` in the STAC JSON.
 
 ## Context
 
-AI agents and LLMs are increasingly used to discover, query, and analyze geospatial data. Machine-readable STAC metadata alone is not enough — agents need plain-language context about what a dataset contains, how to query it, what the fields mean, and what pitfalls to avoid. The [llms.txt](https://llmstxt.org/) standard provides a convention for LLM-friendly documentation.
+AI agents and LLMs are increasingly used to discover, query, and analyze geospatial data. Machine-readable STAC metadata alone is not enough — agents need plain-language context about what a dataset contains, how to query it, what the fields mean, and what pitfalls to avoid.
+
+Portolan originally adopted the [llms.txt](https://llmstxt.org/) convention for this role. As of 2026-07-09 it standardizes on [`AGENTS.md`](https://agents.md/) instead: an emerging, cross-tool Markdown convention (the same file agentic coding tools already look for), which is a better fit for a human-authored, Markdown guide and avoids inventing a Portolan-specific filename. This supersedes the earlier `llms.txt` direction; the `rel` relation moves from `"llms"` to `"agents"` and the filename from `llms.txt` to `AGENTS.md`.
 
 ## Rationale
 
 - AI agents are a primary audience for cloud-native geodata catalogs
 - STAC metadata describes structure but not semantics — agents need both
 - Markdown is the most natural format for LLMs to consume
-- The llms.txt convention is simple, co-located with the data, and versioned alongside it
-- Early experience with [portolan-nl](https://source.coop/cholmes/portolan-nl) shows this pattern works well in practice
+- `AGENTS.md` is co-located with the data, versioned alongside it, and aligns with a convention agents already recognize
+- Content is human-authored and open-ended: publishers add whatever helps an agent use the data (joins, sample queries, data-quality notes, related collections) — things not already in the README
 
 ## Consequences
 
-- All catalogs and collections must maintain an `llms.txt` file
-- The file must be linked in STAC JSON with `rel: "llms"` and `type: "text/markdown"`
+- All catalogs and collections must maintain an `AGENTS.md` file
+- The file must be linked in STAC JSON with `rel: "agents"` and `type: "text/markdown"`, using a relative `href`
+- `AGENTS.md` is a **link**, not an asset
 - Content recommendations are provided but expected to evolve rapidly as best practices emerge
-- Validation rules added:
-  - RULE-0080/0081: error-level rules requiring llms.txt link at catalog and collection levels
-  - RULE-0082/0083: warning-level rules for recommended content in llms.txt files
+- Enforcement (implemented, not just specified):
+  - The shipped JSON schemas (`spec/schema/{catalog,collection}.schema.json`) **require** at least one `rel="agents"` link (via `contains`), not merely validate its shape when present
+  - Error-level `RULE-0080` (catalog) and `RULE-0081` (collection) in `spec/schema/rules.yaml` are backed by CLI validators (`CatalogAgentsMdLinkRule` / `CollectionAgentsMdLinkRule` in `portolan_cli/validation/rules.py`); they flag a missing `AGENTS.md` file or link
+  - `portolan init` and `portolan add` scaffold `AGENTS.md` and emit the link, so freshly-created catalogs are compliant without a follow-up step; `portolan check --fix` (`repair_agents_md`) backfills the file and link for externally-modified catalogs. Scaffolding never overwrites an existing, human-authored `AGENTS.md`
+  - Warning-level `RULE-0082/0083` document recommended content and remain spec-level guidance (not code-enforced, since content is open-ended)
 
 ## References
 
 - [ai-integration.md](../../../spec/ai-integration.md) — Full specification
-- [llmstxt.org](https://llmstxt.org/) — The llms.txt standard
-- [portolan-nl](https://source.coop/cholmes/portolan-nl) — Example implementation on Source Cooperative
+- [agents.md](https://agents.md/) — The AGENTS.md convention
+- [llmstxt.org](https://llmstxt.org/) — The superseded llms.txt standard

--- a/portolan_cli/agents_md.py
+++ b/portolan_cli/agents_md.py
@@ -1,0 +1,220 @@
+"""Framework-free helpers for the ``AGENTS.md`` AI/agent metadata file.
+
+Portolan requires every catalog and collection to carry an ``AGENTS.md`` file
+(Markdown, minimal) referenced by a ``rel="agents"`` link in its STAC JSON
+(ADR-0052, RULE-0080/0081). ``AGENTS.md`` is a **link**, not an asset, and its
+content is human-authored — Portolan only scaffolds an empty template when the
+file is absent and never overwrites an existing one.
+
+This module is deliberately stdlib-only. It is imported by both the generation
+paths (``catalog.py``, ``add.py``, ``metadata/fix.py``) and the validation layer
+(``validation/rules.py``). Keeping it free of ``click``/``rich``/``config`` /
+``output`` preserves the ``validation-no-framework-leakage`` import-linter
+contract, the same reason ``pmtiles_links.py`` exists as a leaf.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePath
+from typing import Any
+
+#: Canonical filename for the AI/agent metadata file (uppercase, matching the
+#: cross-tool ``AGENTS.md`` convention — like ``README.md``).
+AGENTS_MD_FILENAME = "AGENTS.md"
+
+#: STAC link relation type that references the ``AGENTS.md`` file.
+AGENTS_LINK_REL = "agents"
+
+#: Media type the ``AGENTS.md`` link MUST declare.
+AGENTS_MEDIA_TYPE = "text/markdown"
+
+#: Default human-readable title for the ``AGENTS.md`` link.
+AGENTS_LINK_TITLE = "Agent/LLM usage guide"
+
+#: Relative href used when the ``AGENTS.md`` sits next to the STAC JSON.
+AGENTS_LINK_HREF = f"./{AGENTS_MD_FILENAME}"
+
+
+def find_agents_link(links: list[Any]) -> dict[str, Any] | None:
+    """Return the first ``rel="agents"`` link in a STAC ``links`` array, if any."""
+    for link in links:
+        if isinstance(link, dict) and link.get("rel") == AGENTS_LINK_REL:
+            return link
+    return None
+
+
+def build_agents_link(href: str = AGENTS_LINK_HREF) -> dict[str, str]:
+    """Build a well-formed ``rel="agents"`` link dict pointing at ``AGENTS.md``."""
+    return {
+        "rel": AGENTS_LINK_REL,
+        "href": href,
+        "type": AGENTS_MEDIA_TYPE,
+        "title": AGENTS_LINK_TITLE,
+    }
+
+
+def _href_targets_agents_md(href: str) -> bool:
+    """True when ``href``'s final path segment is ``AGENTS.md``."""
+    return PurePath(href).name == AGENTS_MD_FILENAME
+
+
+def agents_link_is_wellformed(link: dict[str, Any]) -> bool:
+    """True when an ``agents`` link points at ``AGENTS.md`` with the markdown type."""
+    return (
+        _href_targets_agents_md(str(link.get("href", ""))) and link.get("type") == AGENTS_MEDIA_TYPE
+    )
+
+
+def agents_md_gap(stac_json: Path) -> str | None:
+    """Describe the ``AGENTS.md`` gap for one STAC object, or ``None`` when compliant.
+
+    Compliant means: a single well-formed ``rel="agents"`` link is present
+    (points at ``AGENTS.md``, ``type: text/markdown``) **and** the referenced
+    file exists on disk. Every non-compliant case reported here is repairable by
+    :func:`ensure_agents_md` (hence ``check --fix``).
+
+    Returns ``None`` when the file is unreadable/malformed so that other rules
+    (schema/JSON validity) own that failure instead of this one.
+    """
+    try:
+        data = json.loads(stac_json.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    links = data.get("links", [])
+    if not isinstance(links, list):
+        return None
+
+    link = find_agents_link(links)
+    if link is None:
+        return "missing rel='agents' AGENTS.md link"
+    if not agents_link_is_wellformed(link):
+        return "rel='agents' link must point at AGENTS.md with type 'text/markdown'"
+
+    target = (stac_json.parent / str(link.get("href", ""))).resolve()
+    if not target.exists():
+        return f"rel='agents' link points at a missing file ({link.get('href')})"
+
+    return None
+
+
+def scaffold_content(title: str, *, is_catalog: bool) -> str:
+    """Return minimal ``AGENTS.md`` template text for a catalog or collection.
+
+    The template is intentionally sparse: it seeds the sections agents benefit
+    from most (things not already in the README — access snippets, schema notes,
+    data-quality caveats, example queries, related collections/join keys) as
+    prompts to be filled in. Content is open-ended; publishers replace or delete
+    prompts freely.
+    """
+    heading = f"# AGENTS.md — {title}\n"
+    scope = "catalog" if is_catalog else "collection"
+    intro = (
+        f"\nGuidance for AI agents and LLMs working with this {scope}. This file "
+        "supplements the README with practical, agent-oriented notes. Replace the "
+        "prompts below with real content; delete anything that does not apply.\n"
+    )
+
+    if is_catalog:
+        sections = [
+            ("## Overview", "What this catalog publishes and how it is organized."),
+            (
+                "## Collections",
+                "Brief description of each collection, with pointers to their AGENTS.md.",
+            ),
+            (
+                "## Data access patterns",
+                "Base URLs / object-store paths, CRS conventions, and code examples.",
+            ),
+            ("## License", "License information for the catalog's data."),
+        ]
+    else:
+        sections = [
+            ("## Overview", "What this collection contains and when to use it."),
+            (
+                "## Accessing the data",
+                "Working code to load the data (e.g. DuckDB SQL, Python).",
+            ),
+            (
+                "## Schema & field notes",
+                "Field names, types, meanings, and any coded or sentinel values.",
+            ),
+            (
+                "## Data quality & usage notes",
+                "Privacy suppressions, known quirks, CRS/units, and other caveats.",
+            ),
+            ("## Example queries", "Practical, working analysis examples."),
+            (
+                "## Related collections",
+                "Cross-references and join keys to complementary collections.",
+            ),
+        ]
+
+    body = "".join(f"\n{header}\n\n<!-- {prompt} -->\n" for header, prompt in sections)
+    return heading + intro + body
+
+
+def _title_for(data: dict[str, Any]) -> str:
+    """Derive a display title for the scaffold from a STAC object's own fields."""
+    title = data.get("title")
+    if isinstance(title, str) and title.strip():
+        return title
+    identifier = data.get("id")
+    if isinstance(identifier, str) and identifier.strip():
+        return identifier
+    return "Portolan"
+
+
+def ensure_agents_md(stac_json: Path) -> bool:
+    """Ensure a STAC object has an ``AGENTS.md`` file and a well-formed link.
+
+    Scaffolds ``AGENTS.md`` next to ``stac_json`` when it is absent (never
+    overwriting an existing, human-authored file) and injects or normalizes the
+    ``rel="agents"`` link in the STAC JSON. Idempotent — a compliant object is
+    left untouched.
+
+    Shared by the write paths (``init``/``add``) and ``check --fix`` so both
+    produce identical output.
+
+    Args:
+        stac_json: Path to a ``catalog.json`` or ``collection.json``.
+
+    Returns:
+        True if the file and/or link were created or normalized; False if
+        nothing changed (already compliant) or ``stac_json`` was unreadable.
+    """
+    try:
+        data = json.loads(stac_json.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+
+    changed = False
+
+    # 1. Scaffold AGENTS.md next to the STAC object if it does not exist.
+    agents_path = stac_json.parent / AGENTS_MD_FILENAME
+    if not agents_path.exists():
+        is_catalog = data.get("type") == "Catalog"
+        agents_path.write_text(
+            scaffold_content(_title_for(data), is_catalog=is_catalog),
+            encoding="utf-8",
+        )
+        changed = True
+
+    # 2. Ensure a well-formed rel="agents" link is present in the STAC JSON.
+    links = data.setdefault("links", [])
+    if not isinstance(links, list):
+        return changed
+    link = find_agents_link(links)
+    if link is None:
+        links.append(build_agents_link())
+        changed = True
+    elif not agents_link_is_wellformed(link):
+        # Normalize a hand-edited / malformed link in place.
+        link.update(build_agents_link())
+        changed = True
+
+    if changed:
+        stac_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    return changed

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -466,6 +466,16 @@ def init_catalog(
     except OSError as e:
         raise CatalogInitError(f"Cannot update catalog.json with self link: {e}") from e
 
+    # Step 4b: AGENTS.md - scaffold the AI/agent guide and add its rel="agents"
+    # link (ADR-0052, RULE-0080). Emitting it here keeps freshly-created catalogs
+    # schema-valid without a follow-up `check --fix`.
+    from portolan_cli.agents_md import ensure_agents_md
+
+    try:
+        ensure_agents_md(catalog_file)
+    except OSError as e:
+        raise CatalogInitError(f"Cannot write AGENTS.md: {e}") from e
+
     # Step 5: config.yaml - sentinel file per issue #290 (sufficient for MANAGED state)
     # Written LAST for atomicity: if any previous step fails, directory stays FRESH
     # and init can be safely retried. Also serves as user configuration file for
@@ -614,6 +624,12 @@ def create_intermediate_catalogs(collection_id: str, catalog_root: Path) -> None
         }
 
         catalog_file.write_text(json.dumps(catalog_data, indent=2))
+
+        # Intermediate catalogs are catalogs too: scaffold AGENTS.md and add the
+        # rel="agents" link so every catalog.json satisfies RULE-0080.
+        from portolan_cli.agents_md import ensure_agents_md
+
+        ensure_agents_md(catalog_file)
 
 
 def update_catalog_links_for_nested(catalog_root: Path, collection_id: str) -> None:

--- a/portolan_cli/check.py
+++ b/portolan_cli/check.py
@@ -627,6 +627,7 @@ def run_fix_workflow(
     if run_metadata:
         from portolan_cli.metadata import fix_metadata
         from portolan_cli.metadata.fix import (
+            repair_agents_md,
             repair_pmtiles_links,
             repair_tabular_flags,
             repair_titles_and_links,
@@ -668,6 +669,10 @@ def run_fix_workflow(
             # Issue #569: backfill the rel="pmtiles" web-map-links link on
             # collections with a PMTiles asset but no link (RULE-0061).
             metadata_fix_report.results.extend(repair_pmtiles_links(catalog_root, dry_run=dry_run))
+
+            # ADR-0052: scaffold AGENTS.md and backfill the rel="agents" link on
+            # catalogs and collections that lack them (RULE-0080/0081).
+            metadata_fix_report.results.extend(repair_agents_md(catalog_root, dry_run=dry_run))
 
             outcome.metadata_fix_report = metadata_fix_report
             if metadata_fix_report.failure_count > 0:

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -215,6 +215,13 @@ def _save_collection_with_links(
     _fix_collection_links(collection_json_path, catalog_root, collection_dir)
     _update_catalog_links(catalog_root, collection_id)
 
+    # Scaffold AGENTS.md and add the rel="agents" link (ADR-0052, RULE-0081).
+    # Idempotent and merge-safe: never overwrites an existing AGENTS.md, only
+    # adds the link when absent, so re-running `add` preserves human edits.
+    from portolan_cli.agents_md import ensure_agents_md
+
+    ensure_agents_md(collection_json_path)
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Spatial extent recomputation

--- a/portolan_cli/metadata/fix.py
+++ b/portolan_cli/metadata/fix.py
@@ -350,6 +350,50 @@ def _repair_pmtiles_collection(collection_json: Path, *, dry_run: bool) -> FixRe
     )
 
 
+def repair_agents_md(catalog_root: Path, *, dry_run: bool = False) -> list[FixResult]:
+    """Backfill missing ``AGENTS.md`` files and ``rel="agents"`` links (RULE-0080/0081).
+
+    Repairs what
+    :class:`~portolan_cli.validation.rules.CatalogAgentsMdLinkRule` and
+    :class:`~portolan_cli.validation.rules.CollectionAgentsMdLinkRule` flag: a
+    catalog or collection missing its ``AGENTS.md`` file or the link that
+    references it. For each affected STAC object the file is scaffolded (never
+    overwriting an existing, human-authored one) and the link is added or
+    normalized. Compliant objects are left untouched.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+        dry_run: If True, report what would change without writing.
+
+    Returns:
+        FixResults for each catalog/collection that was (or would be) modified.
+    """
+    from portolan_cli.agents_md import agents_md_gap, ensure_agents_md
+
+    results: list[FixResult] = []
+
+    for stac_json in sorted(
+        [*catalog_root.rglob("catalog.json"), *catalog_root.rglob("collection.json")]
+    ):
+        rel_parts = stac_json.parent.relative_to(catalog_root).parts
+        if any(part.startswith(".") for part in rel_parts):
+            continue
+        if agents_md_gap(stac_json) is None:
+            continue
+        if not dry_run:
+            ensure_agents_md(stac_json)
+        results.append(
+            FixResult(
+                file_path=stac_json,
+                action=FixAction.UPDATED,
+                success=True,
+                message="Scaffolded AGENTS.md and added rel='agents' link",
+            )
+        )
+
+    return results
+
+
 def _repair_item_titles(
     stac_file: Path,
     data: dict[str, Any],

--- a/portolan_cli/preparation.py
+++ b/portolan_cli/preparation.py
@@ -63,11 +63,14 @@ logger = logging.getLogger(__name__)
 
 # Files to ignore when scanning item directories for assets.
 # These are STAC/Portolan structural files, not user data.
+# AGENTS.md is referenced via a rel="agents" link, not tracked as an asset
+# (ADR-0052: "AGENTS.md is a link, not an asset").
 IGNORED_FILES: frozenset[str] = frozenset(
     {
         "catalog.json",
         "collection.json",
         "versions.json",
+        "AGENTS.md",
     }
 )
 

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -657,6 +657,74 @@ class PMTilesLinkRule(ValidationRule):
         return len(pmtiles_hrefs), missing_links, ext_missing
 
 
+class _AgentsMdLinkRule(ValidationRule):
+    """Shared base: every ``<stac_file>`` MUST carry a ``rel="agents"`` AGENTS.md link.
+
+    Implements RULE-0080 (catalogs) / RULE-0081 (collections): every catalog and
+    collection MUST include an ``AGENTS.md`` file referenced by a well-formed
+    ``rel="agents"`` link (ADR-0052). ERROR-level; ``check --fix`` scaffolds the
+    file and backfills the link. Concrete subclasses set ``name`` and the STAC
+    filename they scan.
+    """
+
+    _stac_filename: str
+
+    def check(self, catalog_path: Path) -> ValidationResult:
+        """Fail when any scanned STAC object lacks its AGENTS.md file or link."""
+        # Import from the framework-free leaf, not a CLI/output layer, to respect
+        # the validation-no-framework-leakage import contract.
+        from portolan_cli.agents_md import agents_md_gap
+
+        stac_files = list(catalog_path.rglob(self._stac_filename))
+        if not stac_files:
+            return self._pass(f"No {self._stac_filename} files found")
+
+        problems: list[str] = []
+        checked = 0
+        for stac_json in stac_files:
+            try:
+                rel_dir = stac_json.parent.relative_to(catalog_path)
+            except ValueError:
+                rel_dir = stac_json.parent
+            # Skip internal dirs (e.g. .portolan/) so we never report a gap that
+            # --fix deliberately leaves alone.
+            if any(part.startswith(".") for part in rel_dir.parts):
+                continue
+            checked += 1
+            gap = agents_md_gap(stac_json)
+            if gap is not None:
+                dir_label = str(rel_dir) if rel_dir.parts else "."
+                problems.append(f"{dir_label}: {gap}")
+
+        if problems:
+            preview = "; ".join(problems[:5])
+            suffix = "" if len(problems) <= 5 else f" (+{len(problems) - 5} more)"
+            return self._fail(
+                f"{len(problems)} location(s) missing AGENTS.md: {preview}{suffix}",
+                fix_hint="Run 'portolan check --fix' to scaffold AGENTS.md and add the link",
+            )
+
+        return self._pass(f"All {checked} location(s) have an AGENTS.md link")
+
+
+class CatalogAgentsMdLinkRule(_AgentsMdLinkRule):
+    """RULE-0080: every ``catalog.json`` MUST reference an ``AGENTS.md`` file."""
+
+    name = "agents_md_catalog_link"
+    severity = Severity.ERROR
+    description = "Check every catalog.json emits a rel='agents' AGENTS.md link"
+    _stac_filename = "catalog.json"
+
+
+class CollectionAgentsMdLinkRule(_AgentsMdLinkRule):
+    """RULE-0081: every ``collection.json`` MUST reference an ``AGENTS.md`` file."""
+
+    name = "agents_md_collection_link"
+    severity = Severity.ERROR
+    description = "Check every collection.json emits a rel='agents' AGENTS.md link"
+    _stac_filename = "collection.json"
+
+
 class MetadataFreshRule(ValidationRule):
     """Check that all registered geo-assets have fresh STAC metadata.
 

--- a/portolan_cli/validation/runner.py
+++ b/portolan_cli/validation/runner.py
@@ -9,8 +9,10 @@ from typing import Any
 from portolan_cli.validation.results import ValidationReport, ValidationResult
 from portolan_cli.validation.rules import (
     BboxValidRule,
+    CatalogAgentsMdLinkRule,
     CatalogExistsRule,
     CatalogJsonValidRule,
+    CollectionAgentsMdLinkRule,
     MetadataFreshRule,
     PartitionSchemaConsistencyRule,
     PartitionStructureRule,
@@ -42,6 +44,8 @@ DEFAULT_RULES: tuple[ValidationRule, ...] = (
     BboxValidRule(),
     PMTilesRecommendedRule(),
     PMTilesLinkRule(),
+    CatalogAgentsMdLinkRule(),
+    CollectionAgentsMdLinkRule(),
     MetadataFreshRule(),
     ProvisionalDatetimeRule(),
     PartitionStructureRule(),
@@ -77,6 +81,8 @@ def _build_rules(
         BboxValidRule(),
         PMTilesRecommendedRule(),
         PMTilesLinkRule(),
+        CatalogAgentsMdLinkRule(),
+        CollectionAgentsMdLinkRule(),
         MetadataFreshRule(),
         ProvisionalDatetimeRule(),
         PartitionStructureRule(),

--- a/spec/README.md
+++ b/spec/README.md
@@ -29,7 +29,7 @@ cloud-native geospatial data.
   - [Point clouds](formats/pointcloud.md)
   - [Tabular (non-geospatial) data](formats/tabular.md)
 - [Best practices](best-practices.md) - Recommended conventions
-- [AI & LLM integration](ai-integration.md) - llms.txt requirements for agent discoverability
+- [AI & LLM integration](ai-integration.md) - AGENTS.md requirements for agent discoverability
 
 ## Architectural Decisions
 
@@ -41,7 +41,7 @@ Spec-related decisions are tracked in the CLI repository's ADR directory:
 - [ADR-0049: STAC-GeoParquet as Scalability Requirement](../context/shared/adr/0049-stac-geoparquet-scalability.md)
 - [ADR-0050: PMTiles as Visualization Requirement](../context/shared/adr/0050-pmtiles-visualization-requirement.md)
 - [ADR-0051: SELF_CONTAINED Catalog Type](../context/shared/adr/0051-self-contained-catalog-type.md)
-- [ADR-0052: Require llms.txt for AI/LLM Integration](../context/shared/adr/0052-llms-txt-requirement.md)
+- [ADR-0052: Require AGENTS.md for AI/LLM Integration](../context/shared/adr/0052-llms-txt-requirement.md)
 
 For all architectural decisions, see [context/shared/adr/](../context/shared/adr/).
 

--- a/spec/ai-integration.md
+++ b/spec/ai-integration.md
@@ -2,20 +2,20 @@
 
 This section covers practices for making Portolan catalogs discoverable and usable by AI agents and large language models. This is a rapidly evolving area — the recommendations here represent early patterns that have proven effective and will be refined as the community gains experience.
 
-## llms.txt
+## AGENTS.md
 
-[llms.txt](https://llmstxt.org/) is an emerging standard for providing LLM-friendly documentation alongside web resources. In Portolan, every catalog and collection includes an `llms.txt` file that gives AI agents the context they need to discover, understand, and query the data.
+[AGENTS.md](https://agents.md/) is an emerging cross-tool standard for a Markdown file that gives AI agents the context they need to work with a project. In Portolan, every catalog and collection includes an `AGENTS.md` file that gives AI agents the context they need to discover, understand, and query the data. (Portolan previously used `llms.txt` for this role; `AGENTS.md` replaces it.)
 
 ### Requirements
 
-Every catalog and collection **MUST** include an `llms.txt` file in markdown format.
+Every catalog and collection **MUST** include an `AGENTS.md` file in Markdown format.
 
-The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
+The `AGENTS.md` file **MUST** be referenced in the STAC JSON `links` array:
 
 ```json
 {
-  "rel": "llms",
-  "href": "./llms.txt",
+  "rel": "agents",
+  "href": "./AGENTS.md",
   "type": "text/markdown",
   "title": "Agent/LLM usage guide"
 }
@@ -23,26 +23,26 @@ The `llms.txt` file **MUST** be referenced in the STAC JSON `links` array:
 
 - The `href` **MUST** use a relative path (consistent with `SELF_CONTAINED` catalog type)
 - The `type` **MUST** be `text/markdown`
-- `llms.txt` is a **link**, not an asset — it describes the data, it is not the data itself
+- `AGENTS.md` is a **link**, not an asset — it describes the data, it is not the data itself
 
 ### Content Recommendations
 
-These recommendations are early and expected to evolve. They reflect patterns that have worked well in practice but are not exhaustive.
+The requirement is only that `AGENTS.md` exist and be linked — its content is open-ended. The recommendations below are early and expected to evolve; they reflect patterns that have worked well in practice but are not exhaustive. Favor content that is **not already in the README** and that helps an agent use the data.
 
-#### Catalog-Level llms.txt
+#### Catalog-Level AGENTS.md
 
-A catalog-level `llms.txt` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
+A catalog-level `AGENTS.md` provides an overview of the entire catalog or sub-catalog. It **SHOULD** include:
 
 - A summary of what the catalog contains and who publishes it
 - A list of all collections with brief descriptions (what each contains, feature count, key fields)
 - Data access patterns (base URLs, S3 paths, code examples)
 - Coordinate system conventions used across the catalog
 - License information
-- Pointers to collection-level `llms.txt` files for detailed documentation
+- Pointers to collection-level `AGENTS.md` files for detailed documentation
 
-#### Collection-Level llms.txt
+#### Collection-Level AGENTS.md
 
-A collection-level `llms.txt` provides everything an AI agent needs to work with a specific collection. It **SHOULD** include:
+A collection-level `AGENTS.md` provides everything an AI agent needs to work with a specific collection. It **SHOULD** include:
 
 - **What the collection is** — a plain-language description, including source, provider, and license
 - **How to access the data** — URLs and working code examples for loading the data (e.g., DuckDB SQL, Python)

--- a/spec/core.md
+++ b/spec/core.md
@@ -11,11 +11,11 @@ project/
 ├── .portolan/
 │   └── config.yaml
 ├── catalog.json
-├── llms.txt
+├── AGENTS.md
 ├── versions.json
 └── {collection_id}/
     ├── collection.json
-    ├── llms.txt
+    ├── AGENTS.md
     ├── versions.json
     └── {item_id}/
         └── data.parquet
@@ -137,8 +137,8 @@ This is standard STAC practice for provenance and enables consumers to trace dat
 
 ## AI & LLM Integration
 
-- **MUST** include an `llms.txt` file at both the catalog root and each collection directory
-- **MUST** link `llms.txt` in the STAC JSON `links` array with `rel: "llms"`
+- **MUST** include an `AGENTS.md` file at both the catalog root and each collection directory
+- **MUST** link `AGENTS.md` in the STAC JSON `links` array with `rel: "agents"`
 
 See [ai-integration.md](ai-integration.md) for full requirements and content recommendations.
 

--- a/spec/examples/tabular-collection.json
+++ b/spec/examples/tabular-collection.json
@@ -71,8 +71,8 @@
       "type": "application/json"
     },
     {
-      "rel": "llms",
-      "href": "./llms.txt",
+      "rel": "agents",
+      "href": "./AGENTS.md",
       "type": "text/markdown",
       "title": "Agent/LLM usage guide"
     },

--- a/spec/formats/tabular.md
+++ b/spec/formats/tabular.md
@@ -161,7 +161,7 @@ When conversion is enabled (`tabular.convert: true`), both the source file and c
 eurostat-electricity-prices/
   collection.json
   versions.json
-  llms.txt
+  AGENTS.md
   electricity-prices.parquet
   electricity-prices.csv        (source, if converted)
 ```
@@ -214,7 +214,7 @@ No item directory or item JSON is needed.
     {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
     {"rel": "self", "href": "./collection.json", "type": "application/json"},
     {"rel": "version-history", "href": "./versions.json", "type": "application/json"},
-    {"rel": "llms", "href": "./llms.txt", "type": "text/markdown", "title": "Agent/LLM usage guide"},
+    {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown", "title": "Agent/LLM usage guide"},
     {
       "rel": "via",
       "href": "https://ec.europa.eu/eurostat/databrowser/view/nrg_pc_205/default/table",
@@ -236,4 +236,4 @@ For tabular collections:
 - **No spatial extent requirement** — `extent.spatial` is optional
 - **No geometry validation** — there is no geometry to validate
 
-All other Portolan core requirements apply unchanged: absolute S3 asset hrefs (when published), relative STAC links, `providers`, provenance via `rel: "via"`, `README.md`, `llms.txt`, and `versions.json` tracking.
+All other Portolan core requirements apply unchanged: absolute S3 asset hrefs (when published), relative STAC links, `providers`, provenance via `rel: "via"`, `README.md`, `AGENTS.md`, and `versions.json` tracking.

--- a/spec/schema/catalog.schema.json
+++ b/spec/schema/catalog.schema.json
@@ -42,10 +42,18 @@
         },
         "links": {
           "type": "array",
-          "description": "Catalog links. MUST use relative paths (SELF_CONTAINED catalog type).",
+          "description": "Catalog links. MUST use relative paths (SELF_CONTAINED catalog type). MUST contain a rel='agents' AGENTS.md link (RULE-0080).",
           "items": {
             "$ref": "#/$defs/CatalogLink"
-          }
+          },
+          "contains": {
+            "type": "object",
+            "properties": {
+              "rel": { "const": "agents" }
+            },
+            "required": ["rel"]
+          },
+          "minContains": 1
         }
       }
     },
@@ -57,7 +65,7 @@
         "rel": {
           "type": "string",
           "description": "Link relation type",
-          "examples": ["root", "self", "child", "parent", "item", "llms"]
+          "examples": ["root", "self", "child", "parent", "item", "agents"]
         },
         "href": {
           "type": "string",
@@ -118,18 +126,18 @@
         {
           "if": {
             "properties": {
-              "rel": { "const": "llms" }
+              "rel": { "const": "agents" }
             },
             "required": ["rel"]
           },
           "then": {
-            "description": "LLM integration link - MUST point to llms.txt with text/markdown type",
+            "description": "AI/agent integration link - MUST point to AGENTS.md with text/markdown type",
             "required": ["type"],
             "properties": {
               "href": {
                 "type": "string",
-                "pattern": "(^|/)llms\\.txt$",
-                "description": "Must point to llms.txt file"
+                "pattern": "(^|/)AGENTS\\.md$",
+                "description": "Must point to AGENTS.md file"
               },
               "type": {
                 "const": "text/markdown"

--- a/spec/schema/collection.schema.json
+++ b/spec/schema/collection.schema.json
@@ -51,10 +51,18 @@
         },
         "links": {
           "type": "array",
-          "description": "Collection links with Portolan requirements. SHOULD include version-history link (see RULE-0070 in rules.yaml).",
+          "description": "Collection links with Portolan requirements. SHOULD include version-history link (see RULE-0070 in rules.yaml). MUST contain a rel='agents' AGENTS.md link (RULE-0081).",
           "items": {
             "$ref": "#/$defs/CollectionLink"
-          }
+          },
+          "contains": {
+            "type": "object",
+            "properties": {
+              "rel": { "const": "agents" }
+            },
+            "required": ["rel"]
+          },
+          "minContains": 1
         },
         "assets": {
           "type": "object",
@@ -157,12 +165,12 @@
         {
           "if": {
             "properties": {
-              "rel": { "const": "llms" }
+              "rel": { "const": "agents" }
             },
             "required": ["rel"]
           },
           "then": {
-            "$ref": "#/$defs/LlmsLink"
+            "$ref": "#/$defs/AgentsLink"
           }
         }
       ]
@@ -184,17 +192,17 @@
       },
       "required": ["rel", "href"]
     },
-    "LlmsLink": {
+    "AgentsLink": {
       "type": "object",
-      "description": "Link to llms.txt for AI/LLM integration - MUST be present",
+      "description": "Link to AGENTS.md for AI/agent integration - MUST be present",
       "properties": {
         "rel": {
-          "const": "llms"
+          "const": "agents"
         },
         "href": {
           "type": "string",
-          "pattern": "(^|/)llms\\.txt$",
-          "description": "Must point to llms.txt file"
+          "pattern": "(^|/)AGENTS\\.md$",
+          "description": "Must point to AGENTS.md file"
         },
         "type": {
           "const": "text/markdown"

--- a/spec/schema/rules.yaml
+++ b/spec/schema/rules.yaml
@@ -438,18 +438,18 @@ rules:
   - id: RULE-0080
     level: error
     scope: catalog
-    description: Catalogs MUST include llms.txt link
+    code_rule: agents_md_catalog_link
+    description: Catalogs MUST include AGENTS.md link
     rationale: |
       AI agents and LLMs are a primary audience for Portolan catalogs.
-      The llms.txt file provides context that STAC metadata alone cannot:
+      The AGENTS.md file provides context that STAC metadata alone cannot:
       plain-language descriptions, usage examples, and pitfalls to avoid.
     validation: |
       For catalog.json:
-        assert any link has rel="llms"
-        if link with rel="llms" exists:
-          assert link.href ends with "llms.txt"
-          assert link.type == "text/markdown"
-          assert file exists at link.href
+        assert any link has rel="agents"
+        assert link.href ends with "AGENTS.md"
+        assert link.type == "text/markdown"
+        assert file exists at link.href
     references:
       - ai-integration.md
       - core.md#ai--llm-integration
@@ -457,17 +457,17 @@ rules:
   - id: RULE-0081
     level: error
     scope: collection
-    description: Collections MUST include llms.txt link
+    code_rule: agents_md_collection_link
+    description: Collections MUST include AGENTS.md link
     rationale: |
-      Collection-level llms.txt provides everything an agent needs to work
+      Collection-level AGENTS.md provides everything an agent needs to work
       with a specific collection: schema docs, query examples, data quality notes.
     validation: |
       For each collection.json:
-        assert any link has rel="llms"
-        if link with rel="llms" exists:
-          assert link.href ends with "llms.txt"
-          assert link.type == "text/markdown"
-          assert file exists at link.href
+        assert any link has rel="agents"
+        assert link.href ends with "AGENTS.md"
+        assert link.type == "text/markdown"
+        assert file exists at link.href
     references:
       - ai-integration.md
       - core.md#ai--llm-integration
@@ -475,32 +475,32 @@ rules:
   - id: RULE-0082
     level: warning
     scope: catalog
-    description: Catalog llms.txt SHOULD include recommended content
+    description: Catalog AGENTS.md SHOULD include recommended content
     rationale: |
-      Effective llms.txt files follow established patterns for maximum utility.
+      Effective AGENTS.md files follow established patterns for maximum utility.
       Missing key sections reduce the file's value to AI agents.
     validation: |
-      For catalog llms.txt:
+      For catalog AGENTS.md:
         warn if file does not mention collections or items
         warn if no code examples present
         warn if no license information present
     references:
-      - ai-integration.md#catalog-level-llmstxt
+      - ai-integration.md#catalog-level-agentsmd
 
   - id: RULE-0083
     level: warning
     scope: collection
-    description: Collection llms.txt SHOULD include recommended content
+    description: Collection AGENTS.md SHOULD include recommended content
     rationale: |
-      Collection llms.txt should enable agents to immediately work with the data.
+      Collection AGENTS.md should enable agents to immediately work with the data.
       Schema documentation and query examples are particularly valuable.
     validation: |
-      For collection llms.txt:
+      For collection AGENTS.md:
         warn if no schema/field documentation present
         warn if no code/query examples present
         warn if no data access URLs present
     references:
-      - ai-integration.md#collection-level-llmstxt
+      - ai-integration.md#collection-level-agentsmd
 
   # =============================================================================
   # Tabular (Non-Geospatial) Data Rules

--- a/tests/fixtures/validation/stac/agents-md-missing-root-link/AGENTS.md
+++ b/tests/fixtures/validation/stac/agents-md-missing-root-link/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md — Present But Unlinked
+
+This file exists on disk, but the sibling catalog.json intentionally omits the
+rel="agents" link. RULE-0080 (CatalogAgentsMdLinkRule) MUST flag the missing link.

--- a/tests/fixtures/validation/stac/agents-md-missing-root-link/catalog.json
+++ b/tests/fixtures/validation/stac/agents-md-missing-root-link/catalog.json
@@ -1,0 +1,19 @@
+{
+  "type": "Catalog",
+  "stac_version": "1.1.0",
+  "id": "agents-md-missing-root-link",
+  "title": "AGENTS.md Present But Unlinked",
+  "description": "Regression fixture: AGENTS.md exists on disk but the root catalog.json has no rel='agents' link (reproduces the portolan-nl gap cited in cli#479). RULE-0080 MUST flag this.",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "self",
+      "href": "./catalog.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/tests/fixtures/validation/stac/valid-tabular/AGENTS.md
+++ b/tests/fixtures/validation/stac/valid-tabular/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Eurostat Electricity Prices
+
+Minimal AGENTS.md fixture for the tabular validation example. See ADR-0052.

--- a/tests/fixtures/validation/stac/valid-tabular/collection.json
+++ b/tests/fixtures/validation/stac/valid-tabular/collection.json
@@ -34,6 +34,6 @@
     {"rel": "parent", "href": "../catalog.json", "type": "application/json"},
     {"rel": "self", "href": "./collection.json", "type": "application/json"},
     {"rel": "version-history", "href": "./versions.json", "type": "application/json"},
-    {"rel": "llms", "href": "./llms.txt", "type": "text/markdown", "title": "Agent/LLM usage guide"}
+    {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown", "title": "Agent/LLM usage guide"}
   ]
 }

--- a/tests/fixtures/validation/stac/valid/AGENTS.md
+++ b/tests/fixtures/validation/stac/valid/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md — Test Catalog
+
+Minimal AGENTS.md fixture for validation tests. See ADR-0052.

--- a/tests/fixtures/validation/stac/valid/catalog.json
+++ b/tests/fixtures/validation/stac/valid/catalog.json
@@ -13,6 +13,12 @@
       "rel": "self",
       "href": "./catalog.json",
       "type": "application/json"
+    },
+    {
+      "rel": "agents",
+      "href": "./AGENTS.md",
+      "type": "text/markdown",
+      "title": "Agent/LLM usage guide"
     }
   ]
 }

--- a/tests/integration/test_check_command.py
+++ b/tests/integration/test_check_command.py
@@ -729,10 +729,15 @@ class TestCheckMetadataFixFlag:
                     # this test stays focused on the scanner's empty report.
                     "title": "Test Catalog",
                     "description": "Test",
-                    "links": [],
+                    # AGENTS.md link present so RULE-0080 / repair_agents_md are a
+                    # no-op and this test stays focused on the empty scanner report.
+                    "links": [
+                        {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+                    ],
                 }
             )
         )
+        (catalog_dir / "AGENTS.md").write_text("# AGENTS.md — Test Catalog\n")
 
         # Run check --metadata --fix (should not error even with empty catalog)
         result = runner.invoke(

--- a/tests/integration/test_cli_json.py
+++ b/tests/integration/test_cli_json.py
@@ -40,10 +40,14 @@ def valid_catalog(tmp_path: Path) -> Path:
                 "id": "test-catalog",
                 "title": "Test Catalog",
                 "description": "A test catalog",
-                "links": [],
+                "links": [
+                    {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+                ],
             }
         )
     )
+    # AGENTS.md required at catalog root (ADR-0052, RULE-0080)
+    (tmp_path / "AGENTS.md").write_text("# AGENTS.md — Test Catalog\n")
     # .portolan directory with management files
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -47,11 +47,16 @@ def _write_catalog_json(catalog_dir: Path) -> None:
                 "stac_version": "1.1.0",
                 "title": "Test Catalog",
                 "description": "Test catalog",
-                "links": [{"rel": "self", "href": "./catalog.json"}],
+                "links": [
+                    {"rel": "self", "href": "./catalog.json"},
+                    {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+                ],
             },
             indent=2,
         )
     )
+    # AGENTS.md required at catalog root (ADR-0052, RULE-0080)
+    (catalog_dir / "AGENTS.md").write_text("# AGENTS.md — Test Catalog\n")
 
 
 def _write_collection_json(
@@ -72,10 +77,15 @@ def _write_collection_json(
             "spatial": {"bbox": [[-180.0, -90.0, 180.0, 90.0]]},
             "temporal": {"interval": [[None, None]]},
         },
-        "links": [{"rel": "self", "href": "./collection.json"}],
+        "links": [
+            {"rel": "self", "href": "./collection.json"},
+            {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+        ],
         "assets": extra_assets or {},
     }
     (collection_dir / "collection.json").write_text(json.dumps(data, indent=2))
+    # AGENTS.md required at collection level (ADR-0052, RULE-0081)
+    (collection_dir / "AGENTS.md").write_text(f"# AGENTS.md — {collection_id}\n")
 
 
 def _write_item_json(

--- a/tests/spec_compliance/test_rules_coverage.py
+++ b/tests/spec_compliance/test_rules_coverage.py
@@ -49,6 +49,8 @@ _EXEMPT_ERROR_RULES: frozenset[str] = frozenset(
 
 # The rules added for Issue #562, with their expected (level, scope, code_rule).
 _NEW_RULES: dict[str, tuple[str, str, str]] = {
+    "RULE-0080": ("error", "catalog", "agents_md_catalog_link"),
+    "RULE-0081": ("error", "collection", "agents_md_collection_link"),
     "RULE-0100": ("error", "catalog", "mandatory_titles"),
     "RULE-0101": ("error", "collection", "mandatory_titles"),
     "RULE-0102": ("error", "catalog", "mandatory_titles"),

--- a/tests/spec_compliance/test_shipped_schema_hermetic.py
+++ b/tests/spec_compliance/test_shipped_schema_hermetic.py
@@ -81,6 +81,11 @@ class TestShippedSchemaValidatesRealOutput:
             errors = validate_document(data, catalog_schema)
             assert not errors, "shipped catalog schema rejected init output:\n" + "\n".join(errors)
 
+            # RULE-0080: init scaffolds AGENTS.md next to catalog.json (ADR-0052).
+            agents = Path("AGENTS.md")
+            assert agents.exists(), "init did not scaffold AGENTS.md"
+            assert "AGENTS.md" in agents.read_text(encoding="utf-8")
+
     @pytest.mark.integration
     def test_add_collection_conforms_to_shipped_schemas(
         self,
@@ -111,6 +116,11 @@ class TestShippedSchemaValidatesRealOutput:
             col_errors = validate_document(collection, collection_schema)
             assert not col_errors, "shipped collection schema rejected add output:\n" + "\n".join(
                 col_errors
+            )
+
+            # RULE-0081: add scaffolds AGENTS.md next to collection.json (ADR-0052).
+            assert (collection_dir / "AGENTS.md").exists(), (
+                "add did not scaffold a collection-level AGENTS.md"
             )
 
 
@@ -162,6 +172,65 @@ class TestShippedSchemaEnforcesConstraints:
         errors = validate_document(bad_catalog, catalog_schema)
         assert errors, "shipped catalog schema accepted a child link with no title"
 
+    @pytest.mark.unit
+    def test_catalog_without_agents_link_is_rejected(self, catalog_schema: dict[str, Any]) -> None:
+        # RULE-0080: catalogs MUST carry a rel="agents" AGENTS.md link. An empty
+        # links array is otherwise schema-valid (see the good_catalog below), so
+        # the differential isolates the requirement: adding only the agents link
+        # must remove an error and make the catalog conform.
+        base = {
+            "type": "Catalog",
+            "stac_version": "1.1.0",
+            "id": "x",
+            "title": "Title",
+            "description": "d",
+            "links": [],
+        }
+        with_agents = {
+            **base,
+            "links": [{"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"}],
+        }
+        errors_without = validate_document(base, catalog_schema)
+        errors_with = validate_document(with_agents, catalog_schema)
+        assert errors_without, "shipped catalog schema accepted a catalog with no rel='agents' link"
+        assert not errors_with, (
+            f"catalog with a rel='agents' link should conform, got: {errors_with}"
+        )
+
+    @pytest.mark.unit
+    def test_collection_without_agents_link_is_rejected(
+        self, collection_schema: dict[str, Any]
+    ) -> None:
+        # RULE-0081: collections MUST carry a rel="agents" AGENTS.md link. Only
+        # the links differ between the two documents, so a strictly smaller error
+        # count with the link present proves the missing link is what is rejected.
+        base = {
+            "type": "Collection",
+            "stac_version": "1.1.0",
+            "id": "c",
+            "title": "Collection",
+            "description": "d",
+            "license": "CC0-1.0",
+            "extent": {
+                "spatial": {"bbox": [[-1, -1, 1, 1]]},
+                "temporal": {"interval": [[None, None]]},
+            },
+            "links": [{"rel": "root", "href": "../catalog.json", "title": "Root"}],
+        }
+        with_agents = {
+            **base,
+            "links": [
+                *base["links"],
+                {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+            ],
+        }
+        errors_without = validate_document(base, collection_schema)
+        errors_with = validate_document(with_agents, collection_schema)
+        assert len(errors_without) > len(errors_with), (
+            "adding a rel='agents' link should resolve at least one schema error "
+            f"(without={errors_without}, with={errors_with})"
+        )
+
 
 class TestValidationIsHermetic:
     """Validation must resolve the STAC $refs offline and never fall back to the network."""
@@ -189,7 +258,9 @@ class TestValidationIsHermetic:
             "id": "x",
             "title": "Title",
             "description": "d",
-            "links": [],
+            "links": [
+                {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+            ],
         }
         # Resolves the STAC base $ref from the vendored bundle AND accepts a
         # conformant catalog -- with no network access. Asserting == [] (not just

--- a/tests/unit/test_add_external.py
+++ b/tests/unit/test_add_external.py
@@ -262,12 +262,16 @@ class TestAddExternal:
         assert via_links[0]["href"] == "https://docs.overturemaps.org/guides/places/"
 
     def test_no_local_file_written(self, tmp_path: Path) -> None:
-        """Nothing is downloaded: only metadata JSON exists in the collection."""
+        """Nothing is downloaded: only metadata sidecars exist in the collection.
+
+        AGENTS.md is scaffolded alongside collection.json (ADR-0052) — it is
+        metadata, not downloaded data, so the "no local data file" invariant holds.
+        """
         setup_catalog(tmp_path)
         add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="overture-places")
         collection_dir = tmp_path / "overture-places"
         files = sorted(p.name for p in collection_dir.iterdir())
-        assert files == ["collection.json"]
+        assert files == ["AGENTS.md", "collection.json"]
 
     def test_links_collection_into_root_catalog(self, tmp_path: Path) -> None:
         setup_catalog(tmp_path)

--- a/tests/unit/test_add_rm_hypothesis.py
+++ b/tests/unit/test_add_rm_hypothesis.py
@@ -1207,11 +1207,12 @@ class TestMultiAssetProperties:
 
     @pytest.mark.unit
     def test_ignored_files_are_stac_structural(self) -> None:
-        """IGNORED_FILES contains only STAC structural files."""
+        """IGNORED_FILES contains only STAC structural files and metadata links."""
         from portolan_cli.add import IGNORED_FILES
 
-        # These are the structural files that should never be assets
-        expected = {"catalog.json", "collection.json", "versions.json"}
+        # Structural files and link targets that must never be tracked as assets.
+        # AGENTS.md is referenced via a rel="agents" link, not an asset (ADR-0052).
+        expected = {"catalog.json", "collection.json", "versions.json", "AGENTS.md"}
         assert IGNORED_FILES == frozenset(expected)
 
     @pytest.mark.unit

--- a/tests/unit/test_agents_md.py
+++ b/tests/unit/test_agents_md.py
@@ -1,0 +1,212 @@
+"""Unit tests for AGENTS.md scaffolding, link injection, and gap detection.
+
+Covers the framework-free leaf ``portolan_cli.agents_md`` and the ``check --fix``
+repair ``portolan_cli.metadata.fix.repair_agents_md`` (ADR-0052, RULE-0080/0081).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.agents_md import (
+    AGENTS_LINK_REL,
+    AGENTS_MD_FILENAME,
+    AGENTS_MEDIA_TYPE,
+    agents_md_gap,
+    build_agents_link,
+    ensure_agents_md,
+    find_agents_link,
+    scaffold_content,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return path
+
+
+def _catalog(**overrides: object) -> dict:
+    base = {
+        "type": "Catalog",
+        "stac_version": "1.1.0",
+        "id": "demo",
+        "title": "Demo Catalog",
+        "description": "d",
+        "links": [{"rel": "root", "href": "./catalog.json", "type": "application/json"}],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestScaffoldContent:
+    def test_catalog_and_collection_differ(self) -> None:
+        cat = scaffold_content("My Catalog", is_catalog=True)
+        coll = scaffold_content("My Coll", is_catalog=False)
+        assert cat.startswith("# AGENTS.md — My Catalog")
+        assert "## Collections" in cat
+        assert "catalog" in cat.lower()
+        # Collection template seeds agent-oriented sections not in the README.
+        assert "## Schema & field notes" in coll
+        assert "## Example queries" in coll
+        assert "## Related collections" in coll
+        assert cat != coll
+
+    def test_title_is_embedded(self) -> None:
+        assert "# AGENTS.md — Census 2020" in scaffold_content("Census 2020", is_catalog=False)
+
+
+class TestLinkHelpers:
+    def test_build_agents_link_shape(self) -> None:
+        link = build_agents_link()
+        assert link["rel"] == AGENTS_LINK_REL == "agents"
+        assert link["href"] == f"./{AGENTS_MD_FILENAME}"
+        assert link["type"] == AGENTS_MEDIA_TYPE == "text/markdown"
+        assert link["title"]
+
+    def test_find_agents_link(self) -> None:
+        links = [{"rel": "root"}, build_agents_link(), {"rel": "self"}]
+        assert find_agents_link(links) is not None
+        assert find_agents_link([{"rel": "root"}]) is None
+        assert find_agents_link([]) is None
+
+
+class TestAgentsMdGap:
+    def test_no_gap_when_link_and_file_present(self, tmp_path: Path) -> None:
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# hi", encoding="utf-8")
+        cj = _write(
+            tmp_path / "catalog.json",
+            _catalog(links=[build_agents_link()]),
+        )
+        assert agents_md_gap(cj) is None
+
+    def test_missing_link_is_a_gap(self, tmp_path: Path) -> None:
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# hi", encoding="utf-8")
+        cj = _write(tmp_path / "catalog.json", _catalog())
+        gap = agents_md_gap(cj)
+        assert gap is not None
+        assert "missing" in gap.lower()
+
+    def test_missing_file_is_a_gap(self, tmp_path: Path) -> None:
+        # Link present but AGENTS.md file does not exist on disk.
+        cj = _write(tmp_path / "catalog.json", _catalog(links=[build_agents_link()]))
+        gap = agents_md_gap(cj)
+        assert gap is not None
+        assert "missing file" in gap.lower()
+
+    def test_malformed_link_is_a_gap(self, tmp_path: Path) -> None:
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# hi", encoding="utf-8")
+        bad = {"rel": "agents", "href": "./llms.txt", "type": "text/markdown"}
+        cj = _write(tmp_path / "catalog.json", _catalog(links=[bad]))
+        gap = agents_md_gap(cj)
+        assert gap is not None
+        assert "AGENTS.md" in gap
+
+    def test_unreadable_json_yields_none(self, tmp_path: Path) -> None:
+        cj = tmp_path / "catalog.json"
+        cj.write_text("{ not json", encoding="utf-8")
+        # Malformed JSON is another rule's problem, not ours.
+        assert agents_md_gap(cj) is None
+
+
+class TestEnsureAgentsMd:
+    def test_creates_file_and_link(self, tmp_path: Path) -> None:
+        cj = _write(tmp_path / "catalog.json", _catalog())
+        changed = ensure_agents_md(cj)
+        assert changed is True
+        agents = tmp_path / AGENTS_MD_FILENAME
+        assert agents.exists()
+        assert "# AGENTS.md — Demo Catalog" in agents.read_text(encoding="utf-8")
+        data = json.loads(cj.read_text(encoding="utf-8"))
+        link = find_agents_link(data["links"])
+        assert link is not None
+        assert link["href"] == "./AGENTS.md"
+        assert link["type"] == "text/markdown"
+
+    def test_collection_scaffold_uses_collection_template(self, tmp_path: Path) -> None:
+        coll = {
+            "type": "Collection",
+            "stac_version": "1.1.0",
+            "id": "roads",
+            "title": "Roads",
+            "description": "d",
+            "links": [],
+        }
+        cj = _write(tmp_path / "collection.json", coll)
+        ensure_agents_md(cj)
+        text = (tmp_path / AGENTS_MD_FILENAME).read_text(encoding="utf-8")
+        assert "## Schema & field notes" in text  # collection-only section
+
+    def test_idempotent_and_never_overwrites(self, tmp_path: Path) -> None:
+        cj = _write(tmp_path / "catalog.json", _catalog())
+        ensure_agents_md(cj)
+        # Human edits the scaffolded file.
+        agents = tmp_path / AGENTS_MD_FILENAME
+        agents.write_text("# Hand-authored, do not clobber", encoding="utf-8")
+        # Second run must be a no-op: link already present, file already exists.
+        changed = ensure_agents_md(cj)
+        assert changed is False
+        assert agents.read_text(encoding="utf-8") == "# Hand-authored, do not clobber"
+
+    def test_normalizes_malformed_link_without_duplicating(self, tmp_path: Path) -> None:
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# hi", encoding="utf-8")
+        bad = {"rel": "agents", "href": "./llms.txt", "type": "text/plain"}
+        cj = _write(tmp_path / "catalog.json", _catalog(links=[bad]))
+        changed = ensure_agents_md(cj)
+        assert changed is True
+        data = json.loads(cj.read_text(encoding="utf-8"))
+        agents_links = [link for link in data["links"] if link["rel"] == "agents"]
+        assert len(agents_links) == 1  # normalized in place, not duplicated
+        assert agents_links[0]["href"] == "./AGENTS.md"
+        assert agents_links[0]["type"] == "text/markdown"
+
+
+class TestRepairAgentsMd:
+    def test_repairs_catalog_and_collection(self, tmp_path: Path) -> None:
+        from portolan_cli.metadata.fix import repair_agents_md
+
+        _write(tmp_path / "catalog.json", _catalog())
+        coll_dir = tmp_path / "roads"
+        coll_dir.mkdir()
+        _write(
+            coll_dir / "collection.json",
+            {
+                "type": "Collection",
+                "stac_version": "1.1.0",
+                "id": "roads",
+                "title": "Roads",
+                "description": "d",
+                "links": [],
+            },
+        )
+
+        results = repair_agents_md(tmp_path)
+
+        assert len(results) == 2
+        assert (tmp_path / AGENTS_MD_FILENAME).exists()
+        assert (coll_dir / AGENTS_MD_FILENAME).exists()
+        # Re-running is a no-op now that everything is compliant.
+        assert repair_agents_md(tmp_path) == []
+
+    def test_dry_run_reports_without_writing(self, tmp_path: Path) -> None:
+        from portolan_cli.metadata.fix import repair_agents_md
+
+        _write(tmp_path / "catalog.json", _catalog())
+        results = repair_agents_md(tmp_path, dry_run=True)
+        assert len(results) == 1
+        assert not (tmp_path / AGENTS_MD_FILENAME).exists()
+
+    def test_skips_hidden_dirs(self, tmp_path: Path) -> None:
+        from portolan_cli.metadata.fix import repair_agents_md
+
+        _write(tmp_path / "catalog.json", _catalog(links=[build_agents_link()]))
+        (tmp_path / AGENTS_MD_FILENAME).write_text("# hi", encoding="utf-8")
+        # A stray catalog.json under .portolan/ must be ignored.
+        hidden = tmp_path / ".portolan"
+        hidden.mkdir()
+        _write(hidden / "catalog.json", _catalog())
+        assert repair_agents_md(tmp_path) == []

--- a/tests/unit/test_validation_runner.py
+++ b/tests/unit/test_validation_runner.py
@@ -26,10 +26,14 @@ class TestCheck:
                     "id": "test-catalog",
                     "title": "Test Catalog",
                     "description": "A test catalog",
-                    "links": [],
+                    "links": [
+                        {"rel": "agents", "href": "./AGENTS.md", "type": "text/markdown"},
+                    ],
                 }
             )
         )
+        # AGENTS.md required at catalog root (ADR-0052, RULE-0080)
+        (tmp_path / "AGENTS.md").write_text("# AGENTS.md — Test Catalog\n")
         # .portolan with management files (required for MANAGED state)
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
@@ -89,9 +93,10 @@ class TestCheck:
         # No .portolan dir = first rule fails
         report = check(tmp_path)
 
-        # Should have run all 17 default rules even though the first one failed
+        # Should have run all 19 default rules even though the first one failed
         # (6 original + 2 partition rules + 3 STAC rules: StacSchemaRule,
         # StacLintRule, MandatoryTitlesRule + 1 BboxValidRule for issue #516
-        # + 4 tabular rules for issue #481 + 1 PMTilesLinkRule for issue #569).
+        # + 4 tabular rules for issue #481 + 1 PMTilesLinkRule for issue #569
+        # + 2 AGENTS.md rules for ADR-0052 RULE-0080/0081).
         # Verifies no short-circuit on failure.
-        assert len(report.results) == 17
+        assert len(report.results) == 19

--- a/tests/unit/validation/test_agents_md_rules.py
+++ b/tests/unit/validation/test_agents_md_rules.py
@@ -1,0 +1,125 @@
+"""Unit tests for the AGENTS.md validation rules (RULE-0080/0081).
+
+CatalogAgentsMdLinkRule and CollectionAgentsMdLinkRule enforce that every
+catalog.json / collection.json references an AGENTS.md file via a well-formed
+``rel="agents"`` link (ADR-0052).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.agents_md import build_agents_link
+from portolan_cli.validation.results import Severity
+from portolan_cli.validation.rules import (
+    CatalogAgentsMdLinkRule,
+    CollectionAgentsMdLinkRule,
+)
+
+pytestmark = pytest.mark.unit
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "validation" / "stac"
+
+
+def _write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _catalog(links: list) -> dict:
+    return {
+        "type": "Catalog",
+        "stac_version": "1.1.0",
+        "id": "demo",
+        "title": "Demo",
+        "description": "d",
+        "links": links,
+    }
+
+
+def _collection(links: list) -> dict:
+    return {
+        "type": "Collection",
+        "stac_version": "1.1.0",
+        "id": "roads",
+        "title": "Roads",
+        "description": "d",
+        "links": links,
+    }
+
+
+class TestCatalogAgentsMdLinkRule:
+    def test_severity_is_error(self) -> None:
+        assert CatalogAgentsMdLinkRule().severity == Severity.ERROR
+        assert CatalogAgentsMdLinkRule().name == "agents_md_catalog_link"
+
+    def test_passes_with_link_and_file(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog([build_agents_link()]))
+        (tmp_path / "AGENTS.md").write_text("# guide", encoding="utf-8")
+        result = CatalogAgentsMdLinkRule().check(tmp_path)
+        assert result.passed
+
+    def test_fails_when_link_missing(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog([]))
+        result = CatalogAgentsMdLinkRule().check(tmp_path)
+        assert not result.passed
+        assert "AGENTS.md" in result.message
+
+    def test_fails_when_file_missing(self, tmp_path: Path) -> None:
+        # Link present, file absent — still a failure (fixable by --fix).
+        _write(tmp_path / "catalog.json", _catalog([build_agents_link()]))
+        result = CatalogAgentsMdLinkRule().check(tmp_path)
+        assert not result.passed
+
+    def test_checks_nested_intermediate_catalogs(self, tmp_path: Path) -> None:
+        # Root is compliant; a nested (intermediate) catalog is not.
+        _write(tmp_path / "catalog.json", _catalog([build_agents_link()]))
+        (tmp_path / "AGENTS.md").write_text("# guide", encoding="utf-8")
+        _write(tmp_path / "region" / "catalog.json", _catalog([]))
+        result = CatalogAgentsMdLinkRule().check(tmp_path)
+        assert not result.passed
+        assert "region" in result.message
+
+    def test_ignores_hidden_dirs(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog([build_agents_link()]))
+        (tmp_path / "AGENTS.md").write_text("# guide", encoding="utf-8")
+        _write(tmp_path / ".portolan" / "catalog.json", _catalog([]))
+        assert CatalogAgentsMdLinkRule().check(tmp_path).passed
+
+    def test_flags_present_file_without_link(self) -> None:
+        # Regression for the portolan-nl gap (cli#479): AGENTS.md exists on disk
+        # but the root catalog.json has no rel="agents" link. RULE-0080 must fail
+        # even though the file is present.
+        fixture = FIXTURES_DIR / "agents-md-missing-root-link"
+        assert (fixture / "AGENTS.md").exists()  # file is present...
+        result = CatalogAgentsMdLinkRule().check(fixture)
+        assert not result.passed  # ...but the link is not
+        assert "missing" in result.message.lower()
+
+
+class TestCollectionAgentsMdLinkRule:
+    def test_severity_and_name(self) -> None:
+        rule = CollectionAgentsMdLinkRule()
+        assert rule.severity == Severity.ERROR
+        assert rule.name == "agents_md_collection_link"
+
+    def test_passes_with_link_and_file(self, tmp_path: Path) -> None:
+        coll_dir = tmp_path / "roads"
+        _write(coll_dir / "collection.json", _collection([build_agents_link()]))
+        (coll_dir / "AGENTS.md").write_text("# guide", encoding="utf-8")
+        assert CollectionAgentsMdLinkRule().check(tmp_path).passed
+
+    def test_fails_when_link_missing(self, tmp_path: Path) -> None:
+        coll_dir = tmp_path / "roads"
+        _write(coll_dir / "collection.json", _collection([]))
+        result = CollectionAgentsMdLinkRule().check(tmp_path)
+        assert not result.passed
+        assert "roads" in result.message
+
+    def test_passes_when_no_collections_present(self, tmp_path: Path) -> None:
+        # A catalog with no collections cannot violate the collection rule.
+        _write(tmp_path / "catalog.json", _catalog([build_agents_link()]))
+        assert CollectionAgentsMdLinkRule().check(tmp_path).passed


### PR DESCRIPTION
## What & why

Migrate Portolan's AI/agent metadata requirement from `llms.txt` to **`AGENTS.md`** (Markdown, minimal, aligned with the cross-tool [agents.md](https://agents.md/) convention) and **actually enforce it end to end**. Previously the requirement was specified everywhere (spec, rules.yaml, ADR-0052) and implemented nowhere — the JSON schema only validated the link *if present*, and there was no generation or validation code.

Decisions (confirmed with maintainer): filename **`AGENTS.md`** (uppercase), link relation **`rel: "agents"`**, `type: text/markdown`, relative `href`. Every **catalog** and **collection** must carry the file, referenced as a **link** (not an asset). Content is open-ended.

## Changes

**Spec / schema**
- `ai-integration.md`, `core.md`, `README.md`, `formats/tabular.md`, example JSON: `llms.txt` → `AGENTS.md`, `rel:"llms"` → `rel:"agents"`.
- `catalog.schema.json` / `collection.schema.json` now **require** a `rel="agents"` link via a `contains` clause (not just validate-if-present — the core #479 ask); href regex → `AGENTS.md`; `LlmsLink` → `AgentsLink`.
- `rules.yaml`: RULE-0080/0081 renamed and given `code_rule` mappings; RULE-0082/0083 renamed, remain spec-level warnings (content is open-ended).

**CLI**
- New framework-free leaf `agents_md.py` (scaffold + link helpers + gap detection), imported by both generation and validation (respects `validation-no-framework-leakage`).
- `CatalogAgentsMdLinkRule` / `CollectionAgentsMdLinkRule` (RULE-0080/0081, error) registered in the runner.
- `init` and `add` scaffold `AGENTS.md` and emit the link so freshly-created output is schema-valid; `check --fix` (`repair_agents_md`) backfills externally-modified catalogs. Scaffolding **never overwrites** an existing, human-authored `AGENTS.md`.

**Tests / fixtures / ADR**
- Unit tests for the leaf, both rules, generation, and `--fix` repair.
- Schema now-required-link assertions + hermetic init/add generation asserts.
- Valid fixtures carry `AGENTS.md` + link; a **local regression fixture** reproduces the portolan-nl "file present, root link absent" gap.
- ADR-0052 updated to `AGENTS.md` and corrected to describe the real (now-implemented) enforcement.

## Verified locally
- New unit/rule tests pass; `spec_compliance` suite green (105).
- Manual end-to-end: `init`/`add` produce `AGENTS.md` + link; removing the link makes `check` fail RULE-0080/0081; `check --fix` restores both.
- All pre-commit hooks pass (mypy --strict, import-linter, complexity, dedup, spell, spec/CLAUDE.md parity).

## Note (out of scope)
`portolan-nl` is a **live external Source Cooperative catalog**, not a fixture in this repo — its root-link gap can't be fixed here. It's covered as a local regression fixture; the external catalog needs a separate republish.

Closes portolan-sdi/portolan-cli#479
Closes portolan-sdi/portolan-cli#565
Refs portolan-sdi/portolan-spec#38, portolan-sdi/portolan-spec#2 (spec is sourced from this repo per ADR-0048; those trackers are addressed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `AGENTS.md` guidance files for catalogs and collections.
  * New and updated validation checks now recognize the required `agents` link and Markdown file.

* **Bug Fixes**
  * Catalog and collection creation now scaffold `AGENTS.md` automatically when missing.
  * Fix workflows can now backfill missing or malformed `agents` links and related files.
  * Asset scans now ignore `AGENTS.md` so it won’t be treated as content data.

* **Documentation**
  * Updated specs and examples to replace the older integration convention with `AGENTS.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->