### PR TITLE
fix: lock the rashid seam to its public API (#688)

### DIFF
--- a/portolan_cli/agents_md.py
+++ b/portolan_cli/agents_md.py
@@ -6,7 +6,8 @@ Portolan requires every catalog and collection to carry an ``AGENTS.md`` file
 content is human-authored — Portolan only scaffolds an empty template when the
 file is absent and never overwrites an existing one.
 
-This module is deliberately stdlib-only (plus the shared atomic JSON writer). It
+This module is deliberately dependency-light: the stdlib, the shared atomic JSON
+writer, and rashid's href helper, which is itself stdlib-only. It
 is imported by both the generation paths (``catalog.py``, ``add.py``,
 ``metadata/fix.py``) and the ``check --fix`` adapter
 (``validation/fixers.py``). Keeping it free of ``click``/``rich``/``config`` /
@@ -19,7 +20,8 @@ from __future__ import annotations
 import json
 from pathlib import Path, PurePath
 from typing import Any
-from urllib.parse import urlparse
+
+from rashid.catalog import is_absolute_href
 
 from portolan_cli.json_io import write_json_atomic
 
@@ -64,11 +66,6 @@ def visible_stac_files(catalog_root: Path) -> list[Path]:
     return found
 
 
-def _is_absolute_href(href: str) -> bool:
-    """True for hrefs with a URI scheme or a leading slash (rashid's ``is_absolute_href``)."""
-    return href.startswith("/") or bool(urlparse(href).scheme)
-
-
 def markdown_link_gap(stac_path: Path, data: dict[str, Any], *, rel: str, target: str) -> bool:
     """True when ``data`` fails rashid's sibling-markdown-link check for ``rel``.
 
@@ -79,8 +76,10 @@ def markdown_link_gap(stac_path: Path, data: dict[str, Any], *, rel: str, target
     ``target`` (or resolves to a file that is absent). Like rashid, *every*
     matching link is graded, not just the first.
 
-    Replicated rather than imported because rashid exposes no public predicate
-    yet — https://github.com/portolan-sdi/rashid/issues/57 tracks the export.
+    Replicated rather than imported because rashid keeps ``_check_markdown_link``
+    private. rashid#57 exported the COG predicate, the structural relations, and
+    the multihash helpers, so those now come from ``rashid.api``; this one still
+    has no public counterpart. A change to PTL-FIL-002/-003 must land here too.
 
     Args:
         stac_path: Path of the STAC JSON; its parent is the sibling directory.
@@ -105,7 +104,7 @@ def markdown_link_gap(stac_path: Path, data: dict[str, Any], *, rel: str, target
         if link.get("type") != AGENTS_MEDIA_TYPE:
             return True
         href = link.get("href")
-        if not isinstance(href, str) or not href or _is_absolute_href(href):
+        if not isinstance(href, str) or not href or is_absolute_href(href):
             return True
         if (directory / href).resolve() != expected or not expected.is_file():
             return True

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -1072,8 +1072,10 @@ def readme_link_gap(stac_path: Path, data: dict[str, Any]) -> bool:
     resolves to one that does not exist). Every case is repaired by
     :func:`ensure_readmes`, so ``check --fix`` can act on the answer.
 
-    Replicated rather than imported because rashid exposes no public predicate
-    yet — https://github.com/portolan-sdi/rashid/issues/57 tracks the export.
+    Replicated rather than imported because rashid keeps ``_check_markdown_link``
+    private. rashid#57 exported the COG predicate, the structural relations, and
+    the multihash helpers, so those now come from ``rashid.api``; this one still
+    has no public counterpart. A change to PTL-FIL-003 must land here too.
 
     Args:
         stac_path: Path of the ``catalog.json``/``collection.json`` (its parent

--- a/tests/unit/validation/test_rashid_public_surface.py
+++ b/tests/unit/validation/test_rashid_public_surface.py
@@ -1,0 +1,71 @@
+"""Every rashid name this package uses must come from rashid's public API.
+
+rashid's version range (``>=0.1.2,<0.2.0``) lets it refactor private modules in
+any patch release. An import of ``rashid.rules._common`` or ``rashid._multihash``
+therefore turns a routine rashid patch into an ``ImportError`` at ``portolan
+check`` startup. rashid#57 promoted the names we need to ``rashid.api``; this
+test keeps the reach from growing back.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SEARCH_ROOTS = ("portolan_cli", "tests")
+
+
+def _rashid_modules(tree: ast.AST) -> list[str]:
+    """Every rashid module path named by an import in ``tree``."""
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.extend(
+                alias.name for alias in node.names if alias.name.split(".")[0] == "rashid"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            if node.module.split(".")[0] == "rashid":
+                modules.append(node.module)
+    return modules
+
+
+def _python_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SEARCH_ROOTS:
+        files.extend(sorted(p for p in (REPO_ROOT / root).rglob("*.py")))
+    return files
+
+
+class TestRashidImportsArePublic:
+    def test_no_import_reaches_a_private_rashid_module(self) -> None:
+        private: list[str] = []
+        for path in _python_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            private.extend(
+                f"{path.relative_to(REPO_ROOT)}: {module}"
+                for module in _rashid_modules(tree)
+                if any(segment.startswith("_") for segment in module.split("."))
+            )
+        assert private == [], (
+            "These imports reach into rashid's private modules, which a rashid "
+            "patch release may rename or delete. Import from rashid.api instead:\n"
+            + "\n".join(private)
+        )
+
+    def test_the_sweep_sees_the_imports_it_is_meant_to_grade(self) -> None:
+        """A sweep that silently matched nothing would pass forever."""
+        found = [module for path in _python_files() for module in _rashid_modules(_parsed(path))]
+        assert "rashid.api" in found
+
+    def test_a_private_import_is_detected(self) -> None:
+        tree = ast.parse("from rashid.rules._common import links_of\nimport rashid._multihash\n")
+        assert _rashid_modules(tree) == ["rashid.rules._common", "rashid._multihash"]
+
+
+def _parsed(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))


### PR DESCRIPTION
## What this changes

A guard test now fails if any file under `portolan_cli/` or `tests/` imports a
rashid module with an underscore segment. `agents_md._is_absolute_href` is gone;
the module imports rashid's public `is_absolute_href` instead. Two docstrings
that cited rashid#57 as pending now name what rashid exported and what it keeps
private.

## Why

Both acceptance criteria in #688 were already met by the validator migration,
with nothing to stop the private reaches from returning. rashid#57 is closed.

## Verification

Real catalog: `~/Documents/dev/arg-censo-portolan/output`, Argentine census
radios, 620 MB, 8 assets, copied to a scratch dir.

```
$ uv run portolan check "$CAT"
✗ Catalog does not conform: 84 errors, 16 warnings
    68 fixable by `portolan check --fix`
    32 need a decision (see Requires: lines)

$ uv run portolan check --fix "$CAT"
✓ Fixed automatically (68)
✗ Catalog does not conform: 16 errors, 16 warnings

$ python -c '...'   # links the AGENTS/README fixers wrote
catalog.json [('agents', 'text/markdown', './AGENTS.md'),
              ('describedby', 'text/markdown', './README.md')]
['AGENTS.md', 'README.md']

$ uv run pytest -m "not network and not slow and not benchmark and not e2e and not e2e_slow"
6219 passed, 9 skipped in 88.20s

$ uv run lint-imports
Contracts: 6 kept, 0 broken.
```

## Related issues

Closes #688. Upstream export: portolan-sdi/rashid#57.