### PR TITLE
ci: raise nightly slow-tests timeout margin and record durations

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -320,7 +320,12 @@ jobs:
   slow-tests:
     name: Slow Tests (Stress/Scale)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The stress/scale suite runs right at the wall: it passed in 28m on
+    # 2026-07-23 and was cancelled at the 30m limit on 2026-07-24. Individual
+    # tests are already capped by --timeout=300, so a cancellation here is the
+    # aggregate suite exceeding the job budget, not a hung test. Give headroom
+    # above the observed ~30m runtime (Live Network uses 45, Mutation 60).
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -345,6 +350,7 @@ jobs:
           uv run pytest tests/ \
             -m slow \
             --timeout=300 \
+            --durations=15 \
             -v
 
   dependency-check:


### PR DESCRIPTION
## Problem

In the same [nightly run](https://github.com/portolan-sdi/portolan-cli/actions/runs/30071857995) that surfaced the mutation-baseline bug (fixed in #666), the **Slow Tests (Stress/Scale)** job was cancelled at its 30-minute `timeout-minutes` wall. It left no captured pytest output, so the log offered nothing to diagnose.

## Diagnosis

Not a hung test. Individual tests are already bounded by `--timeout=300`, so a per-test hang fails fast rather than cancelling the whole job. A *cancellation* means the aggregate `-m slow` suite exceeded the job budget.

The job history shows it running right at the wall, with no margin:

| Date | slow-tests | Duration |
|------|-----------|----------|
| 2026-07-23 | success | 28m |
| 2026-07-24 | cancelled | 30m |

(Earlier nights failed at 19-27m on the 1000-file stress fixtures, since stabilized in b0d68f7.) A green run already takes ~28-30 min, so a few minutes of normal CI variance tips it past 30.

## Fix

- **`timeout-minutes` 30 → 50.** Gives ~20 min of headroom over the observed runtime. Live Network uses 45 and Mutation uses 60, so 50 sits within this workflow's established range.
- **Add `--durations=15`** to the pytest invocation. This run's cancellation left no timing data; recording the slowest tests makes future runtime creep visible in the log instead of invisible.

The stress fixtures were already reduced 1000 → 100 files for speed, so the suite is doing legitimate work rather than obvious waste. The right lever here is headroom plus observability, not trimming coverage.

## Validation

- `nightly.yml` passes the repo's workflow linter and zizmor via pre-commit.
- Scope is the `slow-tests` job only; no other job or test is touched.

Separate from #666 (mutation baseline), branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
