### PR TITLE
fix(test): stop patching builtins.__import__ in pmtiles test, unblocking nightly mutation baseline (#612)

### DIFF
--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -102,15 +102,15 @@ class TestCheckPMTilesAvailable:
             check_pmtiles_available,
         )
 
+        # Setting sys.modules[name] = None makes `import name` raise ImportError,
+        # scoped to gpio_pmtiles only. Do NOT patch builtins.__import__ globally
+        # here: mutmut's trampoline runs `import os` at call time, so a global
+        # __import__ side_effect raises from the trampoline before the function
+        # body's try/except runs, failing the baseline stats phase (#612).
         with patch.dict("sys.modules", {"gpio_pmtiles": None}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
-                # Mock the import to raise ImportError
-                with patch(
-                    "builtins.__import__",
-                    side_effect=ImportError("No module named 'gpio_pmtiles'"),
-                ):
-                    with pytest.raises(PMTilesNotAvailableError):
-                        check_pmtiles_available()
+                with pytest.raises(PMTilesNotAvailableError):
+                    check_pmtiles_available()
 
     @pytest.mark.unit
     def test_raises_when_tippecanoe_not_in_path(self) -> None:


### PR DESCRIPTION
## Problem

The nightly [Mutation Testing job failed](https://github.com/portolan-sdi/portolan-cli/actions/runs/30071857995). Its baseline stats phase died with:

```
FAILED tests/unit/test_pmtiles.py::TestCheckPMTilesAvailable::test_raises_when_gpio_pmtiles_not_installed
  - ImportError: No module named 'gpio_pmtiles'
= 1 failed, 4245 passed, 17 skipped, 53 deselected ...
failed to collect stats. runner returned 1
```

One failing test in mutmut's baseline aborts stats collection, yielding zero testable mutants. That trips the #612 zero-mutant floor guard (deliberately has no `--allow-empty`), and the job fails.

## Root cause

`test_raises_when_gpio_pmtiles_not_installed` patched `builtins.__import__` with a global `ImportError` side_effect on top of the `sys.modules` sentinel it already used.

mutmut runs the suite from a `mutants/` sandbox where every wrapped function becomes a trampoline, and the trampoline's first statement is `import os` (to read `MUTANT_UNDER_TEST`):

```python
def _mutmut_trampoline(orig, mutants, call_args, call_kwargs, self_arg=None):
    import os                              # call-time import
    mutant_under_test = os.environ['MUTANT_UNDER_TEST']
```

Under the global patch, calling `check_pmtiles_available()` raised `ImportError` from the trampoline's own `import os` — before the function body's `try/except ImportError` ran. So `pytest.raises(PMTilesNotAvailableError)` saw a raw `ImportError` and failed. Outside the sandbox there is no trampoline, so the test passed on PRs and the incompatibility stayed hidden until the nightly full-sweep.

## Fix

Drop the `builtins.__import__` patch. The existing `patch.dict("sys.modules", {"gpio_pmtiles": None})` already makes `import gpio_pmtiles` raise `ImportError`, scoped to that one module, and leaves the trampoline's own imports intact.

## Verification

- `tests/unit/test_pmtiles.py`: 43 passed, 1 skipped; ruff + mypy clean.
- Reproduced the trampoline condition directly (call-time `import os`, `MUTANT_UNDER_TEST=stats`): the old pattern leaks the exact CI `ImportError`, the new pattern raises `PMTilesNotAvailableError` as intended.
- `builtins.__import__` was patched in exactly one place across the codebase, so this is the only test with this failure mode.

## Out of scope

The same nightly run's **Slow Tests (Stress/Scale)** job was cancelled at its 30-minute `timeout-minutes` wall, with no captured pytest output. That is independent of the mutation baseline failure and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for environments where the PMTiles dependency is unavailable.
  * Confirmed the application continues to raise the expected availability error when the dependency is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->