### PR TITLE
test: preserve MUTANT_UNDER_TEST in cleared-env push tests (#612)

### DIFF
--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -27,6 +27,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from portolan_cli.sync.push import UploadMetrics
+from tests.conftest import cleared_environ
 
 if TYPE_CHECKING:
     pass
@@ -1452,14 +1453,10 @@ class TestMultiCloudStoreSetup:
         """setup_store should use AWS credentials from environment."""
         from portolan_cli.sync.upload import setup_store
 
-        with patch.dict(
-            "os.environ",
-            {
-                "AWS_ACCESS_KEY_ID": "env_access_key",
-                "AWS_SECRET_ACCESS_KEY": "env_secret_key",
-                "AWS_REGION": "eu-west-1",
-            },
-            clear=True,
+        with cleared_environ(
+            AWS_ACCESS_KEY_ID="env_access_key",
+            AWS_SECRET_ACCESS_KEY="env_secret_key",
+            AWS_REGION="eu-west-1",
         ):
             with patch("portolan_cli.sync.upload.S3Store") as mock_s3:
                 mock_s3.return_value = MagicMock()
@@ -1478,14 +1475,10 @@ class TestMultiCloudStoreSetup:
         """setup_store should fallback to AWS_DEFAULT_REGION if AWS_REGION not set."""
         from portolan_cli.sync.upload import setup_store
 
-        with patch.dict(
-            "os.environ",
-            {
-                "AWS_ACCESS_KEY_ID": "key",
-                "AWS_SECRET_ACCESS_KEY": "secret",
-                "AWS_DEFAULT_REGION": "ap-southeast-1",
-            },
-            clear=True,
+        with cleared_environ(
+            AWS_ACCESS_KEY_ID="key",
+            AWS_SECRET_ACCESS_KEY="secret",
+            AWS_DEFAULT_REGION="ap-southeast-1",
         ):
             with patch("portolan_cli.sync.upload.S3Store") as mock_s3:
                 mock_s3.return_value = MagicMock()
@@ -1500,13 +1493,9 @@ class TestMultiCloudStoreSetup:
         """setup_store should work without region (uses AWS SDK defaults)."""
         from portolan_cli.sync.upload import setup_store
 
-        with patch.dict(
-            "os.environ",
-            {
-                "AWS_ACCESS_KEY_ID": "key",
-                "AWS_SECRET_ACCESS_KEY": "secret",
-            },
-            clear=True,
+        with cleared_environ(
+            AWS_ACCESS_KEY_ID="key",
+            AWS_SECRET_ACCESS_KEY="secret",
         ):
             with patch("portolan_cli.sync.upload.S3Store") as mock_s3:
                 mock_s3.return_value = MagicMock()


### PR DESCRIPTION
## Problem

Nightly Mutation Testing fails during baseline stats collection ([run 30146999503](https://github.com/portolan-sdi/portolan-cli/actions/runs/30146999503/job/89650713722)):

```
FAILED tests/unit/test_push.py::TestMultiCloudStoreSetup::test_setup_store_s3_from_environment - KeyError: 'MUTANT_UNDER_TEST'
```

mutmut instruments every mutated function with a trampoline that reads `os.environ["MUTANT_UNDER_TEST"]` on each call into `portolan_cli`. Three `setup_store` tests used `patch.dict("os.environ", {...}, clear=True)`, which wipes that variable before the code under test runs.

## Fix

Switch the three tests to `cleared_environ`, the helper already in `tests/conftest.py` for exactly this case. It preserves the one mutmut bookkeeping variable and behaves identically to a full clear outside mutation runs. No other `clear=True` environment patches remain in the suite.

## Verification

- `uv run pytest tests/unit/test_push.py` — 86 passed
- ruff check and format clean

Follows the same pattern as #666.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for AWS credentials and region environment settings.
  * Updated S3 setup tests to use consistent environment cleanup utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->