### PR TITLE
fix(ci): gate the nightly sweep on per-shard mutation baselines (#612)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,10 @@ jobs:
   mutation:
     name: Mutation Testing
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Hash-assigned shards hold 2-12 files rather than a uniform 6, so the
+    # largest night runs roughly twice the mutants of the 6-file shard that took
+    # 20 minutes. 90 leaves headroom without letting a hung run burn an hour.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -43,21 +46,35 @@ jobs:
         run: |
           # Mutating all ~45k mutants can't finish in one nightly window, so each
           # night mutates a deterministic 1/NUM_SHARDS slice of the source files,
-          # round-robin over the sorted file list keyed by day-of-year. The whole
-          # tree is covered every NUM_SHARDS nights. Lower NUM_SHARDS to cover more
-          # per night — but only if a run still finishes within timeout-minutes.
+          # keyed by day-of-year. The whole tree is covered every NUM_SHARDS
+          # nights. Lower NUM_SHARDS to cover more per night — but only if a run
+          # still finishes within timeout-minutes, and re-measure the per-shard
+          # rates in .mutation-shards.json, which a new count invalidates.
           # (PR-scoped mutation of changed files is the fast, per-change gate; this
           # sweep is the slow, whole-codebase trend. See #612.)
           NUM_SHARDS=25
-          mapfile -t FILES < <(find portolan_cli -name '*.py' -type f | sort)
           DAY=$(( 10#$(date -u +%j) ))
           SHARD=$(( DAY % NUM_SHARDS ))
-          SHARD_FILES=()
-          for i in "${!FILES[@]}"; do
-            if (( i % NUM_SHARDS == SHARD )); then
-              SHARD_FILES+=("${FILES[$i]}")
-            fi
-          done
+          # Membership is a hash of each file's path, not its index in the sorted
+          # list: index assignment reshuffles every file's shard whenever one file
+          # is added, which would invalidate all recorded per-shard rates on any
+          # commit that adds a module. See scripts/shard_select.py.
+          if ! uv run python scripts/shard_select.py \
+                 --root portolan_cli --num-shards "$NUM_SHARDS" --shard "$SHARD" \
+                 > shard_files.txt; then
+            echo "::error::scripts/shard_select.py failed to select this shard;" \
+                 "refusing to report an unmutated sweep as passing."
+            exit 1
+          fi
+          mapfile -t SHARD_FILES < shard_files.txt
+          if [ "${#SHARD_FILES[@]}" -eq 0 ]; then
+            # ~300 files over 25 shards: an empty one means the selection broke,
+            # not that the tree thinned out. Fail rather than sweep nothing (#612).
+            echo "::error::Shard ${SHARD} of ${NUM_SHARDS} selected no files."
+            exit 1
+          fi
+          echo "shard=${SHARD}" >> "$GITHUB_OUTPUT"
+          echo "num_shards=${NUM_SHARDS}" >> "$GITHUB_OUTPUT"
           # mutmut filters on mutant names (portolan_cli.foo.x_bar__mutmut_1),
           # not file paths, so translate. See scripts/mutant_globs.py and #612.
           # Via a file, not process substitution: the latter discards the
@@ -113,16 +130,25 @@ jobs:
           fi
 
       - name: Enforce mutation floor
+        env:
+          SHARD: ${{ steps.shard.outputs.shard }}
+          NUM_SHARDS: ${{ steps.shard.outputs.num_shards }}
         run: |
-          # Export aggregates and enforce the .mutation-baseline floor. No
-          # --allow-empty here: on the full sweep, zero testable mutants means
+          # Export aggregates and enforce two floors: the repo-wide catastrophe
+          # floor in .mutation-baseline, and this shard's own recorded rate from
+          # .mutation-shards.json (a shard's rate depends on which modules land
+          # in it, so the repo-wide number alone either flaps or gates nothing).
+          # No --allow-empty here: on the full sweep, zero testable mutants means
           # mutation testing is broken (the #612 silent-green guard), not a pass.
           uv run mutmut export-cicd-stats
           uv run python scripts/mutation_score.py \
             --stats mutants/mutmut-cicd-stats.json \
             --baseline .mutation-baseline \
+            --shards .mutation-shards.json \
+            --shard "$SHARD" \
+            --num-shards "$NUM_SHARDS" \
             --summary "$GITHUB_STEP_SUMMARY" \
-            --label "nightly shard"
+            --label "nightly shard ${SHARD}"
 
       - name: Generate mutation report
         if: always()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,8 +68,9 @@ jobs:
           fi
           mapfile -t SHARD_FILES < shard_files.txt
           if [ "${#SHARD_FILES[@]}" -eq 0 ]; then
-            # ~300 files over 25 shards: an empty one means the selection broke,
-            # not that the tree thinned out. Fail rather than sweep nothing (#612).
+            # Backstop: shard_select.py already exits non-zero on an empty shard,
+            # so this only fires if the selector is swapped for one that doesn't.
+            # Either way, a night that mutates nothing is not a passing sweep (#612).
             echo "::error::Shard ${SHARD} of ${NUM_SHARDS} selected no files."
             exit 1
           fi

--- a/.mutation-baseline
+++ b/.mutation-baseline
@@ -1,10 +1,20 @@
-# Minimum mutation kill rate (%). Enforced by scripts/mutation_score.py for both
-# the PR-scoped job (ci.yml, changed files) and the nightly sweep (nightly.yml,
-# rotating shard). Rate = (killed + timeout + suspicious) / testable, where
-# testable excludes no_tests mutants.
+# Repo-wide minimum mutation kill rate (%). Enforced by scripts/mutation_score.py
+# for both the PR-scoped job (ci.yml, changed files) and the nightly sweep
+# (nightly.yml, rotating shard). Rate = (killed + timeout + suspicious) /
+# testable, where testable excludes no_tests mutants.
 #
-# PROVISIONAL: 60 predates any complete mutmut run (the baseline was broken until
-# #612). Re-measure from a real nightly-sweep kill rate and set this from it.
-# Ratchet UP as the suite matures; LOWERING it requires an explicit justification
-# in the PR that does so. First non-comment, non-blank line wins.
-60
+# This is the catastrophe floor: any run under it means the suite stopped
+# reacting to whole modules. Regression detection at shard granularity lives in
+# .mutation-shards.json, because a single 1/25 shard's rate depends on which
+# modules land in it (measured: 14% for sync.upload_progress, 95% for
+# backends.iceberg.config), so no single repo-wide number both catches
+# regressions and stays green.
+#
+# 30 is set from the first complete sweep (shard 8, 2026-07-27, run
+# 30244241948): 44.63% overall, with the weakest module cluster at 14%. It
+# replaces a provisional 60 that predated any complete run — the baseline was
+# broken until #612, so 60 had never been measured against anything.
+#
+# Ratchet UP as the suite matures; LOWERING it requires an explicit
+# justification in the PR that does so. First non-comment, non-blank line wins.
+30

--- a/.mutation-baseline
+++ b/.mutation-baseline
@@ -6,12 +6,12 @@
 # This is the catastrophe floor: any run under it means the suite stopped
 # reacting to whole modules. Regression detection at shard granularity lives in
 # .mutation-shards.json, because a single 1/25 shard's rate depends on which
-# modules land in it (measured: 14% for sync.upload_progress, 95% for
+# modules land in it (measured: 18% for sync.upload_progress, 95% for
 # backends.iceberg.config), so no single repo-wide number both catches
 # regressions and stays green.
 #
 # 30 is set from the first complete sweep (shard 8, 2026-07-27, run
-# 30244241948): 44.63% overall, with the weakest module cluster at 14%. It
+# 30244241948): 44.63% overall, with the weakest module at 18%. It
 # replaces a provisional 60 that predated any complete run — the baseline was
 # broken until #612, so 60 had never been measured against anything.
 #

--- a/.mutation-shards.json
+++ b/.mutation-shards.json
@@ -1,0 +1,22 @@
+{
+  "_comment": [
+    "Per-shard mutation kill rates for the nightly sweep (nightly.yml). A shard",
+    "must hold its own recorded rate, minus 'tolerance' percentage points, on top",
+    "of the repo-wide floor in .mutation-baseline. See scripts/mutation_score.py",
+    "and context/shared/documentation/ci.md.",
+    "",
+    "'shards' starts empty on purpose. Shard membership is a hash of each file's",
+    "path (scripts/shard_select.py), so the one rate measured before this file",
+    "existed (44.63%, shard 8 under index-based assignment, run 30244241948)",
+    "describes a different set of files and would gate the wrong thing. Each",
+    "sweep prints the line to add for the shard it just measured; paste it in.",
+    "",
+    "Raising a recorded rate after writing tests is the ratchet. LOWERING one",
+    "requires a justification in the PR that does so, same as .mutation-baseline.",
+    "Changing num_shards invalidates every rate: the tree is re-partitioned, so",
+    "the scorer refuses to run until they are re-measured."
+  ],
+  "num_shards": 25,
+  "tolerance": 3.0,
+  "shards": {}
+}

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -146,7 +146,7 @@ catastrophe floor every run must clear. `.mutation-shards.json` holds each
 shard's own measured kill rate, and the nightly sweep requires the shard to hold
 that rate minus a small tolerance for timeout jitter. Both are needed because a
 shard's rate depends on which modules land in it — the first complete sweep
-(shard 8, 2026-07-27) measured 44.63% overall, spanning 14% for
+(shard 8, 2026-07-27) measured 44.63% overall, spanning 18% for
 `sync.upload_progress` to 95% for `backends.iceberg.config`. One repo-wide
 number set high enough to catch a regression in the strong modules would red the
 nightly every time a weak shard came up; set low enough to stay green, it would

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -130,16 +130,34 @@ mutation testing runs at two scopes that share one scorer:
   against a real full run; promote it to required by adding it to `ci-success`
   needs.
 - **Nightly sweep** (`mutation` in `nightly.yml`, hard gate): mutates a
-  deterministic `1/NUM_SHARDS` slice of the source files, round-robin by
-  day-of-year, so the whole tree is covered every `NUM_SHARDS` nights (currently
-  25). Lower `NUM_SHARDS` to cover more per night, but only if a run still
-  finishes within `timeout-minutes`.
+  deterministic `1/NUM_SHARDS` slice of the source files, picked by day-of-year,
+  so the whole tree is covered every `NUM_SHARDS` nights (currently 25). Lower
+  `NUM_SHARDS` to cover more per night, but only if a run still finishes within
+  `timeout-minutes` — and re-measure the per-shard rates, which a new count
+  invalidates.
 
-**Threshold:** the floor lives in `.mutation-baseline` (a single integer). Both
-scopes read it via `scripts/mutation_score.py` rather than hardcoding it, so it
-ratchets up in a one-line, reviewable diff. The score counts `killed + timeout +
-suspicious` as killed over `killed_total + survived` testable (`no_tests`
-excluded). **Lowering the floor requires a justification in the PR that does so.**
+**Shard membership is a hash of each file's path** (`scripts/shard_select.py`),
+not its index in the sorted file list. Index assignment shifted every file's
+shard whenever one file was added, which would stale every recorded per-shard
+rate on any commit adding a module. Hashing moves only the added file.
+
+**Two floors.** `.mutation-baseline` holds one repo-wide integer: the
+catastrophe floor every run must clear. `.mutation-shards.json` holds each
+shard's own measured kill rate, and the nightly sweep requires the shard to hold
+that rate minus a small tolerance for timeout jitter. Both are needed because a
+shard's rate depends on which modules land in it — the first complete sweep
+(shard 8, 2026-07-27) measured 44.63% overall, spanning 14% for
+`sync.upload_progress` to 95% for `backends.iceberg.config`. One repo-wide
+number set high enough to catch a regression in the strong modules would red the
+nightly every time a weak shard came up; set low enough to stay green, it would
+gate nothing.
+
+A shard with no recorded rate is gated by the repo-wide floor alone, and the run
+prints the JSON line to paste into `.mutation-shards.json`. Recording it is what
+tightens the gate, so do it when a sweep surfaces one. The score counts
+`killed + timeout + suspicious` as killed over `killed_total + survived`
+testable (`no_tests` excluded). **Lowering either floor requires a justification
+in the PR that does so.**
 
 **Fails loud, never silent.** On the nightly sweep, zero testable mutants means
 mutation testing is broken, not passing — the scorer hard-fails (it used to
@@ -153,7 +171,8 @@ instruments code with a trampoline that reads `os.environ["MUTANT_UNDER_TEST"]`.
 Two consequences the tests must respect: a cleared environment must preserve that
 var (use `cleared_environ()` from `tests/conftest.py`, not
 `patch.dict(..., clear=True)`), and files read by repo-root path (e.g.
-`spec/schema/`) must be listed in `[tool.mutmut] also_copy`. Parallel conversion
+`spec/schema/`, `.mutation-shards.json`) must be listed in
+`[tool.mutmut] also_copy`. Parallel conversion
 falls back to serial when a process pool can't start in the sandbox
 (`convert.py`). (The geoparquet-io #565 CWD guard was evaluated and is **not**
 needed: `isolated_filesystem`/`chdir` tests do not crash the stats phase.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,13 @@ pytest_add_cli_args_test_selection = ["tests/"]
 # suite reads by repo-root path (tests/spec_compliance/conftest.py resolves
 # spec/schema/, test_extensions_doc_parity.py reads spec/extensions.md). Without
 # it the baseline errors with FileNotFoundError on mutants/spec/... (172 KiB).
-also_copy = ["scripts/", ".pip-audit-ignores", ".mutation-baseline", "spec/"]
+also_copy = [
+  "scripts/",
+  ".pip-audit-ignores",
+  ".mutation-baseline",
+  ".mutation-shards.json",
+  "spec/",
+]
 # The stats/baseline run must mirror the fast CI test job, not the whole suite:
 # - --no-cov: pyproject's addopts inject --cov, whose instrumentation conflicts
 #   with mutmut's; without this the stats phase is unreliable.

--- a/scripts/mutation_score.py
+++ b/scripts/mutation_score.py
@@ -21,7 +21,7 @@ Two floors:
     ``.mutation-baseline`` holds one repo-wide floor, the catastrophe guard every
     run must clear. The nightly sweep scores a rotating ``1/NUM_SHARDS`` slice
     whose kill rate depends on which modules land in it — measured shard rates
-    span 14% to 95% — so one repo-wide number either flaps or gates nothing.
+    span 18% to 95% — so one repo-wide number either flaps or gates nothing.
     ``--shard`` adds the per-shard floor recorded in ``.mutation-shards.json``:
     a shard must hold its own recorded rate (minus a tolerance for timeout
     jitter), which catches a regression the repo-wide floor would sleep through.

--- a/scripts/mutation_score.py
+++ b/scripts/mutation_score.py
@@ -17,10 +17,22 @@ are excluded from the rate rather than counted as failures. ``timeout`` and
 killed. Zero testable mutants means mutmut produced or parsed nothing — that is
 mutation testing being broken, never a pass.
 
+Two floors:
+    ``.mutation-baseline`` holds one repo-wide floor, the catastrophe guard every
+    run must clear. The nightly sweep scores a rotating ``1/NUM_SHARDS`` slice
+    whose kill rate depends on which modules land in it — measured shard rates
+    span 14% to 95% — so one repo-wide number either flaps or gates nothing.
+    ``--shard`` adds the per-shard floor recorded in ``.mutation-shards.json``:
+    a shard must hold its own recorded rate (minus a tolerance for timeout
+    jitter), which catches a regression the repo-wide floor would sleep through.
+    A shard with no recorded rate yet is gated by the repo-wide floor alone, and
+    the run prints the line to record. See portolan-sdi/portolan-cli#612.
+
 Usage:
     python scripts/mutation_score.py \\
         --stats mutants/mutmut-cicd-stats.json \\
         --baseline .mutation-baseline \\
+        [--shards .mutation-shards.json --shard 8 --num-shards 25] \\
         [--summary "$GITHUB_STEP_SUMMARY"] [--label "changed files"]
 
 Exit codes: 0 = at or above floor; 1 = below floor, zero testable, or bad input.
@@ -54,6 +66,79 @@ def read_floor(text: str) -> int:
 
 
 @dataclass(frozen=True)
+class ShardBaselines:
+    """Per-shard kill rates recorded from earlier sweeps.
+
+    Attributes:
+        num_shards: Shard count the rates were measured under. Changing
+            ``NUM_SHARDS`` re-partitions the tree, so rates measured under a
+            different count describe different file sets and cannot be compared.
+        tolerance: Percentage points a shard may fall below its recorded rate
+            without failing. Absorbs run-to-run jitter — a mutant that times out
+            on a slow runner but is killed on a fast one moves the rate slightly.
+        rates: Shard index (as a string key, since JSON has no integer keys)
+            mapped to its recorded kill rate.
+    """
+
+    num_shards: int
+    tolerance: float
+    rates: Mapping[str, float]
+
+    def floor_for(self, shard: int, repo_floor: float) -> tuple[float, str]:
+        """Return the floor for ``shard`` and a human-readable source for it.
+
+        An unrecorded shard falls back to ``repo_floor``. A recorded shard uses
+        whichever is higher: its own rate minus the tolerance, or ``repo_floor``.
+        Taking the maximum keeps a shard recorded below the repo floor (measured
+        before the floor rose) from quietly weakening the gate.
+        """
+        recorded = self.rates.get(str(shard))
+        if recorded is None:
+            return repo_floor, ".mutation-baseline (no recorded rate for this shard)"
+        adjusted = round(recorded - self.tolerance, 2)
+        if repo_floor >= adjusted:
+            return repo_floor, f".mutation-baseline (above shard {shard}'s recorded rate)"
+        return adjusted, f"shard {shard}'s recorded {recorded}% less {self.tolerance}pp tolerance"
+
+
+def read_shard_baselines(text: str) -> ShardBaselines:
+    """Parse ``.mutation-shards.json``.
+
+    Raises:
+        ValueError: The document is malformed, or a rate is not a number.
+    """
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError("expected a JSON object at the top level")
+
+    try:
+        num_shards = int(data["num_shards"])
+        tolerance = float(data["tolerance"])
+        raw_rates = data["shards"]
+    except KeyError as exc:
+        raise ValueError(f"missing required key: {exc}") from exc
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"num_shards and tolerance must be numbers: {exc}") from exc
+
+    if not isinstance(raw_rates, dict):
+        raise ValueError("'shards' must be an object keyed by shard index")
+
+    rates: dict[str, float] = {}
+    for key, entry in raw_rates.items():
+        if not isinstance(entry, dict) or "kill_rate" not in entry:
+            raise ValueError(f"shard {key}: expected an object with a 'kill_rate'")
+        try:
+            rates[str(key)] = float(entry["kill_rate"])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"shard {key}: kill_rate must be a number: {exc}") from exc
+
+    return ShardBaselines(num_shards=num_shards, tolerance=tolerance, rates=rates)
+
+
+@dataclass(frozen=True)
 class Score:
     """Outcome of scoring one mutmut run against a floor."""
 
@@ -62,7 +147,7 @@ class Score:
     no_tests: int
     timeout: int
     suspicious: int
-    floor: int
+    floor: float
 
     @property
     def killed_total(self) -> int:
@@ -88,7 +173,7 @@ class Score:
         return rate is not None and rate >= self.floor
 
 
-def evaluate(stats: Mapping[str, int], floor: int) -> Score:
+def evaluate(stats: Mapping[str, int], floor: float) -> Score:
     """Build a :class:`Score` from a stats mapping and floor."""
     return Score(
         killed=int(stats.get("killed", 0)),
@@ -100,17 +185,18 @@ def evaluate(stats: Mapping[str, int], floor: int) -> Score:
     )
 
 
-def render_summary(score: Score, label: str) -> str:
+def render_summary(score: Score, label: str, floor_source: str = "") -> str:
     """Render a GitHub-flavored Markdown table for the step summary."""
     rate = "n/a" if score.kill_rate is None else f"{score.kill_rate}%"
     scope = f" ({label})" if label else ""
+    source = f" — {floor_source}" if floor_source else ""
     lines = [
         f"## Mutation Testing{scope}",
         "",
         "| Metric | Value |",
         "| --- | --- |",
         f"| Kill rate | {rate} |",
-        f"| Floor | {score.floor}% |",
+        f"| Floor | {score.floor}%{source} |",
         f"| Killed | {score.killed_total} |",
         f"| Survived | {score.survived} |",
         f"| Testable | {score.testable} |",
@@ -126,6 +212,13 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--baseline", required=True, type=Path, help=".mutation-baseline")
     parser.add_argument("--summary", type=Path, help="GitHub step-summary file to append")
     parser.add_argument("--label", default="", help="scope label, e.g. 'changed files'")
+    parser.add_argument("--shards", type=Path, help=".mutation-shards.json (with --shard)")
+    parser.add_argument("--shard", type=int, help="shard index being scored")
+    parser.add_argument(
+        "--num-shards",
+        type=int,
+        help="shard count this run used; must match the recorded baselines",
+    )
     parser.add_argument(
         "--allow-empty",
         action="store_true",
@@ -154,9 +247,30 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"::error::Invalid .mutation-baseline floor: {exc}")
         return 1
 
+    floor_source = ".mutation-baseline"
+    baselines: ShardBaselines | None = None
+    if args.shard is not None:
+        if args.shards is None or args.num_shards is None:
+            print("::error::--shard requires both --shards and --num-shards.")
+            return 1
+        try:
+            baselines = read_shard_baselines(args.shards.read_text())
+        except (OSError, ValueError) as exc:
+            print(f"::error::Invalid shard baselines {args.shards}: {exc}")
+            return 1
+        if baselines.num_shards != args.num_shards:
+            print(
+                f"::error::{args.shards} records rates for {baselines.num_shards} "
+                f"shards but this run used {args.num_shards}. Changing the shard "
+                "count re-partitions the tree, so the recorded rates describe "
+                "different files; re-measure before enforcing them."
+            )
+            return 1
+        floor, floor_source = baselines.floor_for(args.shard, floor)
+
     score = evaluate(stats, floor)
 
-    summary = render_summary(score, args.label)
+    summary = render_summary(score, args.label, floor_source)
     if args.summary is not None:
         with args.summary.open("a", encoding="utf-8") as handle:
             handle.write(summary + "\n")
@@ -175,11 +289,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not score.ok:
         print(
             f"::error::Mutation kill rate {score.kill_rate}% is below the "
-            f"{score.floor}% floor from .mutation-baseline."
+            f"{score.floor}% floor — {floor_source}."
         )
         return 1
 
     print(f"Mutation kill rate {score.kill_rate}% meets the {score.floor}% floor.")
+    if baselines is not None and str(args.shard) not in baselines.rates:
+        # Ratchet prompt: until this shard has a recorded rate, only the
+        # repo-wide floor guards it, and a regression inside the gap between the
+        # two goes unnoticed.
+        print(
+            f"::notice::Shard {args.shard} has no recorded rate. Add "
+            f'"{args.shard}": {{"kill_rate": {score.kill_rate}, "measured": '
+            f'"<date>", "run": "<run id>"}} to {args.shards} to gate it against '
+            "this sweep."
+        )
     return 0
 
 

--- a/scripts/shard_select.py
+++ b/scripts/shard_select.py
@@ -26,9 +26,9 @@ absolute path would dot the filesystem prefix into a glob matching no mutant.
 Usage:
     python scripts/shard_select.py --root portolan_cli --num-shards 25 --shard 8
 
-Exit codes: 0 = selected paths written to stdout, one per line (possibly none);
-1 = the root holds no Python files at all, which means a broken checkout rather
-than an empty shard.
+Exit codes: 0 = selected paths written to stdout, one per line; 1 = nothing to
+mutate, whether the root holds no Python files (a broken checkout) or none of
+them hashed into this shard. Neither is a covered sweep, so neither exits 0.
 """
 
 from __future__ import annotations
@@ -113,6 +113,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         selected = select(keys, args.num_shards, args.shard)
     except ValueError as exc:
         print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if not selected:
+        # The tree has files but none hashed here. Printing nothing and exiting 0
+        # would hand the sweep an empty glob list and read as a covered night.
+        print(
+            f"::error::Shard {args.shard} of {args.num_shards} selected none of "
+            f"the {len(keys)} files under {args.root}. Mutating nothing is not a "
+            "passing sweep; lower --num-shards. See portolan-sdi/portolan-cli#612.",
+            file=sys.stderr,
+        )
         return 1
 
     for key in selected:

--- a/scripts/shard_select.py
+++ b/scripts/shard_select.py
@@ -11,11 +11,17 @@ is added or removed, which makes a recorded per-shard kill rate
 (``.mutation-shards.json``) meaningless the moment the tree changes. Hashing
 moves only the added or removed file. See portolan-sdi/portolan-cli#612.
 
-Assignment is BLAKE2b of the POSIX path modulo the shard count: stable across
-runs, machines, and Python versions (unlike ``hash()``, which is salted per
-process). A cryptographic digest rather than CRC-32 because these paths share
-long prefixes — ``portolan_cli/extract/...`` — and CRC-32's weak avalanche
-clustered them, leaving one shard with 17 files and another with 1.
+Assignment is BLAKE2b of the path under the package directory, modulo the shard
+count: stable across runs, machines, and Python versions (unlike ``hash()``,
+which is salted per process). A cryptographic digest rather than CRC-32 because
+these paths share long prefixes — ``portolan_cli/extract/...`` — and CRC-32's
+weak avalanche clustered them, leaving one shard with 17 files and another with
+1. The key drops everything above the package, so where the checkout lives
+cannot change which shard a file belongs to.
+
+Paths are printed relative to the package for the same reason: they feed
+``scripts/mutant_globs.py``, which dots a path into a module name, and an
+absolute path would dot the filesystem prefix into a glob matching no mutant.
 
 Usage:
     python scripts/shard_select.py --root portolan_cli --num-shards 25 --shard 8
@@ -51,6 +57,19 @@ def shard_of(path: str | PurePosixPath, num_shards: int) -> int:
     return int.from_bytes(digest, "big") % num_shards
 
 
+def shard_key(root: Path, path: Path) -> str:
+    """Return the hashed key for ``path``: its location under ``root``'s name.
+
+    The key must not vary with how the caller spelled ``--root``. Hashing the
+    path as walked made assignment depend on the working directory, so an
+    absolute root (a tmp dir, a differently-checked-out CI runner) shuffled every
+    file into a different shard and voided the recorded per-shard baselines.
+    ``portolan_cli/sync/upload.py`` is the key whether the sweep ran from the
+    repo root or anywhere else.
+    """
+    return f"{root.name}/{path.relative_to(root).as_posix()}"
+
+
 def select(paths: Sequence[str], num_shards: int, shard: int) -> list[str]:
     """Return the subset of ``paths`` belonging to ``shard``, sorted.
 
@@ -77,8 +96,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     """CLI entry point. Returns the process exit code."""
     args = _parse_args(argv)
 
-    paths = [p.as_posix() for p in sorted(args.root.rglob("*.py"))]
-    if not paths:
+    # Emit the root-relative key, not the path as walked. The caller feeds these
+    # to mutant_globs.py, which turns a path into a dotted module name; an
+    # absolute path would dot the whole filesystem prefix into the glob and match
+    # no mutant at all.
+    keys = [shard_key(args.root, p) for p in sorted(args.root.rglob("*.py"))]
+    if not keys:
         print(
             f"::error::No Python files under {args.root} — refusing to report an "
             "empty sweep as a covered shard. See portolan-sdi/portolan-cli#612.",
@@ -87,13 +110,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
-        selected = select(paths, args.num_shards, args.shard)
+        selected = select(keys, args.num_shards, args.shard)
     except ValueError as exc:
         print(f"::error::{exc}", file=sys.stderr)
         return 1
 
-    for path in selected:
-        print(path)
+    for key in selected:
+        print(key)
     return 0
 
 

--- a/scripts/shard_select.py
+++ b/scripts/shard_select.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Select one night's slice of source files for the rotating mutation sweep.
+
+The full tree generates ~45k mutants, far more than one nightly window can test,
+so each night mutates ``1/NUM_SHARDS`` of the files and the whole tree is covered
+every ``NUM_SHARDS`` nights.
+
+Files are assigned to a shard by a hash of their path, not by their index in the
+sorted file list. Index assignment reshuffles every file's shard whenever a file
+is added or removed, which makes a recorded per-shard kill rate
+(``.mutation-shards.json``) meaningless the moment the tree changes. Hashing
+moves only the added or removed file. See portolan-sdi/portolan-cli#612.
+
+Assignment is BLAKE2b of the POSIX path modulo the shard count: stable across
+runs, machines, and Python versions (unlike ``hash()``, which is salted per
+process). A cryptographic digest rather than CRC-32 because these paths share
+long prefixes — ``portolan_cli/extract/...`` — and CRC-32's weak avalanche
+clustered them, leaving one shard with 17 files and another with 1.
+
+Usage:
+    python scripts/shard_select.py --root portolan_cli --num-shards 25 --shard 8
+
+Exit codes: 0 = selected paths written to stdout, one per line (possibly none);
+1 = the root holds no Python files at all, which means a broken checkout rather
+than an empty shard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from hashlib import blake2b
+from pathlib import Path, PurePosixPath
+
+
+def shard_of(path: str | PurePosixPath, num_shards: int) -> int:
+    """Return the shard index owning ``path``.
+
+    Args:
+        path: Source path, compared as POSIX text so Windows and Linux agree.
+        num_shards: Total number of shards; must be positive.
+
+    Raises:
+        ValueError: ``num_shards`` is not positive.
+    """
+    if num_shards <= 0:
+        raise ValueError(f"num_shards must be positive, got {num_shards}")
+    posix = str(path).replace("\\", "/")
+    digest = blake2b(posix.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, "big") % num_shards
+
+
+def select(paths: Sequence[str], num_shards: int, shard: int) -> list[str]:
+    """Return the subset of ``paths`` belonging to ``shard``, sorted.
+
+    Raises:
+        ValueError: ``shard`` is outside ``range(num_shards)``, or ``num_shards``
+            is not positive.
+    """
+    if num_shards <= 0:
+        raise ValueError(f"num_shards must be positive, got {num_shards}")
+    if not 0 <= shard < num_shards:
+        raise ValueError(f"shard {shard} is outside 0..{num_shards - 1}")
+    return sorted(p for p in paths if shard_of(p, num_shards) == shard)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Select a mutation-sweep shard.")
+    parser.add_argument("--root", required=True, type=Path, help="package directory to walk")
+    parser.add_argument("--num-shards", required=True, type=int, help="total shard count")
+    parser.add_argument("--shard", required=True, type=int, help="shard index to emit")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code."""
+    args = _parse_args(argv)
+
+    paths = [p.as_posix() for p in sorted(args.root.rglob("*.py"))]
+    if not paths:
+        print(
+            f"::error::No Python files under {args.root} — refusing to report an "
+            "empty sweep as a covered shard. See portolan-sdi/portolan-cli#612.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        selected = select(paths, args.num_shards, args.shard)
+    except ValueError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    for path in selected:
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -542,18 +542,45 @@ class TestShardSelect:
     def test_main_emits_only_the_requested_shard(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """End-to-end: main() prints the shard's files, one per line."""
+        """End-to-end: the shards partition the tree, printed root-relative."""
         from shard_select import main, shard_of
 
         root = tmp_path / "pkg"
         root.mkdir()
-        for i in range(30):
-            (root / f"mod_{i}.py").write_text("x = 1\n")
+        expected = sorted(f"pkg/mod_{i}.py" for i in range(30))
+        for name in expected:
+            (root / Path(name).name).write_text("x = 1\n")
 
-        assert main(["--root", str(root), "--num-shards", "5", "--shard", "2"]) == 0
-        printed = [line for line in capsys.readouterr().out.splitlines() if line]
-        assert printed  # 30 files over 5 shards leaves none empty in practice
-        assert all(shard_of(p, 5) == 2 for p in printed)
+        emitted: list[str] = []
+        for shard in range(5):
+            assert main(["--root", str(root), "--num-shards", "5", "--shard", str(shard)]) == 0
+            printed = [line for line in capsys.readouterr().out.splitlines() if line]
+            # Paths come out relative to the package, never carrying the tmp_path
+            # prefix: mutant_globs.py dots them into module names.
+            assert all(shard_of(p, 5) == shard for p in printed)
+            emitted.extend(printed)
+
+        assert sorted(emitted) == expected  # no file skipped, none mutated twice
+
+    @pytest.mark.integration  # Walks a tmp_path tree
+    def test_assignment_ignores_where_the_package_lives(self, tmp_path: Path) -> None:
+        """The regression macOS CI caught: an absolute root reshuffled the shards.
+
+        Hashing the path as walked made membership depend on the working
+        directory, so the same file landed in a different shard when the sweep
+        ran from a tmp dir — voiding every recorded per-shard baseline.
+        """
+        from shard_select import shard_key
+
+        root = tmp_path / "portolan_cli"
+        (root / "sync").mkdir(parents=True)
+        absolute = root / "sync" / "upload.py"
+        absolute.write_text("x = 1\n")
+
+        assert shard_key(root, absolute) == "portolan_cli/sync/upload.py"
+        assert shard_key(Path("portolan_cli"), Path("portolan_cli/sync/upload.py")) == (
+            "portolan_cli/sync/upload.py"
+        )
 
     @pytest.mark.integration  # Walks a tmp_path tree
     def test_main_fails_when_root_has_no_sources(self, tmp_path: Path) -> None:

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -37,6 +37,10 @@ def real_mutant_name(path: str, mangled: str) -> str:
     contract tests below therefore passed or failed on file ordering alone —
     green under xdist's distribution, red in a single-process run. A fresh
     interpreter has no start method set, so the answer is order-independent.
+
+    Callers are integration tests, not unit tests: each call spawns an
+    interpreter and imports mutmut, which costs about half a second against the
+    100ms unit budget.
     """
     source = (
         "from pathlib import Path;"
@@ -48,6 +52,9 @@ def real_mutant_name(path: str, mangled: str) -> str:
         capture_output=True,
         text=True,
         check=True,
+        # mutmut's import runs module-scope setup; a wedged one would otherwise
+        # hang the job until the whole workflow times out.
+        timeout=120,
     )
     return result.stdout.strip()
 
@@ -236,7 +243,7 @@ class TestMutantGlobs:
         with pytest.raises(ValueError):
             mutant_glob("portolan_cli/data.json")
 
-    @pytest.mark.unit
+    @pytest.mark.integration  # Spawns an interpreter per call to import mutmut
     @requires_mutmut_import
     @pytest.mark.parametrize(
         "path",
@@ -266,7 +273,7 @@ class TestMutantGlobs:
         name = real_mutant_name(path, mangled)
         assert fnmatch.fnmatch(name, mutant_glob(path))
 
-    @pytest.mark.unit
+    @pytest.mark.integration  # Spawns an interpreter to import mutmut
     @requires_mutmut_import
     def test_glob_excludes_sibling_modules_of_a_package(self) -> None:
         """A package glob must not swallow its submodules' mutants."""
@@ -591,6 +598,32 @@ class TestShardSelect:
         empty.mkdir()
 
         assert main(["--root", str(empty), "--num-shards", "5", "--shard", "0"]) == 1
+
+    @pytest.mark.integration  # Walks a tmp_path tree
+    def test_main_fails_when_a_shard_draws_no_files(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A populated tree can still leave a shard empty; that is not a sweep.
+
+        Exiting 0 with no output would hand the workflow an empty glob list, and
+        a night that mutates nothing must not read as a night that found nothing
+        wrong (#612).
+        """
+        from shard_select import main, shard_of
+
+        root = tmp_path / "pkg"
+        root.mkdir()
+        names = [f"mod_{i}.py" for i in range(3)]
+        for name in names:
+            (root / name).write_text("x = 1\n")
+
+        occupied = {shard_of(f"pkg/{name}", 8) for name in names}
+        starved = next(s for s in range(8) if s not in occupied)
+
+        assert main(["--root", str(root), "--num-shards", "8", "--shard", str(starved)]) == 1
+        captured = capsys.readouterr()
+        assert captured.out == ""  # nothing for the workflow to mistake for work
+        assert "selected none of the 3 files" in captured.err
 
 
 class TestShardBaselines:

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -10,6 +10,7 @@ These tests verify that the scripts in scripts/ work correctly:
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -18,12 +19,37 @@ import pytest
 
 # mutmut refuses to import on Windows — ``mutmut/__main__.py`` prints "please use
 # the WSL" and calls ``sys.exit(1)`` at module scope. The contract tests below
-# import it to compare against its real mutant names, so they can only run where
-# mutation testing itself runs. See boxed/mutmut#397.
+# compare against its real mutant names, so they can only run where mutation
+# testing itself runs. See boxed/mutmut#397.
 requires_mutmut_import = pytest.mark.skipif(
     sys.platform == "win32",
     reason="mutmut exits at import on Windows (boxed/mutmut#397)",
 )
+
+
+def real_mutant_name(path: str, mangled: str) -> str:
+    """Return ``mutmut``'s own mutant name for ``path`` and ``mangled``.
+
+    Computed in a subprocess because importing ``mutmut.__main__`` calls
+    ``multiprocessing.set_start_method('fork')`` at module scope, which raises
+    ``RuntimeError: context has already been set`` if any earlier test in the
+    session started a process pool (``test_convert.py`` does). In-process the
+    contract tests below therefore passed or failed on file ordering alone —
+    green under xdist's distribution, red in a single-process run. A fresh
+    interpreter has no start method set, so the answer is order-independent.
+    """
+    source = (
+        "from pathlib import Path;"
+        "from mutmut.__main__ import get_mutant_name;"
+        f"print(get_mutant_name(Path({path!r}), {mangled!r}))"
+    )
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
 
 
 # Add scripts directory to path for imports
@@ -236,9 +262,8 @@ class TestMutantGlobs:
         import fnmatch
 
         from mutant_globs import mutant_glob
-        from mutmut.__main__ import get_mutant_name
 
-        name = get_mutant_name(Path(path), mangled)
+        name = real_mutant_name(path, mangled)
         assert fnmatch.fnmatch(name, mutant_glob(path))
 
     @pytest.mark.unit
@@ -248,11 +273,10 @@ class TestMutantGlobs:
         import fnmatch
 
         from mutant_globs import mutant_glob
-        from mutmut.__main__ import get_mutant_name
 
         package = mutant_glob("portolan_cli/extract/__init__.py")
-        submodule = get_mutant_name(
-            Path("portolan_cli/extract/common/converters/base.py"), "x_run__mutmut_1"
+        submodule = real_mutant_name(
+            "portolan_cli/extract/common/converters/base.py", "x_run__mutmut_1"
         )
         assert not fnmatch.fnmatch(submodule, package)
 
@@ -439,3 +463,289 @@ class TestMutationScore:
         written = summary.read_text()
         assert "changed files" in written
         assert "80" in written  # kill rate
+
+
+class TestShardSelect:
+    """Tests for shard_select.py (which files the nightly sweep mutates)."""
+
+    @pytest.mark.unit
+    def test_assignment_is_stable_across_calls(self) -> None:
+        """The same path always lands in the same shard — no per-process salt."""
+        from shard_select import shard_of
+
+        first = shard_of("portolan_cli/sync/upload_progress.py", 25)
+        assert first == shard_of("portolan_cli/sync/upload_progress.py", 25)
+
+    @pytest.mark.unit
+    def test_windows_and_posix_paths_agree(self) -> None:
+        """Separator style must not change a file's shard."""
+        from shard_select import shard_of
+
+        assert shard_of("portolan_cli\\sync\\upload.py", 25) == shard_of(
+            "portolan_cli/sync/upload.py", 25
+        )
+
+    @pytest.mark.unit
+    def test_shard_is_within_range(self) -> None:
+        """Every path lands in 0..num_shards-1."""
+        from shard_select import shard_of
+
+        paths = [f"portolan_cli/mod_{i}.py" for i in range(200)]
+        assert all(0 <= shard_of(p, 25) < 25 for p in paths)
+
+    @pytest.mark.unit
+    def test_adding_a_file_leaves_other_assignments_alone(self) -> None:
+        """The regression that per-shard baselines depend on.
+
+        Index-based round-robin reshuffled every file's shard whenever a file was
+        added, so a recorded per-shard kill rate went stale on any commit adding
+        a module. Hash assignment moves only the new file.
+        """
+        from shard_select import select
+
+        before = [f"portolan_cli/mod_{i}.py" for i in range(50)]
+        after = sorted([*before, "portolan_cli/aaa_new_module.py"])
+
+        for shard in range(25):
+            was = set(select(before, 25, shard))
+            now = set(select(after, 25, shard))
+            assert was <= now
+            assert now - was <= {"portolan_cli/aaa_new_module.py"}
+
+    @pytest.mark.unit
+    def test_shards_partition_the_file_list(self) -> None:
+        """Every file lands in exactly one shard: no gaps, no double-mutating."""
+        from shard_select import select
+
+        paths = [f"portolan_cli/mod_{i}.py" for i in range(200)]
+        selected = [p for shard in range(25) for p in select(paths, 25, shard)]
+        assert sorted(selected) == sorted(paths)
+        assert len(selected) == len(set(selected))
+
+    @pytest.mark.unit
+    def test_select_rejects_out_of_range_shard(self) -> None:
+        """A shard index outside the count is a caller bug, not an empty result."""
+        from shard_select import select
+
+        with pytest.raises(ValueError):
+            select(["portolan_cli/a.py"], 25, 25)
+
+    @pytest.mark.unit
+    def test_rejects_non_positive_shard_count(self) -> None:
+        """Zero shards would divide by zero; reject it at the edge."""
+        from shard_select import shard_of
+
+        with pytest.raises(ValueError):
+            shard_of("portolan_cli/a.py", 0)
+
+    @pytest.mark.integration  # Walks a tmp_path tree
+    def test_main_emits_only_the_requested_shard(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """End-to-end: main() prints the shard's files, one per line."""
+        from shard_select import main, shard_of
+
+        root = tmp_path / "pkg"
+        root.mkdir()
+        for i in range(30):
+            (root / f"mod_{i}.py").write_text("x = 1\n")
+
+        assert main(["--root", str(root), "--num-shards", "5", "--shard", "2"]) == 0
+        printed = [line for line in capsys.readouterr().out.splitlines() if line]
+        assert printed  # 30 files over 5 shards leaves none empty in practice
+        assert all(shard_of(p, 5) == 2 for p in printed)
+
+    @pytest.mark.integration  # Walks a tmp_path tree
+    def test_main_fails_when_root_has_no_sources(self, tmp_path: Path) -> None:
+        """An empty package means a broken checkout, never a covered sweep (#612)."""
+        from shard_select import main
+
+        empty = tmp_path / "pkg"
+        empty.mkdir()
+
+        assert main(["--root", str(empty), "--num-shards", "5", "--shard", "0"]) == 1
+
+
+class TestShardBaselines:
+    """Tests for the per-shard floors in .mutation-shards.json."""
+
+    @staticmethod
+    def _shards_doc(rates: dict[str, float], *, num_shards: int = 25) -> str:
+        import json
+
+        return json.dumps(
+            {
+                "num_shards": num_shards,
+                "tolerance": 3.0,
+                "shards": {k: {"kill_rate": v} for k, v in rates.items()},
+            }
+        )
+
+    @pytest.mark.unit
+    def test_recorded_rate_raises_the_floor(self) -> None:
+        """A shard is gated on its own measurement, not the repo-wide floor."""
+        from mutation_score import read_shard_baselines
+
+        baselines = read_shard_baselines(self._shards_doc({"8": 44.63}))
+        floor, source = baselines.floor_for(8, repo_floor=30)
+
+        assert floor == 41.63  # 44.63 less the 3pp tolerance
+        assert "44.63" in source
+
+    @pytest.mark.unit
+    def test_unrecorded_shard_falls_back_to_repo_floor(self) -> None:
+        """Shards not yet measured are still gated, just more loosely."""
+        from mutation_score import read_shard_baselines
+
+        baselines = read_shard_baselines(self._shards_doc({}))
+        floor, source = baselines.floor_for(3, repo_floor=30)
+
+        assert floor == 30
+        assert "no recorded rate" in source
+
+    @pytest.mark.unit
+    def test_repo_floor_wins_when_recorded_rate_is_lower(self) -> None:
+        """A stale low record must not weaken the repo-wide floor."""
+        from mutation_score import read_shard_baselines
+
+        baselines = read_shard_baselines(self._shards_doc({"4": 20.0}))
+        floor, _ = baselines.floor_for(4, repo_floor=30)
+
+        assert floor == 30
+
+    @pytest.mark.unit
+    def test_malformed_documents_are_rejected(self) -> None:
+        """Bad baselines fail loudly rather than defaulting to no gate."""
+        import json
+
+        from mutation_score import read_shard_baselines
+
+        with pytest.raises(ValueError):
+            read_shard_baselines("{not json")
+        with pytest.raises(ValueError):
+            read_shard_baselines(json.dumps({"num_shards": 25}))
+        with pytest.raises(ValueError):
+            read_shard_baselines(
+                json.dumps({"num_shards": 25, "tolerance": 3.0, "shards": {"8": 44.63}})
+            )
+
+    @pytest.mark.unit
+    def test_repo_baseline_file_parses(self) -> None:
+        """The committed .mutation-shards.json is valid and matches nightly.yml."""
+        from mutation_score import read_shard_baselines
+
+        repo_root = Path(__file__).parent.parent.parent
+        baselines = read_shard_baselines((repo_root / ".mutation-shards.json").read_text())
+
+        assert baselines.num_shards == 25  # keep in step with NUM_SHARDS in nightly.yml
+        assert baselines.tolerance > 0
+
+    @pytest.mark.unit
+    def test_main_fails_below_shard_floor(self, tmp_path: Path) -> None:
+        """A shard regressing under its recorded rate fails the sweep."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(json.dumps({"killed": 35, "survived": 65}))  # 35%
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("30\n")
+        shards = tmp_path / ".mutation-shards.json"
+        shards.write_text(self._shards_doc({"8": 44.63}))
+
+        code = main(
+            [
+                "--stats",
+                str(stats),
+                "--baseline",
+                str(baseline),
+                "--shards",
+                str(shards),
+                "--shard",
+                "8",
+                "--num-shards",
+                "25",
+            ]
+        )
+        assert code == 1  # 35% clears the repo floor but not the shard's 41.63%
+
+    @pytest.mark.unit
+    def test_main_rejects_stale_shard_count(self, tmp_path: Path) -> None:
+        """Changing NUM_SHARDS re-partitions the tree; recorded rates no longer apply."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(json.dumps({"killed": 90, "survived": 10}))
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("30\n")
+        shards = tmp_path / ".mutation-shards.json"
+        shards.write_text(self._shards_doc({"8": 44.63}, num_shards=25))
+
+        code = main(
+            [
+                "--stats",
+                str(stats),
+                "--baseline",
+                str(baseline),
+                "--shards",
+                str(shards),
+                "--shard",
+                "8",
+                "--num-shards",
+                "10",
+            ]
+        )
+        assert code == 1
+
+    @pytest.mark.unit
+    def test_main_requires_shards_file_with_shard(self, tmp_path: Path) -> None:
+        """--shard without its baselines file is a wiring bug, not a silent pass."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(json.dumps({"killed": 90, "survived": 10}))
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("30\n")
+
+        code = main(["--stats", str(stats), "--baseline", str(baseline), "--shard", "8"])
+        assert code == 1
+
+    @pytest.mark.unit
+    def test_main_prompts_to_record_an_unmeasured_shard(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A passing unmeasured shard prints the line that gates it next time."""
+        import json
+
+        from mutation_score import main
+
+        stats = tmp_path / "stats.json"
+        stats.write_text(json.dumps({"killed": 60, "survived": 40}))
+        baseline = tmp_path / ".mutation-baseline"
+        baseline.write_text("30\n")
+        shards = tmp_path / ".mutation-shards.json"
+        shards.write_text(self._shards_doc({}))
+
+        code = main(
+            [
+                "--stats",
+                str(stats),
+                "--baseline",
+                str(baseline),
+                "--shards",
+                str(shards),
+                "--shard",
+                "7",
+                "--num-shards",
+                "25",
+            ]
+        )
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "::notice::" in out
+        assert "60.0" in out  # the measured rate, ready to paste

--- a/tests/unit/test_upload_progress.py
+++ b/tests/unit/test_upload_progress.py
@@ -10,12 +10,31 @@ See GitHub issue #282 for the upload metrics feature.
 
 from __future__ import annotations
 
+import sys
 import time
-from unittest.mock import patch
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from portolan_cli.sync.upload_progress import UploadProgressReporter
+
+
+@pytest.fixture
+def tty_progress() -> Iterator[MagicMock]:
+    """Run the reporter down its Rich path with ``Progress`` replaced by a spy.
+
+    ``__enter__`` builds the progress bar only when stdout is a TTY and JSON mode
+    is off, which no test reached before — the whole Rich branch (bar columns,
+    task setup, advance calls) went unverified, and mutation testing scored the
+    module at 14%. Yielding the patched class lets a test assert how the bar was
+    configured, not merely that nothing raised.
+    """
+    with (
+        patch("rich.progress.Progress") as progress_cls,
+        patch("sys.stdout.isatty", return_value=True),
+    ):
+        yield progress_cls
 
 
 class TestUploadProgressReporter:
@@ -78,15 +97,9 @@ class TestUploadProgressReporter:
             reporter.advance(bytes_uploaded=1000)
         # Should complete without error and no progress bar
 
-    @pytest.mark.unit
-    def test_non_tty_suppresses_progress(self) -> None:
-        """Non-TTY should suppress progress bar."""
-        with patch("sys.stderr") as mock_stderr:
-            mock_stderr.isatty.return_value = False
-            reporter = UploadProgressReporter(total_files=10, json_mode=False)
-            with reporter:
-                reporter.advance(bytes_uploaded=1000)
-            # Should complete without error
+    # A non-TTY test used to live here. It patched sys.stderr while __enter__
+    # gates on sys.stdout, so it asserted nothing about the branch it named.
+    # TestRichProgressPath.test_no_bar_without_a_tty replaces it.
 
 
 class TestUploadProgressReporterDisplay:
@@ -108,3 +121,221 @@ class TestUploadProgressReporterDisplay:
             time.sleep(0.01)
         # Speed is calculated from bytes / elapsed
         assert reporter.average_speed >= 0
+
+
+class TestConstruction:
+    """Tests pinning the attributes __init__ sets, including defaults."""
+
+    @pytest.mark.unit
+    def test_every_attribute_starts_from_the_arguments(self) -> None:
+        """Each field is seeded from its own argument, with counters at zero."""
+        reporter = UploadProgressReporter(total_files=7, total_bytes=4096, json_mode=True)
+
+        assert reporter.total_files == 7
+        assert reporter.total_bytes == 4096
+        assert reporter.json_mode is True
+        assert reporter.files_completed == 0
+        assert reporter.bytes_completed == 0
+        assert reporter.elapsed_seconds == 0.0
+
+    @pytest.mark.unit
+    def test_defaults_are_zero_bytes_and_progress_on(self) -> None:
+        """Omitted arguments default to unknown size and visible progress."""
+        reporter = UploadProgressReporter(total_files=3)
+
+        assert reporter.total_bytes == 0
+        assert reporter.json_mode is False
+
+
+class TestRichProgressPath:
+    """Tests for the Rich branch of __enter__ (TTY, JSON mode off)."""
+
+    @pytest.mark.unit
+    def test_progress_bar_is_configured_and_started(self, tty_progress: MagicMock) -> None:
+        """On a TTY the bar is built, entered, and given a byte-sized task."""
+        with UploadProgressReporter(total_files=10, total_bytes=5000) as reporter:
+            assert reporter is not None
+
+        tty_progress.assert_called_once()
+        kwargs = tty_progress.call_args.kwargs
+        assert kwargs["transient"] is True  # bar clears itself when the push ends
+        assert kwargs["console"].file is sys.stderr  # stdout stays machine-readable
+
+        instance = tty_progress.return_value
+        instance.__enter__.assert_called_once()
+        instance.add_task.assert_called_once_with("Uploading", total=5000)
+
+    @pytest.mark.unit
+    def test_columns_cover_percentage_speed_and_time(self, tty_progress: MagicMock) -> None:
+        """The bar shows the columns the feature promises (see issue #282)."""
+        from rich.progress import (
+            BarColumn,
+            DownloadColumn,
+            TextColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+            TransferSpeedColumn,
+        )
+
+        with UploadProgressReporter(total_files=1, total_bytes=10):
+            pass
+
+        columns = tty_progress.call_args.args
+        types = [type(column) for column in columns]
+        for expected in (
+            BarColumn,
+            DownloadColumn,
+            TransferSpeedColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+        ):
+            assert expected in types
+
+        texts = [c.text_format for c in columns if isinstance(c, TextColumn)]
+        assert "[bold blue]Uploading" in texts
+        assert "[progress.percentage]{task.percentage:>3.0f}%" in texts
+
+    @pytest.mark.unit
+    def test_task_falls_back_to_file_count_without_byte_totals(
+        self, tty_progress: MagicMock
+    ) -> None:
+        """With no byte total the bar counts files instead, so it still fills."""
+        with UploadProgressReporter(total_files=12, total_bytes=0):
+            pass
+
+        tty_progress.return_value.add_task.assert_called_once_with("Uploading", total=12)
+
+    @pytest.mark.unit
+    def test_json_mode_skips_the_bar_on_a_tty(self, tty_progress: MagicMock) -> None:
+        """JSON output must stay clean even when a terminal is attached."""
+        with UploadProgressReporter(total_files=5, total_bytes=100, json_mode=True):
+            pass
+
+        tty_progress.assert_not_called()
+
+    @pytest.mark.unit
+    def test_no_bar_without_a_tty(self) -> None:
+        """Piped output gets no progress bar (it would corrupt the stream)."""
+        with (
+            patch("rich.progress.Progress") as progress_cls,
+            patch("sys.stdout.isatty", return_value=False),
+        ):
+            with UploadProgressReporter(total_files=5, total_bytes=100):
+                pass
+
+        progress_cls.assert_not_called()
+
+    @pytest.mark.unit
+    def test_missing_rich_degrades_silently(self) -> None:
+        """Rich is optional: without it the upload proceeds, unadorned."""
+        with (
+            patch("sys.stdout.isatty", return_value=True),
+            patch.dict(sys.modules, {"rich.progress": None}),
+        ):
+            with UploadProgressReporter(total_files=2, total_bytes=10) as reporter:
+                reporter.advance(bytes_uploaded=10)
+
+            assert reporter.files_completed == 1  # counting survives the missing bar
+
+    @pytest.mark.unit
+    def test_context_manager_yields_the_reporter_itself(self, tty_progress: MagicMock) -> None:
+        """``with ... as r`` must bind the reporter, not None."""
+        reporter = UploadProgressReporter(total_files=1)
+        with reporter as bound:
+            assert bound is reporter
+
+
+class TestAdvance:
+    """Tests for advance() bookkeeping and its calls into Rich."""
+
+    @pytest.mark.unit
+    def test_advance_reports_bytes_when_byte_totals_are_known(
+        self, tty_progress: MagicMock
+    ) -> None:
+        """With byte totals the bar advances by bytes, one call per file."""
+        with UploadProgressReporter(total_files=2, total_bytes=3000) as reporter:
+            reporter.advance(bytes_uploaded=1000)
+            reporter.advance(bytes_uploaded=2000)
+
+        instance = tty_progress.return_value
+        task = instance.add_task.return_value
+        assert instance.advance.call_count == 2
+        instance.advance.assert_called_with(task, advance=2000)
+        assert reporter.files_completed == 2
+        assert reporter.bytes_completed == 3000
+
+    @pytest.mark.unit
+    def test_advance_reports_one_unit_per_file_without_byte_totals(
+        self, tty_progress: MagicMock
+    ) -> None:
+        """Without byte totals the bar advances one unit per file, not by bytes."""
+        with UploadProgressReporter(total_files=2, total_bytes=0) as reporter:
+            reporter.advance(bytes_uploaded=999)
+
+        task = tty_progress.return_value.add_task.return_value
+        tty_progress.return_value.advance.assert_called_once_with(task, advance=1)
+        assert reporter.bytes_completed == 999  # still tracked for the final report
+
+    @pytest.mark.unit
+    def test_advance_defaults_to_a_file_with_no_byte_count(self) -> None:
+        """A caller that knows no size still moves the file counter."""
+        reporter = UploadProgressReporter(total_files=3, json_mode=True)
+        with reporter:
+            reporter.advance()
+
+        assert reporter.files_completed == 1
+        assert reporter.bytes_completed == 0
+
+
+class TestExit:
+    """Tests for __exit__ timing and teardown."""
+
+    @pytest.mark.unit
+    def test_elapsed_is_a_duration_not_a_clock_reading(self) -> None:
+        """elapsed_seconds measures the block, so it stays near zero here."""
+        reporter = UploadProgressReporter(total_files=1, json_mode=True)
+        with reporter:
+            time.sleep(0.01)
+
+        assert 0 < reporter.elapsed_seconds < 5
+
+    @pytest.mark.unit
+    def test_exception_details_reach_the_progress_bar(self, tty_progress: MagicMock) -> None:
+        """Rich needs the live exception triple to tear the display down cleanly."""
+        error = RuntimeError("upload failed")
+        with pytest.raises(RuntimeError):
+            with UploadProgressReporter(total_files=1, total_bytes=10):
+                raise error
+
+        exit_args = tty_progress.return_value.__exit__.call_args.args
+        assert exit_args[0] is RuntimeError
+        assert exit_args[1] is error
+        assert exit_args[2] is error.__traceback__
+
+    @pytest.mark.unit
+    def test_clean_exit_passes_no_exception(self, tty_progress: MagicMock) -> None:
+        """A successful upload tears the bar down with an empty triple."""
+        with UploadProgressReporter(total_files=1, total_bytes=10):
+            pass
+
+        assert tty_progress.return_value.__exit__.call_args.args == (None, None, None)
+
+    @pytest.mark.unit
+    def test_average_speed_is_bytes_over_elapsed(self) -> None:
+        """Speed divides transferred bytes by the measured duration."""
+        reporter = UploadProgressReporter(total_files=1, total_bytes=1000, json_mode=True)
+        with reporter:
+            reporter.advance(bytes_uploaded=1000)
+            time.sleep(0.01)
+
+        assert reporter.average_speed == pytest.approx(
+            reporter.bytes_completed / reporter.elapsed_seconds
+        )
+
+    @pytest.mark.unit
+    def test_average_speed_is_zero_before_any_elapsed_time(self) -> None:
+        """Reading speed before the context exits must not divide by zero."""
+        reporter = UploadProgressReporter(total_files=1, total_bytes=1000)
+
+        assert reporter.elapsed_seconds == 0.0
+        assert reporter.average_speed == 0.0

--- a/tests/unit/test_upload_progress.py
+++ b/tests/unit/test_upload_progress.py
@@ -27,7 +27,7 @@ def tty_progress() -> Iterator[MagicMock]:
     ``__enter__`` builds the progress bar only when stdout is a TTY and JSON mode
     is off, which no test reached before — the whole Rich branch (bar columns,
     task setup, advance calls) went unverified, and mutation testing scored the
-    module at 14%. Yielding the patched class lets a test assert how the bar was
+    module at 18%. Yielding the patched class lets a test assert how the bar was
     configured, not merely that nothing raised.
     """
     with (


### PR DESCRIPTION
Fixes the nightly mutation job, which failed on [run 30244241948](https://github.com/portolan-sdi/portolan-cli/actions/runs/30244241948/job/89907697053) with:

```
Mutation kill rate 44.63% is below the 60% floor from .mutation-baseline.
```

That failure is the gate working, not breaking. It was the first sweep to test real mutants after #612, and the 60% floor had never been measured against a complete run — `.mutation-baseline` said as much in its own header.

## What the measurement showed

Shard 8 held six files, and its kill rate came almost entirely from one of them:

| Module | Killed | Survived | Rate |
|---|---|---|---|
| `extract.common.converters.esri` | 282 | 467 | 38% (68% of the shard) |
| `sync.upload_progress` | 16 | 72 | 18% |
| `metadata.cog` | 57 | 43 | 57% |
| `remove` | 75 | 23 | 77% |
| `backends.iceberg.config` | 60 | 3 | 95% |

A shard's rate is a property of which modules land in it, spanning 18% to 95%. One repo-wide number set high enough to catch a regression in `iceberg.config` reds the nightly every time an `upload_progress`-heavy shard comes up. Set low enough to stay green, it catches nothing. Lowering 60 to 44 would have bought one green night and then resumed flapping.

## Two floors

`.mutation-baseline` keeps a single repo-wide integer, now 30: the catastrophe floor, cleared by every run, meaning the suite has stopped reacting to whole modules.

`.mutation-shards.json` records each shard's own measured rate. The sweep requires the shard to hold that rate less a 3pp tolerance, which absorbs the jitter of a mutant that times out on a slow runner and is killed on a fast one. Verified locally against real stats:

```
::error::Mutation kill rate 79.55% is below the 84.5% floor
         — shard 3's recorded 87.5% less 3.0pp tolerance.
```

79.55% clears the repo-wide floor with room to spare. Only the shard's own baseline catches it.

`shards` ships empty, and each shard is gated by the repo-wide floor alone until its first sweep records it. The 44.63% above describes the old index-based partition, so recording it would gate the wrong files. Every sweep prints the line to paste:

```
::notice::Shard 3 has no recorded rate. Add "3": {"kill_rate": 87.5,
"measured": "<date>", "run": "<run id>"} to .mutation-shards.json
```

## Stable shard membership

Per-shard baselines are worthless if membership moves, and round-robin over the sorted file list shifted every file's shard whenever one file was added. `scripts/shard_select.py` assigns by BLAKE2b of the path instead, so adding a module moves only that module. (CRC-32 came first and clustered badly on these long shared prefixes, leaving one shard with 17 files and another with 1.)

The cost is uneven shards: 2–12 files rather than a uniform 6. The largest night runs roughly twice the mutants of the 6-file shard that took 20 minutes, so `timeout-minutes` goes from 60 to 90.

## Tests for the weakest module

`sync.upload_progress` scored 18% because no test ever entered its Rich branch — `__enter__` builds the progress bar only on a TTY with JSON mode off. The new tests assert how the bar is configured, not merely that nothing raised: 87.5% (77/88), verified by running mutmut locally on the module.

The 11 survivors are equivalent mutants. mutmut's trampoline keeps the original signature and forwards `args = [bytes_uploaded]` positionally, so a mutated default inside the mutant body is unreachable by any test.

One deleted test: a non-TTY case that patched `sys.stderr` while `__enter__` gates on `sys.stdout`. It asserted nothing about the branch it named, and `test_no_bar_without_a_tty` replaces it.

## Contract tests no longer depend on file ordering

The #612 contract tests imported `mutmut.__main__`, which calls `set_start_method('fork')` at module scope and raises `RuntimeError: context has already been set` once any earlier test has started a process pool. They passed or failed on test ordering alone — green under xdist's distribution, red in a single-process run (9 failures on a clean `main`, reproduced before this branch). They now compute mutant names in a fresh interpreter.

## Verification

- `uv run pytest -m unit`: 4964 passed, 0 failed (9 failed on `main` before this change)
- `uv run mutmut run 'portolan_cli.sync.upload_progress.x*'`: 77 killed, 11 survived, 0 no-tests
- Shard selection, glob translation, and scoring simulated end to end under bash, including the regression and unrecorded-shard paths
- All prek hooks pass, including zizmor, actionlint, mypy, and bandit

## Follow-up

The 608 survivors in the other five modules of shard 8 are untouched. `extract.common.converters.esri` alone accounts for 467 and is tracked in #674. Recording each shard's rate as sweeps surface them is what turns the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Nightly mutation testing now runs deterministically across 25 file shards, improving coverage consistency.
  - Mutation score enforcement now supports repo-wide and per-shard floors, including shard-aware gating and clear messaging for newly measured shards.
  - Mutation testing timeout increased (60 → 90 minutes) to improve completion reliability.
- **Documentation**
  - Updated nightly mutation testing guidance for shard selection, threshold floors, and sandbox file inclusion.
- **Tests**
  - Added extensive unit coverage for shard selection and shard-based mutation baseline behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->