### PR TITLE
fix(ci): filter mutmut by dotted mutant names, not file paths (#612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,15 @@ jobs:
           if [ "${#FILES[@]}" -gt 0 ]; then
             # mutmut filters on mutant names (portolan_cli.foo.x_bar__mutmut_1),
             # not file paths, so translate. See scripts/mutant_globs.py and #612.
-            mapfile -t GLOBS < <(uv run python scripts/mutant_globs.py "${FILES[@]}")
+            # Via a file, not process substitution: the latter discards the
+            # translator's exit status, so a crash would leave GLOBS empty and
+            # the next step would read that as "nothing to mutate" — green.
+            if ! uv run python scripts/mutant_globs.py "${FILES[@]}" > globs.txt; then
+              echo "::error::scripts/mutant_globs.py failed to translate the" \
+                   "changed files; refusing to report an untested PR as passing."
+              exit 1
+            fi
+            mapfile -t GLOBS < globs.txt
           fi
           echo "Changed source files: ${#GLOBS[@]}"
           printf '  %s\n' "${GLOBS[@]}"
@@ -443,16 +451,28 @@ jobs:
             echo "No mutable source changes (only deletions?); nothing to run."
             exit 0
           fi
-          # Surviving mutants make mutmut exit non-zero; the floor check is
-          # authoritative, so don't fail on mutmut's own exit code.
-          uv run mutmut run "${GLOBS[@]}" 2>&1 | tee mutmut-run.log || true
+          # Surviving mutants do NOT fail mutmut — `_run` returns normally after
+          # printing results, so exit 0 covers both "all killed" and "some
+          # survived", and the floor check below is what grades the score. Any
+          # non-zero status is therefore a real failure (broken filter, clean-test
+          # failure, crash) and must fail the step. pipefail keeps `tee` from
+          # reporting success on mutmut's behalf; `|| STATUS=$?` keeps `set -e`
+          # from killing the step before the diagnostics below can run.
+          set -o pipefail
+          STATUS=0
+          uv run mutmut run "${GLOBS[@]}" 2>&1 | tee mutmut-run.log || STATUS=$?
           # A filter that matches nothing writes no stats, which --allow-empty
           # below would read as a pass — the #612 silent-green failure mode.
-          # Catch it here, where it is unambiguously a broken glob.
+          # Name it explicitly, since the generic status is unhelpful here.
           if grep -q "Filtered for specific mutants, but nothing matches" mutmut-run.log; then
             echo "::error::mutmut matched no mutants for the changed files — the" \
                  "glob format is wrong, not the code. See portolan-sdi/portolan-cli#612."
             exit 1
+          fi
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::mutmut run failed with status ${STATUS}; the mutation" \
+                 "gate cannot pass on an incomplete run. See portolan-sdi/portolan-cli#612."
+            exit "$STATUS"
           fi
 
       - name: Enforce mutation floor (changed files)
@@ -461,8 +481,12 @@ jobs:
           # writes no stats — a legitimate pass here (unlike the nightly sweep),
           # encoded by --allow-empty. The nightly full run stays the authoritative
           # broken-baseline gate.
-          uv run mutmut export-cicd-stats || true
+          # No `|| true`: a stats export that errors leaves no file, and the
+          # branch below would then wave the PR through untested (#612).
+          uv run mutmut export-cicd-stats
           if [ ! -f mutants/mutmut-cicd-stats.json ]; then
+            # Reachable only after a successful run, so the filter did match —
+            # these files genuinely contain no mutable code (constants, imports).
             echo "No mutants in changed files; nothing to score."
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,12 +413,17 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           # Files this PR added/modified under portolan_cli (deletions excluded —
-          # a deleted file has no mutants). Trailing * so mutmut fnmatches each
-          # file's mutant names (portolan_cli/foo.py:func__mutmut_1).
-          GLOBS=()
+          # a deleted file has no mutants).
+          FILES=()
           while IFS= read -r f; do
-            [ -n "$f" ] && GLOBS+=("${f}*")
+            [ -n "$f" ] && FILES+=("$f")
           done < <(git diff --name-only --diff-filter=d "$BASE_SHA" HEAD -- 'portolan_cli/**/*.py')
+          GLOBS=()
+          if [ "${#FILES[@]}" -gt 0 ]; then
+            # mutmut filters on mutant names (portolan_cli.foo.x_bar__mutmut_1),
+            # not file paths, so translate. See scripts/mutant_globs.py and #612.
+            mapfile -t GLOBS < <(uv run python scripts/mutant_globs.py "${FILES[@]}")
+          fi
           echo "Changed source files: ${#GLOBS[@]}"
           printf '  %s\n' "${GLOBS[@]}"
           {
@@ -440,7 +445,15 @@ jobs:
           fi
           # Surviving mutants make mutmut exit non-zero; the floor check is
           # authoritative, so don't fail on mutmut's own exit code.
-          uv run mutmut run "${GLOBS[@]}" || true
+          uv run mutmut run "${GLOBS[@]}" 2>&1 | tee mutmut-run.log || true
+          # A filter that matches nothing writes no stats, which --allow-empty
+          # below would read as a pass — the #612 silent-green failure mode.
+          # Catch it here, where it is unambiguously a broken glob.
+          if grep -q "Filtered for specific mutants, but nothing matches" mutmut-run.log; then
+            echo "::error::mutmut matched no mutants for the changed files — the" \
+                 "glob format is wrong, not the code. See portolan-sdi/portolan-cli#612."
+            exit 1
+          fi
 
       - name: Enforce mutation floor (changed files)
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,14 +52,15 @@ jobs:
           mapfile -t FILES < <(find portolan_cli -name '*.py' -type f | sort)
           DAY=$(( 10#$(date -u +%j) ))
           SHARD=$(( DAY % NUM_SHARDS ))
-          GLOBS=()
+          SHARD_FILES=()
           for i in "${!FILES[@]}"; do
             if (( i % NUM_SHARDS == SHARD )); then
-              # Trailing * so mutmut fnmatches this file's mutant names
-              # (e.g. portolan_cli/foo.py:func__mutmut_1).
-              GLOBS+=("${FILES[$i]}*")
+              SHARD_FILES+=("${FILES[$i]}")
             fi
           done
+          # mutmut filters on mutant names (portolan_cli.foo.x_bar__mutmut_1),
+          # not file paths, so translate. See scripts/mutant_globs.py and #612.
+          mapfile -t GLOBS < <(uv run python scripts/mutant_globs.py "${SHARD_FILES[@]}")
           echo "Shard ${SHARD} of ${NUM_SHARDS}: ${#GLOBS[@]} file(s)"
           printf '  %s\n' "${GLOBS[@]}"
           {
@@ -85,7 +86,12 @@ jobs:
             echo "No files in this shard; nothing to run."
             exit 0
           fi
-          uv run mutmut run "${GLOBS[@]}" || true
+          uv run mutmut run "${GLOBS[@]}" 2>&1 | tee mutmut-run.log || true
+          if grep -q "Filtered for specific mutants, but nothing matches" mutmut-run.log; then
+            echo "::error::mutmut matched no mutants for this shard's globs — the" \
+                 "glob format is wrong, not the code. See portolan-sdi/portolan-cli#612."
+            exit 1
+          fi
 
       - name: Enforce mutation floor
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,15 @@ jobs:
           done
           # mutmut filters on mutant names (portolan_cli.foo.x_bar__mutmut_1),
           # not file paths, so translate. See scripts/mutant_globs.py and #612.
-          mapfile -t GLOBS < <(uv run python scripts/mutant_globs.py "${SHARD_FILES[@]}")
+          # Via a file, not process substitution: the latter discards the
+          # translator's exit status, so a crash would leave GLOBS empty and the
+          # next step would skip the shard as "no files" — a silent green sweep.
+          if ! uv run python scripts/mutant_globs.py "${SHARD_FILES[@]}" > globs.txt; then
+            echo "::error::scripts/mutant_globs.py failed to translate this" \
+                 "shard's files; refusing to report an unmutated sweep as passing."
+            exit 1
+          fi
+          mapfile -t GLOBS < globs.txt
           echo "Shard ${SHARD} of ${NUM_SHARDS}: ${#GLOBS[@]} file(s)"
           printf '  %s\n' "${GLOBS[@]}"
           {
@@ -74,8 +82,9 @@ jobs:
           GLOBS_RAW: ${{ steps.shard.outputs.globs }}
         run: |
           # mutmut still generates every mutant (~1 min) then tests only the
-          # shard's. Surviving mutants make mutmut exit non-zero; the floor check
-          # is authoritative, so the job does not fail on mutmut's own exit code.
+          # shard's. Surviving mutants do NOT fail mutmut — it exits 0 and the
+          # floor check grades the score — so any non-zero status is a real
+          # failure and fails the sweep.
           mapfile -t RAW <<< "$GLOBS_RAW"
           GLOBS=()
           for g in "${RAW[@]}"; do [ -n "$g" ] && GLOBS+=("$g"); done
@@ -86,11 +95,21 @@ jobs:
             echo "No files in this shard; nothing to run."
             exit 0
           fi
-          uv run mutmut run "${GLOBS[@]}" 2>&1 | tee mutmut-run.log || true
+          # pipefail keeps `tee` from reporting success on mutmut's behalf;
+          # `|| STATUS=$?` keeps `set -e` from killing the step before the
+          # diagnostics below can run.
+          set -o pipefail
+          STATUS=0
+          uv run mutmut run "${GLOBS[@]}" 2>&1 | tee mutmut-run.log || STATUS=$?
           if grep -q "Filtered for specific mutants, but nothing matches" mutmut-run.log; then
             echo "::error::mutmut matched no mutants for this shard's globs — the" \
                  "glob format is wrong, not the code. See portolan-sdi/portolan-cli#612."
             exit 1
+          fi
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::mutmut run failed with status ${STATUS}; the sweep is" \
+                 "incomplete. See portolan-sdi/portolan-cli#612."
+            exit "$STATUS"
           fi
 
       - name: Enforce mutation floor

--- a/scripts/mutant_globs.py
+++ b/scripts/mutant_globs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Translate source paths into the mutant-name globs ``mutmut run`` filters on.
+
+``mutmut run`` takes mutant *names*, not file paths. A mutant name is the dotted
+module path plus the mangled function name mutmut generates::
+
+    portolan_cli/backends/iceberg/backend.py  ->  portolan_cli.backends.iceberg.backend.x_push__mutmut_1
+
+Both mutation jobs (the PR-scoped diff run and the nightly rotating shard) select
+work by file, so both need this translation. Passing a file path as the filter
+matches nothing: mutmut raises ``AssertionError: Filtered for specific mutants,
+but nothing matches`` and the run tests zero mutants. See
+portolan-sdi/portolan-cli#612.
+
+Mangled names all begin with ``x_`` or ``xǁ``, so the emitted pattern ends in
+``.x*``. That anchors the glob to one module — a bare ``package.*`` would also
+match every submodule beneath it and silently inflate a shard.
+
+Usage:
+    python scripts/mutant_globs.py portolan_cli/readme.py portolan_cli/sync/upload.py
+
+Exit codes: 0 = globs written to stdout, one per line; 1 = no paths given.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from pathlib import PurePosixPath
+
+# Every name mutmut mangles starts with one of these (function: ``x_name``,
+# method: ``xǁClassǁname``), so this suffix selects a module's mutants without
+# reaching into its submodules.
+_MANGLE_GLOB = "x*"
+
+
+def mutant_glob(path: str | PurePosixPath) -> str:
+    """Return the fnmatch pattern matching every mutant name in ``path``.
+
+    Mirrors ``mutmut.__main__.get_mutant_name``: drop the ``.py`` suffix, join
+    the parts with dots, strip a ``src.`` layout prefix, and collapse
+    ``__init__`` into its package.
+
+    Raises:
+        ValueError: ``path`` is not a ``.py`` source file.
+    """
+    pure = PurePosixPath(str(path).replace("\\", "/"))
+    if pure.suffix != ".py":
+        raise ValueError(f"not a Python source file: {path}")
+
+    module = ".".join(pure.with_suffix("").parts)
+    if module.startswith("src."):
+        module = module[len("src.") :]
+    # mutmut rewrites ``pkg.__init__.x_f`` to ``pkg.x_f``, so a package's
+    # ``__init__`` mutants live under the bare package name.
+    if module == "__init__":
+        raise ValueError(f"cannot derive a module name from: {path}")
+    if module.endswith(".__init__"):
+        module = module[: -len(".__init__")]
+
+    return f"{module}.{_MANGLE_GLOB}"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Print one mutant-name glob per source path given on the command line."""
+    paths = list(sys.argv[1:] if argv is None else argv)
+    if not paths:
+        print("error: no source paths given; nothing to mutate", file=sys.stderr)
+        return 1
+
+    for path in paths:
+        print(mutant_glob(path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -16,6 +16,15 @@ from pathlib import Path
 
 import pytest
 
+# mutmut refuses to import on Windows — ``mutmut/__main__.py`` prints "please use
+# the WSL" and calls ``sys.exit(1)`` at module scope. The contract tests below
+# import it to compare against its real mutant names, so they can only run where
+# mutation testing itself runs. See boxed/mutmut#397.
+requires_mutmut_import = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="mutmut exits at import on Windows (boxed/mutmut#397)",
+)
+
 
 # Add scripts directory to path for imports
 @pytest.fixture(autouse=True)
@@ -202,6 +211,7 @@ class TestMutantGlobs:
             mutant_glob("portolan_cli/data.json")
 
     @pytest.mark.unit
+    @requires_mutmut_import
     @pytest.mark.parametrize(
         "path",
         [
@@ -232,6 +242,7 @@ class TestMutantGlobs:
         assert fnmatch.fnmatch(name, mutant_glob(path))
 
     @pytest.mark.unit
+    @requires_mutmut_import
     def test_glob_excludes_sibling_modules_of_a_package(self) -> None:
         """A package glob must not swallow its submodules' mutants."""
         import fnmatch

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -159,6 +159,110 @@ See [this guide](docs/contributing.md) for details.
         assert len(result.warnings) == 1
 
 
+class TestMutantGlobs:
+    """Tests for mutant_globs.py (source path -> mutmut mutant-name pattern)."""
+
+    @pytest.mark.unit
+    def test_module_path_becomes_dotted_prefix(self) -> None:
+        """A source path maps to its dotted module name plus the mangle prefix."""
+        from mutant_globs import mutant_glob
+
+        assert (
+            mutant_glob("portolan_cli/backends/iceberg/backend.py")
+            == "portolan_cli.backends.iceberg.backend.x*"
+        )
+
+    @pytest.mark.unit
+    def test_package_init_collapses_into_package(self) -> None:
+        """mutmut strips ``.__init__.`` from mutant names, so the glob must too."""
+        from mutant_globs import mutant_glob
+
+        assert mutant_glob("portolan_cli/extract/__init__.py") == "portolan_cli.extract.x*"
+
+    @pytest.mark.unit
+    def test_top_level_init_collapses_to_bare_package(self) -> None:
+        """The root ``__init__.py`` mutates under the bare package name."""
+        from mutant_globs import mutant_glob
+
+        assert mutant_glob("portolan_cli/__init__.py") == "portolan_cli.x*"
+
+    @pytest.mark.unit
+    def test_src_prefix_is_stripped(self) -> None:
+        """mutmut strips a ``src.`` layout prefix from module names."""
+        from mutant_globs import mutant_glob
+
+        assert mutant_glob("src/portolan_cli/readme.py") == "portolan_cli.readme.x*"
+
+    @pytest.mark.unit
+    def test_non_python_path_is_rejected(self) -> None:
+        """Only ``.py`` sources have mutants; anything else is a caller bug."""
+        from mutant_globs import mutant_glob
+
+        with pytest.raises(ValueError):
+            mutant_glob("portolan_cli/data.json")
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "portolan_cli/readme.py",
+            "portolan_cli/extract/__init__.py",
+            "portolan_cli/__init__.py",
+            "portolan_cli/backends/iceberg/backend.py",
+        ],
+    )
+    @pytest.mark.parametrize(
+        "mangled",
+        ["x_convert__mutmut_1", "xǁBackendǁpush__mutmut_12"],
+    )
+    def test_glob_matches_real_mutmut_names(self, path: str, mangled: str) -> None:
+        """Contract test against mutmut itself: the glob matches names it emits.
+
+        This is the assertion that would have caught #612's shard bug — the
+        workflows globbed file paths (``portolan_cli/readme.py*``) while mutmut
+        names mutants by dotted module (``portolan_cli.readme.x_...``), so the
+        filter matched nothing and the run tested zero mutants.
+        """
+        import fnmatch
+
+        from mutant_globs import mutant_glob
+        from mutmut.__main__ import get_mutant_name
+
+        name = get_mutant_name(Path(path), mangled)
+        assert fnmatch.fnmatch(name, mutant_glob(path))
+
+    @pytest.mark.unit
+    def test_glob_excludes_sibling_modules_of_a_package(self) -> None:
+        """A package glob must not swallow its submodules' mutants."""
+        import fnmatch
+
+        from mutant_globs import mutant_glob
+        from mutmut.__main__ import get_mutant_name
+
+        package = mutant_glob("portolan_cli/extract/__init__.py")
+        submodule = get_mutant_name(
+            Path("portolan_cli/extract/common/converters/base.py"), "x_run__mutmut_1"
+        )
+        assert not fnmatch.fnmatch(submodule, package)
+
+    @pytest.mark.unit
+    def test_main_prints_one_glob_per_path(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The CLI shim emits one glob per argument for the workflow to consume."""
+        from mutant_globs import main
+
+        code = main(["portolan_cli/readme.py", "portolan_cli/extract/__init__.py"])
+        assert code == 0
+        assert capsys.readouterr().out == "portolan_cli.readme.x*\nportolan_cli.extract.x*\n"
+
+    @pytest.mark.unit
+    def test_main_rejects_empty_input(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """No paths means no globs, which would silently mutate nothing."""
+        from mutant_globs import main
+
+        assert main([]) == 1
+        assert "no source paths" in capsys.readouterr().err
+
+
 class TestMutationScore:
     """Tests for mutation_score.py (shared mutmut floor enforcement)."""
 


### PR DESCRIPTION
## What broke

`mutmut run` selects work by mutant name, and a mutant name is the dotted module path plus mutmut's mangled function name:

```
portolan_cli/backends/iceberg/backend.py
  -> portolan_cli.backends.iceberg.backend.x_push__mutmut_1
```

Both mutation jobs pick their work by file and passed the file path straight through as the filter (`portolan_cli/backends/iceberg/backend.py*`). That fnmatches nothing, so mutmut raised `AssertionError: Filtered for specific mutants, but nothing matches` and tested zero mutants.

The two jobs failed differently:

| Job | Behavior |
| --- | --- |
| `nightly.yml` | `\|\| true` swallowed the assertion, no stats written, floor step reported "no testable mutants" and failed loudly |
| `ci.yml` (PR-scoped) | Same assertion, but `--allow-empty` read the missing stats as "no mutable code in scope" and exited 0 |

So the PR gate has been green while mutating nothing, for as long as the file-path globs have been in place.

**#670 did not cause this.** Fixing the `MUTANT_UNDER_TEST` KeyError let the run reach the filter stage, where the pre-existing bug surfaced.

## The fix

`scripts/mutant_globs.py` translates a source path into the mutant-name glob, mirroring `mutmut.__main__.get_mutant_name`: drop `.py`, join parts with dots, strip a `src.` prefix, collapse `__init__` into its package. Both workflows call it.

The emitted pattern ends in `.x*`, not `.*`, because fnmatch's `*` crosses dots. `portolan_cli.extract.*` would also match `portolan_cli.extract.common.converters.base.x_...` and inflate a shard, breaking the nightly round-robin balance. Every mangled name starts with `x_` (function) or the method form, so `.x*` anchors to exactly one module.

Both workflows now grep the run log for the assertion string and fail hard on it. An unmatched filter is a broken glob, never a pass.

## Verification

- `mutmut run 'portolan_cli.readme.x*'` locally: generates mutants and reaches the stats phase, no assertion.
- Simulated the nightly shard selection under bash: shard 7 of 25 yields 6 well-formed globs.
- `test_glob_matches_real_mutmut_names` feeds real paths through mutmut's own `get_mutant_name` and asserts the generated glob matches the result. That is the assertion that would have caught this.
- Tests also cover the `src.` prefix, `__init__` collapsing, sibling-module exclusion, and the CLI. 36 passed in `tests/unit/test_scripts.py`.

Refs #612.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutation-testing checks to detect when file filters match no mutants, preventing false-positive successful runs.
  * Added more reliable handling of changed files, deleted files, and nightly test shards.

* **Tests**
  * Added coverage for converting Python source paths into mutation-test filters, including packages, initialization modules, invalid paths, and command-line behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->