### PR TITLE
fix(test): stabilize 1000-file versioning stress fixtures

### DIFF
--- a/context/shared/known-issues/duckdb-query-interrupted-transient.md
+++ b/context/shared/known-issues/duckdb-query-interrupted-transient.md
@@ -1,7 +1,17 @@
 # DuckDB "Query interrupted" transient failure during bulk conversion
 
 ## Status
-**Known issue** — Workaround applied (bounded retry in `_convert_vector`)
+**Known issue** — Workaround applied (bounded retry, shared across every
+conversion entry point the `add` pipeline uses).
+
+> **Update (Issue #339 follow-up):** the original retry was added to
+> `convert.py::_convert_vector`, but bulk `portolan add` converts single-layer
+> vectors through `preparation.py::convert_vector` (and tabular files through
+> `preparation.py::convert_tabular`) — **not** `_convert_vector` — so the nightly
+> `test_add_1000_files_*` job kept flaking on the exact same `Query interrupted`.
+> The retry logic was extracted into `convert.py::run_with_transient_convert_retry`
+> and is now applied on every add-path conversion seam (`_convert_vector`,
+> `_convert_vector_layer`, `preparation.convert_vector`, `preparation.convert_tabular`).
 
 ## Description
 During large bulk `portolan add` runs, a single vector→GeoParquet conversion
@@ -36,15 +46,23 @@ FAILED tests/integration/test_versioning_stress.py::TestScaleAt1000Files::test_a
 - Does not affect correctness of the 999 files that convert normally.
 
 ## Workaround Applied
-`portolan_cli/convert.py::_convert_vector` retries a transient interrupt up to
-`_CONVERT_MAX_ATTEMPTS` (3) times. Detection is by exception **type name**
-(`InterruptException`) plus message (`"query interrupted"`) — we deliberately do
-**not** `import duckdb` (a transitive dependency we don't declare; a direct
-import would break the deptry transitive-import contract). Any non-transient
-error still fails on the first attempt.
+`portolan_cli/convert.py::run_with_transient_convert_retry` runs a conversion
+callable and retries a transient interrupt up to `_CONVERT_MAX_ATTEMPTS` (3)
+times. Detection is by exception **type name** (`InterruptException`) plus
+message (`"query interrupted"`) — we deliberately do **not** `import duckdb` (a
+transitive dependency we don't declare; a direct import would break the deptry
+transitive-import contract). Any non-transient error still fails on the first
+attempt.
 
-See `_is_transient_conversion_error` and the retry loop in `_convert_vector`, and
-`tests/unit/test_convert.py::TestVectorConversionRetriesTransientInterrupt`.
+Every conversion seam the `add` pipeline can reach is wrapped in this helper:
+- `convert.py::_convert_vector` (single-layer, `convert_file` route)
+- `convert.py::_convert_vector_layer` (multi-layer GeoPackage/FileGDB)
+- `preparation.py::convert_vector` (single-layer vectors — the `add` route)
+- `preparation.py::convert_tabular` (CSV/TSV/XLSX)
+
+See `_is_transient_conversion_error`,
+`tests/unit/test_convert.py::TestVectorConversionRetriesTransientInterrupt`, and
+`tests/unit/test_preparation.py::TestConvertVectorRetriesTransientInterrupt`.
 
 ## If This Resurfaces
 If a file fails all 3 attempts, the signal source is likely *sustained* rather

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -19,7 +19,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, TypeVar, cast
 
 from portolan_cli.constants import GEOSPATIAL_EXTENSIONS
 from portolan_cli.conversion_config import (
@@ -557,6 +557,56 @@ def _is_transient_conversion_error(exc: BaseException) -> bool:
     return type(exc).__name__ == "InterruptException" or "query interrupted" in str(exc).lower()
 
 
+_ConvertT = TypeVar("_ConvertT")
+
+
+def run_with_transient_convert_retry(
+    operation: Callable[[], _ConvertT],
+    *,
+    source_name: str,
+) -> _ConvertT:
+    """Run a DuckDB-backed conversion, retrying transient interrupts.
+
+    ``geoparquet-io`` runs conversions through DuckDB, which can raise a
+    transient ``InterruptException('Query interrupted')`` (see
+    :func:`_is_transient_conversion_error`). ``operation`` is retried up to
+    ``_CONVERT_MAX_ATTEMPTS`` times so a single interrupted query does not fail a
+    whole bulk ``add`` (the interrupt flag clears once raised, and each attempt
+    opens a fresh ``gpio.convert()`` connection); any other error propagates on
+    the first occurrence.
+
+    Shared by every conversion entry point the ``add`` pipeline uses
+    (:func:`_convert_vector`, :func:`_convert_vector_layer`, and
+    ``preparation.convert_vector`` / ``preparation.convert_tabular``) so the
+    retry is applied uniformly rather than on a single code path (Issue #339
+    nightly ``test_add_1000_files_*`` flake).
+
+    Args:
+        operation: Zero-argument callable performing the conversion.
+        source_name: Human-readable source name for retry log messages.
+
+    Returns:
+        Whatever ``operation`` returns.
+    """
+    for attempt in range(1, _CONVERT_MAX_ATTEMPTS + 1):
+        try:
+            return operation()
+        except Exception as exc:
+            is_last_attempt = attempt == _CONVERT_MAX_ATTEMPTS
+            if is_last_attempt or not _is_transient_conversion_error(exc):
+                raise
+            logger.warning(
+                "Transient interrupt converting %s (attempt %d/%d), retrying: %s",
+                source_name,
+                attempt,
+                _CONVERT_MAX_ATTEMPTS,
+                exc,
+            )
+    # Unreachable: the final attempt always returns or re-raises above. Present
+    # only so the type checker sees every path terminates.
+    raise AssertionError("vector conversion retry loop exited without returning")
+
+
 def _convert_vector(
     source: Path,
     output_dir: Path,
@@ -605,23 +655,7 @@ def _convert_vector(
         table.write(str(output_path))
         return output_path
 
-    for attempt in range(1, _CONVERT_MAX_ATTEMPTS + 1):
-        try:
-            return _run()
-        except Exception as exc:
-            is_last_attempt = attempt == _CONVERT_MAX_ATTEMPTS
-            if is_last_attempt or not _is_transient_conversion_error(exc):
-                raise
-            logger.warning(
-                "Transient interrupt converting %s (attempt %d/%d), retrying: %s",
-                source.name,
-                attempt,
-                _CONVERT_MAX_ATTEMPTS,
-                exc,
-            )
-    # Unreachable: the final attempt always returns or re-raises above. Present
-    # only so the type checker sees every path terminates.
-    raise AssertionError("vector conversion retry loop exited without returning")
+    return run_with_transient_convert_retry(_run, source_name=source.name)
 
 
 def _apply_vector_settings(table: Any, settings: VectorSettings) -> Any:
@@ -1215,6 +1249,11 @@ def _convert_vector_layer(
     if settings is None:
         settings = VectorSettings()
 
-    table = gpio.convert(source, layer=layer)
-    table = _apply_vector_settings(table, settings)
-    table.write(output)
+    resolved = settings
+
+    def _run() -> None:
+        table = gpio.convert(source, layer=layer)
+        table = _apply_vector_settings(table, resolved)
+        table.write(output)
+
+    run_with_transient_convert_retry(_run, source_name=f"{source.name}:{layer}")

--- a/portolan_cli/preparation.py
+++ b/portolan_cli/preparation.py
@@ -27,6 +27,7 @@ import pystac
 from portolan_cli import extension_registry as _reg
 from portolan_cli.collection_id import normalize_collection_id, validate_collection_id
 from portolan_cli.config import get_setting, load_merged_metadata
+from portolan_cli.convert import run_with_transient_convert_retry
 from portolan_cli.crs import transform_bbox_to_wgs84
 from portolan_cli.errors import NoGeometryError
 from portolan_cli.formats import FormatType, detect_format, is_cloud_optimized_geotiff
@@ -1117,8 +1118,13 @@ def convert_vector(source: Path, dest_dir: Path) -> Path:
         shutil.copy2(source, output_path)
         return output_path
 
-    # Convert using geoparquet-io fluent API
-    gpio.convert(str(source)).write(str(output_path))
+    # Convert using geoparquet-io fluent API. Wrapped in the shared retry so a
+    # transient DuckDB "Query interrupted" does not fail a bulk add (Issue #339
+    # nightly test_add_1000_files_* flake); this is the code path add uses.
+    run_with_transient_convert_retry(
+        lambda: gpio.convert(str(source)).write(str(output_path)),
+        source_name=source.name,
+    )
 
     return output_path
 
@@ -1153,11 +1159,15 @@ def convert_tabular(source: Path, dest_dir: Path) -> Path:
     # Convert CSV/TSV/XLSX using geoparquet-io
     # gpio.convert() auto-detects format and handles non-geo files correctly
     # (logs "Reading as plain table" and returns Table with geometry_column=None)
-    table = gpio.convert(str(source))
+    # Write with standard Parquet settings (compression, row groups); gpio v1.2.0+
+    # handles geometry_column=None correctly in all write strategies. Wrapped in
+    # the shared retry so a transient DuckDB "Query interrupted" does not fail a
+    # bulk add on the tabular path (Issue #339).
+    def _run() -> None:
+        table = gpio.convert(str(source))
+        table.write(str(output_path))
 
-    # Write with standard Parquet settings (compression, row groups)
-    # gpio v1.2.0+ handles geometry_column=None correctly in all write strategies
-    table.write(str(output_path))
+    run_with_transient_convert_retry(_run, source_name=source.name)
 
     return output_path
 

--- a/tests/integration/test_versioning_stress.py
+++ b/tests/integration/test_versioning_stress.py
@@ -1213,8 +1213,16 @@ class TestScaleAt1000Files:
 
         return catalog_root, collection_dir
 
+    # Per-test timeout override for the 1000-file scale tests. The nightly Slow
+    # Tests job runs with a global --timeout=300, but converting 1000 files is
+    # legitimately O(n): the add alone measured ~291s on a dev machine (fixture
+    # generation is extra, and CI runners are slower), so 300s false-times-out.
+    # This is a headroom bump, not masking a regression — the work is linear
+    # per-file conversion. The job-level `timeout-minutes: 30` still catches a
+    # genuine hang.
     @pytest.mark.integration
     @pytest.mark.slow
+    @pytest.mark.timeout(900)
     def test_add_1000_files_populates_versions(
         self, catalog_with_1000_files: tuple[Path, Path], runner: CliRunner
     ) -> None:
@@ -1239,6 +1247,7 @@ class TestScaleAt1000Files:
 
     @pytest.mark.integration
     @pytest.mark.slow
+    @pytest.mark.timeout(900)  # See note above: 1000-file add is O(n) (~291s), 300s is too tight.
     def test_add_1000_files_updates_catalog_versions(
         self, catalog_with_1000_files: tuple[Path, Path], runner: CliRunner
     ) -> None:

--- a/tests/unit/test_preparation.py
+++ b/tests/unit/test_preparation.py
@@ -313,3 +313,88 @@ class TestExtractBboxWgs84:
             result = _extract_bbox_wgs84(meta)
         assert result == [-1.0, -1.0, 2.0, 2.0]
         transform.assert_called_once_with(meta.bbox, "EPSG:3857")
+
+
+class TestConvertVectorRetriesTransientInterrupt:
+    """The add pipeline's ``convert_vector`` retries a transient DuckDB interrupt.
+
+    Regression guard for the Issue #339 nightly ``test_add_1000_files_*`` flake:
+    ``add`` converts single-layer vectors via ``preparation.convert_vector`` (not
+    ``convert.convert_file``/``_convert_vector``), so the bounded transient-interrupt
+    retry must protect *this* code path too. A single ``InterruptException`` on the
+    first ``gpio.convert`` must be retried and succeed; a non-transient error must
+    still fail fast.
+    """
+
+    def test_convert_vector_retries_then_succeeds(self, tmp_path: Path) -> None:
+        import geoparquet_io as gpio
+
+        from portolan_cli.preparation import convert_vector
+
+        class InterruptException(Exception):
+            pass
+
+        class _FakeTable:
+            def write(self, path: str) -> None:
+                Path(path).write_text("parquet-bytes")
+
+        calls = {"n": 0}
+
+        def fake_convert(src: str) -> _FakeTable:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise InterruptException("Query interrupted")
+            return _FakeTable()
+
+        with patch.object(gpio, "convert", fake_convert):
+            out = convert_vector(tmp_path / "in.geojson", tmp_path)
+
+        assert calls["n"] == 2, "should retry exactly once after the transient interrupt"
+        assert out == tmp_path / "in.parquet"
+        assert out.exists()
+
+    def test_convert_vector_does_not_retry_non_transient(self, tmp_path: Path) -> None:
+        import geoparquet_io as gpio
+
+        from portolan_cli.preparation import convert_vector
+
+        calls = {"n": 0}
+
+        def fake_convert(src: str) -> None:
+            calls["n"] += 1
+            raise ValueError("No CRS found")
+
+        with patch.object(gpio, "convert", fake_convert):
+            with pytest.raises(ValueError, match="No CRS found"):
+                convert_vector(tmp_path / "in.geojson", tmp_path)
+
+        assert calls["n"] == 1
+
+    def test_convert_tabular_retries_then_succeeds(self, tmp_path: Path) -> None:
+        import geoparquet_io as gpio
+
+        from portolan_cli.preparation import convert_tabular
+
+        class InterruptException(Exception):
+            pass
+
+        class _FakeTable:
+            geometry_column = None
+
+            def write(self, path: str) -> None:
+                Path(path).write_text("parquet-bytes")
+
+        calls = {"n": 0}
+
+        def fake_convert(src: str) -> _FakeTable:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise InterruptException("Query interrupted")
+            return _FakeTable()
+
+        with patch.object(gpio, "convert", fake_convert):
+            out = convert_tabular(tmp_path / "in.csv", tmp_path)
+
+        assert calls["n"] == 2, "should retry exactly once after the transient interrupt"
+        assert out == tmp_path / "in.parquet"
+        assert out.exists()


### PR DESCRIPTION
## Summary

Greens the two nightly **Slow Tests (Stress/Scale)** failures in
`tests/integration/test_versioning_stress.py` (nightly run
[29896466220](https://github.com/portolan-sdi/portolan-cli/actions/runs/29896466220),
`Slow Tests` job). Investigated first — the two failures had different, honest root causes (one product-side, one runner-side); neither was a fixture collision.

## Failure 2 — `test_add_1000_files_updates_catalog_versions`: "1 item failed" (`assert 1 == 0`)

**Root cause: product-side robustness gap — right mitigation, wrong code path.**

`geoparquet-io` runs conversions through DuckDB, which non-deterministically raises `InterruptException('Query interrupted')` on ~1/1000 files during a bulk `add` (a different file each run). #643 added a bounded retry for exactly this — but it landed on `convert.py::_convert_vector`, while `portolan add` converts single-layer vectors through **`preparation.py::convert_vector`** (and tabular files through `preparation.py::convert_tabular`), which call `gpio.convert(...).write(...)` directly with no retry. So the add path was never protected and kept flaking on the identical symptom documented in `context/shared/known-issues/duckdb-query-interrupted-transient.md`.

This is **not** a fixture bug: the fixture's 1000 filenames (`file_0000`…`file_0999`) and coordinates are unique and valid; 999/1000 succeeding is the transient-interrupt signature, not a name/data collision.

**Fix:** extract the retry loop into a shared `convert.py::run_with_transient_convert_retry(operation, *, source_name)` helper and apply it on **every** conversion seam the add pipeline can reach:
- `convert.py::_convert_vector` (single-layer, `convert_file` route)
- `convert.py::_convert_vector_layer` (multi-layer GeoPackage/FileGDB)
- `preparation.py::convert_vector` (single-layer vectors — **the add route**)
- `preparation.py::convert_tabular` (CSV/TSV/XLSX)

New unit tests in `tests/unit/test_preparation.py::TestConvertVectorRetriesTransientInterrupt` lock in that the add-path functions now retry a transient interrupt and still fail fast on non-transient errors.

## Failure 1 — `test_add_1000_files_populates_versions`: `Timeout (>300.0s)`

**Root cause: runner slowness, not a perf regression.**

The nightly job runs `pytest -m slow --timeout=300`. Converting 1000 files is legitimately O(n) (per-file DuckDB convert + metadata + checksums + item.json): the **add alone measured ~277–291s on a dev machine**, with fixture generation on top, and CI runners are slower. So 300s false-times-out. Per-file timing is linear (120 files ≈ 25s → ~0.21s/file), so this is headroom, not pathological slowness.

**Fix:** per-test `@pytest.mark.timeout(900)` override on both 1000-file scale tests (with a justifying comment). 900s comfortably clears a slow runner while staying well under the job-level `timeout-minutes: 30`; the marker overrides the CLI `--timeout=300` for just these two tests.

## Verification

- Full 1000-file `add` repro: **exit 0**, "Added 1000 files to 1 collection" (~291s, add-only).
- `test_add_1000_files_populates_versions` run locally under `--timeout=300`: **1 passed in 277s** (marker override in effect).
- Unit tests: `tests/unit/test_convert.py` + `tests/unit/test_preparation.py` → **111 passed** (incl. 3 new retry tests).
- `mypy portolan_cli` and `ruff check`/`format` clean; all pre-commit hooks pass.

## Note for review

Failure 2 was a genuine (if low-severity, transient-infra) product gap: the #643 retry never covered the code path `add` actually uses. This PR fixes it in the product, not by masking it in the test. Worth a glance to confirm you're happy consolidating the four conversion seams onto the one shared retry helper.
