### PR TITLE
fix(ci): run the checks on every pull request, not only those onto main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # No branch filter. A pull request aimed anywhere else still runs
+    # these checks; without that, a stacked pull request shows green
+    # having run none of them.
   workflow_dispatch:  # Allow manual triggering
 
 # Least-privilege default; no job here writes to the repo.


### PR DESCRIPTION
## What this changes

The `pull_request` trigger no longer filters on `main`, so a pull request aimed at any branch runs lint, security, and the test matrix. `push` stays filtered to `main`, which is what keeps a pull request from running the matrix twice.

## Why

`repo-checks.yml` carries no branch filter, so its two checks report on every pull request. CI carried one. A pull request onto anything but `main` therefore showed two green checks having run nothing that reads the code — worse than no signal, because it looks like one.

## Verification

Tested in rashid, which carries the same trigger (portolan-sdi/rashid#83). A throwaway pull request onto a non-`main` base, which today triggers no CI at all:

```console
$ gh pr view 82 --json statusCheckRollup ...
checks / layout             COMPLETED   SUCCESS
checks / pull-request       COMPLETED   FAILURE
ci / complexity-trend       COMPLETED   SUCCESS
ci / lint                   COMPLETED   SUCCESS
ci / security               COMPLETED   SUCCESS
ci / test (ubuntu, 3.10)    IN_PROGRESS
ci / test (ubuntu, 3.11)    IN_PROGRESS
ci / test (ubuntu, 3.12)    IN_PROGRESS
ci / test (ubuntu, 3.13)    IN_PROGRESS
```

Seven `ci /` jobs where there would have been none. The `pull-request` failure is the throwaway's one-line body, and shows that check reporting on a base CI ignored.

- [x] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Adjacent to portolan-sdi/portolan-ops#26, which covers which checks gate a merge. This one covers whether they run.
