### PR TITLE
fix(ci): repair mutation-testing baseline and bound the run (#612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       iceberg: ${{ steps.filter.outputs.iceberg }}
+      python: ${{ steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -47,6 +48,8 @@ jobs:
               - 'portolan_cli/backends/iceberg/**'
               - 'tests/iceberg/**'
               - 'pyproject.toml'
+            python:
+              - 'portolan_cli/**/*.py'
 
   quality:
     name: Quality Gates (prek — single rule source)
@@ -361,6 +364,101 @@ jobs:
       - name: Check package contents
         run: |
           uv run python -c "import tarfile; t = tarfile.open(list(__import__('pathlib').Path('dist').glob('*.tar.gz'))[0]); print('\n'.join(t.getnames()))"
+
+  mutation-pr:
+    name: Mutation Testing (changed files)
+    needs: changes
+    # PR-only: mutate just the portolan_cli files this PR changed, so mutation
+    # feedback lands on new code when the author can act on it. The nightly sweep
+    # (nightly.yml) covers the whole tree over time. Advisory for now — NOT in
+    # ci-success below — because the .mutation-baseline floor is not yet validated
+    # against a real full run; promote it to a required gate (add to ci-success
+    # needs) once the floor is trustworthy. See #612.
+    if: github.event_name == 'pull_request' && needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the PR base commit is available to diff against.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.6.14"
+
+      - name: Set up Python
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          retry_wait_seconds: 10
+          command: uv python install 3.11
+
+      - name: Install dependencies
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: uv sync --all-extras
+
+      - name: Determine changed source files
+        id: changed
+        env:
+          # Trusted github context, passed via env not spliced into the script
+          # body (zizmor template-injection guard).
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Files this PR added/modified under portolan_cli (deletions excluded —
+          # a deleted file has no mutants). Trailing * so mutmut fnmatches each
+          # file's mutant names (portolan_cli/foo.py:func__mutmut_1).
+          GLOBS=()
+          while IFS= read -r f; do
+            [ -n "$f" ] && GLOBS+=("${f}*")
+          done < <(git diff --name-only --diff-filter=d "$BASE_SHA" HEAD -- 'portolan_cli/**/*.py')
+          echo "Changed source files: ${#GLOBS[@]}"
+          printf '  %s\n' "${GLOBS[@]}"
+          {
+            echo 'globs<<GLOBS_EOF'
+            printf '%s\n' "${GLOBS[@]}"
+            echo 'GLOBS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run mutation testing on changed files
+        env:
+          GLOBS_RAW: ${{ steps.changed.outputs.globs }}
+        run: |
+          mapfile -t RAW <<< "$GLOBS_RAW"
+          GLOBS=()
+          for g in "${RAW[@]}"; do [ -n "$g" ] && GLOBS+=("$g"); done
+          if [ "${#GLOBS[@]}" -eq 0 ]; then
+            echo "No mutable source changes (only deletions?); nothing to run."
+            exit 0
+          fi
+          # Surviving mutants make mutmut exit non-zero; the floor check is
+          # authoritative, so don't fail on mutmut's own exit code.
+          uv run mutmut run "${GLOBS[@]}" || true
+
+      - name: Enforce mutation floor (changed files)
+        run: |
+          # A PR touching only comments/docstrings yields no mutants, so mutmut
+          # writes no stats — a legitimate pass here (unlike the nightly sweep),
+          # encoded by --allow-empty. The nightly full run stays the authoritative
+          # broken-baseline gate.
+          uv run mutmut export-cicd-stats || true
+          if [ ! -f mutants/mutmut-cicd-stats.json ]; then
+            echo "No mutants in changed files; nothing to score."
+            exit 0
+          fi
+          uv run python scripts/mutation_score.py \
+            --stats mutants/mutmut-cicd-stats.json \
+            --baseline .mutation-baseline \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --label "changed files" \
+            --allow-empty
 
   ci-success:
     name: CI Success

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,16 @@ jobs:
           # mutmut still generates every mutant (~1 min) then tests only the
           # shard's. Surviving mutants make mutmut exit non-zero; the floor check
           # is authoritative, so the job does not fail on mutmut's own exit code.
-          mapfile -t GLOBS <<< "$GLOBS_RAW"
+          mapfile -t RAW <<< "$GLOBS_RAW"
+          GLOBS=()
+          for g in "${RAW[@]}"; do [ -n "$g" ] && GLOBS+=("$g"); done
+          if [ "${#GLOBS[@]}" -eq 0 ]; then
+            # An empty shard means no source files — the floor check below (no
+            # --allow-empty) is the authoritative #612 silent-green guard, so let
+            # it fail on zero mutants rather than running mutmut with an empty glob.
+            echo "No files in this shard; nothing to run."
+            exit 0
+          fi
           uv run mutmut run "${GLOBS[@]}" || true
 
       - name: Enforce mutation floor

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,80 +38,57 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run mutation testing
+      - name: Select nightly shard
+        id: shard
         run: |
-          # mutmut 3.x auto-detects paths (config in pyproject.toml [tool.mutmut])
-          uv run mutmut run
-
-      - name: Check mutation score
-        run: |
-          # mutmut 3.x: export structured JSON for CI parsing
-          uv run mutmut export-cicd-stats
-
-          # Parse JSON stats (mutmut 3.x outputs to mutants/mutmut-cicd-stats.json)
-          STATS_FILE="mutants/mutmut-cicd-stats.json"
-          if [ ! -f "$STATS_FILE" ]; then
-            echo "::error::No mutation stats file found at $STATS_FILE"
-            exit 1
-          fi
-
-          KILLED=$(jq -r '.killed' "$STATS_FILE")
-          SURVIVED=$(jq -r '.survived' "$STATS_FILE")
-          NO_TESTS=$(jq -r '.no_tests' "$STATS_FILE")
-          TIMEOUT=$(jq -r '.timeout' "$STATS_FILE")
-          SUSPICIOUS=$(jq -r '.suspicious' "$STATS_FILE")
-
-          # Total testable mutants (exclude "no tests" from calculation)
-          TESTABLE=$((KILLED + SURVIVED))
-
-          echo "Mutation results:"
-          echo "  Killed: $KILLED"
-          echo "  Survived: $SURVIVED"
-          echo "  No tests: $NO_TESTS"
-          echo "  Timeout: $TIMEOUT"
-          echo "  Suspicious: $SUSPICIOUS"
-          echo "  Total testable: $TESTABLE"
-
-          # Zero testable mutants means mutmut generated/parsed nothing — that
-          # is mutation testing being SILENTLY BROKEN, not a pass. This exact
-          # no-op shipped before (the old code `exit 0`d here), so treat it as a
-          # hard failure that demands investigation.
-          if [ "$TESTABLE" -eq 0 ]; then
-            echo "::error::No testable mutants were generated/parsed — mutation testing is silently broken. See portolan-sdi/portolan-cli#612 (sandbox baseline + scalability)."
-            exit 1
-          fi
-
-          # Calculate kill rate (higher is better)
-          KILL_RATE=$(echo "scale=2; $KILLED * 100 / $TESTABLE" | bc)
-          echo "Mutation kill rate: $KILL_RATE% ($KILLED killed, $SURVIVED survived)"
-
-          # Floor comes from .mutation-baseline (first non-comment, non-blank
-          # line) so it can be ratcheted in a reviewable, single-line diff.
-          MIN_KILL_RATE=$(grep -vE '^\s*#' .mutation-baseline | grep -vE '^\s*$' | head -1)
-          if ! [[ "$MIN_KILL_RATE" =~ ^[0-9]+$ ]]; then
-            echo "::error::.mutation-baseline floor is not an integer: '$MIN_KILL_RATE'"
-            exit 1
-          fi
-
+          # Mutating all ~45k mutants can't finish in one nightly window, so each
+          # night mutates a deterministic 1/NUM_SHARDS slice of the source files,
+          # round-robin over the sorted file list keyed by day-of-year. The whole
+          # tree is covered every NUM_SHARDS nights. Lower NUM_SHARDS to cover more
+          # per night — but only if a run still finishes within timeout-minutes.
+          # (PR-scoped mutation of changed files is the fast, per-change gate; this
+          # sweep is the slow, whole-codebase trend. See #612.)
+          NUM_SHARDS=25
+          mapfile -t FILES < <(find portolan_cli -name '*.py' -type f | sort)
+          DAY=$(( 10#$(date -u +%j) ))
+          SHARD=$(( DAY % NUM_SHARDS ))
+          GLOBS=()
+          for i in "${!FILES[@]}"; do
+            if (( i % NUM_SHARDS == SHARD )); then
+              # Trailing * so mutmut fnmatches this file's mutant names
+              # (e.g. portolan_cli/foo.py:func__mutmut_1).
+              GLOBS+=("${FILES[$i]}*")
+            fi
+          done
+          echo "Shard ${SHARD} of ${NUM_SHARDS}: ${#GLOBS[@]} file(s)"
+          printf '  %s\n' "${GLOBS[@]}"
           {
-            echo "## Mutation Testing"
-            echo ""
-            echo "| Metric | Value |"
-            echo "| --- | --- |"
-            echo "| Kill rate | ${KILL_RATE}% |"
-            echo "| Floor | ${MIN_KILL_RATE}% |"
-            echo "| Killed | $KILLED |"
-            echo "| Survived | $SURVIVED |"
-            echo "| Total testable | $TESTABLE |"
-          } >> "$GITHUB_STEP_SUMMARY"
+            echo 'globs<<GLOBS_EOF'
+            printf '%s\n' "${GLOBS[@]}"
+            echo 'GLOBS_EOF'
+          } >> "$GITHUB_OUTPUT"
 
-          below_floor=$(echo "$KILL_RATE < $MIN_KILL_RATE" | bc)
-          if [ "$below_floor" -eq 1 ]; then
-            echo "::error::Mutation kill rate ($KILL_RATE%) is below the ${MIN_KILL_RATE}% floor from .mutation-baseline"
-            echo "Tests are not catching enough bugs. Review survived mutants:"
-            uv run mutmut results --all true | grep -E ': survived$' | head -20
-            exit 1
-          fi
+      - name: Run mutation testing (rotating shard)
+        env:
+          GLOBS_RAW: ${{ steps.shard.outputs.globs }}
+        run: |
+          # mutmut still generates every mutant (~1 min) then tests only the
+          # shard's. Surviving mutants make mutmut exit non-zero; the floor check
+          # is authoritative, so the job does not fail on mutmut's own exit code.
+          mapfile -t GLOBS <<< "$GLOBS_RAW"
+          uv run mutmut run "${GLOBS[@]}" || true
+
+      - name: Enforce mutation floor
+        run: |
+          # Export aggregates and enforce the .mutation-baseline floor. No
+          # --allow-empty here: on the full sweep, zero testable mutants means
+          # mutation testing is broken (the #612 silent-green guard), not a pass.
+          uv run mutmut export-cicd-stats
+          uv run python scripts/mutation_score.py \
+            --stats mutants/mutmut-cicd-stats.json \
+            --baseline .mutation-baseline \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --label "nightly shard"
 
       - name: Generate mutation report
         if: always()

--- a/.mutation-baseline
+++ b/.mutation-baseline
@@ -1,6 +1,10 @@
-# Minimum mutation kill rate (%) enforced by the nightly `mutation` job.
-# Rate = killed / (killed + survived) from mutmut's cicd-stats.
+# Minimum mutation kill rate (%). Enforced by scripts/mutation_score.py for both
+# the PR-scoped job (ci.yml, changed files) and the nightly sweep (nightly.yml,
+# rotating shard). Rate = (killed + timeout + suspicious) / testable, where
+# testable excludes no_tests mutants.
 #
-# Ratchet this UP as the test suite matures; LOWERING it requires an explicit
-# justification in the PR that does so. First non-comment, non-blank line wins.
+# PROVISIONAL: 60 predates any complete mutmut run (the baseline was broken until
+# #612). Re-measure from a real nightly-sweep kill rate and set this from it.
+# Ratchet UP as the suite matures; LOWERING it requires an explicit justification
+# in the PR that does so. First non-comment, non-blank line wins.
 60

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -116,27 +116,47 @@ Runs at 4 AM UTC daily. Can be triggered manually.
 
 ### Jobs
 
-#### `mutation` — Mutation Testing
+#### Mutation Testing (two scopes)
 
-Uses `mutmut` to verify tests actually catch bugs.
+Uses `mutmut` to verify tests actually catch bugs. The full codebase generates
+~45k mutants — far more than any single run can test in a nightly window — so
+mutation testing runs at two scopes that share one scorer:
 
-**Threshold:** the floor lives in `.mutation-baseline` (a single integer, currently
-60). The job reads it rather than hardcoding the number, so it can be ratcheted up
-in a one-line, reviewable diff as the suite matures. **Lowering it requires a
-justification in the PR that does so.**
+- **PR-scoped** (`mutation-pr` in `ci.yml`, PR-only, advisory): mutates only the
+  `portolan_cli` files the PR changed, so feedback lands on new code when the
+  author can act on it. Skipped when a PR touches no source. A PR that changes
+  only comments/docstrings produces no mutants and passes (`--allow-empty`).
+  Advisory today — not in the `ci-success` gate — until the floor is validated
+  against a real full run; promote it to required by adding it to `ci-success`
+  needs.
+- **Nightly sweep** (`mutation` in `nightly.yml`, hard gate): mutates a
+  deterministic `1/NUM_SHARDS` slice of the source files, round-robin by
+  day-of-year, so the whole tree is covered every `NUM_SHARDS` nights (currently
+  25). Lower `NUM_SHARDS` to cover more per night, but only if a run still
+  finishes within `timeout-minutes`.
 
-**Fails loud, never silent.** If mutmut generates zero testable mutants — i.e.
-mutation testing is broken, not passing — the job hard-fails (it used to `exit 0`
-and report a green nightly, hiding a broken setup). `[tool.mutmut]` in
-`pyproject.toml` copies the `scripts/` package + data files into the mutants
-sandbox and scopes the stats run to the fast, offline suite with `--no-cov`.
+**Threshold:** the floor lives in `.mutation-baseline` (a single integer). Both
+scopes read it via `scripts/mutation_score.py` rather than hardcoding it, so it
+ratchets up in a one-line, reviewable diff. The score counts `killed + timeout +
+suspicious` as killed over `killed_total + survived` testable (`no_tests`
+excluded). **Lowering the floor requires a justification in the PR that does so.**
 
-> **Status:** mutation testing is being repaired — the sandbox baseline still fails
-> on a test that passes normally, and the ~45k generated mutants exceed the nightly
-> window. Tracked in [#612](https://github.com/portolan-sdi/portolan-cli/issues/612).
-> Until it is resolved the nightly `mutation` job **correctly fails** rather than
-> silently passing. (The geoparquet-io #565 CWD guard was evaluated and is **not**
-> needed: `isolated_filesystem`/`chdir` tests do not crash the stats phase.)
+**Fails loud, never silent.** On the nightly sweep, zero testable mutants means
+mutation testing is broken, not passing — the scorer hard-fails (it used to
+`exit 0` and report a green nightly, hiding a broken setup). `[tool.mutmut]` in
+`pyproject.toml` copies the `scripts/` package, `spec/` schemas, and data files
+into the mutants sandbox and scopes the stats run to the fast, offline suite with
+`--no-cov`.
+
+**Sandbox stability.** mutmut runs the suite from a copied `mutants/` sandbox and
+instruments code with a trampoline that reads `os.environ["MUTANT_UNDER_TEST"]`.
+Two consequences the tests must respect: a cleared environment must preserve that
+var (use `cleared_environ()` from `tests/conftest.py`, not
+`patch.dict(..., clear=True)`), and files read by repo-root path (e.g.
+`spec/schema/`) must be listed in `[tool.mutmut] also_copy`. Parallel conversion
+falls back to serial when a process pool can't start in the sandbox
+(`convert.py`). (The geoparquet-io #565 CWD guard was evaluated and is **not**
+needed: `isolated_filesystem`/`chdir` tests do not crash the stats phase.)
 
 Why this matters: AI-generated tests can be tautological — they may pass but not actually verify behavior. Mutation testing injects bugs and checks if tests catch them.
 
@@ -293,9 +313,16 @@ Your tests aren't catching enough injected bugs. Review the mutation report arti
 
 ### "No testable mutants were generated"
 
-Mutation testing is broken, not passing — the job hard-fails on this. Usually the
-mutmut sandbox baseline failed (a test that passes normally but not in `mutants/`)
-or the `[tool.mutmut]` sandbox is missing a file. See [#612](https://github.com/portolan-sdi/portolan-cli/issues/612).
+On the nightly sweep this is broken, not passing — the scorer hard-fails. Usual
+causes: the mutmut sandbox baseline failed (a test that passes normally but not in
+`mutants/`), or the `[tool.mutmut] also_copy` sandbox is missing a repo-root file
+the suite reads. Reproduce locally with `uv run mutmut run` and read the
+"Running stats" output for the first failing test. See
+[#612](https://github.com/portolan-sdi/portolan-cli/issues/612).
+
+The PR-scoped job treats "no mutants" as a pass (`--allow-empty`), since a PR may
+change only non-mutable lines. If the PR job reports it while the nightly is green,
+that is expected, not a failure.
 
 ### "Complexity exceeds threshold"
 

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -1029,11 +1029,38 @@ def convert_directory(
         return ConversionReport(results=results)
 
     # Serial path
-    results = []
-    for file_path in files:
-        # Determine output directory for this file
-        file_output_dir = output_dir if output_dir else file_path.parent
+    results = _convert_files_serial(
+        files,
+        output_dir=output_dir,
+        catalog_path=catalog_path,
+        cog_settings=cog_settings,
+        vector_settings=vector_settings,
+        force=force,
+        on_progress=on_progress,
+    )
+    return ConversionReport(results=results)
 
+
+def _convert_files_serial(
+    files: list[Path],
+    *,
+    output_dir: Path | None,
+    catalog_path: Path | None,
+    cog_settings: CogSettings | None,
+    vector_settings: VectorSettings | None,
+    force: bool,
+    on_progress: Callable[[ConversionResult], None] | None,
+) -> list[ConversionResult]:
+    """Convert files one at a time in the current process.
+
+    The default path for every existing caller (``workers <= 1`` or a single
+    file), and the fallback used by :func:`_convert_files_parallel` when a
+    process pool cannot start. Outputs land side-by-side with each source unless
+    ``output_dir`` overrides it, matching the parallel path exactly.
+    """
+    results: list[ConversionResult] = []
+    for file_path in files:
+        file_output_dir = output_dir if output_dir else file_path.parent
         result = convert_file(
             file_path,
             output_dir=file_output_dir,
@@ -1043,12 +1070,9 @@ def convert_directory(
             force=force,
         )
         results.append(result)
-
-        # Invoke callback if provided
         if on_progress is not None:
             on_progress(result)
-
-    return ConversionReport(results=results)
+    return results
 
 
 def _convert_files_parallel(
@@ -1069,49 +1093,89 @@ def _convert_files_parallel(
     each future completes (it is never pickled into a worker), preserving the
     streaming-progress contract (ADR-0040). A worker that dies or raises is
     captured into a FAILED result so one bad file does not abort the batch.
+
+    If the pool itself cannot run (``BrokenProcessPool`` -- e.g. a restricted
+    container with no ``/dev/shm``, a seccomp-filtered ``clone``, or a nested
+    multiprocessing context such as mutmut's mutation runner), the remaining
+    files are converted serially in this process instead of all being reported
+    FAILED.
     """
     import multiprocessing
     from concurrent.futures import ProcessPoolExecutor, as_completed
+    from concurrent.futures.process import BrokenProcessPool
 
     # Use a "spawn" context, not fork. GDAL/rasterio run worker threads, and
     # fork()-ing a multi-threaded process can deadlock the child (and aborts on
     # macOS). Spawn re-imports this module cleanly in each worker.
     mp_context = multiprocessing.get_context("spawn")
 
-    results: list[ConversionResult] = []
-    with ProcessPoolExecutor(max_workers=workers, mp_context=mp_context) as executor:
-        future_to_file = {
-            executor.submit(
-                convert_file,
-                file_path,
-                output_dir=output_dir if output_dir else file_path.parent,
-                catalog_path=catalog_path,
-                cog_settings=cog_settings,
-                vector_settings=vector_settings,
-                force=force,
-            ): file_path
-            for file_path in files
-        }
-        for future in as_completed(future_to_file):
-            file_path = future_to_file[future]
-            try:
-                result = future.result()
-            except Exception as e:  # pragma: no cover - defensive (process crash/pickle)
-                logger.exception("Parallel conversion worker failed for %s", file_path)
-                result = ConversionResult(
-                    source=file_path,
-                    output=None,
-                    format_from=file_path.suffix.lstrip(".").upper(),
-                    format_to=None,
-                    status=ConversionStatus.FAILED,
-                    error=str(e),
-                    duration_ms=0,
-                )
-            results.append(result)
-            if on_progress is not None:
-                on_progress(result)
+    # Keyed by source path so a mid-run pool failure can convert only the files
+    # that have not completed yet, without re-firing on_progress for the rest.
+    completed: dict[Path, ConversionResult] = {}
 
-    return results
+    def _record(file_path: Path, result: ConversionResult) -> None:
+        completed[file_path] = result
+        if on_progress is not None:
+            on_progress(result)
+
+    try:
+        with ProcessPoolExecutor(max_workers=workers, mp_context=mp_context) as executor:
+            future_to_file = {
+                executor.submit(
+                    convert_file,
+                    file_path,
+                    output_dir=output_dir if output_dir else file_path.parent,
+                    catalog_path=catalog_path,
+                    cog_settings=cog_settings,
+                    vector_settings=vector_settings,
+                    force=force,
+                ): file_path
+                for file_path in files
+            }
+            for future in as_completed(future_to_file):
+                file_path = future_to_file[future]
+                try:
+                    result = future.result()
+                except BrokenProcessPool:
+                    # The pool itself died; let the outer handler fall back to
+                    # serial rather than marking this file FAILED.
+                    raise
+                except Exception as e:  # pragma: no cover - defensive (worker crash/pickle)
+                    logger.exception("Parallel conversion worker failed for %s", file_path)
+                    result = ConversionResult(
+                        source=file_path,
+                        output=None,
+                        format_from=file_path.suffix.lstrip(".").upper(),
+                        format_to=None,
+                        status=ConversionStatus.FAILED,
+                        error=str(e),
+                        duration_ms=0,
+                    )
+                _record(file_path, result)
+    except BrokenProcessPool:
+        # A ProcessPoolExecutor can fail to start or keep workers in restricted
+        # environments (no /dev/shm, seccomp-filtered clone, or a nested
+        # multiprocessing context such as mutmut's mutation runner). Rather than
+        # report every file FAILED, finish the batch serially in this process.
+        remaining = [file_path for file_path in files if file_path not in completed]
+        logger.warning(
+            "Process pool unavailable; converting %d remaining file(s) serially",
+            len(remaining),
+        )
+        serial_results = _convert_files_serial(
+            remaining,
+            output_dir=output_dir,
+            catalog_path=catalog_path,
+            cog_settings=cog_settings,
+            vector_settings=vector_settings,
+            force=force,
+            on_progress=on_progress,
+        )
+        for file_path, result in zip(remaining, serial_results, strict=True):
+            completed[file_path] = result
+
+    # Preserve the caller's input order regardless of completion order.
+    return [completed[file_path] for file_path in files]
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,11 @@ pytest_add_cli_args_test_selection = ["tests/"]
 # guard).
 # scripts/ (imported by a few tests) and the data files those tests read must
 # be present in the sandbox, or collection/execution dies there.
-also_copy = ["scripts/", ".pip-audit-ignores", ".mutation-baseline"]
+# spec/ holds the shipped STAC schemas + extensions.md that the spec_compliance
+# suite reads by repo-root path (tests/spec_compliance/conftest.py resolves
+# spec/schema/, test_extensions_doc_parity.py reads spec/extensions.md). Without
+# it the baseline errors with FileNotFoundError on mutants/spec/... (172 KiB).
+also_copy = ["scripts/", ".pip-audit-ignores", ".mutation-baseline", "spec/"]
 # The stats/baseline run must mirror the fast CI test job, not the whole suite:
 # - --no-cov: pyproject's addopts inject --cov, whose instrumentation conflicts
 #   with mutmut's; without this the stats phase is unreliable.

--- a/scripts/mutation_score.py
+++ b/scripts/mutation_score.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Score a mutmut run against the ``.mutation-baseline`` floor.
+
+Both mutation jobs share this module so the parse-and-enforce logic lives in one
+tested place instead of duplicated shell: the nightly sweep and the PR-scoped
+diff job each run ``mutmut``, export ``mutmut-cicd-stats.json``, then call this
+script to enforce the floor and render a GitHub step-summary table.
+
+Scoring:
+    killed_total = killed + timeout + suspicious   # the suite reacted
+    testable     = killed_total + survived          # no_tests excluded
+    kill_rate    = killed_total / testable * 100
+
+``no_tests`` mutants (no covering test at all) are outside the suite's reach and
+are excluded from the rate rather than counted as failures. ``timeout`` and
+``suspicious`` mutants provoked a reaction from the suite, so they count as
+killed. Zero testable mutants means mutmut produced or parsed nothing — that is
+mutation testing being broken, never a pass.
+
+Usage:
+    python scripts/mutation_score.py \\
+        --stats mutants/mutmut-cicd-stats.json \\
+        --baseline .mutation-baseline \\
+        [--summary "$GITHUB_STEP_SUMMARY"] [--label "changed files"]
+
+Exit codes: 0 = at or above floor; 1 = below floor, zero testable, or bad input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+_STAT_KEYS = ("killed", "survived", "no_tests", "timeout", "suspicious")
+
+
+def read_floor(text: str) -> int:
+    """Return the floor from ``.mutation-baseline`` contents.
+
+    The first non-comment, non-blank line is the floor. A ``#`` comment or blank
+    line is skipped. A non-integer floor raises ``ValueError`` rather than
+    silently defaulting.
+    """
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        return int(line)  # raises ValueError on a non-integer line
+    raise ValueError("no floor value found in baseline file")
+
+
+@dataclass(frozen=True)
+class Score:
+    """Outcome of scoring one mutmut run against a floor."""
+
+    killed: int
+    survived: int
+    no_tests: int
+    timeout: int
+    suspicious: int
+    floor: int
+
+    @property
+    def killed_total(self) -> int:
+        """Mutants the suite reacted to (clean kill, timeout, or suspicious)."""
+        return self.killed + self.timeout + self.suspicious
+
+    @property
+    def testable(self) -> int:
+        """Mutants a test could kill (excludes ``no_tests``)."""
+        return self.killed_total + self.survived
+
+    @property
+    def kill_rate(self) -> float | None:
+        """Kill rate as a percentage, or ``None`` when nothing is testable."""
+        if self.testable == 0:
+            return None
+        return round(self.killed_total * 100 / self.testable, 2)
+
+    @property
+    def ok(self) -> bool:
+        """True only when there are testable mutants and the floor is met."""
+        rate = self.kill_rate
+        return rate is not None and rate >= self.floor
+
+
+def evaluate(stats: Mapping[str, int], floor: int) -> Score:
+    """Build a :class:`Score` from a stats mapping and floor."""
+    return Score(
+        killed=int(stats.get("killed", 0)),
+        survived=int(stats.get("survived", 0)),
+        no_tests=int(stats.get("no_tests", 0)),
+        timeout=int(stats.get("timeout", 0)),
+        suspicious=int(stats.get("suspicious", 0)),
+        floor=floor,
+    )
+
+
+def render_summary(score: Score, label: str) -> str:
+    """Render a GitHub-flavored Markdown table for the step summary."""
+    rate = "n/a" if score.kill_rate is None else f"{score.kill_rate}%"
+    scope = f" ({label})" if label else ""
+    lines = [
+        f"## Mutation Testing{scope}",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| Kill rate | {rate} |",
+        f"| Floor | {score.floor}% |",
+        f"| Killed | {score.killed_total} |",
+        f"| Survived | {score.survived} |",
+        f"| Testable | {score.testable} |",
+        f"| No tests | {score.no_tests} |",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Enforce the mutmut kill-rate floor.")
+    parser.add_argument("--stats", required=True, type=Path, help="mutmut-cicd-stats.json")
+    parser.add_argument("--baseline", required=True, type=Path, help=".mutation-baseline")
+    parser.add_argument("--summary", type=Path, help="GitHub step-summary file to append")
+    parser.add_argument("--label", default="", help="scope label, e.g. 'changed files'")
+    parser.add_argument(
+        "--allow-empty",
+        action="store_true",
+        help=(
+            "Treat zero testable mutants as a pass, not a broken run. Use for a "
+            "diff-scoped run where the changed files may contain no mutable code; "
+            "omit for a full sweep, where zero mutants means mutation testing broke."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    args = _parse_args(argv)
+
+    try:
+        stats = json.loads(args.stats.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"::error::Could not read mutation stats {args.stats}: {exc}")
+        return 1
+
+    try:
+        floor = read_floor(args.baseline.read_text())
+    except (OSError, ValueError) as exc:
+        print(f"::error::Invalid .mutation-baseline floor: {exc}")
+        return 1
+
+    score = evaluate(stats, floor)
+
+    summary = render_summary(score, args.label)
+    if args.summary is not None:
+        with args.summary.open("a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+    print(summary)
+
+    if score.testable == 0:
+        if args.allow_empty:
+            print("No mutable code in scope; nothing to test.")
+            return 0
+        print(
+            "::error::No testable mutants were generated or parsed — mutation "
+            "testing is broken. See portolan-sdi/portolan-cli#612."
+        )
+        return 1
+
+    if not score.ok:
+        print(
+            f"::error::Mutation kill rate {score.kill_rate}% is below the "
+            f"{score.floor}% floor from .mutation-baseline."
+        )
+        return 1
+
+    print(f"Mutation kill rate {score.kill_rate}% meets the {score.floor}% floor.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,44 @@ try:
 except ModuleNotFoundError:
     pass  # Iceberg tests don't need matplotlib
 
+import os
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest import mock
 
 import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+
+# =============================================================================
+# Environment Isolation
+# =============================================================================
+
+# mutmut instruments every mutated function with a trampoline that reads
+# os.environ["MUTANT_UNDER_TEST"] on each call into portolan_cli. A bare
+# patch.dict(os.environ, {}, clear=True) wipes that var, so any cleared-env test
+# that then calls into portolan_cli fails the mutation baseline with
+# KeyError: 'MUTANT_UNDER_TEST' (portolan-sdi/portolan-cli#612). Preserve just
+# that one bookkeeping var. Outside mutmut it is absent, so this is identical to
+# a full clear.
+_MUTMUT_ENV_KEY = "MUTANT_UNDER_TEST"
+
+
+@contextmanager
+def cleared_environ(**overrides: str) -> Iterator[None]:
+    """Clear os.environ for the block, preserving mutmut's bookkeeping var.
+
+    Drop-in replacement for ``mock.patch.dict(os.environ, {}, clear=True)`` that
+    keeps the environment sandbox-stable under mutation testing. Pass keyword
+    ``overrides`` to seed specific variables into the otherwise-empty environment.
+    """
+    preserved = {k: v for k, v in os.environ.items() if k == _MUTMUT_ENV_KEY}
+    preserved.update(overrides)
+    with mock.patch.dict(os.environ, preserved, clear=True):
+        yield
 
 
 # =============================================================================

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,6 +15,8 @@ from unittest import mock
 
 import pytest
 
+from tests.conftest import cleared_environ
+
 if TYPE_CHECKING:
     pass
 
@@ -950,7 +952,7 @@ class TestDotenvLoading:
         env_file = tmp_path / ".env"
         env_file.write_text("PORTOLAN_REMOTE=s3://from-dotenv/\n")
 
-        with mock.patch.dict(os.environ, {}, clear=True):
+        with cleared_environ():
             load_dotenv_from_catalog(tmp_path)
             result = get_setting("remote", catalog_path=tmp_path)
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -829,6 +829,145 @@ class TestConvertDirectoryBasic:
             convert_directory(valid_points_geojson)
 
 
+class TestConvertDirectoryPoolFallback:
+    """Parallel conversion falls back to serial when the process pool can't start.
+
+    A ``ProcessPoolExecutor`` can fail to spawn workers in restricted
+    environments: locked-down containers with no ``/dev/shm``, seccomp filters
+    that block ``clone``, or a nested multiprocessing context such as mutmut's
+    mutation runner (which re-sets the start method during worker bootstrap and
+    surfaces as ``BrokenProcessPool`` in the parent). Without a fallback every
+    file is reported FAILED even though the inputs are valid. Conversion must
+    still complete by dropping to the serial path. Regression guard for the
+    mutation-testing baseline (issue #612).
+    """
+
+    @pytest.mark.unit
+    def test_falls_back_to_serial_when_pool_broken(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        valid_points_geojson: Path,
+        valid_polygons_geojson: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A pool that can't start still yields both converted files, none FAILED."""
+        import concurrent.futures
+        import shutil
+        from concurrent.futures.process import BrokenProcessPool
+
+        from portolan_cli.convert import convert_directory
+
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        shutil.copy(valid_points_geojson, input_dir / "points.geojson")
+        shutil.copy(valid_polygons_geojson, input_dir / "polygons.geojson")
+
+        class _BrokenPool:
+            """Stand-in ProcessPoolExecutor whose workers never start."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def __enter__(self) -> _BrokenPool:
+                return self
+
+            def __exit__(self, *args: object) -> bool:
+                return False
+
+            def submit(self, *args: object, **kwargs: object) -> object:
+                raise BrokenProcessPool("simulated worker startup failure")
+
+        monkeypatch.setattr(concurrent.futures, "ProcessPoolExecutor", _BrokenPool)
+
+        # workers=4 + 2 files selects the parallel path; the broken pool must not
+        # sink the batch.
+        report = convert_directory(input_dir, workers=4)
+
+        assert report.succeeded == 2
+        assert report.failed == 0
+        assert (input_dir / "points.parquet").exists()
+        assert (input_dir / "polygons.parquet").exists()
+
+    @pytest.mark.unit
+    def test_pool_dies_midrun_keeps_completed_and_fires_progress_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        valid_points_geojson: Path,
+        valid_polygons_geojson: Path,
+        tmp_path: Path,
+    ) -> None:
+        """A mid-run pool death converts only the remainder; no file is dropped or doubled."""
+        import concurrent.futures
+        import shutil
+        from concurrent.futures.process import BrokenProcessPool
+
+        from portolan_cli.convert import ConversionResult, ConversionStatus, convert_directory
+
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+        # Sorted order: a_points.geojson before b_polygons.geojson.
+        shutil.copy(valid_points_geojson, input_dir / "a_points.geojson")
+        shutil.copy(valid_polygons_geojson, input_dir / "b_polygons.geojson")
+
+        class _Future:
+            def __init__(self, source: Path, ok: bool) -> None:
+                self._source = source
+                self._ok = ok
+
+            def result(self) -> ConversionResult:
+                if not self._ok:
+                    raise BrokenProcessPool("pool died after first file")
+                # A sentinel status the serial path never produces, so we can
+                # prove this result came from the pool and was NOT re-converted.
+                return ConversionResult(
+                    source=self._source,
+                    output=self._source.with_suffix(".parquet"),
+                    format_from="GEOJSON",
+                    format_to="GEOPARQUET",
+                    status=ConversionStatus.SKIPPED,
+                    error=None,
+                    duration_ms=0,
+                )
+
+        class _PartialPool:
+            """First submitted file succeeds; the pool then dies."""
+
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                self._n = 0
+
+            def __enter__(self) -> _PartialPool:
+                return self
+
+            def __exit__(self, *args: object) -> bool:
+                return False
+
+            def submit(self, _fn: object, source: Path, **_kw: object) -> _Future:
+                self._n += 1
+                fut = _Future(source, ok=self._n == 1)
+                return fut
+
+        monkeypatch.setattr(concurrent.futures, "ProcessPoolExecutor", _PartialPool)
+        # as_completed must yield the futures; identity keeps submission order.
+        monkeypatch.setattr(concurrent.futures, "as_completed", lambda fs: list(fs))
+
+        progressed: list[Path] = []
+        report = convert_directory(
+            input_dir, workers=4, on_progress=lambda r: progressed.append(r.source)
+        )
+
+        by_name = {r.source.name: r for r in report.results}
+        # First file kept its pool result (SKIPPED), never re-run serially.
+        assert by_name["a_points.geojson"].status == ConversionStatus.SKIPPED
+        # Second file was converted by the serial fallback.
+        assert by_name["b_polygons.geojson"].status == ConversionStatus.SUCCESS
+        assert (input_dir / "b_polygons.parquet").exists()
+        # Every file reported exactly once — no drops, no double-fires.
+        assert sorted(p.name for p in progressed) == [
+            "a_points.geojson",
+            "b_polygons.geojson",
+        ]
+
+
 class TestConvertDirectoryCallback:
     """Tests for convert_directory() callback functionality."""
 

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -157,3 +157,170 @@ See [this guide](docs/contributing.md) for details.
 
         assert len(result.errors) == 2
         assert len(result.warnings) == 1
+
+
+class TestMutationScore:
+    """Tests for mutation_score.py (shared mutmut floor enforcement)."""
+
+    @pytest.mark.unit
+    def test_read_floor_skips_comments_and_blanks(self) -> None:
+        """First non-comment, non-blank line is parsed as the integer floor."""
+        from mutation_score import read_floor
+
+        text = "# a comment\n\n   # indented comment\n60\n70\n"
+        assert read_floor(text) == 60
+
+    @pytest.mark.unit
+    def test_read_floor_rejects_non_integer(self) -> None:
+        """A non-integer floor is a hard error, not a silent default."""
+        from mutation_score import read_floor
+
+        with pytest.raises(ValueError):
+            read_floor("# header\nninety\n")
+
+    @pytest.mark.unit
+    def test_evaluate_zero_testable_is_broken(self) -> None:
+        """Zero testable mutants means mutmut produced nothing — never a pass."""
+        from mutation_score import evaluate
+
+        score = evaluate(
+            {"killed": 0, "survived": 0, "no_tests": 5, "timeout": 0, "suspicious": 0},
+            floor=60,
+        )
+        assert score.testable == 0
+        assert score.ok is False
+        assert score.kill_rate is None
+
+    @pytest.mark.unit
+    def test_evaluate_below_floor_fails(self) -> None:
+        """Kill rate under the floor fails the run."""
+        from mutation_score import evaluate
+
+        score = evaluate(
+            {"killed": 1, "survived": 9, "no_tests": 0, "timeout": 0, "suspicious": 0},
+            floor=60,
+        )
+        assert score.testable == 10
+        assert score.kill_rate == 10.0
+        assert score.ok is False
+
+    @pytest.mark.unit
+    def test_evaluate_at_floor_passes(self) -> None:
+        """Kill rate exactly at the floor passes (>=, not >)."""
+        from mutation_score import evaluate
+
+        score = evaluate(
+            {"killed": 6, "survived": 4, "no_tests": 0, "timeout": 0, "suspicious": 0},
+            floor=60,
+        )
+        assert score.kill_rate == 60.0
+        assert score.ok is True
+
+    @pytest.mark.unit
+    def test_evaluate_counts_timeout_and_suspicious_as_killed(self) -> None:
+        """Timeout and suspicious mutants are killed (the test suite reacted)."""
+        from mutation_score import evaluate
+
+        # 5 clean-killed + 3 timeout + 2 suspicious = 10 killed, 0 survived.
+        score = evaluate(
+            {"killed": 5, "survived": 0, "no_tests": 0, "timeout": 3, "suspicious": 2},
+            floor=60,
+        )
+        assert score.killed_total == 10
+        assert score.testable == 10
+        assert score.kill_rate == 100.0
+        assert score.ok is True
+
+    @pytest.mark.unit
+    def test_main_exits_nonzero_below_floor(self, tmp_path: Path) -> None:
+        """End-to-end: main() reads files and returns exit 1 below the floor."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(
+            json.dumps(
+                {
+                    "killed": 1,
+                    "survived": 9,
+                    "no_tests": 0,
+                    "timeout": 0,
+                    "suspicious": 0,
+                }
+            )
+        )
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("# floor\n60\n")
+
+        code = main(["--stats", str(stats), "--baseline", str(baseline)])
+        assert code == 1
+
+    @pytest.mark.unit
+    def test_main_zero_testable_fails_by_default(self, tmp_path: Path) -> None:
+        """Nightly semantics: zero testable mutants is a broken run (exit 1)."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(json.dumps({"killed": 0, "survived": 0, "no_tests": 3}))
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("60\n")
+
+        assert main(["--stats", str(stats), "--baseline", str(baseline)]) == 1
+
+    @pytest.mark.unit
+    def test_main_zero_testable_allowed_with_flag(self, tmp_path: Path) -> None:
+        """PR semantics: --allow-empty treats no mutants in scope as a pass (exit 0)."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(json.dumps({"killed": 0, "survived": 0, "no_tests": 3}))
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("60\n")
+
+        code = main(["--stats", str(stats), "--baseline", str(baseline), "--allow-empty"])
+        assert code == 0
+
+    @pytest.mark.unit
+    def test_main_exits_zero_at_or_above_floor(self, tmp_path: Path) -> None:
+        """End-to-end: a passing run returns exit 0 and writes a summary table."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(
+            json.dumps(
+                {
+                    "killed": 8,
+                    "survived": 2,
+                    "no_tests": 1,
+                    "timeout": 0,
+                    "suspicious": 0,
+                }
+            )
+        )
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("60\n")
+        summary = tmp_path / "summary.md"
+
+        code = main(
+            [
+                "--stats",
+                str(stats),
+                "--baseline",
+                str(baseline),
+                "--summary",
+                str(summary),
+                "--label",
+                "changed files",
+            ]
+        )
+        assert code == 0
+        written = summary.read_text()
+        assert "changed files" in written
+        assert "80" in written  # kill rate

--- a/tests/unit/test_upload.py
+++ b/tests/unit/test_upload.py
@@ -25,6 +25,8 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+from tests.conftest import cleared_environ
+
 if TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -451,7 +453,7 @@ class TestCheckCredentials:
         """Missing S3 credentials should return helpful hints."""
         from portolan_cli.sync.upload import check_credentials
 
-        with patch.dict(os.environ, {}, clear=True):
+        with cleared_environ():
             with patch("portolan_cli.sync.upload._load_aws_credentials_from_profile") as mock_load:
                 mock_load.return_value = (None, None, None, None)
                 valid, hint = check_credentials("s3://mybucket/path")
@@ -467,7 +469,7 @@ class TestCheckCredentials:
 
         # Fixture patches Path.home() - assert it exists to mark as used
         assert mock_aws_credentials.exists()
-        with patch.dict(os.environ, {}, clear=True):
+        with cleared_environ():
             valid, hint = check_credentials("s3://mybucket/path", profile="myprofile")
             assert valid is True
             assert hint == ""
@@ -479,7 +481,7 @@ class TestCheckCredentials:
 
         # Fixture patches Path.home() - assert it exists to mark as used
         assert mock_aws_credentials.exists()
-        with patch.dict(os.environ, {}, clear=True):
+        with cleared_environ():
             valid, hint = check_credentials("s3://mybucket/path", profile="nonexistent")
             assert valid is False
             assert "nonexistent" in hint
@@ -544,7 +546,7 @@ class TestCheckCredentials:
         adc_file.write_text('{"type": "authorized_user"}')
 
         with (
-            patch.dict(os.environ, {}, clear=True),
+            cleared_environ(),
             patch("pathlib.Path.home", return_value=tmp_path),
         ):
             valid, hint = check_credentials("gs://mybucket/path")
@@ -586,7 +588,7 @@ class TestCheckCredentials:
         """Missing Azure credentials should return helpful hints."""
         from portolan_cli.sync.upload import check_credentials
 
-        with patch.dict(os.environ, {}, clear=True):
+        with cleared_environ():
             valid, hint = check_credentials("az://myaccount/container")
             assert valid is False
             assert "AZURE_STORAGE_ACCOUNT_KEY" in hint


### PR DESCRIPTION
Closes #612.

## Problem

Mutation testing was silently non-functional. The mutmut sandbox baseline failed on tests that pass in the normal tree, and the ~45k generated mutants could never finish in a nightly window. The old nightly masked this by `exit 0`-ing on zero mutants.

## Baseline fixes (three sandbox-stability classes)

Each was found by running `mutmut run` and reading the first failing test in the "Running stats" phase; fixing one surfaced the next (354 → 981 → 2951 baseline tests passing).

1. **Process pool can't start → every file FAILED.** `check --fix` defaults `workers` to `os.cpu_count()`, so conversion runs in a spawn `ProcessPoolExecutor`. Inside mutmut's runner the workers crash (`BrokenProcessPool`), marking all files FAILED. `convert.py` now falls back to serial conversion when the pool can't start. This also hardens real restricted environments (no `/dev/shm`, seccomp-filtered `clone`), where the old code silently failed every conversion.
2. **Repo files missing from the sandbox.** The `spec_compliance` suite reads `spec/schema/*.json` and `spec/extensions.md` by repo-root path, which aren't in the `mutants/` sandbox. Added `spec/` to `[tool.mutmut] also_copy`.
3. **`clear=True` wiped mutmut's bookkeeping var.** mutmut's trampoline reads `os.environ["MUTANT_UNDER_TEST"]` on every call into mutated code. Six tests used `patch.dict(os.environ, {}, clear=True)`, wiping it and raising `KeyError`. New `cleared_environ()` helper (`tests/conftest.py`) clears the environment but preserves that one var; outside mutmut it behaves identically to a full clear.

## Scaling (never run 45k at once)

- **PR-scoped** (`ci.yml`, advisory): mutate only the `portolan_cli` files a PR changed, so feedback lands on new code. Skipped when no source changes; `--allow-empty` passes comment-only diffs. **Advisory** (not in `ci-success`) until the floor is validated — promote by adding it to `ci-success` needs.
- **Nightly rotating shard** (`nightly.yml`, hard gate): mutate `1/25` of the tree per night, round-robin by day-of-year; whole tree covered every 25 nights. Lower `NUM_SHARDS` to cover more per night if the run still fits `timeout-minutes`.
- **`scripts/mutation_score.py`**: one unit-tested scorer for both scopes, replacing the duplicated nightly bash. Score = `(killed + timeout + suspicious) / testable`, `no_tests` excluded. Zero testable is broken on the nightly sweep (the #612 silent-green guard) but a pass under `--allow-empty` for PRs.

## Baseline number

`.mutation-baseline` stays **60, provisional** — it predates any complete run. Re-measure from a real nightly-sweep kill rate and ratchet.

## Verification

- New tests are TDD (red→green): `TestConvertDirectoryPoolFallback` (startup + mid-run pool death, no dropped/doubled files) and `TestMutationScore` (floor parsing, scoring, exit codes, allow-empty).
- Locally, each fix cleared its baseline blocker in sequence. The **full green baseline is left for a CI runner** rather than a local 45k-mutant run.
- `actionlint` + `zizmor` pass on both workflows; full pre-commit suite green.

The geoparquet-io #565 CWD guard was re-confirmed **not** needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved batch conversion reliability by preserving input order, reporting progress consistently, and falling back to serial processing when parallel workers fail.

- **CI & Quality**
  - Added pull-request mutation testing for changed Python files.
  - Nightly mutation testing now runs deterministic file subsets.
  - Added mutation score reporting and enforcement with clearer handling of empty results.

- **Documentation**
  - Clarified mutation-testing thresholds, scopes, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->