### PR TITLE
fix(add): generate + register COG thumbnail asset (#657)

### DIFF
--- a/portolan_cli/preparation.py
+++ b/portolan_cli/preparation.py
@@ -1013,6 +1013,13 @@ def prepare_item(
         )
     bbox = _extract_bbox_wgs84(metadata)
 
+    # Step 4b: Generate the COG thumbnail sidecar so the scan below registers it
+    # (Issue #657). The add path converts via convert_raster(), which does not
+    # generate a thumbnail like convert_file() does, so without this rasters get
+    # no thumbnail asset. The raster check lives in the helper, not here, because
+    # prepare_item sits at the xenon complexity ceiling.
+    _generate_raster_thumbnail(output_path, catalog_root, format_type)
+
     # Step 5: Scan assets and compute statistics
     stac_assets, asset_files, _asset_paths = _scan_item_assets(
         item_dir=item_dir,
@@ -1227,3 +1234,42 @@ def convert_raster(source: Path, dest_dir: Path) -> Path:
     )
 
     return output_path
+
+
+def _generate_raster_thumbnail(cog_path: Path, catalog_root: Path, format_type: FormatType) -> None:
+    """Write a ``{stem}.thumb.jpg`` next to a COG so the asset scan registers it.
+
+    Mirrors the thumbnail step in ``convert.convert_file`` for the add path,
+    which converts through the bare ``convert_raster`` wrapper and would
+    otherwise leave rasters with no thumbnail asset (Issue #657). Gated on the
+    ``generate_thumbnail`` COG setting and best-effort: a thumbnail failure must
+    never fail the add. Skips generation when the sidecar already exists so a
+    hand-curated thumbnail or a re-add is left untouched.
+
+    Non-raster formats return immediately. The gate lives here rather than at the
+    call site to keep ``prepare_item`` inside the xenon complexity ceiling.
+
+    Args:
+        cog_path: Path to the converted file.
+        catalog_root: Catalog root, for loading COG settings.
+        format_type: Format of the converted file; only RASTER is handled.
+    """
+    from portolan_cli.conversion_config import get_cog_settings
+    from portolan_cli.convert import generate_cog_thumbnail
+
+    if format_type != FormatType.RASTER:
+        return
+
+    settings = get_cog_settings(catalog_root)
+    if not settings.generate_thumbnail:
+        return
+    if cog_path.with_name(f"{cog_path.stem}.thumb.jpg").exists():
+        return
+    try:
+        generate_cog_thumbnail(
+            cog_path,
+            max_size=settings.thumbnail_max_size,
+            quality=settings.thumbnail_quality,
+        )
+    except Exception as e:  # nosec B110 - thumbnail is optional, failure is non-fatal
+        logger.warning("Thumbnail generation failed for %s: %s", cog_path.name, e)

--- a/tests/integration/test_add_integration.py
+++ b/tests/integration/test_add_integration.py
@@ -272,6 +272,70 @@ class TestAddIntegration:
         assert (collection_dir / "collection.json").exists()
 
     @pytest.mark.integration
+    def test_add_raster_registers_thumbnail_asset(
+        self, initialized_catalog: Path, valid_rgb_cog: Path
+    ) -> None:
+        """add generates a COG thumbnail sidecar and registers it as an asset (Issue #657).
+
+        The add path converts via convert_raster(), which historically did not
+        generate a thumbnail, so COG items had only a "data" asset. This asserts
+        the thumbnail is both written to disk and registered with role
+        "thumbnail" in the item.json.
+        """
+        # Per ADR-0022: Copy file INTO catalog first
+        collection_dir = initialized_catalog / "imagery"
+        item_dir = collection_dir / valid_rgb_cog.stem
+        item_dir.mkdir(parents=True)
+        in_catalog_path = item_dir / valid_rgb_cog.name
+        shutil.copy(valid_rgb_cog, in_catalog_path)
+
+        add(
+            path=in_catalog_path,
+            catalog_root=initialized_catalog,
+            collection_id="imagery",
+        )
+
+        # The .thumb.jpg sidecar is written next to the COG.
+        thumb_path = item_dir / f"{valid_rgb_cog.stem}.thumb.jpg"
+        assert thumb_path.exists(), "add did not generate the COG thumbnail sidecar"
+
+        # And it is registered as a thumbnail-role asset in the item.json.
+        item_json = item_dir / f"{valid_rgb_cog.stem}.json"
+        assets = json.loads(item_json.read_text())["assets"]
+        thumbnail_assets = [
+            asset for asset in assets.values() if "thumbnail" in asset.get("roles", [])
+        ]
+        assert len(thumbnail_assets) == 1, f"expected one thumbnail asset, got {assets}"
+        assert thumbnail_assets[0]["href"] == f"./{valid_rgb_cog.stem}.thumb.jpg"
+        assert thumbnail_assets[0]["type"] == "image/jpeg"
+
+    @pytest.mark.integration
+    def test_add_raster_thumbnail_disabled_via_config(
+        self, initialized_catalog: Path, valid_rgb_cog: Path
+    ) -> None:
+        """generate_thumbnail=false suppresses the COG thumbnail sidecar (Issue #657)."""
+        (initialized_catalog / ".portolan" / "config.yaml").write_text(
+            "version: 1\nconversion:\n  cog:\n    generate_thumbnail: false\n"
+        )
+        collection_dir = initialized_catalog / "imagery"
+        item_dir = collection_dir / valid_rgb_cog.stem
+        item_dir.mkdir(parents=True)
+        in_catalog_path = item_dir / valid_rgb_cog.name
+        shutil.copy(valid_rgb_cog, in_catalog_path)
+
+        add(
+            path=in_catalog_path,
+            catalog_root=initialized_catalog,
+            collection_id="imagery",
+        )
+
+        assert not (item_dir / f"{valid_rgb_cog.stem}.thumb.jpg").exists()
+        item_json = item_dir / f"{valid_rgb_cog.stem}.json"
+        assets = json.loads(item_json.read_text())["assets"]
+        thumbnail_assets = [a for a in assets.values() if "thumbnail" in a.get("roles", [])]
+        assert thumbnail_assets == []
+
+    @pytest.mark.integration
     def test_add_multiple_items_same_collection(
         self, initialized_catalog: Path, valid_points_geojson: Path, valid_polygons_geojson: Path
     ) -> None:


### PR DESCRIPTION
<!-- Rebased onto release/v1.0.0b0 for the beta bundle. -->

## What this changes

`portolan add` on a raster now writes a `{stem}.thumb.jpg` next to the COG and registers it as a `thumbnail`-role asset. Generation is gated on `conversion.cog.generate_thumbnail`, skipped when a thumbnail already exists, and best-effort so a failure never fails the add. Rasters only.

## Why

Closes #657. The add path converts through the bare `convert_raster()`, not `convert_file()`, and only `convert_file()` called `generate_cog_thumbnail()`. The asset scan already registered a sidecar it found, so only generation was missing.

## Verification

Real data, `tests/fixtures/realdata/rapidai4eo-sample.tif`, added to a fresh catalog. The new test is red on this base without the fix, green with it.

```console
$ portolan add imagery/rapidai4eo-sample/rapidai4eo-sample.tif
✓ Added 1 file to 1 collection

$ jq -c '.assets.thumbnail' imagery/rapidai4eo-sample/rapidai4eo-sample.json
{"href":"./rapidai4eo-sample.thumb.jpg","type":"image/jpeg","roles":["thumbnail"]}

$ uv run pytest tests/integration/test_add_integration.py   # 19 passed
$ uv run xenon --max-absolute=C portolan_cli                # exit 0
```

The raster check sits inside the helper, not at the call site, because `prepare_item` was already at the xenon C ceiling and the earlier revision of this branch failed CI at rank D.

## Related issues

- Closes #657
