### PR TITLE
fix: route every remaining JSON write through the atomic helper (#687)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -88,6 +88,7 @@ from portolan_cli.formats import (
     list_layers,
 )
 from portolan_cli.humanize import humanize_slug
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.preparation import (
     _MEDIA_TYPE_MAP as _MEDIA_TYPE_MAP,  # noqa: PLC0414
 )
@@ -1516,8 +1517,7 @@ def _update_item_with_asset(
     }
 
     # Write updated item
-    with open(item_json_path, "w", encoding="utf-8") as f:
-        json.dump(item_data, f, indent=2)
+    write_json_atomic(item_json_path, item_data)
 
     # Detect if this is a collection-level asset
     is_collection_level = item_dir.resolve() == collection_dir.resolve()
@@ -1584,5 +1584,4 @@ def _update_collection_with_asset(
     }
 
     # Write updated collection
-    with open(collection_json_path, "w", encoding="utf-8") as f:
-        json.dump(collection_data, f, indent=2)
+    write_json_atomic(collection_json_path, collection_data)

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -887,7 +887,6 @@ def update_catalog_versions(
         CatalogVersionsCorruptedError: If catalog versions.json is invalid JSON
             or has invalid structure.
     """
-    import tempfile
 
     from portolan_cli.output import warn
 
@@ -952,22 +951,7 @@ def update_catalog_versions(
             # Update catalog-level updated timestamp
             content["updated"] = now
 
-            # Atomic write (same pattern as versions.py)
-            parent = versions_path.parent
-            parent.mkdir(parents=True, exist_ok=True)
-
-            with tempfile.NamedTemporaryFile(
-                mode="w",
-                dir=parent,
-                delete=False,
-                suffix=".tmp",
-            ) as tmp:
-                json.dump(content, tmp, indent=2)
-                tmp.write("\n")
-                tmp_path = tmp.name
-
-            # Atomic rename
-            Path(tmp_path).replace(versions_path)
+            write_json_atomic(versions_path, content)
         finally:
             _unlock_file(lock_file)
 

--- a/portolan_cli/collection.py
+++ b/portolan_cli/collection.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from portolan_cli.bbox import to_2d_bbox
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.models.collection import (
     CollectionModel,
     ExtentModel,
@@ -136,8 +137,7 @@ def write_collection_json(collection: CollectionModel, path: Path) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     output_path = path / "collection.json"
 
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(collection.to_dict(), f, indent=2)
+    write_json_atomic(output_path, collection.to_dict())
 
     return output_path
 
@@ -155,8 +155,7 @@ def write_schema_json(schema: SchemaModel, path: Path) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     output_path = path / "schema.json"
 
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(schema.to_dict(), f, indent=2)
+    write_json_atomic(output_path, schema.to_dict())
 
     return output_path
 

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -5,7 +5,7 @@ This module orchestrates the extraction pipeline for ArcGIS ImageServer:
 2. Compute tile grid based on service limits and desired tile size
 3. Download tiles via exportImage API (async, parallel with rate limiting)
 4. Convert each tile to COG format using rio-cogeo
-5. Save extraction report for resume support (with file locking)
+5. Save extraction report for resume support (atomic writes)
 6. Auto-init Portolan catalog (unless raw mode) using standard API
 
 The extractor does NOT create STAC metadata directly. Instead, it extracts
@@ -31,40 +31,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import sys
 import time
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
-
-# Cross-platform file locking
-if sys.platform == "win32":
-    import msvcrt
-
-    def _lock_file(f: Any) -> None:
-        """Lock file on Windows using msvcrt."""
-        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
-
-    def _unlock_file(f: Any) -> None:
-        """Unlock file on Windows using msvcrt."""
-        try:
-            msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
-        except OSError:
-            pass  # May fail if not locked
-
-else:
-    import fcntl
-
-    def _lock_file(f: Any) -> None:
-        """Lock file on Unix using fcntl."""
-        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
-
-    def _unlock_file(f: Any) -> None:
-        """Unlock file on Unix using fcntl."""
-        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
-
 
 import httpx
 from rio_cogeo.cogeo import cog_translate
@@ -84,6 +56,7 @@ from portolan_cli.extract.arcgis.imageserver.resume import (
     should_process_tile,
 )
 from portolan_cli.extract.arcgis.imageserver.tiling import TileSpec, compute_tile_grid
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.metadata_seeding import seed_metadata_yaml
 from portolan_cli.output import detail, error, info, success, warn
 
@@ -546,46 +519,29 @@ def _intersect_bbox(
     }
 
 
-def _save_resume_state_locked(state: ImageServerResumeState, path: Path) -> None:
-    """Save resume state with file locking to prevent race conditions.
+def _save_resume_state(state: ImageServerResumeState, path: Path) -> None:
+    """Save resume state atomically.
 
-    Uses platform-specific locking (fcntl on Unix, msvcrt on Windows)
-    for atomic writes when multiple concurrent tasks complete simultaneously.
+    Concurrent tile tasks each save the whole state, so two saves can overlap.
+    :func:`write_json_atomic` gives each one its own temp file and lands it with
+    ``os.replace``, so a reader sees one complete state and the last writer wins.
+    That replaces the old shared-``.tmp``-plus-``flock`` dance, which serialized
+    writers only after both had already truncated the same temp file.
 
     Args:
         state: Resume state to save.
         path: Path to write the JSON file.
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write to temp file then rename for atomicity
-    temp_path = path.with_suffix(".tmp")
-
-    try:
-        with open(temp_path, "w", encoding="utf-8") as f:
-            # Acquire exclusive lock (cross-platform)
-            _lock_file(f)
-            try:
-                data = {
-                    "extraction_type": "imageserver",
-                    "service_url": state.service_url,
-                    "started_at": state.started_at.isoformat().replace("+00:00", "Z"),
-                    "tiles": {
-                        "succeeded": sorted([list(coord) for coord in state.succeeded_tiles]),
-                        "failed": sorted([list(coord) for coord in state.failed_tiles]),
-                    },
-                }
-                json.dump(data, f, indent=2)
-            finally:
-                _unlock_file(f)
-
-        # Atomic rename
-        temp_path.rename(path)
-    except Exception:
-        # Clean up temp file on error
-        if temp_path.exists():
-            temp_path.unlink()
-        raise
+    data = {
+        "extraction_type": "imageserver",
+        "service_url": state.service_url,
+        "started_at": state.started_at.isoformat().replace("+00:00", "Z"),
+        "tiles": {
+            "succeeded": sorted([list(coord) for coord in state.succeeded_tiles]),
+            "failed": sorted([list(coord) for coord in state.failed_tiles]),
+        },
+    }
+    write_json_atomic(path, data)
 
 
 def _create_empty_result(output_dir: Path) -> ExtractionResult:
@@ -971,7 +927,7 @@ async def _extract_all_tiles(
             # Batch resume state saves
             stats.tiles_since_last_save += 1
             if stats.tiles_since_last_save >= RESUME_SAVE_INTERVAL or not result.success:
-                _save_resume_state_locked(resume_state, resume_path)
+                _save_resume_state(resume_state, resume_path)
                 stats.tiles_since_last_save = 0
 
     return stats
@@ -1223,7 +1179,7 @@ async def extract_imageserver(
         on_progress=on_progress,
         collection_name=collection_name,
     )
-    _save_resume_state_locked(resume_state, resume_path)
+    _save_resume_state(resume_state, resume_path)
 
     # Add skipped tiles to results (computed BEFORE extraction)
     for tile in skipped_tile_specs:

--- a/portolan_cli/extract/arcgis/imageserver/report.py
+++ b/portolan_cli/extract/arcgis/imageserver/report.py
@@ -20,6 +20,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from portolan_cli.json_io import write_json_atomic
+
 if TYPE_CHECKING:
     from portolan_cli.extract.arcgis.imageserver.discovery import ImageServerMetadata
     from portolan_cli.metadata_extraction import ExtractedMetadata
@@ -428,7 +430,7 @@ def save_imageserver_report(report: ImageServerExtractionReport, path: Path) -> 
         path: Path to write the JSON file.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    write_json_atomic(path, report.to_dict())
 
 
 def load_imageserver_report(path: Path) -> ImageServerExtractionReport:

--- a/portolan_cli/extract/arcgis/imageserver/resume.py
+++ b/portolan_cli/extract/arcgis/imageserver/resume.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from portolan_cli.json_io import write_json_atomic
+
 logger = logging.getLogger(__name__)
 
 
@@ -222,4 +224,4 @@ def save_resume_state(state: ImageServerResumeState, report_path: Path) -> None:
         },
     }
 
-    report_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_json_atomic(report_path, data)

--- a/portolan_cli/extract/common/report.py
+++ b/portolan_cli/extract/common/report.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from portolan_cli.json_io import write_json_atomic
+
 
 @dataclass
 class LayerResult:
@@ -292,7 +294,7 @@ class ExtractionReport:
 def save_report(report: ExtractionReport, path: Path) -> None:
     """Save extraction report to JSON file."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+    write_json_atomic(path, report.to_dict())
 
 
 def load_report(path: Path) -> ExtractionReport:

--- a/portolan_cli/extract/common/styles.py
+++ b/portolan_cli/extract/common/styles.py
@@ -43,6 +43,7 @@ from portolan_cli.extract.common.converters.sld import (
     SLDConverterError,
     convert_sld,
 )
+from portolan_cli.json_io import write_json_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -267,7 +268,7 @@ def _write_style_file(
     styles_dir.mkdir(parents=True, exist_ok=True)
 
     style_path = styles_dir / f"{name}.json"
-    style_path.write_text(json.dumps(style_dict, indent=2), encoding="utf-8")
+    write_json_atomic(style_path, style_dict)
 
     return style_path
 

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -34,6 +34,7 @@ from pystac.layout import AsIsLayoutStrategy
 from portolan_cli.config import load_merged_metadata
 from portolan_cli.formats import FormatType
 from portolan_cli.humanize import humanize_slug
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.metadata import extract_geoparquet_metadata
 from portolan_cli.metadata.geoparquet import GeoParquetMetadata
 from portolan_cli.preparation import PreparedItem
@@ -166,7 +167,7 @@ def _fix_collection_links(
         deduped_links.append(link)
     collection_data["links"] = deduped_links
 
-    collection_json_path.write_text(json.dumps(collection_data, indent=2), encoding="utf-8")
+    write_json_atomic(collection_json_path, collection_data)
 
 
 def _update_catalog_links(catalog_root: Path, collection_id: str) -> None:

--- a/portolan_cli/item.py
+++ b/portolan_cli/item.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
 from portolan_cli.models.item import AssetModel, ItemModel
 
@@ -180,8 +181,7 @@ def write_item_json(item: ItemModel, path: Path) -> Path:
     path.mkdir(parents=True, exist_ok=True)
     output_path = path / f"{item.id}.json"
 
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(item.to_dict(), f, indent=2)
+    write_json_atomic(output_path, item.to_dict())
 
     return output_path
 

--- a/portolan_cli/schema/export.py
+++ b/portolan_cli/schema/export.py
@@ -6,9 +6,10 @@ Exports schema.json to JSON, CSV, or Parquet for editing in external tools.
 from __future__ import annotations
 
 import csv
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from portolan_cli.json_io import write_json_atomic
 
 if TYPE_CHECKING:
     from portolan_cli.models.schema import SchemaModel
@@ -24,8 +25,7 @@ def export_schema_json(schema: SchemaModel, path: Path) -> Path:
     Returns:
         Path to written file.
     """
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(schema.to_dict(), f, indent=2)
+    write_json_atomic(path, schema.to_dict())
     return path
 
 
@@ -42,8 +42,7 @@ def _write_sidecar_meta(schema: SchemaModel, path: Path) -> Path:
         "crs": schema.crs,
         "statistics": schema.statistics,
     }
-    with open(meta_path, "w", encoding="utf-8") as f:
-        json.dump(meta, f, indent=2)
+    write_json_atomic(meta_path, meta)
     return meta_path
 
 

--- a/portolan_cli/sync/pull.py
+++ b/portolan_cli/sync/pull.py
@@ -37,6 +37,7 @@ from portolan_cli.async_utils import (
     CircuitBreakerError,
     get_default_concurrency,
 )
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import detail, error, info, output_section, success, warn
 from portolan_cli.sync.checksums import compute_checksum
 from portolan_cli.sync.download import download_file, get_remote_file_size_async
@@ -1003,7 +1004,7 @@ async def _process_stac_file_sizes(
                 detail(f"Fetched file:size for {stac_file.name}:{asset_key}")
 
     if modified:
-        stac_file.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+        write_json_atomic(stac_file, data)
 
     return populated
 

--- a/portolan_cli/viz/pmtiles.py
+++ b/portolan_cli/viz/pmtiles.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from portolan_cli.errors import PortolanError
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import error, info, success, warn
 
 # The PMTiles constants and pure asset/link classifiers now live in the
@@ -403,7 +404,7 @@ def add_pmtiles_asset_to_collection(
                     needs_update = True
 
         if needs_update:
-            collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            write_json_atomic(collection_json_path, data)
         return
 
     asset_dict: dict[str, Any] = {
@@ -420,7 +421,7 @@ def add_pmtiles_asset_to_collection(
     assets[pmtiles_key] = asset_dict
     data["assets"] = assets
 
-    collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_json_atomic(collection_json_path, data)
 
 
 def ensure_web_map_links_extension(collection_path: Path) -> bool:
@@ -448,7 +449,7 @@ def ensure_web_map_links_extension(collection_path: Path) -> bool:
 
     extensions.append(WEB_MAP_LINKS_EXTENSION)
     data["stac_extensions"] = extensions
-    collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_json_atomic(collection_json_path, data)
     return True
 
 
@@ -519,7 +520,7 @@ def add_pmtiles_link_to_collection(
             changed = True
 
     if changed:
-        collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        write_json_atomic(collection_json_path, data)
 
 
 def add_thumbnail_asset_to_collection(
@@ -556,7 +557,7 @@ def add_thumbnail_asset_to_collection(
     }
     data["assets"] = assets
 
-    collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_json_atomic(collection_json_path, data)
 
 
 def _compute_sha256(path: Path) -> str:

--- a/portolan_cli/viz/style.py
+++ b/portolan_cli/viz/style.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from portolan_cli.config import load_config
+from portolan_cli.json_io import write_json_atomic
 from portolan_cli.utils import get_dict, get_list
 
 logger = logging.getLogger(__name__)
@@ -267,7 +268,7 @@ def write_style_file(
         raise ValueError(msg)
     style_dir.mkdir(parents=True, exist_ok=True)
     style_path = style_dir / f"{name}.json"
-    style_path.write_text(json.dumps(style_dict, indent=2), encoding="utf-8")
+    write_json_atomic(style_path, style_dict)
     return style_path
 
 
@@ -502,7 +503,7 @@ def register_style_assets(
     else:
         data.pop("portolan:styles", None)
 
-    collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_json_atomic(collection_json_path, data)
 
 
 # =============================================================================
@@ -609,7 +610,7 @@ def register_legend_assets(
     else:
         data.pop("portolan:legends", None)
 
-    collection_json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_json_atomic(collection_json_path, data)
 
 
 # =============================================================================

--- a/tests/unit/test_json_io.py
+++ b/tests/unit/test_json_io.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -127,6 +128,24 @@ class TestWriteTextAtomic:
         assert [p.name for p in tmp_path.iterdir()] == ["config.yaml"]
 
 
+def _collection_dict(collection_id: str = "roads", title: str = "Roads") -> dict[str, object]:
+    return {
+        "type": "Collection",
+        "stac_version": "1.1.0",
+        "id": collection_id,
+        "title": title,
+        "description": f"{title} collection.",
+        "license": "CC-BY-4.0",
+        "extent": {
+            "spatial": {"bbox": [[-1.0, -1.0, 1.0, 1.0]]},
+            "temporal": {"interval": [[None, None]]},
+        },
+        "links": [],
+        "assets": {},
+        "stac_extensions": [],
+    }
+
+
 class TestAdoptedWriteSites:
     """Round-trip proof that adopting the helper keeps non-ASCII literal."""
 
@@ -157,3 +176,123 @@ class TestAdoptedWriteSites:
         assert '"title": "Córdoba"' in raw
         assert "\\u00f3" not in raw
         assert raw.endswith("\n")
+
+
+def _fail_replace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the rename half of every atomic write fail, as a full disk would."""
+
+    def _boom(src: str, dst: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr("portolan_cli.json_io.os.replace", _boom)
+
+
+class TestSitesAdoptedInIssue687:
+    """The write sites converted in #687 cannot truncate what was already there.
+
+    Each test kills the write at ``os.replace`` — the last step, after the new
+    bytes are on disk — because that is the window an in-place writer cannot
+    survive: it has already truncated the destination by then.
+    """
+
+    def test_pmtiles_extension_write_preserves_the_prior_collection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from portolan_cli.viz.pmtiles import ensure_web_map_links_extension
+
+        collection_dir = tmp_path / "roads"
+        collection_dir.mkdir()
+        target = collection_dir / "collection.json"
+        write_json_atomic(target, _collection_dict())
+        before = target.read_text(encoding="utf-8")
+
+        _fail_replace(monkeypatch)
+        with pytest.raises(OSError, match="disk full"):
+            ensure_web_map_links_extension(collection_dir)
+
+        assert target.read_text(encoding="utf-8") == before
+        assert _temp_siblings(collection_dir) == []
+
+    def test_style_file_write_preserves_the_prior_style(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from portolan_cli.viz.style import write_style_file
+
+        style_dir = tmp_path / "styles"
+        style_dir.mkdir()
+        target = style_dir / "default.json"
+        write_json_atomic(target, {"version": 8, "layers": []})
+        before = target.read_text(encoding="utf-8")
+
+        _fail_replace(monkeypatch)
+        with pytest.raises(OSError, match="disk full"):
+            write_style_file(style_dir, "default", {"version": 8, "layers": [{"id": "roads"}]})
+
+        assert target.read_text(encoding="utf-8") == before
+        assert _temp_siblings(style_dir) == []
+
+    def test_resume_state_write_preserves_the_prior_state(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The extractor kept its own temp-and-rename; it now shares the helper."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _save_resume_state
+        from portolan_cli.extract.arcgis.imageserver.resume import ImageServerResumeState
+
+        target = tmp_path / "resume.json"
+        started = datetime(2026, 7, 30, 9, 0, tzinfo=timezone.utc)
+        _save_resume_state(
+            ImageServerResumeState(
+                succeeded_tiles={(0, 0)},
+                failed_tiles=set(),
+                service_url="https://example.org/ImageServer",
+                started_at=started,
+            ),
+            target,
+        )
+        before = target.read_text(encoding="utf-8")
+
+        _fail_replace(monkeypatch)
+        with pytest.raises(OSError, match="disk full"):
+            _save_resume_state(
+                ImageServerResumeState(
+                    succeeded_tiles={(0, 0), (0, 1)},
+                    failed_tiles=set(),
+                    service_url="https://example.org/ImageServer",
+                    started_at=started,
+                ),
+                target,
+            )
+
+        assert json.loads(target.read_text(encoding="utf-8"))["tiles"]["succeeded"] == [[0, 0]]
+        assert target.read_text(encoding="utf-8") == before
+        assert _temp_siblings(tmp_path) == []
+
+    def test_collection_json_write_preserves_the_prior_collection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from portolan_cli.collection import write_collection_json
+        from portolan_cli.models.collection import (
+            CollectionModel,
+            ExtentModel,
+            SpatialExtent,
+            TemporalExtent,
+        )
+
+        target = tmp_path / "collection.json"
+        write_json_atomic(target, _collection_dict())
+        before = target.read_text(encoding="utf-8")
+
+        replacement = CollectionModel(
+            id="roads",
+            description="Replacement.",
+            extent=ExtentModel(
+                spatial=SpatialExtent(bbox=[[-1.0, -1.0, 1.0, 1.0]]),
+                temporal=TemporalExtent(interval=[[None, None]]),
+            ),
+        )
+        _fail_replace(monkeypatch)
+        with pytest.raises(OSError, match="disk full"):
+            write_collection_json(replacement, tmp_path)
+
+        assert target.read_text(encoding="utf-8") == before
+        assert _temp_siblings(tmp_path) == []

--- a/tests/unit/test_json_write_sites.py
+++ b/tests/unit/test_json_write_sites.py
@@ -1,0 +1,104 @@
+"""No module in ``portolan_cli`` may write JSON in place.
+
+An in-place write truncates the destination before the new bytes land, so a
+process killed mid-write leaves a zero-length ``collection.json`` where a valid
+one used to be. :func:`portolan_cli.json_io.write_json_atomic` writes to a temp
+file and ``os.replace``s it into position, which cannot truncate. Issue #682
+introduced the helper, #687 finished adopting it, and this sweep keeps a raw
+``json.dump(data, handle)`` or ``path.write_text(json.dumps(data))`` from
+reappearing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "portolan_cli"
+
+# json_io.py is the one place allowed to serialize straight to a file handle:
+# it owns the temp-file-then-replace dance the rest of the package delegates to.
+EXEMPT = frozenset({PACKAGE_ROOT / "json_io.py"})
+
+
+def _is_json_attr(node: ast.expr, name: str) -> bool:
+    """True for ``json.dump``/``json.dumps`` (the qualified form we use)."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == name
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "json"
+    )
+
+
+def _contains_json_dumps(node: ast.expr) -> bool:
+    return any(
+        isinstance(inner, ast.Call) and _is_json_attr(inner.func, "dumps")
+        for inner in ast.walk(node)
+    )
+
+
+def in_place_json_writes(tree: ast.AST) -> list[int]:
+    """Line numbers of writes that serialize JSON straight onto a destination.
+
+    Two shapes: ``json.dump(data, handle)`` (a file object, so two-plus
+    positional args) and ``dest.write_text(json.dumps(data))``. A bare
+    ``json.dumps(data)`` that feeds a checksum or an upload body is fine — no
+    file is truncated — so only these two forms count.
+    """
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_json_attr(node.func, "dump") and len(node.args) >= 2:
+            lines.append(node.lineno)
+        elif (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "write_text"
+            and node.args
+            and _contains_json_dumps(node.args[0])
+        ):
+            lines.append(node.lineno)
+    return sorted(lines)
+
+
+def _package_files() -> list[Path]:
+    return sorted(p for p in PACKAGE_ROOT.rglob("*.py") if p not in EXEMPT)
+
+
+class TestNoInPlaceJsonWrites:
+    def test_every_json_write_goes_through_the_atomic_helper(self) -> None:
+        offenders: list[str] = []
+        for path in _package_files():
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            offenders.extend(
+                f"{path.relative_to(REPO_ROOT)}:{line}" for line in in_place_json_writes(tree)
+            )
+        assert offenders == [], (
+            "These writes truncate the destination before the new JSON lands. "
+            "Use portolan_cli.json_io.write_json_atomic instead:\n" + "\n".join(offenders)
+        )
+
+    def test_the_sweep_reads_the_package_it_grades(self) -> None:
+        """A sweep over an empty file list would pass forever."""
+        files = _package_files()
+        assert len(files) > 100
+        assert PACKAGE_ROOT / "viz" / "pmtiles.py" in files
+
+    def test_a_json_dump_to_a_handle_is_detected(self) -> None:
+        source = 'with open(p, "w") as f:\n    json.dump(data, f, indent=2)\n'
+        assert in_place_json_writes(ast.parse(source)) == [2]
+
+    def test_a_write_text_of_json_dumps_is_detected(self) -> None:
+        source = 'p.write_text(json.dumps(data, indent=2), encoding="utf-8")\n'
+        assert in_place_json_writes(ast.parse(source)) == [1]
+
+    def test_serializing_without_writing_a_file_is_allowed(self) -> None:
+        """``json.dumps`` for a checksum or an upload body truncates nothing."""
+        source = 'body = json.dumps(data, indent=2).encode("utf-8")\ndigest = json.dumps(crs)\n'
+        assert in_place_json_writes(ast.parse(source)) == []


### PR DESCRIPTION
Closes #687.

PR #682 added `write_json_atomic` and adopted it for the STAC and metadata writers. The rest of the package still wrote in place, so a process killed between the truncating `open()` and the final flush left a zero-length `collection.json`, `item.json`, style, or resume file where a valid one had been. This converts the 21 remaining sites: `viz/pmtiles.py`, `viz/style.py`, `sync/pull.py`, `item.py`, `collection.py`, `add.py`, `finalization.py`, `schema/export.py`, `catalog.py`, and the four `extract/` writers.

The ImageServer extractor gives up its own locking. It wrote to one shared `.tmp` path and serialized writers with `flock` — after both had already truncated that temp file — then landed it with `Path.rename`, which cannot replace an existing file on Windows. Each writer now gets its own temp file and `os.replace`.

`catalog.py` keeps its `flock` on the dedicated `.versions.lock`: that guards a read-modify-write, which atomicity alone does not.

## Verification

Real catalog built from `tests/fixtures/realdata/nwi-wetlands.parquet` and `rapidai4eo-sample.tif`, then `portolan check --fix` to drive the converted fixer writes:

```
$ portolan add wetlands/ --datetime 2024-06-15
✓ Added 1 file to 1 collection
$ portolan add imagery/ --datetime 2019-05-01
✓ Added 1 file to 1 collection
$ portolan check --fix       # findings are fixture data quality, not writes
$ python - <<'PY' ... PY
json files: 8
valid, newline-terminated: 8
offenders: []
leftover .tmp files: []
```

The crash window, on that catalog's real `wetlands/collection.json`, with `os.replace` forced to fail:

```
before: 2476 bytes, 2 assets
write failed as expected: simulated disk full
after:  2476 bytes, unchanged=True
still parses: 'wetlands'
leftover temp files: []
```

Tests: 5033 unit passed. An AST sweep over `portolan_cli/` fails if `json.dump(data, handle)` or `path.write_text(json.dumps(data))` reappears; four site-level tests kill the write at `os.replace` and assert the previous file survives byte-for-byte.
