### PR TITLE
refactor: rename the validation extraction seam from reis to rashid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,7 +215,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions require an ADR in `context/shared/adr/`
 - **NO** new dependencies without discussion (document in ADR)
 
-<!-- freshness: last-verified: 2026-07-08 -->
+<!-- freshness: last-verified: 2026-07-27 -->
 ## Design Principles
 
 | Principle | Meaning | ADR |

--- a/context/shared/adr/0055-extension-registry-single-source.md
+++ b/context/shared/adr/0055-extension-registry-single-source.md
@@ -22,7 +22,7 @@ as `application/octet-stream` / role `data`; `.svg`, `.qix`, `.tfw`, `.gdb`,
 `.tsv`, `.zarr`, `.copc.laz` were each recognized in some surfaces and absent
 from others. Nothing failed a test when the surfaces disagreed.
 
-The vocabulary is also the natural core of `reis`, the validator being extracted
+The vocabulary is also the natural core of `rashid`, the validator being extracted
 from this repo (issue #563), so it is worth single-sourcing now.
 
 ## Decision
@@ -39,14 +39,14 @@ not shipped in the wheel (the same reason `constants.PORTOLAN_SPEC_VERSION`
 mirrors `spec/schema/spec-version.json`). It is a stdlib-only leaf that imports
 nothing from `portolan_cli`, so — like `scan_classify`, `bbox`, and
 `metadata.scan` (see the validation-seam contract in `pyproject.toml`) — it
-moves cleanly into `reis` at extraction time.
+moves cleanly into `rashid` at extraction time.
 
 `spec/extensions.md` remains the human doc and is tied to the registry by
 `tests/spec_compliance/test_extensions_doc_parity.py`, which parses the markdown
 tables and fails on any disagreement.
 
 We chose a typed Python module over a shipped data file (YAML/JSON) because
-`reis` is Python: the module extracts by moving, gives `mypy --strict` coverage
+`rashid` is Python: the module extracts by moving, gives `mypy --strict` coverage
 of every row, and needs no runtime parsing or `importlib.resources`.
 
 ## Consequences
@@ -68,9 +68,9 @@ of every row, and needs no runtime parsing or `importlib.resources`.
 
 - **Reconcile values in place + a drift test, no registry.** Lighter, and the
   issue offered it as an option, but leaves the tables hand-written in four
-  places and does not give `reis` a format module. Rejected in favor of a real
+  places and does not give `rashid` a format module. Rejected in favor of a real
   single source.
 - **Canonical machine-readable data file (YAML/JSON) in `spec/schema/`.** Matches
   the `rules.yaml` / `spec-version.json` precedent and is language-neutral, but
-  `spec/` is not shipped at runtime and `reis` is Python, so the file would need
+  `spec/` is not shipped at runtime and `rashid` is Python, so the file would need
   a packaged copy or codegen. A typed module avoids both.

--- a/context/shared/adr/0056-hermetic-shipped-schema-validation.md
+++ b/context/shared/adr/0056-hermetic-shipped-schema-validation.md
@@ -19,7 +19,7 @@ The shipped schemas extend upstream STAC v1.1.0 via `allOf` + absolute-URL
 `$ref` (`https://schemas.stacspec.org/v1.1.0/...`). Those references cannot be
 resolved offline, which is why the stubs existed. Validating against the real
 schemas therefore requires resolving the STAC closure without network access,
-because the test suite is hermetic and this logic is the seed of `reis`, the
+because the test suite is hermetic and this logic is the seed of `rashid`, the
 validator being extracted from this repo (issue #563).
 
 Two forces complicate a naive "just load the schema":
@@ -36,7 +36,7 @@ Two forces complicate a naive "just load the schema":
 1. **Vendor the STAC v1.1.0 `$ref` closure** (11 files) as package data under
    `portolan_cli/validation/_vendored/stac/1.1.0/`, fetched by
    `scripts/refresh_stac_schemas.py`. Files stay byte-identical to upstream.
-2. **Add `portolan_cli/validation/schema_registry.py`** (in the reis extraction
+2. **Add `portolan_cli/validation/schema_registry.py`** (in the rashid extraction
    seam): builds a `referencing.Registry` from the vendored closure and exposes
    `validate_document(instance, schema)`. It keys each resource by its canonical
    retrieval URL and normalizes `$id` at load time, side-stepping the malformed
@@ -75,6 +75,6 @@ Two forces complicate a naive "just load the schema":
   filter** (mirroring `stac_rules.py`). Rejected for now: it re-introduces href
   special-casing and pre-judges #573. `format`-off is simpler and neutral.
 - **Fetch STAC schemas over the network at test time.** Rejected: non-hermetic,
-  flaky, and unusable for the offline `reis` extraction.
+  flaky, and unusable for the offline `rashid` extraction.
 - **Depend on a package that ships STAC schemas.** None does cleanly; `pystac`
   ships no JSON Schemas. Vendoring the closure is explicit and auditable.

--- a/portolan_cli/extension_registry.py
+++ b/portolan_cli/extension_registry.py
@@ -12,7 +12,7 @@ helpers below), and ``spec/extensions.md`` is tied to it by a parity test
 (``tests/spec_compliance/test_extensions_doc_parity.py``). See ADR-0055.
 
 It is deliberately a stdlib-only leaf that imports nothing from ``portolan_cli``
-so it can be lifted wholesale into ``reis`` (the validator being extracted, see
+so it can be lifted wholesale into ``rashid`` (the validator being extracted, see
 issue #563) without dragging the app layers along.
 """
 

--- a/portolan_cli/validation/rules.py
+++ b/portolan_cli/validation/rules.py
@@ -621,7 +621,7 @@ class PMTilesLinkRule(ValidationRule):
         """
         # Import from the framework-free leaf, not pmtiles.py: the latter pulls
         # in output/thumbnail/style (and click/rich/config), which would break
-        # the reis extraction seam (issue #563).
+        # the rashid extraction seam (issue #563).
         from portolan_cli.viz.pmtiles_links import (
             WEB_MAP_LINKS_EXTENSION,
             pmtiles_asset_hrefs,

--- a/portolan_cli/validation/schema_registry.py
+++ b/portolan_cli/validation/schema_registry.py
@@ -24,7 +24,7 @@ design and the href/IRI policy is unresolved (discussion #573), so enforcing
 decision. Validation is structural only.
 
 This module is part of the ``portolan_cli.validation`` extraction seam (the
-future ``reis`` package, issue #563): it imports no CLI, output, or config
+future ``rashid`` package, issue #563): it imports no CLI, output, or config
 layer, and no application framework.
 """
 

--- a/portolan_cli/viz/pmtiles_links.py
+++ b/portolan_cli/viz/pmtiles_links.py
@@ -5,8 +5,8 @@ layer can classify PMTiles assets and links **without** importing
 ``pmtiles.py``, which pulls in the ``output``/``thumbnail``/``style`` layers
 (and transitively ``click``/``rich``/``config``).
 
-Keeping them in a stdlib-only leaf preserves the reis extraction seam
-(issue #563; the ``validation-seam-for-reis`` / ``validation-no-framework-leakage``
+Keeping them in a stdlib-only leaf preserves the rashid extraction seam
+(issue #563; the ``validation-seam-for-rashid`` / ``validation-no-framework-leakage``
 import-linter contracts): ``portolan_cli.validation`` must stay free of the
 CLI/output/config framework layers. ``pmtiles.py`` re-imports these names so its
 public API is unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,10 +321,10 @@ source_modules = ["portolan_cli.backends.iceberg"]
 forbidden_modules = ["portolan_cli.cli"]
 
 [[tool.importlinter.contracts]]
-id = "validation-seam-for-reis"
-name = "Validation must not import CLI/output/config layers (reis extraction seam)"
+id = "validation-seam-for-rashid"
+name = "Validation must not import CLI/output/config layers (rashid extraction seam)"
 type = "forbidden"
-# portolan_cli.validation is nearly extraction-ready as the future `reis`
+# portolan_cli.validation is nearly extraction-ready as the future `rashid`
 # package (see issue #563). It stays free of the app-framework layers so the
 # seam is cheap to protect now, ahead of the post-sprint extraction.
 source_modules = ["portolan_cli.validation"]
@@ -336,7 +336,7 @@ forbidden_modules = [
 # Intentional extraction-time couplings: validation reaches into these
 # pure-logic/data modules for classification, bbox checks, and metadata scan.
 # They are leaves (or a self-contained subtree) that carry no CLI/output/config
-# dependency, so they move with `reis` or vendor trivially at extraction time.
+# dependency, so they move with `rashid` or vendor trivially at extraction time.
 # Documented per the second checkbox on #563 (which listed only scan_classify;
 # metadata.scan and bbox are the same kind of coupling, added since).
 #   portolan_cli.validation -> portolan_cli.scan.classify
@@ -348,7 +348,7 @@ forbidden_modules = [
 
 [[tool.importlinter.contracts]]
 id = "validation-no-framework-leakage"
-name = "Validation must not import Click or Rich (reis extraction seam)"
+name = "Validation must not import Click or Rich (rashid extraction seam)"
 type = "forbidden"
 # Framework tripwire: Click/Rich only ever reach validation *through* the
 # cli/output layers forbidden above. Guarding the external packages directly

--- a/spec/schema/spec-version.json
+++ b/spec/schema/spec-version.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://portolan.dev/schema/spec-version.json",
   "title": "Portolan Specification Version",
-  "description": "Canonical machine-readable home for the Portolan specification version. Tools (the CLI, the read-only mirror, reis, and external conformance checkers) read spec_version from this file to claim or verify conformance against a specific version of the Portolan spec. See spec/README.md#versioning for the bump policy. This is distinct from the versions.json manifest schema version (versions.schema.json).",
+  "description": "Canonical machine-readable home for the Portolan specification version. Tools (the CLI, the read-only mirror, rashid, and external conformance checkers) read spec_version from this file to claim or verify conformance against a specific version of the Portolan spec. See spec/README.md#versioning for the bump policy. This is distinct from the versions.json manifest schema version (versions.schema.json).",
   "spec_version": "0.1.1",
   "versioning": "semver",
   "stability": "pre-release",


### PR DESCRIPTION
The validator package was renamed upstream (portolan-sdi/rashid, released v0.1.0 as `rashid` on PyPI); this renames the extraction seam to match. Rename-only: the import-linter contract id (`validation-seam-for-reis` becomes `validation-seam-for-rashid`) plus docstring and ADR mentions. No code, rule ids, schema URIs, or spec_version change.

Groundwork for delegating `portolan check` to rashid (plan in progress; see rashid#36-#46 for the upstream half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project documentation and architecture guidance to consistently reference the `rashid` extraction path.
  - Refreshed documentation verification metadata.
  - Clarified schema version documentation to accurately identify the tools that consume it.
  - Standardized terminology in validation, extension, visualization, and project configuration documentation.
  - No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->