### PR TITLE
fix(metadata): preserve thumbnail, bands, stac_extensions on refresh (#659)

### DIFF
--- a/portolan_cli/metadata/update.py
+++ b/portolan_cli/metadata/update.py
@@ -25,15 +25,15 @@ from portolan_cli.item import (
     _extract_geometry_from_file,
     _get_media_type,
     create_item,
-    read_item_json,
     write_item_json,
 )
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.models.collection import (
     CollectionModel,
     ExtentModel,
     SpatialExtent,
 )
-from portolan_cli.models.item import AssetModel, ItemModel
+from portolan_cli.models.item import ItemModel
 from portolan_cli.versions import (
     Asset,
     Version,
@@ -48,16 +48,25 @@ logger = logging.getLogger(__name__)
 def update_item_metadata(item_path: Path, file_path: Path) -> ItemModel:
     """Re-extract metadata from file and update existing STAC item.
 
-    Reads the existing item, extracts fresh metadata from the data file,
-    updates bbox, geometry, datetime, and assets while preserving
-    user-added fields (title, description).
+    Refreshes only the fields this metadata pass owns, the item's bbox,
+    geometry, datetime, and the data asset's href, and preserves everything
+    else on disk. That deliberately includes the item's ``stac_extensions``,
+    the data asset's ``bands`` / ``statistics``, every non-``data`` asset such
+    as the ``thumbnail`` that ``portolan add`` registers for COGs (#657), and
+    the data asset's media type, which the refresh backfills only when it is
+    missing.
+
+    The update edits the raw item JSON in place rather than round-tripping
+    through :class:`ItemModel`. The model only carries href/type/roles/title for
+    assets and drops ``stac_extensions`` entirely, so serializing through it
+    would silently destroy those fields (#659).
 
     Args:
         item_path: Path to existing item JSON file.
         file_path: Path to the data file (GeoParquet or COG).
 
     Returns:
-        Updated ItemModel.
+        Updated ItemModel (a lossy view, the on-disk JSON is the full record).
 
     Raises:
         FileNotFoundError: If item_path or file_path doesn't exist.
@@ -68,49 +77,53 @@ def update_item_metadata(item_path: Path, file_path: Path) -> ItemModel:
     if not item_path.exists():
         raise FileNotFoundError(f"Item file not found: {item_path}")
 
-    # Read existing item
-    existing_item = read_item_json(item_path)
+    # Load the raw item as the source of truth so nothing outside the refresh's
+    # scope is dropped.
+    item_data: dict[str, Any] = json.loads(item_path.read_text(encoding="utf-8"))
 
     # Extract fresh metadata from file
     bbox, geometry = _extract_geometry_from_file(file_path)
+    item_data["bbox"] = bbox
+    item_data["geometry"] = geometry
 
-    # Create new datetime
-    new_datetime = datetime.now(timezone.utc).isoformat()
+    # Bump datetime, preserving every other property.
+    properties = item_data.setdefault("properties", {})
+    properties["datetime"] = datetime.now(timezone.utc).isoformat()
 
-    # Create updated properties (preserve existing, update datetime)
-    updated_properties: dict[str, Any] = dict(existing_item.properties)
-    updated_properties["datetime"] = new_datetime
+    # Refresh the data asset's href/type in place, leaving its bands/statistics
+    # (and any human-authored title) and all other assets untouched.
+    assets: dict[str, Any] = item_data.setdefault("assets", {})
+    data_key = _find_data_asset_key(assets)
+    data_asset = assets.setdefault(data_key, {})
+    data_asset["href"] = file_path.name
+    # Keep the media type `add` registered. `add` derives it from the extension
+    # registry, which gives a COG the `profile=cloud-optimized` suffix that
+    # PORTO-CORE-026 makes a MUST; the local extension map here does not, so
+    # overwriting would downgrade a valid COG asset to plain GeoTIFF. Only
+    # backfill when the field is absent or blank.
+    if not data_asset.get("type"):
+        data_asset["type"] = _get_media_type(file_path)
+    data_asset.setdefault("roles", ["data"])
 
-    # Determine media type
-    media_type = _get_media_type(file_path)
+    # Write the full record back to disk. Atomic, so a kill mid-write cannot
+    # leave a truncated item.json where a valid one used to be (issue #687).
+    write_json_atomic(item_path, item_data)
 
-    # Create updated assets
-    assets = {
-        "data": AssetModel(
-            href=str(file_path.name),
-            type=media_type,
-            roles=["data"],
-            title="Data file",
-        )
-    }
+    return ItemModel.from_dict(item_data)
 
-    # Create updated item, preserving user-added fields
-    updated_item = ItemModel(
-        id=existing_item.id,
-        geometry=geometry,
-        bbox=bbox,
-        properties=updated_properties,
-        assets=assets,
-        collection=existing_item.collection,
-        title=existing_item.title,  # Preserve user field
-        description=existing_item.description,  # Preserve user field
-        links=existing_item.links,  # Preserve links
-    )
 
-    # Write updated item back to disk
-    write_item_json(updated_item, item_path.parent)
+def _find_data_asset_key(assets: dict[str, Any]) -> str:
+    """Return the key of the item's data asset, defaulting to ``"data"``.
 
-    return updated_item
+    Prefers an asset whose ``roles`` include ``"data"``, then a literal
+    ``"data"`` key, so the href/type refresh lands on the real data asset
+    without disturbing sibling assets (thumbnail, metadata, ...).
+    """
+    for key, asset in assets.items():
+        roles = asset.get("roles") if isinstance(asset, dict) else None
+        if isinstance(roles, list) and "data" in roles:
+            return key
+    return "data"
 
 
 def create_missing_item(file_path: Path, collection_path: Path) -> Path:

--- a/tests/unit/test_metadata_update.py
+++ b/tests/unit/test_metadata_update.py
@@ -9,6 +9,7 @@ Tests for Phase 2c: Update Functions
 
 from __future__ import annotations
 
+import json
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -189,6 +190,128 @@ class TestUpdateItemMetadata:
         # Verify file was updated on disk
         updated_from_disk = read_item_json(item_path)
         assert updated_from_disk.bbox is not None
+
+    @pytest.mark.unit
+    def test_update_item_metadata_preserves_thumbnail_asset(self, tmp_path: Path) -> None:
+        """Non-data assets (e.g. the thumbnail from #657) survive the refresh (#659)."""
+        collection_dir = tmp_path / "my-collection"
+        collection_dir.mkdir()
+
+        source_file = REALDATA_FIXTURES / "open-buildings.parquet"
+        if not source_file.exists():
+            pytest.skip("Test fixture not available")
+
+        data_file = collection_dir / "data.parquet"
+        shutil.copy(source_file, data_file)
+
+        item = create_item(item_id="data", data_path=data_file, collection_id="my-collection")
+        item_path = write_item_json(item, collection_dir)
+
+        # Inject a thumbnail asset alongside the data asset, as `add` does for COGs.
+        item_json = json.loads(item_path.read_text())
+        item_json["assets"]["thumbnail"] = {
+            "href": "./data.thumb.jpg",
+            "type": "image/jpeg",
+            "roles": ["thumbnail"],
+        }
+        item_path.write_text(json.dumps(item_json, indent=2))
+
+        update_item_metadata(item_path, data_file)
+
+        # Read the raw JSON, the ItemModel round-trip is itself lossy for these.
+        result = json.loads(item_path.read_text())
+        assert "thumbnail" in result["assets"], "thumbnail asset was destroyed by the refresh"
+        assert result["assets"]["thumbnail"]["href"] == "./data.thumb.jpg"
+        assert result["assets"]["thumbnail"]["roles"] == ["thumbnail"]
+        assert "data" in result["assets"]
+
+    @pytest.mark.unit
+    def test_update_item_metadata_preserves_stac_extensions(self, tmp_path: Path) -> None:
+        """stac_extensions (projection, raster, ...) survive the refresh (#659)."""
+        collection_dir = tmp_path / "my-collection"
+        collection_dir.mkdir()
+
+        source_file = REALDATA_FIXTURES / "open-buildings.parquet"
+        if not source_file.exists():
+            pytest.skip("Test fixture not available")
+
+        data_file = collection_dir / "data.parquet"
+        shutil.copy(source_file, data_file)
+
+        item = create_item(item_id="data", data_path=data_file, collection_id="my-collection")
+        item_path = write_item_json(item, collection_dir)
+
+        extensions = [
+            "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
+            "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
+        ]
+        item_json = json.loads(item_path.read_text())
+        item_json["stac_extensions"] = extensions
+        item_path.write_text(json.dumps(item_json, indent=2))
+
+        update_item_metadata(item_path, data_file)
+
+        result = json.loads(item_path.read_text())
+        assert result.get("stac_extensions") == extensions
+
+    @pytest.mark.unit
+    def test_update_item_metadata_preserves_data_asset_bands(self, tmp_path: Path) -> None:
+        """The data asset's bands / statistics survive the refresh (#659)."""
+        collection_dir = tmp_path / "my-collection"
+        collection_dir.mkdir()
+
+        source_file = REALDATA_FIXTURES / "open-buildings.parquet"
+        if not source_file.exists():
+            pytest.skip("Test fixture not available")
+
+        data_file = collection_dir / "data.parquet"
+        shutil.copy(source_file, data_file)
+
+        item = create_item(item_id="data", data_path=data_file, collection_id="my-collection")
+        item_path = write_item_json(item, collection_dir)
+
+        bands = [{"name": "b1", "statistics": {"minimum": 0.0, "maximum": 255.0}}]
+        item_json = json.loads(item_path.read_text())
+        item_json["assets"]["data"]["bands"] = bands
+        item_path.write_text(json.dumps(item_json, indent=2))
+
+        update_item_metadata(item_path, data_file)
+
+        result = json.loads(item_path.read_text())
+        assert result["assets"]["data"].get("bands") == bands
+
+    @pytest.mark.unit
+    def test_update_item_metadata_preserves_cog_media_type(self, tmp_path: Path) -> None:
+        """The refresh must not downgrade a COG's media type (PORTO-CORE-026, #659).
+
+        PORTO-CORE-026 makes the ``profile=cloud-optimized`` suffix a MUST for a
+        COG data asset, and that is what ``portolan add`` writes. A metadata
+        refresh owns the asset's href and type, so it must re-derive the same
+        registry-backed string rather than the bare GeoTIFF one.
+        """
+        cog_file = REALDATA_FIXTURES / "rapidai4eo-sample.tif"
+        if not cog_file.exists():
+            pytest.skip("COG fixture not available")
+
+        collection_dir = tmp_path / "cog-collection"
+        collection_dir.mkdir()
+
+        data_file = collection_dir / "image.tif"
+        shutil.copy(cog_file, data_file)
+
+        item = create_item(item_id="image", data_path=data_file, collection_id="cog-collection")
+        item_path = write_item_json(item, collection_dir)
+
+        # Write the spec-correct media type that `add` registers for a COG.
+        cog_media_type = "image/tiff; application=geotiff; profile=cloud-optimized"
+        item_json = json.loads(item_path.read_text())
+        item_json["assets"]["data"]["type"] = cog_media_type
+        item_path.write_text(json.dumps(item_json, indent=2))
+
+        update_item_metadata(item_path, data_file)
+
+        result = json.loads(item_path.read_text())
+        assert result["assets"]["data"]["type"] == cog_media_type
 
 
 class TestCreateMissingItem:


### PR DESCRIPTION
## What this changes

`check --fix --metadata` no longer rebuilds an item's assets as data-only. The thumbnail asset, the `bands` array, and `stac_extensions` survive a refresh. The refresh also stops overwriting the data asset's media type, which downgraded COGs below PORTO-CORE-026.

## Why

Fixes #659. Two later changes raised the stakes. #658 creates the item thumbnail the refresh deleted, and #713 made README bands rendering read the array it deleted. On `release/v1.0.0b0` the refresh also undoes rashid's own checksum repair inside a single `check --fix`, because it runs last.

## Verification

Real data, `tests/fixtures/realdata/rapidai4eo-sample.tif`, against `release/v1.0.0b0` at 9a5b1f6.

```console
$ portolan add imagery/rapidai4eo-sample/rapidai4eo-sample.tif --datetime 2024-06-15
$ cp singleband.tif imagery/rapidai4eo-sample/rapidai4eo-sample.tif   # go stale
$ portolan check --fix --metadata
```

Before, the item lost its extensions, thumbnail, and bands, while `proj:*` stayed in `properties` with the declarations stripped:

```diff
-    "stac_extensions": [
-        "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
-        "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
-    ],
-            "bands": [ ...4 bands with min/max/mean/stddev... ],
-        "thumbnail": { "href": "./rapidai4eo-sample.thumb.jpg", ... }
```

After, only the intended diffs remain (bbox, geometry, `datetime`, refreshed `file:size` and `file:checksum`). Downstream effects on the same catalog:

```console
$ portolan readme imagery
# before: no "## Bands" section at all
# after:  4-row bands table with min / max / mean / stddev

$ portolan check
# before: 7 errors, 4 warnings   (2x PTL-AST-003, rashid's own fix undone)
# after:  7 errors, 2 warnings
```

Media type on refresh, before `image/tiff; application=geotiff`, after `image/tiff; application=geotiff; profile=cloud-optimized`.

- [ ] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Fixes #659. Context from #657 and #713.
