### PR TITLE
fix(add): index tabular collections in catalog-level versions.json (#650)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -21,6 +21,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 import pystac
@@ -161,6 +162,9 @@ from portolan_cli.stac import (
 )
 from portolan_cli.sync.checksums import compute_checksum, multihash_sha256
 from portolan_cli.viz.style import enrich_cog_assets
+
+if TYPE_CHECKING:
+    from portolan_cli.versions import Version
 
 logger = logging.getLogger(__name__)
 
@@ -649,11 +653,59 @@ def _update_versions(
     else:
         raise ValueError("Either asset_files or (output_path, checksum) must be provided")
 
-    publish_version(
+    published = publish_version(
         collection_id,
         assets=assets,
         catalog_root=catalog_root,
     )
+
+    # Mirror the collection's new state into the catalog-level versions.json
+    # index, the "update versions.json then catalog versions.json" step of the
+    # add flow in .claude/rules/stac-assets.md. The deferred tabular and
+    # companion path reaches versions.json only through here, so without this
+    # the collection is missing from the catalog-level index (issue #650).
+    _mirror_into_catalog_index(catalog_root, collection_id, published)
+
+
+def _mirror_into_catalog_index(
+    catalog_root: Path,
+    collection_id: str,
+    published: Version,
+) -> None:
+    """Mirror a published collection version into the catalog-level versions.json.
+
+    Kept separate from :func:`_update_versions` so the error branch does not push
+    that function past the rank-C complexity ceiling CI enforces.
+    ``update_catalog_versions`` no-ops when the catalog has no catalog-level
+    versions.json, which is the case for non-file backends.
+
+    A catalog-level failure is logged and swallowed, never raised. The
+    collection-level version is already on disk at this point, so failing the
+    add here would report an error for work that succeeded. This mirrors
+    ``finalization._finalize_with_file_backend``.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+        collection_id: Collection identifier, "climate/hittekaart" for nested.
+        published: The Version just written by ``publish_version``.
+    """
+    from portolan_cli.catalog import update_catalog_versions
+
+    try:
+        update_catalog_versions(
+            catalog_root=catalog_root,
+            collection_id=collection_id,
+            current_version=published.version,
+            asset_count=len(published.assets),
+            total_size_bytes=sum(a.size_bytes for a in published.assets.values()),
+        )
+    except Exception:
+        logger.warning(
+            "Failed to update catalog-level versions.json for collection '%s'. "
+            "Collection version was published but catalog-level view may be stale.",
+            collection_id,
+            exc_info=True,
+        )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_tabular_support.py
+++ b/tests/unit/test_tabular_support.py
@@ -369,6 +369,91 @@ class TestTabularEnabledCheck:
         catalog_links = json_mod.loads((catalog_root / "catalog.json").read_text())["links"]
         assert any(link.get("rel") == "agents" for link in catalog_links)
 
+    def test_nested_tabular_collection_sidecar_placed_next_to_collection_json(
+        self, tmp_path: Path
+    ) -> None:
+        """Nested tabular collection id must write versions.json beside collection.json.
+
+        Regression for issue #650 (defect 1): a collection id containing a '/'
+        (e.g. "group/mytable") wrote its own versions.json to the catalog root
+        under the bare last segment ("mytable/") instead of next to its
+        collection.json. Item-level and geo collection-level assets were fine;
+        only the deferred tabular path hit the backend's _versions_path bug.
+        """
+        from portolan_cli.add import add_files
+
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        _setup_test_catalog(catalog_root)
+
+        # Nested collection id "group/mytable"
+        collection_dir = catalog_root / "group" / "mytable"
+        collection_dir.mkdir(parents=True)
+
+        parquet_file = collection_dir / "mytable.parquet"
+        pq.write_table(pa.table({"geo": ["DE", "FR"], "price": [1.0, 2.0]}), parquet_file)
+
+        config_file = catalog_root / ".portolan" / "config.yaml"
+        config_file.write_text("tabular:\n  enabled: true\n")
+
+        _added, _skipped, failures = add_files(paths=[parquet_file], catalog_root=catalog_root)
+
+        assert failures == []
+        # Sidecar must sit next to collection.json, NOT at the catalog root.
+        assert (collection_dir / "versions.json").exists(), (
+            "versions.json must be written next to the nested collection.json"
+        )
+        assert not (catalog_root / "mytable" / "versions.json").exists(), (
+            "versions.json must not be misplaced at catalog_root/<last-segment>/"
+        )
+
+    def test_tabular_collection_recorded_in_catalog_level_versions(self, tmp_path: Path) -> None:
+        """Tabular collection-level assets must be indexed in catalog versions.json.
+
+        Regression for issue #650 (defect 2): the deferred tabular path published
+        the collection-level versions.json but never mirrored the collection into
+        the catalog-level versions.json 'collections' map, leaving it empty.
+        """
+        from portolan_cli.add import add_files
+
+        catalog_root = tmp_path / "catalog"
+        catalog_root.mkdir()
+        _setup_test_catalog(catalog_root)
+        # A file-backend catalog has a catalog-level versions.json (init writes it).
+        (catalog_root / "versions.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "1.0.0",
+                    "catalog_id": "test-catalog",
+                    "created": "2026-01-01T00:00:00+00:00",
+                    "collections": {},
+                },
+                indent=2,
+            )
+        )
+
+        collection_dir = catalog_root / "demographics"
+        collection_dir.mkdir()
+        parquet_file = collection_dir / "census.parquet"
+        pq.write_table(
+            pa.table({"tract_id": ["001", "002"], "population": [5000, 7500]}), parquet_file
+        )
+
+        config_file = catalog_root / ".portolan" / "config.yaml"
+        config_file.write_text("tabular:\n  enabled: true\n")
+
+        _added, _skipped, failures = add_files(paths=[parquet_file], catalog_root=catalog_root)
+
+        assert failures == []
+        catalog_versions = json.loads((catalog_root / "versions.json").read_text())
+        collections = catalog_versions["collections"]
+        assert "demographics" in collections, (
+            "collection must be recorded in catalog-level versions.json"
+        )
+        entry = collections["demographics"]
+        assert entry["current_version"] == "1.0.0"
+        assert entry["asset_count"] == 1
+
     def test_tabular_companion_asset_works_regardless_of_config(self, tmp_path: Path) -> None:
         """Tabular files WITH a companion geo file work regardless of tabular.enabled.
 


### PR DESCRIPTION
## What this changes

Adding a collection-level (tabular) asset now records the collection in the catalog-level `versions.json`. Before, that path published a version and wrote the collection's own sidecar, but never appeared in the root index.

## Why

Fixes #650. The root `versions.json` is the push manifest, uploaded last for atomicity, so a tabular-only catalog published an empty manifest while an equivalent geo catalog published a populated one. The sidecar-placement half of #650 is already fixed on this base by #723, so this leaves the backend alone.

## Verification

Real catalog, non-geo parquet at `group/mytable/mytable.parquet`, against `release/v1.0.0b0`.

Before, the collection is absent from the root index:

```console
$ portolan add group/mytable/mytable.parquet
$ cat versions.json
{ "schema_version": "1.0.0", "catalog_id": "mycat", "collections": {} }
```

After:

```console
$ cat versions.json
  "collections": {
    "group/mytable": { "current_version": "1.0.0", "asset_count": 1, "total_size_bytes": 747 }
  }
```

The geo path was already correct and is unchanged, `group/geostuff` indexes under its full nested id either way. It reproduces for flat collection ids too, so it was never about nesting.

Removing the mirror call makes the new test fail, so it guards behavior rather than restating it:

```console
tests/unit/test_tabular_support.py:450: AssertionError: collection must be recorded
assert 'demographics' in {}
```

- [ ] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Fixes #650. Sidecar placement was fixed separately by #723.
