### PR TITLE
fix: derive COG predictor and resampling from the source raster

### DIFF
--- a/.claude/rules/conversion-and-visualization.md
+++ b/.claude/rules/conversion-and-visualization.md
@@ -160,7 +160,11 @@ render paths.
 
 ## COG and output-location defaults
 
-COG defaults are DEFLATE, predictor=2, 512x512 tiles, nearest resampling.
+COG defaults are DEFLATE and 512x512 tiles. Predictor and overview resampling
+default to `auto`, meaning `derive_cog_defaults()` reads them off the source
+raster's dtype: floats get predictor 3 and `average`, integers get predictor 2
+and `nearest`, multi-band uint8 imagery gets no predictor. Call
+`resolve_cog_settings()` before handing a profile to rio-cogeo (Issue #690).
 Conversion output goes **side-by-side for vectors, in-place for rasters**.
 Accept non-cloud-native formats with a warning, do not hard-fail.
 Raster band metadata lands on the data asset, see `.claude/rules/stac-assets.md`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -293,17 +293,29 @@ conversion:
 
 Configure Cloud-Optimized GeoTIFF conversion parameters.
 
-Portolan ships one opinionated default set rather than per-datatype tuning:
-
 | Setting | Default | Why |
 |---------|---------|-----|
 | Compression | DEFLATE | Lossless, and every GeoTIFF reader supports it |
-| Predictor | 2 (horizontal differencing) | Improves the compression ratio across data types |
 | Tile size | 512×512 | Matches the rio-cogeo default; larger tiles mean fewer HTTP range requests |
-| Overview resampling | nearest | Safe for categorical data, elevation, and imagery alike |
+| Predictor | `auto` | Derived from the source raster's dtype |
+| Overview resampling | `auto` | Derived from the source raster's dtype |
 
-These favor batch conversion over per-file optimization. Reach for
-`rio_cogeo.cog_translate()` directly when a specific dataset needs WEBP for
+Predictor and overview resampling both depend on what the pixels mean, so
+Portolan reads them off the source rather than hardcoding one pair:
+
+| Source raster | Predictor | Resampling |
+|---------------|-----------|------------|
+| Floating point (elevation, model output) | 3 (floating point) | `average` |
+| Integer (class codes, counts) | 2 (horizontal differencing) | `nearest` |
+| Multi-band uint8 (RGB imagery) | 1 (none) | `nearest` |
+
+Averaging class codes would invent classes that do not exist, so integer data
+keeps `nearest`. Set `resampling: average` explicitly for continuous integer
+rasters where blocky overviews matter. A raster Portolan cannot open falls back
+to predictor 2 and `nearest`.
+
+Compression stays one opinionated value rather than per-datatype tuning. Reach
+for `rio_cogeo.cog_translate()` directly when a specific dataset needs WEBP for
 imagery or LERC for elevation.
 
 ```yaml
@@ -312,8 +324,8 @@ conversion:
     compression: JPEG # DEFLATE (default), JPEG, LZW, ZSTD, WEBP
     quality: 95 # Quality 1-100 (applies to JPEG and WEBP)
     tile_size: 512 # Internal tile size in pixels
-    predictor: 2 # 1=none, 2=horizontal (default), 3=floating point
-    resampling: nearest # Overview resampling: nearest, bilinear, cubic, etc.
+    predictor: auto # auto (default), 1=none, 2=horizontal, 3=floating point
+    resampling: auto # auto (default), nearest, bilinear, cubic, average, etc.
     generate_thumbnail: true # Auto-generate JPEG thumbnail (default: true)
     thumbnail_max_size: 512 # Max dimension in pixels (default: 512)
     thumbnail_quality: 75 # JPEG quality 1-100 (default: 75)
@@ -373,7 +385,8 @@ These are complementary. Use `conversion.vector` for consistent spatial optimiza
 | Scenario | Configuration |
 |----------|---------------|
 | RGB imagery (smaller files) | `compression: JPEG`, `quality: 95` |
-| Elevation data (lossless) | `compression: DEFLATE`, `predictor: 3` |
+| Elevation data (lossless) | `compression: DEFLATE` (predictor 3 is derived) |
+| Continuous integer rasters | `resampling: average` |
 | Analytics (fast reads) | `compression: LZW`, `tile_size: 256` |
 | Disable thumbnails | `generate_thumbnail: false` |
 | Large thumbnails for preview | `thumbnail_max_size: 1024`, `thumbnail_quality: 90` |

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -75,9 +75,14 @@ conversion:
   cog:
     compression: DEFLATE  # DEFLATE, LZW, ZSTD, JPEG, WEBP
     tile_size: 512        # 256, 512, 1024
-    predictor: 2          # 1=none, 2=horizontal, 3=floating-point
-    resampling: nearest   # nearest, bilinear, cubic, lanczos, average
+    predictor: auto       # auto, 1=none, 2=horizontal, 3=floating-point
+    resampling: auto      # auto, nearest, bilinear, cubic, lanczos, average
     quality: 75           # JPEG/WEBP quality (1-100)
 ```
+
+`auto` derives the setting from the source raster's dtype: floats get predictor 3
+and `average` overviews, integers get predictor 2 and `nearest`, and multi-band
+uint8 imagery gets no predictor. See
+[COG settings](configuration.md#cog-settings) for the full table.
 
 See `get_cog_settings()` and `CogSettings` for programmatic access.

--- a/portolan_cli/conversion_config.py
+++ b/portolan_cli/conversion_config.py
@@ -26,7 +26,7 @@ See:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
@@ -188,6 +188,14 @@ LOSSY_COMPRESSIONS: frozenset[str] = frozenset({"JPEG", "WEBP"})
 # Compression methods that support quality setting
 QUALITY_COMPRESSIONS: frozenset[str] = frozenset({"JPEG", "WEBP"})
 
+# Sentinel meaning "derive this from the source raster" (Issue #690).
+AUTO = "auto"
+
+# Fallback pair used when a raster cannot be inspected. These are the values
+# Portolan hardcoded before #690: safe everywhere, optimal nowhere.
+FALLBACK_PREDICTOR = 2
+FALLBACK_RESAMPLING = "nearest"
+
 # Valid resampling methods for overview generation
 # See: rio_cogeo.cogeo.cog_translate overview_resampling parameter
 VALID_RESAMPLING_METHODS: frozenset[str] = frozenset(
@@ -215,18 +223,87 @@ class CogSettings:
         compression: Compression algorithm (DEFLATE, JPEG, LZW, ZSTD, etc.).
         quality: Quality setting (1-100). Applies to JPEG and WEBP compression.
         tile_size: Internal tile size in pixels (default 512).
-        predictor: Compression predictor (1=none, 2=horizontal, 3=floating point).
-        resampling: Overview resampling method (nearest, bilinear, cubic, etc.).
+        predictor: Compression predictor (1=none, 2=horizontal, 3=floating point),
+            or "auto" to derive it from the source raster's dtype.
+        resampling: Overview resampling method (nearest, bilinear, cubic, etc.),
+            or "auto" to derive it from the source raster's dtype.
     """
 
     compression: str = "DEFLATE"
     quality: int | None = None
     tile_size: int = 512
-    predictor: int = 2
-    resampling: str = "nearest"
+    predictor: int | str = AUTO
+    resampling: str = AUTO
     generate_thumbnail: bool = True
     thumbnail_max_size: int = 512
     thumbnail_quality: int = 75
+
+
+def derive_cog_defaults(source: Path) -> tuple[int, str]:
+    """Pick a predictor and an overview resampling method for one raster.
+
+    The spec's conversion defaults tie both settings to what the pixels mean
+    (see specs/best-practices/conversion-defaults.md in portolan-spec):
+
+    - Floating-point rasters (elevation, model output) compress better with the
+      floating-point predictor, and their overviews should be averaged.
+    - Integer rasters may carry class codes, so their overviews stay nearest:
+      averaging two class codes invents a class that does not exist.
+    - Multi-band byte imagery gains nothing from horizontal differencing, so it
+      gets no predictor at all.
+
+    Continuous versus categorical has no perfect signal. Dtype is the one signal
+    that is cheap and rarely wrong, and both results stay overridable through
+    ``conversion.cog`` in ``.portolan/config.yaml``.
+
+    Args:
+        source: Raster to inspect.
+
+    Returns:
+        A ``(predictor, resampling)`` pair. Unreadable rasters yield the
+        conservative fallback, ``(2, "nearest")``.
+    """
+    import rasterio
+
+    try:
+        with rasterio.open(source) as src:
+            dtype = str(src.dtypes[0])
+            band_count = int(src.count)
+    except Exception as exc:  # noqa: BLE001 - any read failure means "use fallback"
+        logger.debug("Could not inspect %s for COG defaults (%s); using fallback", source, exc)
+        return FALLBACK_PREDICTOR, FALLBACK_RESAMPLING
+
+    if dtype.startswith("float") or dtype.startswith("complex"):
+        return 3, "average"
+    if dtype == "uint8" and band_count >= 3:
+        return 1, FALLBACK_RESAMPLING
+    return FALLBACK_PREDICTOR, FALLBACK_RESAMPLING
+
+
+def resolve_cog_settings(settings: CogSettings, source: Path) -> CogSettings:
+    """Replace any "auto" field in ``settings`` with a value read off ``source``.
+
+    Configured values pass through untouched. Call this immediately before
+    handing a profile to rio-cogeo, never at config load time: derivation needs
+    the raster, and one catalog holds many.
+
+    Args:
+        settings: Settings as loaded from config.
+        source: Raster about to be converted.
+
+    Returns:
+        Settings with concrete ``predictor`` and ``resampling`` values.
+    """
+    if settings.predictor != AUTO and settings.resampling != AUTO:
+        return settings
+
+    derived_predictor, derived_resampling = derive_cog_defaults(source)
+
+    return replace(
+        settings,
+        predictor=derived_predictor if settings.predictor == AUTO else settings.predictor,
+        resampling=derived_resampling if settings.resampling == AUTO else settings.resampling,
+    )
 
 
 def validate_cog_settings(settings: CogSettings) -> list[str]:
@@ -253,7 +330,7 @@ def validate_cog_settings(settings: CogSettings) -> list[str]:
         )
 
     # Validate resampling
-    if settings.resampling not in VALID_RESAMPLING_METHODS:
+    if settings.resampling != AUTO and settings.resampling not in VALID_RESAMPLING_METHODS:
         warnings.append(
             f"Unknown resampling method '{settings.resampling}'. "
             f"Valid values: {', '.join(sorted(VALID_RESAMPLING_METHODS))}. "
@@ -294,15 +371,19 @@ def validate_cog_settings(settings: CogSettings) -> list[str]:
         )
 
     # Validate predictor
-    if settings.predictor not in (1, 2, 3):
+    if settings.predictor != AUTO and settings.predictor not in (1, 2, 3):
         warnings.append(
             f"Predictor {settings.predictor} is invalid. "
-            "Valid values: 1 (none), 2 (horizontal), 3 (floating point). "
-            "Using predictor=2."
+            "Valid values: 1 (none), 2 (horizontal), 3 (floating point), "
+            "or 'auto' to derive from the source raster. Using predictor=2."
         )
 
     # Warn about predictor with lossy compression
-    if settings.compression in LOSSY_COMPRESSIONS and settings.predictor != 1:
+    if (
+        settings.compression in LOSSY_COMPRESSIONS
+        and settings.predictor != AUTO
+        and settings.predictor != 1
+    ):
         warnings.append(
             f"Predictor={settings.predictor} is ignored for lossy compression "
             f"'{settings.compression}'. Consider setting predictor=1 to avoid confusion."
@@ -374,16 +455,18 @@ def get_cog_settings(catalog_path: Path) -> CogSettings:
     if not isinstance(tile_size, int):
         tile_size = 512
 
-    predictor = cog.get("predictor")
-    if not isinstance(predictor, int):
-        predictor = 2
-
-    resampling = cog.get("resampling")
-    if not isinstance(resampling, str):
-        resampling = "nearest"
+    # predictor and resampling both accept "auto", meaning "derive from the
+    # source raster at conversion time" (Issue #690). Anything unparsable
+    # falls back to "auto" rather than to a hardcoded value.
+    raw_predictor = cog.get("predictor", AUTO)
+    predictor: int | str
+    if isinstance(raw_predictor, bool) or not isinstance(raw_predictor, int):
+        predictor = AUTO
     else:
-        # Normalize resampling to lowercase
-        resampling = resampling.lower()
+        predictor = raw_predictor
+
+    raw_resampling = cog.get("resampling", AUTO)
+    resampling = raw_resampling.lower() if isinstance(raw_resampling, str) else AUTO
 
     generate_thumbnail = cog.get("generate_thumbnail")
     if not isinstance(generate_thumbnail, bool):

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -29,6 +29,7 @@ from portolan_cli.conversion_config import (
     VectorSettings,
     get_cog_settings,
     get_vector_settings,
+    resolve_cog_settings,
 )
 from portolan_cli.errors import (
     ConversionFailedError,
@@ -781,9 +782,9 @@ def _convert_raster(source: Path, output_dir: Path, settings: CogSettings | None
 
     Uses COG settings from config if provided, otherwise the built-in defaults:
     - DEFLATE compression
-    - Predictor=2 (horizontal differencing)
     - 512x512 tiles
-    - Nearest resampling
+    - Predictor and overview resampling derived from the source raster's dtype
+      (see derive_cog_defaults)
 
     Args:
         source: Source raster file.
@@ -805,6 +806,9 @@ def _convert_raster(source: Path, output_dir: Path, settings: CogSettings | None
     # Use defaults if no settings provided
     if settings is None:
         settings = CogSettings()
+
+    # Fill in any "auto" field from the raster itself (Issue #690)
+    settings = resolve_cog_settings(settings, source)
 
     output_path = output_dir / f"{source.stem}.tif"
 

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -70,7 +70,7 @@ import httpx
 from rio_cogeo.cogeo import cog_translate
 from rio_cogeo.profiles import cog_profiles
 
-from portolan_cli.conversion_config import CogSettings, get_cog_settings
+from portolan_cli.conversion_config import CogSettings, get_cog_settings, resolve_cog_settings
 from portolan_cli.extract.arcgis.imageserver.discovery import discover_imageserver
 from portolan_cli.extract.arcgis.imageserver.report import (
     ImageServerExtractionReport,
@@ -371,30 +371,33 @@ async def _convert_to_cog(
     loop = asyncio.get_event_loop()
 
     def _do_convert() -> None:
+        # Fill in any "auto" field from the downloaded tile (Issue #690)
+        settings = resolve_cog_settings(cog_settings, input_path)
+
         # Get base profile and customize with our settings
-        profile = cog_profiles.get(cog_settings.compression.lower())  # type: ignore[no-untyped-call]
+        profile = cog_profiles.get(settings.compression.lower())  # type: ignore[no-untyped-call]
 
         # Apply predictor (for lossless compression)
-        if cog_settings.compression.upper() not in ("JPEG", "WEBP"):
-            profile["predictor"] = cog_settings.predictor
+        if settings.compression.upper() not in ("JPEG", "WEBP"):
+            profile["predictor"] = settings.predictor
 
         # Apply quality for lossy compression
-        if cog_settings.quality is not None and cog_settings.compression.upper() in (
+        if settings.quality is not None and settings.compression.upper() in (
             "JPEG",
             "WEBP",
         ):
-            profile["quality"] = cog_settings.quality
+            profile["quality"] = settings.quality
 
         # Apply tile size
-        profile["blockxsize"] = cog_settings.tile_size
-        profile["blockysize"] = cog_settings.tile_size
+        profile["blockxsize"] = settings.tile_size
+        profile["blockysize"] = settings.tile_size
 
         cog_translate(
             str(input_path),
             str(output_path),
             profile,
             # CogSettings.resampling is validated at config load time
-            overview_resampling=cog_settings.resampling,  # type: ignore[arg-type]
+            overview_resampling=settings.resampling,  # type: ignore[arg-type]
             quiet=True,
         )
 

--- a/portolan_cli/preparation.py
+++ b/portolan_cli/preparation.py
@@ -1181,9 +1181,9 @@ def convert_raster(source: Path, dest_dir: Path) -> Path:
 
     Uses Portolan's opinionated COG defaults (see convert command design):
     - DEFLATE compression (universal compatibility, lossless)
-    - Predictor=2 (horizontal differencing, improves compression)
     - 512x512 tiles (matches rio-cogeo default, fewer HTTP requests)
-    - Nearest resampling (safe for all data types: categorical, imagery, elevation)
+    - Predictor and overview resampling derived from the source raster's dtype
+      (see derive_cog_defaults)
 
     For fine-tuned control, power users should use rio_cogeo.cog_translate() directly.
 
@@ -1196,6 +1196,8 @@ def convert_raster(source: Path, dest_dir: Path) -> Path:
     """
     from rio_cogeo.cogeo import cog_translate
     from rio_cogeo.profiles import cog_profiles
+
+    from portolan_cli.conversion_config import derive_cog_defaults
 
     output_path = dest_dir / f"{source.stem}.tif"
 
@@ -1211,16 +1213,17 @@ def convert_raster(source: Path, dest_dir: Path) -> Path:
     # Convert using rio-cogeo with Portolan's opinionated defaults
     profile = cog_profiles.get("deflate")  # type: ignore[no-untyped-call]
 
-    # Apply predictor=2 for better compression
+    # Derive predictor and overview resampling from the raster (Issue #690)
     # Note: profile is a copy of the deflate profile dict
-    profile["predictor"] = 2
+    predictor, resampling = derive_cog_defaults(source)
+    profile["predictor"] = predictor
 
     cog_translate(
         str(source),
         str(output_path),
         profile,
         quiet=True,
-        overview_resampling="nearest",  # Safe for all data types
+        overview_resampling=resampling,  # type: ignore[arg-type]
     )
 
     return output_path

--- a/tests/integration/test_convert_workflow.py
+++ b/tests/integration/test_convert_workflow.py
@@ -484,3 +484,98 @@ conversion:
         else:
             # WEBP not available - that's OK, just verify error is clear
             assert result.error is not None
+
+
+# =============================================================================
+# COG Defaults Derived From the Source Raster (Issue #690)
+# =============================================================================
+
+
+def _write_raster(path: Path, *, dtype: str, count: int = 1) -> Path:
+    """Write a small GeoTIFF with a chosen dtype and band count."""
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    profile = {
+        "driver": "GTiff",
+        "height": 1024,
+        "width": 1024,
+        "count": count,
+        "dtype": dtype,
+        "crs": "EPSG:4326",
+        "transform": from_origin(0, 10.24, 0.01, 0.01),
+    }
+    with rasterio.open(path, "w", **profile) as dst:
+        for band in range(1, count + 1):
+            values = np.random.default_rng(seed=band).random((1024, 1024)) * 100
+            dst.write(values.astype(dtype), band)
+    return path
+
+
+def _predictor_of(path: Path) -> int:
+    """Read the TIFF predictor GDAL actually wrote."""
+    import rasterio
+
+    with rasterio.open(path) as src:
+        return int(src.tags(ns="IMAGE_STRUCTURE").get("PREDICTOR", 1))
+
+
+@pytest.mark.integration
+class TestCogDefaultsFromSourceRaster:
+    """Conversion picks predictor and resampling from what the pixels are."""
+
+    def test_float_raster_written_with_floating_point_predictor(self, tmp_path: Path) -> None:
+        """A float32 raster gets predictor 3 rather than horizontal differencing."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        result = convert_file(source, output_dir=tmp_path)
+
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+        assert _predictor_of(result.output) == 3
+
+    def test_integer_raster_keeps_horizontal_predictor(self, tmp_path: Path) -> None:
+        """An int16 raster still gets predictor 2."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        source = _write_raster(tmp_path / "landcover.tif", dtype="int16")
+
+        result = convert_file(source, output_dir=tmp_path)
+
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+        assert _predictor_of(result.output) == 2
+
+    def test_byte_imagery_written_without_a_predictor(self, tmp_path: Path) -> None:
+        """Three-band uint8 imagery gets no predictor."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        source = _write_raster(tmp_path / "rgb.tif", dtype="uint8", count=3)
+
+        result = convert_file(source, output_dir=tmp_path)
+
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+        assert _predictor_of(result.output) == 1
+
+    def test_config_predictor_overrides_derivation(self, tmp_path: Path) -> None:
+        """An explicit predictor in config.yaml beats the derived one."""
+        from portolan_cli.convert import ConversionStatus, convert_file
+
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("""
+conversion:
+  cog:
+    predictor: 1
+""")
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        result = convert_file(source, output_dir=tmp_path, catalog_path=tmp_path)
+
+        assert result.status == ConversionStatus.SUCCESS
+        assert result.output is not None
+        assert _predictor_of(result.output) == 1

--- a/tests/unit/test_conversion_config.py
+++ b/tests/unit/test_conversion_config.py
@@ -415,8 +415,8 @@ class TestCogSettingsDataclass:
         assert settings.compression == "DEFLATE"
         assert settings.quality is None  # Only applies to JPEG
         assert settings.tile_size == 512
-        assert settings.predictor == 2
-        assert settings.resampling == "nearest"
+        assert settings.predictor == "auto"  # Derived from the source raster
+        assert settings.resampling == "auto"  # Derived from the source raster
 
     @pytest.mark.unit
     def test_custom_jpeg_settings(self) -> None:
@@ -469,9 +469,9 @@ class TestGetCogSettings:
         settings = get_cog_settings(tmp_path)
 
         assert settings.compression == "DEFLATE"
-        assert settings.predictor == 2
+        assert settings.predictor == "auto"
         assert settings.tile_size == 512
-        assert settings.resampling == "nearest"
+        assert settings.resampling == "auto"
 
     @pytest.mark.unit
     def test_loads_compression_from_config(self, tmp_path: Path) -> None:
@@ -531,9 +531,9 @@ conversion:
         settings = get_cog_settings(tmp_path)
 
         assert settings.compression == "LZW"
-        assert settings.predictor == 2  # Default
+        assert settings.predictor == "auto"  # Default
         assert settings.tile_size == 512  # Default
-        assert settings.resampling == "nearest"  # Default
+        assert settings.resampling == "auto"  # Default
 
     @pytest.mark.unit
     def test_handles_missing_conversion_section(self, tmp_path: Path) -> None:
@@ -1268,3 +1268,201 @@ conversion:
         settings = get_vector_settings(tmp_path)
 
         assert settings.partition is False
+
+
+# =============================================================================
+# COG Defaults Derived From the Source Raster (Issue #690)
+# =============================================================================
+
+
+def _write_raster(path: Path, *, dtype: str, count: int = 1) -> Path:
+    """Write a tiny GeoTIFF used to exercise default derivation."""
+    import numpy as np
+    import rasterio
+    from rasterio.transform import from_origin
+
+    profile = {
+        "driver": "GTiff",
+        "height": 8,
+        "width": 8,
+        "count": count,
+        "dtype": dtype,
+        "crs": "EPSG:4326",
+        "transform": from_origin(0, 8, 1, 1),
+    }
+    with rasterio.open(path, "w", **profile) as dst:
+        for band in range(1, count + 1):
+            dst.write(np.zeros((8, 8), dtype=dtype), band)
+    return path
+
+
+class TestDeriveCogDefaults:
+    """Tests for derive_cog_defaults()."""
+
+    @pytest.mark.unit
+    def test_float_raster_gets_floating_point_predictor_and_average(self, tmp_path: Path) -> None:
+        """Continuous float data gets predictor 3 and average overviews."""
+        from portolan_cli.conversion_config import derive_cog_defaults
+
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        predictor, resampling = derive_cog_defaults(source)
+
+        assert predictor == 3
+        assert resampling == "average"
+
+    @pytest.mark.unit
+    def test_float64_raster_also_gets_floating_point_predictor(self, tmp_path: Path) -> None:
+        """float64 is treated the same as float32."""
+        from portolan_cli.conversion_config import derive_cog_defaults
+
+        source = _write_raster(tmp_path / "model.tif", dtype="float64")
+
+        assert derive_cog_defaults(source) == (3, "average")
+
+    @pytest.mark.unit
+    def test_integer_raster_keeps_horizontal_predictor_and_nearest(self, tmp_path: Path) -> None:
+        """Integer data may be categorical, so overviews stay class-preserving."""
+        from portolan_cli.conversion_config import derive_cog_defaults
+
+        source = _write_raster(tmp_path / "landcover.tif", dtype="int16")
+
+        assert derive_cog_defaults(source) == (2, "nearest")
+
+    @pytest.mark.unit
+    def test_byte_imagery_skips_the_predictor(self, tmp_path: Path) -> None:
+        """Multi-band uint8 imagery gains nothing from horizontal differencing."""
+        from portolan_cli.conversion_config import derive_cog_defaults
+
+        source = _write_raster(tmp_path / "rgb.tif", dtype="uint8", count=3)
+
+        assert derive_cog_defaults(source) == (1, "nearest")
+
+    @pytest.mark.unit
+    def test_single_band_uint8_keeps_horizontal_predictor(self, tmp_path: Path) -> None:
+        """One-band uint8 is usually a class raster, not imagery."""
+        from portolan_cli.conversion_config import derive_cog_defaults
+
+        source = _write_raster(tmp_path / "mask.tif", dtype="uint8")
+
+        assert derive_cog_defaults(source) == (2, "nearest")
+
+    @pytest.mark.unit
+    def test_unreadable_source_falls_back_to_conservative_defaults(self, tmp_path: Path) -> None:
+        """An unreadable raster yields the pre-#690 defaults rather than an error."""
+        from portolan_cli.conversion_config import derive_cog_defaults
+
+        broken = tmp_path / "broken.tif"
+        broken.write_text("not a raster")
+
+        assert derive_cog_defaults(broken) == (2, "nearest")
+
+
+class TestResolveCogSettings:
+    """Tests for resolve_cog_settings()."""
+
+    @pytest.mark.unit
+    def test_auto_fields_are_derived_from_source(self, tmp_path: Path) -> None:
+        """Both auto fields are filled in from the raster."""
+        from portolan_cli.conversion_config import CogSettings, resolve_cog_settings
+
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        resolved = resolve_cog_settings(CogSettings(), source)
+
+        assert resolved.predictor == 3
+        assert resolved.resampling == "average"
+
+    @pytest.mark.unit
+    def test_explicit_values_win_over_derivation(self, tmp_path: Path) -> None:
+        """A configured predictor or resampling method is never overridden."""
+        from portolan_cli.conversion_config import CogSettings, resolve_cog_settings
+
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        resolved = resolve_cog_settings(CogSettings(predictor=1, resampling="bilinear"), source)
+
+        assert resolved.predictor == 1
+        assert resolved.resampling == "bilinear"
+
+    @pytest.mark.unit
+    def test_one_auto_field_resolves_independently(self, tmp_path: Path) -> None:
+        """Auto and explicit fields can be mixed."""
+        from portolan_cli.conversion_config import CogSettings, resolve_cog_settings
+
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        resolved = resolve_cog_settings(CogSettings(predictor=2), source)
+
+        assert resolved.predictor == 2
+        assert resolved.resampling == "average"
+
+    @pytest.mark.unit
+    def test_other_settings_are_preserved(self, tmp_path: Path) -> None:
+        """Resolution touches only predictor and resampling."""
+        from portolan_cli.conversion_config import CogSettings, resolve_cog_settings
+
+        source = _write_raster(tmp_path / "elevation.tif", dtype="float32")
+
+        resolved = resolve_cog_settings(
+            CogSettings(compression="ZSTD", tile_size=256, generate_thumbnail=False), source
+        )
+
+        assert resolved.compression == "ZSTD"
+        assert resolved.tile_size == 256
+        assert resolved.generate_thumbnail is False
+
+
+class TestAutoSentinelConfig:
+    """Tests for the 'auto' sentinel in config parsing and validation."""
+
+    @pytest.mark.unit
+    def test_defaults_are_auto(self) -> None:
+        """CogSettings defers both raster-dependent settings to the source."""
+        from portolan_cli.conversion_config import CogSettings
+
+        settings = CogSettings()
+
+        assert settings.predictor == "auto"
+        assert settings.resampling == "auto"
+
+    @pytest.mark.unit
+    def test_auto_is_valid(self) -> None:
+        """validate_cog_settings() accepts the sentinel."""
+        from portolan_cli.conversion_config import CogSettings, validate_cog_settings
+
+        assert validate_cog_settings(CogSettings()) == []
+
+    @pytest.mark.unit
+    def test_explicit_auto_in_config(self, tmp_path: Path) -> None:
+        """'auto' can be written out in config.yaml."""
+        from portolan_cli.conversion_config import get_cog_settings
+
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("""
+conversion:
+  cog:
+    predictor: auto
+    resampling: auto
+""")
+        settings = get_cog_settings(tmp_path)
+
+        assert settings.predictor == "auto"
+        assert settings.resampling == "auto"
+
+    @pytest.mark.unit
+    def test_unparseable_predictor_falls_back_to_auto(self, tmp_path: Path) -> None:
+        """A non-integer, non-'auto' predictor reverts to derivation."""
+        from portolan_cli.conversion_config import get_cog_settings
+
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("""
+conversion:
+  cog:
+    predictor: [2]
+""")
+        settings = get_cog_settings(tmp_path)
+
+        assert settings.predictor == "auto"


### PR DESCRIPTION
## What this changes

COG conversion now reads the predictor and overview resampling off the source
raster instead of hardcoding `predictor=2` and `nearest`. Floats get predictor 3
and `average`, integers keep 2 and `nearest`, multi-band uint8 gets no
predictor. Both settings accept an explicit value in `.portolan/config.yaml`,
which still wins.

## Why

Published COGs diverged from the spec's own conversion defaults, inflating
float rasters and making continuous overviews blocky. Closes #690.

## Verification

Ran against a 2048x2048 window of Copernicus DEM GLO-30 tile N42/E013 from
https://copernicus-dem-30m.s3.amazonaws.com (float32) plus the repo's
`tests/fixtures/realdata/rapidai4eo-sample.tif` (Planet imagery, int16).

```console
$ portolan add elevation/ imagery/
✓ Added 2 files to 2 collections

$ python -c "print IMAGE_STRUCTURE tags of each output"
elevation/n42e013/copernicus-dem-subset.tif   dtype=float32  bands=1  PREDICTOR=3
imagery/rapidai4eo/rapidai4eo-sample.tif      dtype=int16    bands=4  PREDICTOR=2

$ # same DEM subset, forced both ways
predictor=2  16.61 MB
predictor=3  13.71 MB

$ uv run pytest tests/unit tests/integration -m "not slow"
6067 passed, 9 skipped, 4 deselected in 343.89s
```

## Related issues

- Closes #690