### PR TITLE
chore: adopt the org pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,40 @@
-## PR Title
-Write a clear, action-oriented title. This will be used for changelog and release notes.
-Examples: "Add `portolan publish` command for S3 sync" or "Fix collection asset path resolution"
+<!-- ops-sync:begin — synced from portolan-sdi/portolan-ops. Edit there, not here. -->
 
-## Description
-<!-- Concise summary of what changed and why. This may be used in release notes. -->
+<!-- Title in conventional-commit form: it becomes the squash commit message. -->
 
-## Technical Details
-<!-- Implementation notes, breaking changes, migration steps. For reviewers. -->
+## What this changes
+
+<!-- Two or three sentences. What behaves differently once this merges. -->
+
+## Why
+
+<!-- One or two sentences. Link the issue rather than restating it. -->
+
+## Verification
+
+<!-- Paste the command you ran and the output you got. Name the data it ran
+     against: a URL or a catalog path. Green tests are not verification. -->
+
+- [ ] This change does not alter behavior (docs, chore, or CI only).
+
+## Related issues
+
+<!--
+Budget: 200 words outside code blocks, no section longer than six lines. A
+reviewer should finish this in under a minute. Prose follows the org style
+guide: https://github.com/portolan-sdi/portolan-ops/blob/main/STYLE.md
+
+CI checks the budget and the verification evidence on every push and edit.
+-->
+
+<!-- ops-sync:end -->
 
 ## Breaking Changes
-**Does this PR introduce breaking changes?** No / Yes
 
-<!-- If yes, describe what breaks and how users should migrate -->
-
-## Related Issue(s)
-- #
+<!-- What breaks, and how users migrate. Leave empty when nothing does. -->
 
 ## Checklist
+
 See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).
 
 - [ ] Tests written **first** and exercise real behavior (TDD)


### PR DESCRIPTION
## What this changes

The pull request template now leads with the org's canonical sections, wrapped in `ops-sync` markers, with this repo's own checklist below them. Contributors get a form whose sections the `checks / pull-request` gate actually accepts.

## Why

The canonical template reaches only the `portolan-sdi/.github` repo, where GitHub serves it as an org default. A default applies to repos with no template of their own, and this repo has one, so it never saw the canonical sections.

portolan-ops#28 makes sync maintain the marked region from here on. Seeding it first means that sync splices in place instead of prepending a second template above the stale one.

## Verification

Simulated `scripts/sync.py`'s splice against this file, using the block from the ops branch:

```console
$ python3 -c '...BLOCK_RE.sub(block, dest_text, count=1)...'
rashid               idempotent=True  markers=2
portolan-cli         idempotent=True  markers=2
portolan-browser     idempotent=True  markers=2
```

Sync rewrites the marked region to what it already holds and leaves the checklist untouched.

- [x] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Prepares portolan-sdi/portolan-ops#28.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template with structured sections for change details, rationale, verification, related issues, and breaking changes.
  * Expanded contributor checklist requirements to cover testing, integration coverage, validation checks, code coverage, review feedback, and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->