### PR TITLE
RFC: Portolan as a pure STAC profile (v0.2.0) — thin index, derived capabilities, no Portolan extension

### DIFF
--- a/context/shared/adr/0057-portolan-pure-profile.md
+++ b/context/shared/adr/0057-portolan-pure-profile.md
@@ -1,0 +1,84 @@
+# ADR-0057: Portolan as a pure STAC profile — thin index, derived capabilities, no Portolan extension
+
+## Status
+
+Proposed
+
+> RFC for team discussion. Detailed proposal, draft docs, and a validated reference example set live in
+> [`spec/rfc/pure-profile-v0.2.0/`](../../../spec/rfc/pure-profile-v0.2.0/). Nothing in the canonical
+> `spec/` is rewritten by this PR; the breaking edits land only if the direction is accepted.
+
+## Context
+
+A post-workshop review (2026-07-09) found the emerging design overloading STAC:
+
+- Parquet partitions modelled as STAC `Item`s.
+- A relational (multi-table) model pushed into STAC JSON links.
+- A new Portolan STAC extension (`stac-portolan-extension`, created 2026-07-09) whose only field is a
+  version marker.
+- Format-specific mandates (PMTiles required).
+- `portolan:geospatial` as a required boolean, plus a validator special-case for tabular bbox.
+
+Underneath sits a real tension between two goals the spec is trying to satisfy as a **mandatory
+union**: AI/analytics access (agents querying with DuckDB) and cheap, browsable catalogs
+(visualization, the portal experience). Satisfying both as mandatory taxes both.
+
+Applying one rule exposes how much is ceremony — **keep a custom field only if it is (a) not derivable
+from ground truth, (b) has no home in an existing extension, and (c) is consumer-needed.** Under it,
+almost every Portolan-specific field fails.
+
+## Decision
+
+Reframe Portolan as a **pure STAC profile**: a set of requirements + a conformance vocabulary,
+expressed entirely through STAC core + existing extensions (`table`, `projection`, `alternate-assets`,
+`osi`, `iceberg`). Concretely:
+
+1. **No Portolan STAC extension.** No `stac_extensions` entry, no `portolan:` fields. Repurpose the
+   `stac-portolan-extension` repo as the profile / conformance-vocabulary home.
+2. **Thin index, layered concerns.** STAC = discovery (Catalog → Collection → data assets; the `Item`
+   is vestigial for vector/tabular data). Tables = GeoParquet or Iceberg (hidden partitioning; the
+   `static` catalog mode stays serverless-on-object-store). Meaning + relations = OSI. Presentation =
+   optional.
+3. **Identity + profile version via `conformsTo`** (reused OGC/STAC-API idiom; version in the URI).
+   Distinct from STAC `stac_version` and the data version in `versions.json`.
+4. **Capabilities are derived, not declared.** Presence is read from the artifacts
+   (`roles:["visual"]` ⇒ visualization; OSI link ⇒ semantic); the spec defines a **contract** per
+   capability, enforced by `portolan check`.
+5. **Drop `portolan:geospatial`** — arbitrary + derivable; `bbox` is uniformly an AOI; map-viewability
+   is the visualization capability.
+6. **Drop `portolan:datetime_provisional` as a stored field** — validator-computed WARNING.
+7. **`AGENTS.md` (agents, hierarchical) + `README.md` (humans)** replace `llms.txt`
+   (supersedes ADR-0052).
+8. **Multi-table models = one collection, tables as assets;** relations in OSI (`osi:relations`,
+   incl. spatial-predicate relations), not Items or links.
+9. **Visualization is a capability + contract, not a mandated format.** PMTiles = recommended default.
+
+The mandatory **core contract** (PC-01…PC-18) and the derived **capability contracts** are drafted in
+[`capabilities.md`](../../../spec/rfc/pure-profile-v0.2.0/capabilities.md).
+
+## Consequences
+
+- **Breaking** (spec `0.1.1 → 0.2.0`): removed fields, `llms.txt → AGENTS.md`, schema tightening
+  (machine-readable schema required), `SELF_CONTAINED` omits `self` links.
+- **Simpler + more portable:** the design validates as plain STAC and renders in STAC Browser today
+  (see evidence below); Portolan "invents nothing."
+- **Companion changes** in sibling repos: `stac-osi-extension` adds `osi:relations` (spatial-predicate
+  aware; current schema already accepts it); `stac-iceberg-extension` allows asset-scoped `iceberg:*`
+  for multi-table collections.
+- `portolan check` / `reis` (`schema/rules.yaml`) becomes the operative definition of conformance.
+
+## Evidence
+
+Reference set in [`spec/rfc/pure-profile-v0.2.0/examples/`](../../../spec/rfc/pure-profile-v0.2.0/examples/):
+`buildings` (single-table, H3-partitioned, not itemised, viz) + `cadastre` (multi-table model with OSI
+semantics). Validated with `stac-node-validator` v2.0.0-rc.3 (**3/3 pass**, all extensions incl. the
+proposed `osi:relations`) and rendered in **STAC Browser v5.0.0-rc.1** (multi-table assets, OSI
+metrics/relations, `table:columns` schema, and the VISUAL-badged tiles asset all display).
+
+## Open questions
+
+- Schema-in-STAC (`table:columns`): SHOULD (CLI-generated) vs MUST.
+- `versions.json`: minimal manifest in core vs a `versioning` capability.
+- Accepted-format allowlist for the data asset.
+- `AGENTS.md`/`README.md` required per collection vs root-only.
+- PMTiles: capability + contract vs mandatory format.

--- a/spec/rfc/pure-profile-v0.2.0/README.md
+++ b/spec/rfc/pure-profile-v0.2.0/README.md
@@ -1,0 +1,83 @@
+# RFC: Portolan as a pure STAC profile — thin index, derived capabilities, no Portolan extension (v0.2.0)
+
+> Target: `portolan-cli` `spec/` (source of truth; syncs to `portolan-spec`). Proposed spec bump:
+> **0.1.1 → 0.2.0** (breaking: schema tightening + requirement changes + removed fields).
+> This RFC can be merged as one change or split into the focused PRs listed at the end.
+
+## Summary
+
+Reframe Portolan as a **thin STAC discovery index** over cloud-native data, with meaning/relations in
+**OSI** and tables in **GeoParquet/Iceberg**. The result removes the bespoke Portolan STAC extension
+entirely and expresses everything through existing standards + a conformance vocabulary.
+
+## Motivation
+
+Post-workshop review found we were overloading STAC: partitions modelled as Items, relations pushed
+into JSON, a new marker extension, and format-specific mandates (PMTiles). Applying one rule — *keep a
+custom field only if it is (a) not derivable, (b) has no home in an existing extension, and (c) is
+consumer-needed* — collapses almost all of it.
+
+## Normative changes
+
+### Removed
+- **The Portolan STAC extension** (`stac-portolan-extension`) — no fields survive the rule. Repurpose
+  that repo as the **profile / conformance-vocabulary home** (hosts the `conformsTo` tier URIs + prose
+  spec), not a fields extension.
+- **`portolan:version`** — replaced by a `conformsTo` core URI (version in the path).
+- **`portolan:geospatial`** — arbitrary + derivable; replaced by *uniform bbox = AOI* semantics and
+  the visualization capability. (Update `core.md` "Spatial Extent for Tabular Collections" and
+  `formats/tabular.md` accordingly.)
+- **`portolan:datetime_provisional`** as a stored field — becomes a validator-computed WARNING.
+
+### Changed
+- **`core.md`** — adopt the **Core Contract** (PC-01…PC-18, see `capabilities.md`). Notable:
+  - `SELF_CONTAINED` now **omits `self` links** (schema requires `self.href` to be an absolute IRI;
+    relative `root`/`parent`/`child` are fine). *Verified against `stac-node-validator`.*
+  - Every data asset MUST be a **self-describing, range-readable** format (schema readable from the
+    asset); STAC `table:columns` restatement is **SHOULD** (CLI-generated).
+  - `bbox` is uniformly an **AOI**; no `geospatial` branching.
+- **`ai-integration.md`** — replace the `llms.txt` requirement with **`AGENTS.md`** at catalog root
+  and each collection (hierarchical, `rel:"agents"`); keep **`README.md`** for humans. *Supersedes
+  ADR-0052.*
+- **`extensions.md`** — document that Portolan adds **no STAC extension**; list the ecosystem
+  extensions used (`table`, `projection`, `alternate-assets`, `osi`, `iceberg`).
+- **`schema/rules.yaml`** — encode PC-01…PC-18 + the capability contracts as validator rules;
+  remove rules referencing the removed fields.
+- **`schema/spec-version.json`** — bump to `0.2.0`.
+
+### Added
+- **`conformance.md`** (new) — identity + profile version via `conformsTo`; the versioned core URI;
+  three-versions distinction. *(File included in this packet.)*
+- **`capabilities.md`** (new) — the Core Contract table + the derived capability contracts
+  (visualization / semantic / iceberg / versioning). *(File included in this packet.)*
+- **Multi-table guidance** (in `formats/vector.md` or `structure.md`) — a data model = one collection,
+  tables as **assets**; relations in OSI (`osi:relations`), not Items or links.
+
+## Companion changes (separate repos, referenced here)
+- **`stac-osi-extension`** — add `osi:relations` (denormalized summary mirroring `osi:metrics`),
+  including **spatial-predicate** relations (`predicate`, `spatial`). *Validated: current OSI schema
+  already accepts the field.*
+- **`stac-iceberg-extension`** — allow **asset-scoped** `iceberg:*` so one collection can hold
+  multiple Iceberg tables (currently collection-singular).
+
+## Examples & evidence
+- Reference set under `spec/examples/portolan/` (from this work's `example/`): `buildings`
+  (single-table, not itemised, viz) + `cadastre` (multi-table model, OSI semantics).
+- **`stac-node-validator` v2.0.0-rc.3: 3/3 pass**, all extensions pass.
+- **STAC Browser v5.0.0-rc.1**: catalogue, multi-table assets, OSI metrics/relations, `table:columns`
+  schema, and the VISUAL badge all render.
+
+## Open decisions for the group (please weigh in)
+- **A** — schema-in-STAC (`table:columns`): SHOULD (CLI-generated, proposed) vs MUST.
+- **B** — `versions.json`: minimal manifest in core (proposed) vs a `versioning` capability.
+- **C** — accepted-format allowlist for the data asset (Parquet/Iceberg required; GeoJSON/CSV only for
+  tiny data?).
+- **D** — `AGENTS.md`/`README.md` required per collection (proposed, CLI-scaffolded) vs root-only.
+- **PMTiles** — capability + contract (proposed) vs mandatory format.
+
+## If we'd rather split it
+1. Remove Portolan extension + `portolan:*` fields → `conformsTo`.
+2. `AGENTS.md`/`README.md` (supersede ADR-0052).
+3. Capabilities + contracts (`capabilities.md`, `rules.yaml`).
+4. Multi-table model guidance + OSI companion changes.
+5. Visualization capability reframe.

--- a/spec/rfc/pure-profile-v0.2.0/capabilities.md
+++ b/spec/rfc/pure-profile-v0.2.0/capabilities.md
@@ -1,0 +1,50 @@
+# Core Contract & Capabilities
+
+Conformance is **"passes the checks,"** not "claims to." This document defines the mandatory **core
+contract** every Portolan node satisfies, and the **optional capability contracts** that are verified
+only when a capability is present (presence is *derived* from the artifacts, never declared).
+
+## Core (MUST unless noted) — `portolan check` verifies
+
+| ID | Requirement | Level |
+|---|---|---|
+| PC-01 | Valid STAC 1.1.0 (Catalog / Collection / Item as used) | MUST |
+| PC-02 | `SELF_CONTAINED`: structural links (`root`/`parent`/`child`) are relative and resolve; **`self` links are omitted** (schema requires `self.href` to be an absolute IRI) | MUST |
+| PC-03 | Data asset hrefs are absolute object-storage URLs | MUST |
+| PC-04 | Every Catalog/Collection has non-empty, human-readable `title` + `description` | MUST |
+| PC-05 | Every `child`/`item` link has a `title` | MUST |
+| PC-06 | `AGENTS.md` at catalog root and each collection, linked `rel:"agents"` (hierarchical) | MUST |
+| PC-07 | `README.md` at catalog root (title, description, license, provenance) | MUST |
+| PC-08 | Every Collection has `extent.spatial.bbox`, interpreted uniformly as **AOI** | MUST |
+| PC-09 | Every bbox valid (no NaN/Inf/sentinels; WGS84 ranges; south ≤ north) | MUST |
+| PC-10 | Items/collections carry `datetime` or a start/end interval | SHOULD (absent → WARNING) |
+| PC-11 | Every dataset has ≥1 asset `roles:["data"]`, resolvable href, correct media type | MUST |
+| PC-12 | Data is a self-describing, cloud-native, range-readable format so schema+types(+CRS) are machine-readable from the asset | MUST |
+| PC-13 | Schema restated in STAC as asset/collection `table:columns` (+ `proj:code`), CLI-generated | SHOULD |
+| PC-14 | Collection declares a `license` | MUST |
+| PC-15 | `providers` with roles | SHOULD |
+| PC-16 | `rel:"via"` to the canonical external source when data is derived from one | MUST (if derived) |
+| PC-17 | `versions.json` with ≥ current version id + asset checksum(s) | MUST |
+| PC-18 | Declare profile version via one `conformsTo` core URI | SHOULD |
+
+Core deliberately **excludes** visualization, semantics, iceberg and relations.
+
+**Open judgment calls:** PC-13 SHOULD vs MUST · PC-17 core vs a `versioning` capability · PC-12
+accepted-format allowlist · PC-06/07 per-collection vs root-only. See the RFC.
+
+## Capabilities — optional, derived from presence, contract-guaranteed
+
+A capability is present iff its **signal** is present; the **contract** is what makes it reliable.
+Nothing is declared in `conformsTo`.
+
+| Capability | Signal (how a client detects it) | Contract (`portolan check` when present) |
+|---|---|---|
+| **Visualization** | a `roles:["visual"]` asset (or renderable-from-source) | zero-infra renderable; covers the dataset; declared derived from its data source (staleness-detectable). Format-agnostic; PMTiles = recommended default |
+| **Semantic** | OSI model link / `osi:*` fields | model resolves; `osi:relations`/`osi:metrics` consistent with it; referenced columns exist in the schema |
+| **Iceberg / table-format** | Iceberg asset / `iceberg:*` fields | `metadata.json` resolvable and `iceberg_scan()`-able; declared `iceberg:*` match the metadata |
+| **Versioning / time-travel** *(candidate)* | multi-version `versions.json` / Iceberg snapshots | predecessor/successor resolvable; checksums verify |
+
+**Why derived, not declared:** capability presence is already in the artifacts, so a declaration would
+duplicate ground truth (the same reason `portolan:geospatial` is dropped) — and a declaration can lie
+(claim `viz` over a broken tile) where inspection + contract cannot. A viewer's reliability comes from
+the contract on the artifact, which is stronger than a self-reported flag.

--- a/spec/rfc/pure-profile-v0.2.0/conformance.md
+++ b/spec/rfc/pure-profile-v0.2.0/conformance.md
@@ -1,0 +1,45 @@
+# Conformance & Versioning
+
+Portolan is a **STAC profile**, not a STAC extension. A catalog does not carry a `portolan:` marker
+field; it conforms by satisfying the requirements a validator (`portolan check`) enforces, and it
+declares the **profile version** it targets via `conformsTo`.
+
+## Declaring conformance
+
+A Portolan Catalog (and, where it differs, a Collection) SHOULD declare the profile version with a
+single core conformance URI, following the OGC API / STAC API `conformsTo` idiom:
+
+```json
+{
+  "type": "Catalog",
+  "id": "example",
+  "conformsTo": ["https://portolan-sdi.github.io/spec/v0.2.0/core"]
+}
+```
+
+- The **version lives in the URI path** (`.../v0.2.0/core`). A version bump changes the URI; clients
+  match the URIs they understand (capability negotiation) rather than parsing a bare semver.
+- This is the **only** Portolan identity/version signal. There is no `portolan:version` field and no
+  Portolan `stac_extensions` entry.
+- Declaring it is optional-in-principle (a validator can check against known versions) but recommended
+  so tooling can select the right ruleset and give clear diagnostics.
+
+`conformsTo` is formally a STAC API landing-page field; Portolan reuses it on static catalogs. If an
+implementation objects to that, the fallback is a single `portolan:conforms_to` field — the *only*
+field that would then justify a Portolan extension.
+
+## Capabilities are NOT declared here
+
+Optional capabilities (visualization, semantic, iceberg, …) are **derived by inspecting the
+artifacts**, not enumerated in `conformsTo`. See [capabilities.md](capabilities.md). Their *contracts*
+are versioned lockstep with the profile, in the spec text.
+
+## Three distinct versions — do not conflate
+
+| Version of… | Mechanism | Owner |
+|---|---|---|
+| The **STAC spec** | `stac_version` (e.g. `"1.1.0"`) | STAC core field |
+| The **Portolan profile** | `conformsTo` URI (`.../v0.2.0/core`) | this spec |
+| The **data itself** | `versions.json` / Iceberg snapshots / `version`-extension links | the dataset |
+
+None of these requires a `portolan:version` field.

--- a/spec/rfc/pure-profile-v0.2.0/examples/AGENTS.md
+++ b/spec/rfc/pure-profile-v0.2.0/examples/AGENTS.md
@@ -1,0 +1,24 @@
+# Portolan catalogue — agent guide
+
+This is a **Portolan** catalogue: a thin STAC index over cloud-native GeoParquet on object storage.
+This file is the catalogue-wide guide; each collection has its own `AGENTS.md` (nearest one wins).
+
+## How to use this catalogue
+- The tree is `catalog.json` → `{collection}/collection.json`. Structural links are relative.
+- **Data is not in STAC.** STAC points at it. Query the GeoParquet directly with DuckDB.
+- **Capabilities are derived, not declared.** To know if a dataset can be mapped, look for an asset
+  with `roles:["visual"]`. To know if it has a semantic model, look for `osi:*` fields / an OSI link.
+- Profile: this catalogue declares `conformsTo: [".../spec/v0.2.0/core"]`. That is the only Portolan
+  identity/version marker — there is no `portolan:` field and no Portolan STAC extension.
+
+## Setup for queries
+```sql
+INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;
+```
+
+## Collections
+- `buildings/` — building footprints, one row per building (~5.65M), GeoParquet partitioned by H3.
+- `cadastre/` — a multi-table model (parcels, buildings, ownerships); see its `AGENTS.md` and the
+  linked OSI model for the join graph.
+
+License: CC-BY-4.0, National Land Survey of Finland. Cite NLS.

--- a/spec/rfc/pure-profile-v0.2.0/examples/README.md
+++ b/spec/rfc/pure-profile-v0.2.0/examples/README.md
@@ -1,0 +1,31 @@
+# Finland — Portolan reference catalogue
+
+A small, self-contained reference catalogue demonstrating the **converged Portolan design**
+(post-2026-07-09 workshop). It is a *thin STAC index* over cloud-native data; the data itself lives
+in object storage as GeoParquet.
+
+## What this demonstrates
+
+- **STAC as a thin index.** Catalog → Collections → data assets. No STAC `Item`s (they're vestigial
+  for vector/tabular data); partitions are *not* itemised.
+- **No bespoke Portolan STAC extension.** Everything rides on STAC core + `table` + `projection` +
+  `alternate-assets` + `osi`. Identity and profile version are declared once via `conformsTo`.
+- **Capabilities are derived, not declared.** A client learns what a dataset supports by looking:
+  a `roles:["visual"]` asset ⇒ visualization; an OSI model link ⇒ semantics.
+- **Two shapes:**
+  - `buildings/` — a single-table dataset, GeoParquet Hive-partitioned by H3 cell, **not** itemised;
+    ships a visualization capability (PMTiles).
+  - `cadastre/` — a **multi-table data model** (parcels · buildings · ownerships) in one collection;
+    relations and meaning live in the linked **OSI** model (semantic capability), including a
+    spatial-predicate relation.
+
+## Access
+
+Data is queried directly with DuckDB over object storage — see each collection's `AGENTS.md` for the
+exact SQL. Structural links are relative, so this catalogue can be browsed locally (e.g. in STAC
+Browser) without a live bucket.
+
+## License & provenance
+
+Source: National Land Survey of Finland (NLS) Topographic Database, CC-BY-4.0. See the `via` link in
+`catalog.json` and each collection's `providers`.

--- a/spec/rfc/pure-profile-v0.2.0/examples/buildings/AGENTS.md
+++ b/spec/rfc/pure-profile-v0.2.0/examples/buildings/AGENTS.md
@@ -1,0 +1,29 @@
+# Building footprints — agent guide
+
+One row per building from the NLS Topographic Database (`rakennus`). GeoParquet, EPSG:3067,
+~5.65M rows, Hive-partitioned by `h3_3` (H3 resolution-3 cell). **Not itemised** — there is no STAC
+Item per partition; use the glob.
+
+## Query (DuckDB)
+```sql
+INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;
+
+-- whole dataset (wildcard the partitions)
+SELECT count(*)
+FROM read_parquet('s3://example-bucket/fi/buildings/**/*.parquet', hive_partitioning = true)
+WHERE municipality_code = '091';
+
+-- one partition (substitute the h3_3 value)
+SELECT * FROM read_parquet('s3://example-bucket/fi/buildings/h3_3=831f5cfffffffff/data.parquet');
+```
+Within a partition, GeoParquet's bbox covering column prunes row-groups.
+
+## Columns
+`mtk_id` (PK) · `municipality_code` · `use` · `h3_3` (partition key) · `geometry` (WKB, EPSG:3067).
+Also restated machine-readably in the collection's `table:columns`.
+
+## Capabilities present
+- **Visualization** — yes (`tiles` asset, PMTiles, `roles:["visual"]`).
+- **Semantic** — no OSI model for this dataset.
+
+License: CC-BY-4.0, National Land Survey of Finland.

--- a/spec/rfc/pure-profile-v0.2.0/examples/buildings/README.md
+++ b/spec/rfc/pure-profile-v0.2.0/examples/buildings/README.md
@@ -1,0 +1,8 @@
+# Finland building footprints
+
+Building footprints (one row per building, ~5.65M) from the National Land Survey of Finland
+Topographic Database. Stored as GeoParquet in EPSG:3067, Hive-partitioned by H3 resolution-3 cell.
+
+- **Access:** query directly with DuckDB (see `AGENTS.md`).
+- **Visualization:** PMTiles vector tiles (the `tiles` asset).
+- **License:** CC-BY-4.0 — cite the National Land Survey of Finland.

--- a/spec/rfc/pure-profile-v0.2.0/examples/buildings/collection.json
+++ b/spec/rfc/pure-profile-v0.2.0/examples/buildings/collection.json
@@ -1,0 +1,65 @@
+{
+  "type": "Collection",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/table/v1.2.0/schema.json",
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json"
+  ],
+  "id": "fi-buildings",
+  "title": "Finland building footprints",
+  "description": "Building footprints from the NLS Topographic Database (rakennus feature class). One row per building, ~5.65M rows. GeoParquet, Hive-partitioned by H3 resolution-3 cell (h3_3). Partitions are NOT itemised (too many, not user-meaningful); read the whole dataset with a wildcard glob, or one partition by substituting h3_3. Coordinates in EPSG:3067; STAC bbox is WGS84. See AGENTS.md for query recipes.",
+  "license": "CC-BY-4.0",
+  "conformsTo": [
+    "https://portolan-sdi.github.io/spec/v0.2.0/core"
+  ],
+  "keywords": ["buildings", "footprints", "Finland", "NLS", "GeoParquet"],
+  "providers": [
+    { "name": "National Land Survey of Finland (NLS)", "roles": ["producer", "licensor"], "url": "https://www.maanmittauslaitos.fi/en" },
+    { "name": "Example Org", "roles": ["processor", "host"], "url": "https://example.org" }
+  ],
+  "extent": {
+    "spatial": { "bbox": [[19.0, 59.0, 31.6, 70.1]] },
+    "temporal": { "interval": [["2024-01-01T00:00:00Z", null]] }
+  },
+  "table:primary_geometry": "geometry",
+  "table:row_count": 5650000,
+  "table:columns": [
+    { "name": "mtk_id", "type": "string", "description": "Stable feature id from the source database. Primary key." },
+    { "name": "municipality_code", "type": "string", "description": "Municipality code (kuntakoodi)." },
+    { "name": "use", "type": "string", "description": "Building use class (käyttötarkoitus)." },
+    { "name": "h3_3", "type": "string", "description": "H3 resolution-3 cell id. Hive partition key." },
+    { "name": "geometry", "type": "binary", "description": "Building footprint polygon, WKB, EPSG:3067." }
+  ],
+  "assets": {
+    "data": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/fi/buildings/",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "title": "Building footprints — Hive-partitioned GeoParquet (h3_3=*)",
+      "description": "Directory of GeoParquet partitions. Read all: read_parquet('.../fi/buildings/**/*.parquet', hive_partitioning=true). One partition: substitute h3_3. Schema is self-describing in the files; also restated in table:columns above (CLI-generated).",
+      "proj:code": "EPSG:3067",
+      "alternate:name": "HTTPS",
+      "alternate": {
+        "s3": {
+          "href": "s3://example-bucket/fi/buildings/",
+          "alternate:name": "S3"
+        }
+      }
+    },
+    "tiles": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/fi/buildings/buildings.pmtiles",
+      "type": "application/vnd.pmtiles",
+      "roles": ["visual"],
+      "title": "PMTiles vector tiles",
+      "description": "Visualization capability (zero-infra, range-read). Derived from the 'data' asset; regenerate when the data changes. NOTE: formal derived_from + staleness declaration is still an open spec item."
+    }
+  },
+  "links": [
+    { "rel": "root", "href": "../catalog.json", "type": "application/json" },
+    { "rel": "parent", "href": "../catalog.json", "type": "application/json" },
+    { "rel": "agents", "href": "./AGENTS.md", "type": "text/markdown", "title": "Dataset agent guide" },
+    { "rel": "version-history", "href": "./versions.json", "type": "application/json", "title": "Version manifest" },
+    { "rel": "via", "href": "https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/expert-users/product-descriptions/topographic-database", "type": "text/html", "title": "Source: NLS Topographic Database (rakennus)" }
+  ]
+}

--- a/spec/rfc/pure-profile-v0.2.0/examples/cadastre/AGENTS.md
+++ b/spec/rfc/pure-profile-v0.2.0/examples/cadastre/AGENTS.md
@@ -1,0 +1,39 @@
+# Cadastre (multi-table model) — agent guide
+
+A **data model published as one collection**: three tables, each a data asset. GeoParquet, EPSG:3067.
+The canonical join graph and meaning live in the **OSI model** (`semantics.osi.yaml`); STAC carries a
+denormalized summary in `osi:relations` / `osi:metrics`.
+
+## Tables (assets)
+- `parcels` — PK `parcel_id`, `geometry` (polygon).
+- `buildings` — PK `building_id`, FK `parcel_id` → parcels, `geometry` (polygon).
+- `ownerships` — PK `ownership_id`, FK `parcel_id` → parcels, `owner_name`, `share_pct` (no geometry).
+
+## Relations (from the OSI model)
+- `buildings.parcel_id → parcels.parcel_id` (N:1)
+- `ownerships.parcel_id → parcels.parcel_id` (N:1)
+- `buildings ST_Within parcels` (N:1, **spatial predicate** — no stored key). This is the
+  spatial-relation case OSI's spatial extension is being designed for; it is a **proposed** field.
+
+## Query (DuckDB)
+```sql
+INSTALL spatial; LOAD spatial; INSTALL httpfs; LOAD httpfs;
+
+-- buildings with their parcel + owner (key join)
+SELECT b.building_id, p.parcel_id, o.owner_name, o.share_pct
+FROM read_parquet('s3://example-bucket/fi/cadastre/buildings/**/*.parquet') b
+JOIN read_parquet('s3://example-bucket/fi/cadastre/parcels/**/*.parquet')    p USING (parcel_id)
+JOIN read_parquet('s3://example-bucket/fi/cadastre/ownerships/**/*.parquet') o USING (parcel_id);
+
+-- spatial-predicate relation (no stored key)
+SELECT b.building_id, p.parcel_id
+FROM read_parquet('s3://example-bucket/fi/cadastre/buildings/**/*.parquet') b
+JOIN read_parquet('s3://example-bucket/fi/cadastre/parcels/**/*.parquet')   p
+  ON ST_Within(ST_GeomFromWKB(b.geometry), ST_GeomFromWKB(p.geometry));
+```
+
+## Capabilities present
+- **Semantic** — yes (OSI model linked; `osi:*` fields present).
+- **Visualization** — none shipped for this model (query/analysis dataset).
+
+License: CC-BY-4.0, National Land Survey of Finland.

--- a/spec/rfc/pure-profile-v0.2.0/examples/cadastre/README.md
+++ b/spec/rfc/pure-profile-v0.2.0/examples/cadastre/README.md
@@ -1,0 +1,10 @@
+# Finland cadastre (Uusimaa sample)
+
+A multi-table cadastral **data model** published as a single Portolan collection: parcels, buildings,
+and ownership records. The tables are related (buildings and ownerships reference parcels); the
+relationships, metrics and meaning are described in the linked **OSI semantic model**
+(`semantics.osi.yaml`).
+
+- **Tables:** `parcels`, `buildings` (both GeoParquet, EPSG:3067), `ownerships` (Parquet, non-spatial).
+- **Access & joins:** see `AGENTS.md` for DuckDB recipes, including a spatial-predicate join.
+- **License:** CC-BY-4.0 — cite the National Land Survey of Finland.

--- a/spec/rfc/pure-profile-v0.2.0/examples/cadastre/collection.json
+++ b/spec/rfc/pure-profile-v0.2.0/examples/cadastre/collection.json
@@ -1,0 +1,76 @@
+{
+  "type": "Collection",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/alternate-assets/v1.2.0/schema.json",
+    "https://portolan-sdi.github.io/stac-osi-extension/v0.1.1/schema.json"
+  ],
+  "id": "fi-cadastre",
+  "title": "Finland cadastre (Uusimaa sample)",
+  "description": "A multi-table data model published as ONE Portolan collection (a product released as a unit): parcels (polygons), buildings (polygons, one per building), and ownerships (non-spatial records). Each table is a data asset; the join graph, meaning and metrics live in the linked OSI semantic model — including a spatial-predicate relation (buildings ST_Within parcels). Coordinates EPSG:3067; STAC bbox is WGS84. See AGENTS.md.",
+  "license": "CC-BY-4.0",
+  "conformsTo": [
+    "https://portolan-sdi.github.io/spec/v0.2.0/core"
+  ],
+  "keywords": ["cadastre", "parcels", "buildings", "ownership", "Finland", "data model"],
+  "providers": [
+    { "name": "National Land Survey of Finland (NLS)", "roles": ["producer", "licensor"], "url": "https://www.maanmittauslaitos.fi/en" },
+    { "name": "Example Org", "roles": ["processor", "host"], "url": "https://example.org" }
+  ],
+  "extent": {
+    "spatial": { "bbox": [[23.0, 59.9, 26.0, 60.8]] },
+    "temporal": { "interval": [["2024-01-01T00:00:00Z", null]] }
+  },
+  "osi:version": "0.1.0",
+  "osi:semantic_model_href": "./semantics.osi.yaml",
+  "osi:metrics": [
+    { "name": "total_parcel_area_km2", "description": "Sum of parcel areas over the model AOI." },
+    { "name": "building_count", "description": "Number of building rows." },
+    { "name": "avg_ownership_share", "description": "Average ownership share across ownership records." }
+  ],
+  "osi:relations": [
+    { "from": "buildings", "to": "parcels", "on": "parcel_id", "cardinality": "N:1" },
+    { "from": "ownerships", "to": "parcels", "on": "parcel_id", "cardinality": "N:1" },
+    { "from": "buildings", "to": "parcels", "predicate": "ST_Within", "spatial": true, "cardinality": "N:1" }
+  ],
+  "assets": {
+    "parcels": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/fi/cadastre/parcels/",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "title": "Parcels (GeoParquet)",
+      "description": "Cadastral parcels. PK parcel_id; geometry polygon (WKB, EPSG:3067). Schema self-describing in the files; meaning in the OSI model.",
+      "proj:code": "EPSG:3067"
+    },
+    "buildings": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/fi/cadastre/buildings/",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "title": "Buildings (GeoParquet)",
+      "description": "Buildings on parcels. PK building_id; FK parcel_id → parcels; geometry polygon (WKB, EPSG:3067).",
+      "proj:code": "EPSG:3067"
+    },
+    "ownerships": {
+      "href": "https://example-bucket.s3.eu-north-1.amazonaws.com/fi/cadastre/ownerships/",
+      "type": "application/vnd.apache.parquet",
+      "roles": ["data"],
+      "title": "Ownerships (Parquet, non-spatial)",
+      "description": "Ownership records. PK ownership_id; FK parcel_id → parcels; owner_name, share_pct. No geometry — a non-spatial table inside the model."
+    },
+    "osi_model": {
+      "href": "./semantics.osi.yaml",
+      "type": "application/yaml",
+      "roles": ["metadata"],
+      "title": "OSI semantic model",
+      "description": "Canonical description of entities, relations (incl. spatial-predicate), metrics and meaning for this model. STAC's osi:relations/osi:metrics are a denormalized summary of this."
+    }
+  },
+  "links": [
+    { "rel": "root", "href": "../catalog.json", "type": "application/json" },
+    { "rel": "parent", "href": "../catalog.json", "type": "application/json" },
+    { "rel": "agents", "href": "./AGENTS.md", "type": "text/markdown", "title": "Dataset agent guide" },
+    { "rel": "version-history", "href": "./versions.json", "type": "application/json", "title": "Version manifest" },
+    { "rel": "via", "href": "https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/expert-users/product-descriptions/cadastral-index-map", "type": "text/html", "title": "Source: NLS cadastral data" }
+  ]
+}

--- a/spec/rfc/pure-profile-v0.2.0/examples/cadastre/semantics.osi.yaml
+++ b/spec/rfc/pure-profile-v0.2.0/examples/cadastre/semantics.osi.yaml
@@ -1,0 +1,41 @@
+# OSI semantic model (illustrative) — Finland cadastre
+# Canonical description of the multi-table model. STAC's osi:relations / osi:metrics summarize this.
+osi_version: "0.1.0"
+model:
+  name: fi_cadastre
+  description: Cadastral model — parcels, buildings on them, and ownership records.
+
+  entities:
+    parcels:
+      primary_key: parcel_id
+      geometry: { column: geometry, type: polygon, crs: "EPSG:3067" }
+      attributes:
+        - { name: parcel_id, type: string, description: Cadastral parcel identifier. }
+        - { name: municipality_code, type: string }
+        - { name: area_m2, type: double }
+    buildings:
+      primary_key: building_id
+      geometry: { column: geometry, type: polygon, crs: "EPSG:3067" }
+      attributes:
+        - { name: building_id, type: string }
+        - { name: parcel_id, type: string, description: FK to parcels.parcel_id. }
+        - { name: use, type: string }
+    ownerships:
+      primary_key: ownership_id
+      geometry: null            # non-spatial table inside a spatial model
+      attributes:
+        - { name: ownership_id, type: string }
+        - { name: parcel_id, type: string, description: FK to parcels.parcel_id. }
+        - { name: owner_name, type: string }
+        - { name: share_pct, type: double }
+
+  relations:
+    - { from: buildings,  to: parcels, on: parcel_id, cardinality: "N:1" }
+    - { from: ownerships, to: parcels, on: parcel_id, cardinality: "N:1" }
+    # spatial-predicate relation (no stored key) — proposed OSI spatial capability
+    - { from: buildings,  to: parcels, predicate: ST_Within, spatial: true, cardinality: "N:1" }
+
+  metrics:
+    - { name: total_parcel_area_km2, expression: "sum(parcels.area_m2) / 1e6" }
+    - { name: building_count,        expression: "count(buildings.building_id)" }
+    - { name: avg_ownership_share,   expression: "avg(ownerships.share_pct)" }


### PR DESCRIPTION
## RFC / discussion PR — not for merge as-is

Proposal to converge Portolan on **"STAC as a thin index"** after the 2026-07-09 workshop.

**This PR adds only a proposal** — it does **not** rewrite any canonical `spec/` file:
- `context/shared/adr/0057-portolan-pure-profile.md` — the decision record (Status: Proposed)
- `spec/rfc/pure-profile-v0.2.0/` — the full RFC, draft `conformance.md` + `capabilities.md`, and a
  **validated, STAC-Browser-rendered** reference example set (`buildings` single-table + `cadastre`
  multi-table model with OSI semantics)

### The gist
- **No Portolan STAC extension** — every field is derivable or already homed elsewhere.
- **Identity + version via `conformsTo`**; **capabilities derived, not declared** (contract per capability).
- **Drop `portolan:geospatial`**; `bbox` is uniformly an AOI.
- **`AGENTS.md` + `README.md`** replace `llms.txt` (supersedes ADR-0052).
- **Multi-table models** = one collection, tables as assets; relations in **OSI** (incl. spatial-predicate).
- **Visualization** = capability + contract, not a mandated format (the PMTiles debate).

### Evidence
`stac-node-validator` v2.0.0-rc.3 → **3/3 pass** (all extensions incl. proposed `osi:relations`);
renders in **STAC Browser v5.0.0-rc.1**.

### Asks
1. React to the direction (ADR-0057) — merge as one or split into 5 focused PRs (see RFC).
2. The PMTiles reframe (capability + contract).
3. Four core judgment calls (schema MUST/SHOULD · `versions.json` core vs capability · format allowlist · per-collection docs).
