### PR TITLE
chore(ci): surface non-blocking network-test failures in run summary + tracking issue

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -221,10 +221,45 @@ jobs:
         # Keep the workflow green; the tracking-issue step below is the signal.
         continue-on-error: true
         run: |
+          # -rfE prints a short "FAILED/ERROR" summary at the tail; tee keeps a
+          # copy so the run-summary + tracking-issue steps below can name the
+          # tests that failed. Default bash pipefail preserves pytest's exit
+          # code through the pipe, so the step outcome is unchanged.
           uv run pytest tests/ \
             -m network \
             --timeout=120 \
-            -v
+            -v -rfE \
+            2>&1 | tee network-test-output.txt
+
+      - name: Surface network-test failure in run summary
+        # continue-on-error above keeps the job badge green even though the
+        # step's real outcome was 'failure' — which has misled triage. Make the
+        # failure legible in the run summary and capture the failing test names
+        # for the tracking issue body. Pass/fail semantics are untouched: this
+        # only runs on the failure path and only adds information.
+        if: steps.nettests.outcome == 'failure'
+        run: |
+          {
+            echo "## ⚠️ Live network tests FAILED (non-blocking)"
+            echo ""
+            echo "The \`nettests\` step outcome was **failure**, but the job badge"
+            echo "stays green by design (live third-party services). See the"
+            echo "tracking issue for history."
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if grep -E '^(FAILED|ERROR)' network-test-output.txt \
+               > network-test-failures.txt; then
+            {
+              echo "Failing tests:"
+              echo ""
+              echo '```'
+              cat network-test-failures.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "_No individual FAILED/ERROR lines were captured (the step may" \
+                 "have crashed before pytest reported)._" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Track live-network status as a single issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -234,11 +269,23 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           script: |
+            const fs = require('fs');
             const {owner, repo} = context.repo;
             const outcome = process.env.TESTS_OUTCOME;
             const runUrl = process.env.RUN_URL;
             const label = 'nightly-network-failure';
             const title = 'Nightly live-network tests are failing';
+
+            // Failing-test names captured by the "Surface network-test failure"
+            // step (pytest -rfE short summary). Best-effort: absent if the step
+            // crashed before pytest reported.
+            let failures = '';
+            try {
+              failures = fs.readFileSync('network-test-failures.txt', 'utf8').trim();
+            } catch {}
+            const failuresBlock = failures
+              ? ['**Failing tests:**', '', '```', failures, '```']
+              : ['_Failing test names were not captured — see the run log._'];
 
             // Ensure the tracking label exists (idempotent).
             try {
@@ -260,6 +307,8 @@ jobs:
                 'The nightly **live-network** test job failed against third-party',
                 'services. This job is non-blocking (live servers can be flaky), but a',
                 'persistent failure may indicate a real regression in an extractor.',
+                '',
+                ...failuresBlock,
                 '',
                 `Latest failing run: ${runUrl}`,
                 '',


### PR DESCRIPTION
## Problem

The nightly **Live Network Tests** job runs against live third-party
services and uses `continue-on-error: true` so a flaky remote endpoint
does not red the whole nightly run. That non-blocking design is
intentional and is **kept**.

The side effect: the job badge showed **green even when the test step's
real outcome was `failure`**. During triage a human saw "Live Network
Tests ✅", assumed network tests passed, and missed that the step had
actually failed. The auto-filed tracking issue also only said
"live-network tests are failing" without naming *which* tests.

## What this changes (visibility only — pass/fail semantics unchanged)

1. **Run summary reflects the real outcome.** The `nettests` step now
   emits pytest's `-rfE` short summary and tees it to
   `network-test-output.txt`. A new step, gated on
   `steps.nettests.outcome == 'failure'`, appends a clear
   "⚠️ Live network tests FAILED (non-blocking)" line plus the failing
   test names to `$GITHUB_STEP_SUMMARY`. So even though the badge stays
   green, the run summary shows the failure.

2. **Tracking issue names the failing tests.** The existing
   `actions/github-script` step now reads the captured `FAILED/ERROR`
   list and includes it in the auto-open issue body, instead of a
   generic message.

## Why it's safe

- `continue-on-error: true` is preserved — the job is still non-blocking.
- Default bash `pipefail` keeps pytest's exit code through the `| tee`
  pipe, so `steps.nettests.outcome` is computed exactly as before.
- The new summary step only runs on the failure path and only *adds*
  information; the github-script step's existing
  `TESTS_OUTCOME`-based open-on-failure / close-on-success branching is
  untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
