### PR TITLE
feat: give collections a provider model and derived provenance (#684)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -152,7 +152,10 @@ from portolan_cli.remove import remove_files  # noqa: F401
 from portolan_cli.stac import (
     MergeStrategy,
     apply_human_license,
+    apply_human_providers,
+    apply_provenance,
     create_collection,
+    update_catalog_provenance,
     update_collection_file_statistics,
 )
 from portolan_cli.sync.checksums import compute_checksum, multihash_sha256
@@ -534,8 +537,12 @@ def _ensure_tabular_collection(
     )
 
     # A tabular-only add never reaches finalize_items, so apply the same
-    # human-authored license metadata.yaml carries for geo collections.
-    apply_human_license(collection, load_merged_metadata(collection_dir, catalog_root))
+    # human-authored license, providers, and derived provenance metadata.yaml
+    # carries for geo collections (issue #654 / issue #684).
+    merged_metadata = load_merged_metadata(collection_dir, catalog_root)
+    apply_human_license(collection, merged_metadata)
+    apply_human_providers(collection, merged_metadata)
+    apply_provenance(collection, merged_metadata)
 
     # Save collection.json
     collection_dir.mkdir(parents=True, exist_ok=True)
@@ -564,6 +571,9 @@ def _ensure_tabular_collection(
     ensure_agents_md_tree(catalog_root)
     ensure_schema_uris(catalog_root)
     ensure_readmes(catalog_root)
+
+    # Issue #684: and the root-catalog sync stamp, for an all-mirror tree.
+    update_catalog_provenance(catalog_root)
 
     # Log based on bbox source (priority order)
     if bbox_source == "metadata.yaml":

--- a/portolan_cli/errors.py
+++ b/portolan_cli/errors.py
@@ -310,6 +310,23 @@ class InvalidBboxError(ValidationError):
         super().__init__(f"Invalid bounding box: {reason}", reason=reason)
 
 
+class InvalidProvidersError(ValidationError):
+    """Raised when metadata.yaml declares a providers array Portolan cannot use.
+
+    Generation tolerates a missing providers block — the host is seeded from
+    ``contact`` and PTL-PRV-001 tells the human to name a producer. It cannot
+    tolerate input where no conformant array exists, such as two entries both
+    claiming the ``host`` role: nothing can choose between them.
+
+    Error code: PRTLN-VAL003
+    """
+
+    code = "PRTLN-VAL003"
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"Invalid providers in metadata.yaml: {reason}", reason=reason)
+
+
 # Conversion Errors (PRTLN-CNV*)
 class ConversionError(PortolanError):
     """Base class for conversion-related errors."""

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -49,10 +49,13 @@ from portolan_cli.stac import (
     add_table_extension,
     aggregate_table_metadata,
     apply_human_license,
+    apply_human_providers,
     apply_human_titles,
+    apply_provenance,
     create_collection,
     load_catalog,
     update_catalog_file_statistics,
+    update_catalog_provenance,
     update_collection_file_statistics,
     update_collection_summaries,
 )
@@ -996,6 +999,11 @@ def _finalize_collection(
     apply_human_titles(collection, merged_metadata)
     apply_human_license(collection, merged_metadata)
 
+    # Issue #684: providers name who produced the data and who hosts this copy,
+    # and their relationship is what makes this collection official or a mirror.
+    apply_human_providers(collection, merged_metadata)
+    apply_provenance(collection, merged_metadata)
+
     # Add items or collection-level assets to collection (in memory)
     _add_prepared_items_to_collection(collection, items, merge_strategy)
 
@@ -1103,5 +1111,9 @@ def finalize_items(
             "Catalog may have stale or missing aggregate size data.",
             exc_info=True,
         )
+
+    # Issue #684: a catalog whose every collection is a mirror carries the sync
+    # time itself. Needs the whole tree, so it runs after the last collection.
+    update_catalog_provenance(catalog_root)
 
     return results

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Any
 
 from portolan_cli.config import load_merged_metadata
+from portolan_cli.providers import HOST_ROLE, PROVIDER_ROLES
 
 logger = logging.getLogger(__name__)
 
@@ -358,6 +359,89 @@ def _validate_license(metadata: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_provider_roles(roles: Any, index: int) -> list[str]:
+    """Validate one provider's roles against the four STAC defines."""
+    if not isinstance(roles, list):
+        return [f"Field 'providers[{index}].roles' must be a list"]
+
+    errors: list[str] = []
+    for role in roles:
+        if not isinstance(role, str) or role not in PROVIDER_ROLES:
+            errors.append(
+                f"Field 'providers[{index}].roles' has unknown role '{role}'. "
+                f"Use one of {', '.join(PROVIDER_ROLES)}"
+            )
+    return errors
+
+
+def _validate_host_contact(host: dict[str, Any], index: int) -> list[str]:
+    """The host provider must be reachable: a url or an email, per PORTO-CORE-051."""
+    url = host.get("url")
+    email = host.get("email")
+    has_url = isinstance(url, str) and url.strip()
+    has_email = isinstance(email, str) and email.strip()
+
+    if not has_url and not has_email:
+        return [
+            f"Field 'providers[{index}]' carries the host role, so it needs a 'url' or an 'email'"
+        ]
+    if has_email and not EMAIL_PATTERN.match(str(email)):
+        return [f"Invalid email format in 'providers[{index}].email': '{email}'"]
+    return []
+
+
+def _validate_providers(metadata: dict[str, Any]) -> list[str]:
+    """Validate the optional 'providers' array (issue #684).
+
+    The array is optional here because the host is seeded from ``contact`` when
+    it is absent, and because a producer is a human fact Portolan cannot invent —
+    a collection with no producer keeps reporting PTL-PRV-001 from
+    ``portolan check``. What this catches is an array that exists but cannot be
+    put in conformant shape.
+
+    Args:
+        metadata: The full metadata dictionary.
+
+    Returns:
+        List of validation error messages.
+    """
+    providers = metadata.get("providers")
+    if providers is None:
+        return []
+    if not isinstance(providers, list):
+        return ["Field 'providers' must be a list"]
+
+    errors: list[str] = []
+    hosts: list[int] = []
+
+    for index, provider in enumerate(providers):
+        if not isinstance(provider, dict):
+            errors.append(f"Field 'providers[{index}]' must be a mapping with a 'name'")
+            continue
+
+        name = provider.get("name")
+        if name is None:
+            errors.append(f"Field 'providers[{index}].name' is missing")
+        elif not str(name).strip():
+            errors.append(f"Field 'providers[{index}].name' cannot be empty")
+
+        roles = provider.get("roles")
+        if roles is not None:
+            errors.extend(_validate_provider_roles(roles, index))
+            if isinstance(roles, list) and HOST_ROLE in roles:
+                hosts.append(index)
+
+    if len(hosts) > 1:
+        listed = ", ".join(f"providers[{i}]" for i in hosts)
+        errors.append(
+            f"Exactly one provider may carry the host role, but {len(hosts)} do: {listed}"
+        )
+    for index in hosts:
+        errors.extend(_validate_host_contact(providers[index], index))
+
+    return errors
+
+
 def _validate_doi(metadata: dict[str, Any]) -> list[str]:
     """Validate the optional 'doi' field format.
 
@@ -427,6 +511,7 @@ def validate_metadata(metadata: dict[str, Any]) -> list[str]:
     errors.extend(_validate_license(metadata))
 
     # Optional fields with format validation
+    errors.extend(_validate_providers(metadata))
     errors.extend(_validate_doi(metadata))
     errors.extend(_validate_title_description(metadata))
 
@@ -629,6 +714,32 @@ contact:
   email: ""                         # Contact email
 
 license: ""                         # SPDX identifier (e.g., "CC-BY-4.0", "MIT")
+
+# -----------------------------------------------------------------------------
+# Providers: who made this data, and who maintains this copy of it
+#
+# Name the organization that originally created the data with the "producer"
+# role. Add "licensor" and "processor" where they apply. Roles may be combined,
+# so a self-published collection is one entry holding both producer and host.
+#
+# The "host" is whoever maintains this catalog, not the cloud vendor storing it:
+# a catalog on S3 run by a city GIS office lists the office, never AWS. Leave the
+# host out and it is taken from `contact` above. Order does not matter; Portolan
+# writes the host last, as the spec requires.
+#
+# Producer and host together decide what kind of catalog this is. Same
+# organization means official, this catalog being the data's canonical home.
+# Different organizations mean a mirror, and Portolan then links back to
+# `source_url` below and records each sync.
+# -----------------------------------------------------------------------------
+
+# providers:
+#   - name: "National Statistics Institute"
+#     roles: ["producer", "licensor"]
+#     url: "https://stats.example.org"
+#   - name: "City GIS Office"       # omit to derive this from `contact`
+#     roles: ["host"]
+#     url: "https://gis.example.org"   # a url or an email is required on the host
 
 # -----------------------------------------------------------------------------
 # OPTIONAL: Discovery and citation

--- a/portolan_cli/providers.py
+++ b/portolan_cli/providers.py
@@ -1,0 +1,217 @@
+"""The provider model behind a collection's STAC ``providers`` array (issue #684).
+
+The spec requires every collection to name at least one provider with the
+``producer`` role and exactly one with ``host``, listed last, and requires the
+host to carry a ``url`` or an ``email``. Ordering and role arithmetic are
+mechanical, so the human writes a plain ``providers`` list in metadata.yaml and
+this module puts it in conformant shape:
+
+- the single host moves to the end, whatever order it was written in;
+- a missing host is seeded from ``contact``, which metadata.yaml already
+  requires and which is what the spec means by the maintainer contact;
+- ``processor`` and ``licensor`` roles pass through untouched, and one
+  organization may hold several roles.
+
+Producers cannot be invented. A collection whose human named no producer keeps
+firing PTL-PRV-001, which ``validation.remediation`` routes to INSTRUCT.
+
+``derive_provenance`` reads official-vs-mirror back off the finished array,
+matching ``rashid.rules.provenance.provenance_of`` field for field so generation
+and validation never disagree about which kind of catalog this is.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from portolan_cli.errors import InvalidProvidersError
+
+PRODUCER_ROLE = "producer"
+HOST_ROLE = "host"
+
+#: The four roles STAC defines for a provider.
+PROVIDER_ROLES: tuple[str, ...] = ("producer", "processor", "licensor", "host")
+
+#: Optional provider fields carried through from metadata.yaml. ``email`` is not
+#: a core STAC field but is a valid extension of the provider object, and the
+#: Portolan schema accepts it in place of ``url`` on the host (PTL-PRV-003).
+_OPTIONAL_FIELDS = ("description", "url", "email")
+
+Provenance = Literal["official", "mirror"]
+
+
+def _text(value: object) -> str | None:
+    """Return a stripped non-empty string, or None for anything else."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _roles_of(provider: Mapping[str, Any]) -> list[str]:
+    raw = provider.get("roles")
+    if not isinstance(raw, list):
+        return []
+    return [role for role in raw if isinstance(role, str)]
+
+
+def _with_role(providers: list[dict[str, Any]], role: str) -> list[dict[str, Any]]:
+    return [provider for provider in providers if role in _roles_of(provider)]
+
+
+def _normalized_name(provider: Mapping[str, Any]) -> str | None:
+    name = _text(provider.get("name"))
+    return name.casefold() if name is not None else None
+
+
+def _validated_roles(entry: Mapping[str, Any], index: int) -> list[str]:
+    """Validate one entry's roles against the four STAC defines."""
+    raw = entry.get("roles")
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise InvalidProvidersError(f"providers[{index}].roles must be a list")
+
+    for role in raw:
+        if not isinstance(role, str) or role not in PROVIDER_ROLES:
+            raise InvalidProvidersError(
+                f"providers[{index}].roles has unknown role {role!r}; "
+                f"use one of {', '.join(PROVIDER_ROLES)}"
+            )
+    return list(raw)
+
+
+def _validated_entry(entry: object, index: int) -> dict[str, Any]:
+    """Turn one metadata.yaml providers entry into a STAC provider object."""
+    if not isinstance(entry, Mapping):
+        raise InvalidProvidersError(f"providers[{index}] must be a mapping with a 'name'")
+
+    name = _text(entry.get("name"))
+    if name is None:
+        raise InvalidProvidersError(f"providers[{index}].name cannot be empty")
+
+    provider: dict[str, Any] = {"name": name}
+    roles = _validated_roles(entry, index)
+    if roles:
+        provider["roles"] = roles
+    for field in _OPTIONAL_FIELDS:
+        value = _text(entry.get(field))
+        if value is not None:
+            provider[field] = value
+    return provider
+
+
+def _host_from_contact_text(text: str) -> dict[str, Any]:
+    """Treat a bare ``contact`` string as the maintainer, and as an address if it is one."""
+    host: dict[str, Any] = {"name": text, "roles": [HOST_ROLE]}
+    if "@" in text:
+        host["email"] = text
+    return host
+
+
+def _host_from_contact_mapping(contact: Mapping[str, Any]) -> dict[str, Any] | None:
+    email = _text(contact.get("email"))
+    name = _text(contact.get("name"))
+    if name is None and email is None:
+        return None
+
+    host: dict[str, Any] = {"name": name or email, "roles": [HOST_ROLE]}
+    if email is not None:
+        host["email"] = email
+    url = _text(contact.get("url"))
+    if url is not None:
+        host["url"] = url
+    return host
+
+
+def _host_from_contact(contact: object) -> dict[str, Any] | None:
+    """Build a host provider from metadata.yaml's ``contact``.
+
+    The spec calls the host provider the maintainer-contact requirement for a
+    Portolan catalog, and ``contact`` is where metadata.yaml already records the
+    maintainer, so it is the same fact in two shapes.
+    """
+    if isinstance(contact, str):
+        text = _text(contact)
+        return _host_from_contact_text(text) if text is not None else None
+    if isinstance(contact, Mapping):
+        return _host_from_contact_mapping(contact)
+    return None
+
+
+def _declared_host(providers: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the one entry claiming the host role, refusing to pick between two."""
+    hosts = _with_role(providers, HOST_ROLE)
+    if len(hosts) > 1:
+        names = ", ".join(repr(host["name"]) for host in hosts)
+        raise InvalidProvidersError(
+            f"exactly one provider may carry the 'host' role, but {len(hosts)} do: {names}"
+        )
+    return hosts[0] if hosts else None
+
+
+def resolve_providers(metadata: object) -> list[dict[str, Any]] | None:
+    """Build a collection's STAC providers array from merged metadata.yaml.
+
+    Args:
+        metadata: Merged metadata.yaml mapping (other types yield None).
+
+    Returns:
+        The providers array with the host last, or None when the metadata
+        declares no providers and carries no usable contact.
+
+    Raises:
+        InvalidProvidersError: When an entry is malformed, names an unknown role,
+            or when two entries both claim the ``host`` role.
+    """
+    if not isinstance(metadata, Mapping):
+        return None
+
+    raw = metadata.get("providers")
+    providers: list[dict[str, Any]] = []
+    if isinstance(raw, list):
+        providers = [_validated_entry(entry, index) for index, entry in enumerate(raw)]
+
+    host = _declared_host(providers)
+    if host is None:
+        host = _host_from_contact(metadata.get("contact"))
+        if host is not None:
+            providers.append(host)
+
+    if not providers:
+        return None
+    if host is None:
+        return providers
+    return [provider for provider in providers if provider is not host] + [host]
+
+
+def derive_provenance(providers: list[dict[str, Any]] | None) -> Provenance | None:
+    """Derive whether a collection is official or a mirror of someone else's data.
+
+    Official when the producer and the host are the same organization, mirror
+    when they differ. Mirrors what ``rashid.rules.provenance.provenance_of``
+    computes, including the case-folded name comparison, so a collection
+    Portolan generates is classified the same way ``portolan check`` classifies
+    it.
+
+    Args:
+        providers: A collection's providers array, as plain dicts.
+
+    Returns:
+        ``"official"``, ``"mirror"``, or None when the array names no producer
+        or does not name exactly one host.
+    """
+    if not providers:
+        return None
+
+    producers = _with_role(providers, PRODUCER_ROLE)
+    hosts = _with_role(providers, HOST_ROLE)
+    if not producers or len(hosts) != 1:
+        return None
+
+    host_name = _normalized_name(hosts[0])
+    if host_name is None:
+        return None
+    if any(_normalized_name(producer) == host_name for producer in producers):
+        return "official"
+    return "mirror"

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -24,6 +24,7 @@ from pystac.summaries import Summarizer, SummaryStrategy
 from portolan_cli.constants import PARTITION_EXTENSION_URI, PORTOLAN_SCHEMA_URI
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic
+from portolan_cli.providers import derive_provenance, resolve_providers
 
 # Any versioned Portolan profile URI, not just the current one: matching the
 # whole family is what lets a stale claim be rewritten rather than duplicated.
@@ -538,6 +539,116 @@ def apply_human_license(collection: pystac.Collection, metadata: object) -> None
         if link.rel == "license" and link.href == href:
             return
     collection.add_link(pystac.Link(rel="license", target=href, title="License"))
+
+
+def apply_human_providers(collection: pystac.Collection, metadata: object) -> None:
+    """Apply the human-authored providers array from metadata.yaml (issue #684).
+
+    Every collection must name a producer and exactly one host, listed last
+    (PTL-PRV-001, PTL-PRV-002). ``providers.resolve_providers`` does the ordering
+    and seeds the host from ``contact``; this writes the result onto the
+    collection. Metadata that declares nothing leaves any existing array alone,
+    so a re-add never wipes providers a human wrote straight into
+    ``collection.json``.
+
+    Args:
+        collection: The collection to update in place.
+        metadata: The merged metadata.yaml mapping (other types ignored).
+
+    Raises:
+        InvalidProvidersError: When metadata.yaml declares a providers array
+            Portolan cannot put in conformant shape.
+    """
+    resolved = resolve_providers(metadata)
+    if not resolved:
+        return
+
+    collection.providers = [
+        pystac.Provider(
+            name=str(provider["name"]),
+            description=provider.get("description"),
+            roles=provider.get("roles"),
+            url=provider.get("url"),
+            extra_fields={"email": provider["email"]} if "email" in provider else None,
+        )
+        for provider in resolved
+    ]
+
+
+def _collection_provenance(collection: pystac.Collection) -> str | None:
+    """Derive official vs mirror from the providers already on the collection."""
+    return derive_provenance([provider.to_dict() for provider in collection.providers or []])
+
+
+def apply_provenance(
+    collection: pystac.Collection,
+    metadata: object,
+    *,
+    synced_at: datetime | None = None,
+) -> None:
+    """Record how this collection relates to the data's original source (issue #684).
+
+    Source provenance is derived from the providers, never declared separately: a
+    collection is official when its producer also hosts it, and a mirror when
+    they differ. A mirror links back to the source with ``rel="via"``
+    (PTL-PRO-001) and records the sync in a top-level RFC 3339 ``updated`` field
+    (PTL-PRO-003). An official collection is the source, so it gets neither
+    (PTL-PRO-004).
+
+    The sync a mirror records is the sync *from its source*, which for Portolan
+    is the moment ``add`` copied or converted the data, not a later ``push`` to
+    object storage.
+
+    Args:
+        collection: The collection to update in place.
+        metadata: The merged metadata.yaml mapping (other types ignored).
+        synced_at: The sync time to record. Defaults to now, in UTC.
+    """
+    provenance = _collection_provenance(collection)
+    if provenance is None:
+        return
+
+    source_url = metadata.get("source_url") if isinstance(metadata, dict) else None
+    source_url = source_url.strip() if isinstance(source_url, str) and source_url.strip() else None
+
+    if provenance == "official":
+        if source_url is not None:
+            from portolan_cli.output import warn as warn_output
+
+            warn_output(
+                f"{collection.id}: producer and host are the same organization, so the "
+                f"collection is official and carries no via link to {source_url}"
+            )
+        return
+
+    collection.extra_fields["updated"] = to_rfc3339(synced_at or datetime.now(timezone.utc))
+
+    if source_url is None:
+        import logging
+
+        logging.getLogger(__name__).debug(
+            "%s mirrors data it did not produce but metadata.yaml declares no source_url",
+            collection.id,
+        )
+        return
+    for link in collection.links:
+        if link.rel == "via" and link.href == source_url:
+            return
+    collection.add_link(
+        pystac.Link(
+            rel="via",
+            target=source_url,
+            media_type="text/html",
+            title="Original source",
+        )
+    )
+
+
+def to_rfc3339(moment: datetime) -> str:
+    """Format a datetime as the RFC 3339 date-time STAC's ``updated`` field wants."""
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def add_partition_metadata_to_collection(
@@ -1539,6 +1650,52 @@ def update_catalog_file_statistics(catalog_root: Path) -> None:
         catalog_data["portolan:total_size_bytes"] = total_size
         catalog_data["portolan:asset_count"] = asset_count
         catalog_data["portolan:collection_count"] = collection_count
+        write_json_atomic(catalog_path, catalog_data)
+    except (json.JSONDecodeError, OSError):
+        pass
+
+
+def update_catalog_provenance(catalog_root: Path) -> None:
+    """Stamp the root catalog's sync time when the whole tree is a mirror (issue #684).
+
+    PTL-PRO-003 requires the top-level ``updated`` field on every mirror
+    collection, and on the root catalog too when every collection under it is a
+    mirror — at that point the catalog as a whole is a copy of data published
+    elsewhere. A tree that mixes official and mirrored collections leaves the
+    root alone, since the catalog is not wholly either one.
+
+    The value is the newest sync time among the collections, so the root reports
+    the freshness a consumer would compare against the source.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+    """
+    import json
+
+    catalog_path = catalog_root / "catalog.json"
+    if not catalog_path.exists():
+        return
+
+    stamps: list[str] = []
+    for collection_json in catalog_root.rglob("collection.json"):
+        try:
+            data = json.loads(collection_json.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("type") != "Collection":
+            continue
+        if derive_provenance(data.get("providers")) != "mirror":
+            return
+        updated = data.get("updated")
+        if isinstance(updated, str):
+            stamps.append(updated)
+
+    if not stamps:
+        return
+
+    try:
+        catalog_data = json.loads(catalog_path.read_text(encoding="utf-8"))
+        catalog_data["updated"] = max(stamps)
         write_json_atomic(catalog_path, catalog_data)
     except (json.JSONDecodeError, OSError):
         pass

--- a/tests/integration/test_generated_catalog_conformance.py
+++ b/tests/integration/test_generated_catalog_conformance.py
@@ -33,11 +33,6 @@ KNOWN_GAPS = frozenset(
         # Thumbnail rendering lives behind the optional [thumbnails] extra and
         # is not part of the default add pipeline.
         "PTL-VIZ-001",
-        # PTL-PRV-001: every collection needs a provider with the producer role.
-        # Portolan has no provider model — metadata.yaml carries `contact` and
-        # `attribution`, neither of which maps onto STAC providers without a
-        # design decision about roles and ordering (PTL-PRV-002/003).
-        "PTL-PRV-001",
         # PTL-DAT-007: every row group needs spatial statistics. geoparquet-io
         # writes a single row group for a file this small and emits neither a
         # bbox covering column nor native GeospatialStatistics for it, so the
@@ -71,6 +66,24 @@ def _build_catalog(root: Path) -> None:
                 "license": "CC-BY-4.0",
                 "contact": "data@example.org",
                 "source": "Example municipal open-data portal",
+                # A mirror, the more demanding of the two provenance shapes: the
+                # producer differs from the host, so generation owes a rel:'via'
+                # link and an 'updated' stamp on both collections and, because
+                # every collection here is a mirror, on the root catalog too
+                # (PTL-PRV-001/002/003, PTL-PRO-001/003).
+                "providers": [
+                    {
+                        "name": "Example Statistics Agency",
+                        "roles": ["producer", "licensor"],
+                        "url": "https://stats.example.org",
+                    },
+                    {
+                        "name": "Example Municipal Open Data",
+                        "roles": ["host"],
+                        "url": "https://data.example.org/contact",
+                    },
+                ],
+                "source_url": "https://stats.example.org/downloads/roads",
             }
         ),
         encoding="utf-8",

--- a/tests/integration/test_provider_generation.py
+++ b/tests/integration/test_provider_generation.py
@@ -1,0 +1,234 @@
+"""Generated collections declare providers and their derived provenance (issue #684).
+
+``init`` + ``add`` used to emit collections with no ``providers`` array, so every
+generated catalog failed PTL-PRV-001 against its own ``portolan check``. These
+tests build real catalogs both ways the spec recognises — official, where the
+producer also hosts, and mirror, where they differ — and assert that rashid finds
+nothing to report in either the provider or the provenance rule family.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import yaml
+from click.testing import CliRunner
+from rashid import Severity, validate
+
+from portolan_cli.cli import cli
+
+pytestmark = pytest.mark.integration
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
+
+OFFICIAL_PROVIDERS = [
+    {
+        "name": "Example City GIS",
+        "roles": ["producer", "licensor", "host"],
+        "url": "https://gis.example.org",
+    }
+]
+
+MIRROR_PROVIDERS = [
+    {"name": "INDEC", "roles": ["producer", "licensor"], "url": "https://indec.gob.ar"},
+    {"name": "Example City GIS", "roles": ["host"], "url": "https://gis.example.org"},
+]
+
+
+def _build_catalog(root: Path, metadata: dict[str, Any], *, tabular: bool = False) -> None:
+    collection_dir = root / "roads"
+    collection_dir.mkdir(parents=True)
+    shutil.copy(FIXTURE, collection_dir / "roads.parquet")
+
+    paths = [str(collection_dir / "roads.parquet")]
+    if tabular:
+        tabular_dir = root / "demographics"
+        tabular_dir.mkdir(parents=True)
+        pq.write_table(
+            pa.table({"tract_id": ["001", "002"], "population": [5000, 7500]}),
+            tabular_dir / "census.parquet",
+        )
+        paths.append(str(tabular_dir / "census.parquet"))
+
+    portolan_dir = root / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "metadata.yaml").write_text(yaml.dump(metadata), encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "init",
+            str(root),
+            "--auto",
+            "--title",
+            "Provider Catalog",
+            "--description",
+            "Roads published to exercise the provider model.",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    if tabular:
+        config = portolan_dir / "config.yaml"
+        config.write_text(config.read_text() + "tabular:\n  enabled: true\n", encoding="utf-8")
+
+    result = runner.invoke(
+        cli,
+        ["add", "--portolan-dir", str(root), *paths],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+
+def _read(path: Path) -> dict[str, Any]:
+    loaded: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return loaded
+
+
+def _rfc3339(value: object) -> datetime:
+    """Parse an offset-bearing RFC 3339 date-time, the shape PTL-PRO-003 accepts."""
+    assert isinstance(value, str), f"expected an RFC 3339 string, got {value!r}"
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _rel(collection: dict[str, Any], rel: str) -> list[dict[str, Any]]:
+    return [link for link in collection.get("links", []) if link.get("rel") == rel]
+
+
+def _provider_findings(root: Path) -> list[str]:
+    report = validate(root, structural=True, data=True)
+    return sorted(
+        f.rule_id
+        for f in report.findings
+        if f.severity is Severity.ERROR
+        and (f.rule_id.startswith("PTL-PRV") or f.rule_id.startswith("PTL-PRO"))
+    )
+
+
+@pytest.fixture(scope="module")
+def official_catalog(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    root = tmp_path_factory.mktemp("official") / "catalog"
+    _build_catalog(
+        root,
+        {
+            "license": "CC-BY-4.0",
+            "contact": {"name": "Example City GIS", "email": "gis@example.org"},
+            "providers": OFFICIAL_PROVIDERS,
+        },
+        tabular=True,
+    )
+    return root
+
+
+@pytest.fixture(scope="module")
+def mirror_catalog(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    root = tmp_path_factory.mktemp("mirror") / "catalog"
+    _build_catalog(
+        root,
+        {
+            "license": "CC-BY-4.0",
+            "contact": {"name": "Example City GIS", "email": "gis@example.org"},
+            "providers": MIRROR_PROVIDERS,
+            "source_url": "https://indec.gob.ar/descargas/roads",
+        },
+    )
+    return root
+
+
+class TestOfficialCatalog:
+    def test_the_collection_declares_the_providers_with_the_host_last(
+        self, official_catalog: Path
+    ) -> None:
+        collection = _read(official_catalog / "roads" / "collection.json")
+
+        assert collection["providers"] == OFFICIAL_PROVIDERS
+
+    def test_a_tabular_collection_declares_them_too(self, official_catalog: Path) -> None:
+        """The tabular path never reaches finalize_items, so it applies them itself."""
+        collection = _read(official_catalog / "demographics" / "collection.json")
+
+        assert collection["providers"] == OFFICIAL_PROVIDERS
+
+    def test_it_carries_no_upstream_links(self, official_catalog: Path) -> None:
+        """PTL-PRO-004: an official collection is the source, not a mirror."""
+        collection = _read(official_catalog / "roads" / "collection.json")
+
+        assert _rel(collection, "via") == []
+        assert _rel(collection, "canonical") == []
+
+    def test_it_carries_no_updated_stamp(self, official_catalog: Path) -> None:
+        collection = _read(official_catalog / "roads" / "collection.json")
+
+        assert "updated" not in collection
+
+    def test_rashid_reports_no_provider_or_provenance_error(self, official_catalog: Path) -> None:
+        assert _provider_findings(official_catalog) == []
+
+
+class TestMirrorCatalog:
+    def test_the_collection_declares_the_providers_with_the_host_last(
+        self, mirror_catalog: Path
+    ) -> None:
+        collection = _read(mirror_catalog / "roads" / "collection.json")
+
+        assert [p["name"] for p in collection["providers"]] == ["INDEC", "Example City GIS"]
+        assert collection["providers"][-1]["roles"] == ["host"]
+
+    def test_it_links_back_to_the_source_as_text_html(self, mirror_catalog: Path) -> None:
+        """PTL-PRO-001 wants the via link, and wants it typed text/html."""
+        collection = _read(mirror_catalog / "roads" / "collection.json")
+
+        via = _rel(collection, "via")
+        assert len(via) == 1
+        assert via[0]["href"] == "https://indec.gob.ar/descargas/roads"
+        assert via[0]["type"] == "text/html"
+
+    def test_it_records_the_sync_time(self, mirror_catalog: Path) -> None:
+        """PTL-PRO-003 wants a top-level RFC 3339 updated field on the mirror."""
+        collection = _read(mirror_catalog / "roads" / "collection.json")
+
+        assert _rfc3339(collection.get("updated")).tzinfo is not None
+
+    def test_the_root_catalog_records_it_too(self, mirror_catalog: Path) -> None:
+        """PTL-PRO-003 reaches the root when every collection in the tree is a mirror."""
+        catalog = _read(mirror_catalog / "catalog.json")
+
+        assert _rfc3339(catalog.get("updated")).tzinfo is not None
+
+    def test_rashid_reports_no_provider_or_provenance_error(self, mirror_catalog: Path) -> None:
+        assert _provider_findings(mirror_catalog) == []
+
+
+class TestContactSeedsTheHost:
+    def test_a_producer_alone_still_yields_a_conformant_host(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """PTL-PRV-002 and -003 are satisfied from contact, which is already required."""
+        root = tmp_path_factory.mktemp("seeded") / "catalog"
+        _build_catalog(
+            root,
+            {
+                "license": "CC-BY-4.0",
+                "contact": {"name": "Example City GIS", "email": "gis@example.org"},
+                "providers": [{"name": "INDEC", "roles": ["producer"]}],
+                "source_url": "https://indec.gob.ar/descargas/roads",
+            },
+        )
+
+        collection = _read(root / "roads" / "collection.json")
+
+        assert collection["providers"][-1] == {
+            "name": "Example City GIS",
+            "roles": ["host"],
+            "email": "gis@example.org",
+        }
+        assert _provider_findings(root) == []

--- a/tests/integration/test_rashid_roundtrip.py
+++ b/tests/integration/test_rashid_roundtrip.py
@@ -33,11 +33,11 @@ pytestmark = pytest.mark.integration
 FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
 
 # Errors a generated catalog still carries: thumbnail rendering lives behind an
-# optional extra, Portolan has no provider model, and geoparquet-io writes a
-# single row group with no per-row-group spatial statistics for a file this
-# small. Shared with tests/integration/test_generated_catalog_conformance.py,
-# which is the gate that keeps the list honest.
-GENERATION_GAPS = frozenset({"PTL-VIZ-001", "PTL-PRV-001", "PTL-DAT-007"})
+# optional extra, and geoparquet-io writes a single row group with no
+# per-row-group spatial statistics for a file this small. Shared with
+# tests/integration/test_generated_catalog_conformance.py, which is the gate that
+# keeps the list honest.
+GENERATION_GAPS = frozenset({"PTL-VIZ-001", "PTL-DAT-007"})
 
 # What the corruptions below must produce, and nothing else.
 EXPECTED_FROM_DAMAGE = frozenset(
@@ -65,6 +65,17 @@ def _build_catalog(root: Path) -> None:
                 "license": "CC-BY-4.0",
                 "contact": "data@example.org",
                 "source": "Example municipal open-data portal",
+                # Official: one organization both produced the roads and hosts
+                # them, so the collection is the data's canonical home and
+                # carries no upstream links (PTL-PRO-004). The mirror shape is
+                # covered by the conformance gate and test_provider_generation.
+                "providers": [
+                    {
+                        "name": "Example Municipal GIS",
+                        "roles": ["producer", "licensor", "host"],
+                        "url": "https://gis.example.org",
+                    }
+                ],
             }
         ),
         encoding="utf-8",

--- a/tests/unit/test_apply_human_providers.py
+++ b/tests/unit/test_apply_human_providers.py
@@ -1,0 +1,192 @@
+"""Unit tests for putting metadata.yaml's providers on a collection (issue #684).
+
+A generated collection used to declare no providers at all, which rashid rejects
+under PTL-PRV-001. Two appliers close that: ``apply_human_providers`` writes the
+array, and ``apply_provenance`` reads official-vs-mirror back off it to decide
+whether a ``via`` link and an ``updated`` stamp belong on the collection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pystac
+import pytest
+
+from portolan_cli.stac import apply_human_providers, apply_provenance
+
+pytestmark = pytest.mark.unit
+
+
+SYNCED_AT = datetime(2026, 7, 30, 9, 15, 0, tzinfo=timezone.utc)
+
+MIRROR = {
+    "providers": [
+        {"name": "INDEC", "roles": ["producer"], "url": "https://indec.gob.ar"},
+        {"name": "Source Cooperative", "roles": ["host"], "url": "https://source.coop"},
+    ],
+    "source_url": "https://indec.gob.ar/descargas",
+}
+
+OFFICIAL = {
+    "providers": [
+        {"name": "City GIS", "roles": ["producer", "host"], "url": "https://gis.example"},
+    ],
+}
+
+
+def _collection() -> pystac.Collection:
+    return pystac.Collection(
+        id="roads",
+        description="Roads",
+        extent=pystac.Extent(
+            spatial=pystac.SpatialExtent([[-1.0, -1.0, 1.0, 1.0]]),
+            temporal=pystac.TemporalExtent([[datetime.now(timezone.utc), None]]),
+        ),
+        license="CC-BY-4.0",
+    )
+
+
+def _links(collection: pystac.Collection, rel: str) -> list[pystac.Link]:
+    return [link for link in collection.links if link.rel == rel]
+
+
+def _provider_dicts(collection: pystac.Collection) -> list[dict[str, object]]:
+    return [p.to_dict() for p in collection.providers or []]
+
+
+class TestApplyHumanProviders:
+    def test_writes_the_array_with_the_host_last(self) -> None:
+        collection = _collection()
+
+        apply_human_providers(collection, MIRROR)
+
+        assert [p["name"] for p in _provider_dicts(collection)] == [
+            "INDEC",
+            "Source Cooperative",
+        ]
+
+    def test_carries_email_onto_the_host_provider(self) -> None:
+        """PTL-PRV-003 accepts an email, which is not a core STAC provider field."""
+        collection = _collection()
+
+        apply_human_providers(
+            collection,
+            {"providers": [{"name": "INDEC", "roles": ["producer"]}], "contact": "d@example.org"},
+        )
+
+        assert _provider_dicts(collection)[-1] == {
+            "name": "d@example.org",
+            "roles": ["host"],
+            "email": "d@example.org",
+        }
+
+    def test_leaves_providers_unset_when_nothing_is_declared(self) -> None:
+        collection = _collection()
+
+        apply_human_providers(collection, {})
+        apply_human_providers(collection, "not-a-mapping")
+
+        assert not collection.providers
+
+    def test_does_not_clobber_existing_providers_with_nothing(self) -> None:
+        """A re-add with no provider metadata must not wipe what is already there."""
+        collection = _collection()
+        apply_human_providers(collection, MIRROR)
+
+        apply_human_providers(collection, {})
+
+        assert len(_provider_dicts(collection)) == 2
+
+    def test_is_idempotent(self) -> None:
+        collection = _collection()
+
+        apply_human_providers(collection, MIRROR)
+        apply_human_providers(collection, MIRROR)
+
+        assert len(_provider_dicts(collection)) == 2
+
+
+class TestApplyProvenanceForAMirror:
+    def test_adds_the_via_link_as_text_html(self) -> None:
+        collection = _collection()
+        apply_human_providers(collection, MIRROR)
+
+        apply_provenance(collection, MIRROR, synced_at=SYNCED_AT)
+
+        via = _links(collection, "via")
+        assert len(via) == 1
+        assert via[0].href == "https://indec.gob.ar/descargas"
+        assert via[0].media_type == "text/html"
+
+    def test_stamps_updated_as_rfc3339(self) -> None:
+        collection = _collection()
+        apply_human_providers(collection, MIRROR)
+
+        apply_provenance(collection, MIRROR, synced_at=SYNCED_AT)
+
+        assert collection.extra_fields["updated"] == "2026-07-30T09:15:00Z"
+
+    def test_restamps_updated_on_a_later_sync(self) -> None:
+        collection = _collection()
+        apply_human_providers(collection, MIRROR)
+        apply_provenance(collection, MIRROR, synced_at=SYNCED_AT)
+
+        later = datetime(2026, 8, 1, 0, 0, 0, tzinfo=timezone.utc)
+        apply_provenance(collection, MIRROR, synced_at=later)
+
+        assert collection.extra_fields["updated"] == "2026-08-01T00:00:00Z"
+
+    def test_does_not_duplicate_the_via_link(self) -> None:
+        collection = _collection()
+        apply_human_providers(collection, MIRROR)
+
+        apply_provenance(collection, MIRROR, synced_at=SYNCED_AT)
+        apply_provenance(collection, MIRROR, synced_at=SYNCED_AT)
+
+        assert len(_links(collection, "via")) == 1
+
+    def test_stamps_updated_even_without_a_source_url(self) -> None:
+        """PTL-PRO-001 stays for the human to answer; PTL-PRO-003 need not."""
+        metadata = {"providers": MIRROR["providers"]}
+        collection = _collection()
+        apply_human_providers(collection, metadata)
+
+        apply_provenance(collection, metadata, synced_at=SYNCED_AT)
+
+        assert _links(collection, "via") == []
+        assert collection.extra_fields["updated"] == "2026-07-30T09:15:00Z"
+
+
+class TestApplyProvenanceForAnOfficialCatalog:
+    def test_adds_no_via_link(self) -> None:
+        """PTL-PRO-004: an official collection is the source, not a mirror."""
+        metadata = {**OFFICIAL, "source_url": "https://gis.example/downloads"}
+        collection = _collection()
+        apply_human_providers(collection, metadata)
+
+        apply_provenance(collection, metadata, synced_at=SYNCED_AT)
+
+        assert _links(collection, "via") == []
+
+    def test_adds_no_updated_stamp(self) -> None:
+        collection = _collection()
+        apply_human_providers(collection, OFFICIAL)
+
+        apply_provenance(collection, OFFICIAL, synced_at=SYNCED_AT)
+
+        assert "updated" not in collection.extra_fields
+
+
+class TestApplyProvenanceWhenUnderivable:
+    def test_touches_nothing_without_providers(self) -> None:
+        collection = _collection()
+
+        apply_provenance(
+            collection,
+            {"source_url": "https://example.org/downloads"},
+            synced_at=SYNCED_AT,
+        )
+
+        assert _links(collection, "via") == []
+        assert "updated" not in collection.extra_fields

--- a/tests/unit/test_metadata_yaml_providers.py
+++ b/tests/unit/test_metadata_yaml_providers.py
@@ -1,0 +1,143 @@
+"""Validation for the metadata.yaml providers block (issue #684).
+
+``portolan metadata validate`` should catch a malformed providers array before
+generation does, so the human sees the problem next to the file they wrote
+rather than as a PTL-PRV finding from ``portolan check``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from portolan_cli.metadata_yaml import validate_metadata
+
+pytestmark = pytest.mark.unit
+
+
+def _metadata(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "contact": {"name": "GIS Office", "email": "gis@example.org"},
+        "license": "CC-BY-4.0",
+    }
+    base.update(overrides)
+    return base
+
+
+def _provider_errors(providers: Any) -> list[str]:
+    return [e for e in validate_metadata(_metadata(providers=providers)) if "provider" in e]
+
+
+class TestValidProviders:
+    def test_a_producer_and_a_host_pass(self) -> None:
+        assert (
+            validate_metadata(
+                _metadata(
+                    providers=[
+                        {"name": "INDEC", "roles": ["producer"], "url": "https://indec.gob.ar"},
+                        {
+                            "name": "Source Cooperative",
+                            "roles": ["host"],
+                            "url": "https://source.coop",
+                        },
+                    ]
+                )
+            )
+            == []
+        )
+
+    def test_one_organization_holding_both_roles_passes(self) -> None:
+        assert (
+            validate_metadata(
+                _metadata(
+                    providers=[
+                        {
+                            "name": "City GIS",
+                            "roles": ["producer", "host"],
+                            "email": "gis@example.org",
+                        }
+                    ]
+                )
+            )
+            == []
+        )
+
+    def test_a_producer_without_a_host_passes(self) -> None:
+        """The host is seeded from contact, so leaving it out is legitimate."""
+        assert (
+            validate_metadata(_metadata(providers=[{"name": "INDEC", "roles": ["producer"]}])) == []
+        )
+
+    def test_licensor_and_processor_roles_pass(self) -> None:
+        assert (
+            validate_metadata(
+                _metadata(
+                    providers=[
+                        {"name": "INDEC", "roles": ["producer", "licensor"]},
+                        {"name": "Consultancy", "roles": ["processor"]},
+                        {"name": "Host Org", "roles": ["host"], "url": "https://host.example"},
+                    ]
+                )
+            )
+            == []
+        )
+
+    def test_an_absent_providers_block_passes(self) -> None:
+        assert validate_metadata(_metadata()) == []
+
+
+class TestInvalidProviders:
+    def test_rejects_a_non_list(self) -> None:
+        assert _provider_errors("INDEC") == ["Field 'providers' must be a list"]
+
+    def test_rejects_a_non_mapping_entry(self) -> None:
+        errors = _provider_errors(["INDEC"])
+        assert errors == ["Field 'providers[0]' must be a mapping with a 'name'"]
+
+    def test_rejects_a_blank_name(self) -> None:
+        errors = _provider_errors([{"name": "  ", "roles": ["producer"]}])
+        assert errors == ["Field 'providers[0].name' cannot be empty"]
+
+    def test_rejects_an_unknown_role(self) -> None:
+        errors = _provider_errors([{"name": "Someone", "roles": ["publisher"]}])
+        assert len(errors) == 1
+        assert "publisher" in errors[0]
+        assert "producer" in errors[0]
+
+    def test_rejects_roles_that_are_not_a_list(self) -> None:
+        errors = _provider_errors([{"name": "Someone", "roles": "producer"}])
+        assert errors == ["Field 'providers[0].roles' must be a list"]
+
+    def test_rejects_two_hosts(self) -> None:
+        errors = _provider_errors(
+            [
+                {"name": "Host A", "roles": ["host"], "url": "https://a.example"},
+                {"name": "Host B", "roles": ["host"], "url": "https://b.example"},
+            ]
+        )
+        assert len(errors) == 1
+        assert "Exactly one provider may carry the host role" in errors[0]
+
+    def test_rejects_a_host_with_neither_url_nor_email(self) -> None:
+        errors = _provider_errors([{"name": "Host Org", "roles": ["host"]}])
+        assert len(errors) == 1
+        assert "url" in errors[0]
+        assert "email" in errors[0]
+
+    def test_rejects_an_invalid_host_email(self) -> None:
+        errors = _provider_errors(
+            [{"name": "Host Org", "roles": ["host"], "email": "not-an-email"}]
+        )
+        assert len(errors) == 1
+        assert "not-an-email" in errors[0]
+
+    def test_reports_the_index_of_the_offending_entry(self) -> None:
+        errors = _provider_errors(
+            [
+                {"name": "INDEC", "roles": ["producer"]},
+                {"name": "Someone", "roles": ["publisher"]},
+            ]
+        )
+        assert len(errors) == 1
+        assert "providers[1]" in errors[0]

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,0 +1,227 @@
+"""Unit tests for the provider model and the provenance it derives (issue #684).
+
+The spec requires every collection to name a producer and exactly one host,
+listed last. ``resolve_providers`` turns the ``providers`` array a human wrote in
+metadata.yaml into that shape, seeding the host from ``contact`` when the human
+left it out. ``derive_provenance`` then reads official-vs-mirror back off the
+result, matching rashid's ``provenance_of`` so generation and validation agree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portolan_cli.errors import InvalidProvidersError
+from portolan_cli.providers import derive_provenance, resolve_providers
+
+pytestmark = pytest.mark.unit
+
+
+CONTACT = {"contact": {"name": "GIS Office", "email": "gis@example.org"}}
+
+
+def _names(providers: list[dict[str, object]]) -> list[str]:
+    return [str(p["name"]) for p in providers]
+
+
+def _roles_of(providers: list[dict[str, object]], name: str) -> list[str]:
+    for provider in providers:
+        if provider["name"] == name:
+            roles = provider.get("roles")
+            return list(roles) if isinstance(roles, list) else []
+    raise AssertionError(f"no provider named {name!r} in {_names(providers)}")
+
+
+class TestResolveProviders:
+    def test_returns_none_when_nothing_is_declared(self) -> None:
+        """No providers and no contact leaves authorship to the human (PTL-PRV-001)."""
+        assert resolve_providers({}) is None
+        assert resolve_providers("not-a-mapping") is None
+
+    def test_moves_the_host_last_regardless_of_written_order(self) -> None:
+        """PTL-PRV-002 wants the host last, so the human's order cannot break it."""
+        providers = resolve_providers(
+            {
+                "providers": [
+                    {"name": "Source Cooperative", "roles": ["host"], "url": "https://source.coop"},
+                    {"name": "INDEC", "roles": ["producer"], "url": "https://indec.gob.ar"},
+                ]
+            }
+        )
+
+        assert providers is not None
+        assert _names(providers) == ["INDEC", "Source Cooperative"]
+
+    def test_keeps_declared_order_among_non_hosts(self) -> None:
+        providers = resolve_providers(
+            {
+                "providers": [
+                    {"name": "Host Org", "roles": ["host"], "url": "https://host.example"},
+                    {"name": "Producer Org", "roles": ["producer"]},
+                    {"name": "Processor Org", "roles": ["processor"]},
+                ]
+            }
+        )
+
+        assert providers is not None
+        assert _names(providers) == ["Producer Org", "Processor Org", "Host Org"]
+
+    def test_preserves_licensor_and_processor_roles(self) -> None:
+        """The spec says these SHOULD appear where they apply, so they survive."""
+        providers = resolve_providers(
+            {
+                "providers": [
+                    {
+                        "name": "INDEC",
+                        "roles": ["producer", "licensor"],
+                        "url": "https://indec.gob.ar",
+                    },
+                    {"name": "Host Org", "roles": ["host"], "email": "ops@host.example"},
+                ]
+            }
+        )
+
+        assert providers is not None
+        assert _roles_of(providers, "INDEC") == ["producer", "licensor"]
+
+    def test_one_organization_may_hold_producer_and_host(self) -> None:
+        providers = resolve_providers(
+            {
+                "providers": [
+                    {
+                        "name": "City GIS",
+                        "roles": ["producer", "host"],
+                        "url": "https://gis.example",
+                    }
+                ]
+            }
+        )
+
+        assert providers is not None
+        assert _names(providers) == ["City GIS"]
+        assert _roles_of(providers, "City GIS") == ["producer", "host"]
+
+    def test_seeds_the_host_from_contact_when_none_is_declared(self) -> None:
+        """contact is already required, and the spec calls host the maintainer contact."""
+        providers = resolve_providers(
+            {"providers": [{"name": "INDEC", "roles": ["producer"]}], **CONTACT}
+        )
+
+        assert providers is not None
+        assert _names(providers) == ["INDEC", "GIS Office"]
+        assert _roles_of(providers, "GIS Office") == ["host"]
+        assert providers[-1]["email"] == "gis@example.org"
+
+    def test_seeds_the_host_from_a_bare_contact_email_string(self) -> None:
+        providers = resolve_providers(
+            {
+                "providers": [{"name": "INDEC", "roles": ["producer"]}],
+                "contact": "data@example.org",
+            }
+        )
+
+        assert providers is not None
+        assert providers[-1]["name"] == "data@example.org"
+        assert providers[-1]["email"] == "data@example.org"
+
+    def test_a_declared_host_wins_over_contact(self) -> None:
+        providers = resolve_providers(
+            {
+                "providers": [
+                    {"name": "INDEC", "roles": ["producer"]},
+                    {"name": "Declared Host", "roles": ["host"], "url": "https://declared.example"},
+                ],
+                **CONTACT,
+            }
+        )
+
+        assert providers is not None
+        assert _names(providers) == ["INDEC", "Declared Host"]
+
+    def test_contact_alone_yields_a_host_only_array(self) -> None:
+        """PTL-PRV-001 still fires, but PTL-PRV-002 and -003 are satisfied."""
+        providers = resolve_providers(dict(CONTACT))
+
+        assert providers == [{"name": "GIS Office", "roles": ["host"], "email": "gis@example.org"}]
+
+    def test_rejects_two_declared_hosts(self) -> None:
+        """Nothing can pick between them, so say so instead of emitting both."""
+        with pytest.raises(InvalidProvidersError, match="exactly one"):
+            resolve_providers(
+                {
+                    "providers": [
+                        {"name": "Host A", "roles": ["host"], "url": "https://a.example"},
+                        {"name": "Host B", "roles": ["host"], "url": "https://b.example"},
+                    ]
+                }
+            )
+
+    def test_rejects_an_unknown_role(self) -> None:
+        with pytest.raises(InvalidProvidersError, match="publisher"):
+            resolve_providers({"providers": [{"name": "Someone", "roles": ["publisher"]}]})
+
+    def test_rejects_a_nameless_provider(self) -> None:
+        with pytest.raises(InvalidProvidersError, match="name"):
+            resolve_providers({"providers": [{"name": "   ", "roles": ["producer"]}]})
+
+    def test_ignores_a_providers_value_that_is_not_a_list(self) -> None:
+        assert resolve_providers({"providers": "INDEC", **CONTACT}) == [
+            {"name": "GIS Office", "roles": ["host"], "email": "gis@example.org"}
+        ]
+
+    def test_carries_url_description_and_email_through(self) -> None:
+        providers = resolve_providers(
+            {
+                "providers": [
+                    {
+                        "name": "INDEC",
+                        "roles": ["producer"],
+                        "url": "https://indec.gob.ar",
+                        "description": "National statistics institute",
+                    },
+                    {"name": "Host Org", "roles": ["host"], "email": "ops@host.example"},
+                ]
+            }
+        )
+
+        assert providers is not None
+        assert providers[0]["description"] == "National statistics institute"
+        assert providers[0]["url"] == "https://indec.gob.ar"
+        assert providers[1]["email"] == "ops@host.example"
+
+
+class TestDeriveProvenance:
+    def test_official_when_producer_and_host_are_the_same_organization(self) -> None:
+        providers = [
+            {"name": "City GIS", "roles": ["producer", "host"], "url": "https://g.example"}
+        ]
+
+        assert derive_provenance(providers) == "official"
+
+    def test_official_across_two_entries_with_the_same_name(self) -> None:
+        providers = [
+            {"name": "City GIS", "roles": ["producer"]},
+            {"name": "city gis", "roles": ["host"], "email": "gis@example.org"},
+        ]
+
+        assert derive_provenance(providers) == "official"
+
+    def test_mirror_when_they_differ(self) -> None:
+        providers = [
+            {"name": "INDEC", "roles": ["producer"]},
+            {"name": "Source Cooperative", "roles": ["host"], "url": "https://source.coop"},
+        ]
+
+        assert derive_provenance(providers) == "mirror"
+
+    def test_underivable_without_a_producer(self) -> None:
+        providers = [{"name": "Host Org", "roles": ["host"], "email": "ops@host.example"}]
+
+        assert derive_provenance(providers) is None
+
+    def test_underivable_without_a_host(self) -> None:
+        assert derive_provenance([{"name": "INDEC", "roles": ["producer"]}]) is None
+
+    def test_underivable_for_an_empty_array(self) -> None:
+        assert derive_provenance([]) is None
+        assert derive_provenance(None) is None


### PR DESCRIPTION
Closes #684.

`init` + `add` produced collections with no `providers` array, so every generated catalog failed its own `check` under PTL-PRV-001. metadata.yaml now carries a `providers` array, and generation writes it onto the collection at both call sites, including the tabular path that never reaches `finalize_items`.

## What the human writes, and what generation owns

Roles are written freely, one organization may hold several, and order does not matter. Generation moves the single host last (PTL-PRV-002) and seeds a missing host from `contact` — the spec calls the host provider the maintainer-contact requirement, and `contact` is where metadata.yaml already records the maintainer, so its email satisfies PTL-PRV-003. Two declared hosts raise `InvalidProvidersError`, because nothing can choose between them. Producers are never invented: a collection naming none keeps reporting PTL-PRV-001 as an INSTRUCT finding.

## Provenance is derived, not declared

Same producer and host means official, and the collection carries no upstream links (PTL-PRO-004). Different means mirror, which gets a `rel="via"` link typed `text/html` from `source_url` (PTL-PRO-001) and a top-level RFC 3339 `updated` field (PTL-PRO-003), plus that stamp on the root catalog when every collection in the tree is a mirror. `derive_provenance` mirrors rashid's `provenance_of` field for field, case-folded name comparison included, so generation and validation never disagree.

One judgment call worth your review: the stamp records the sync **from the source**, which for Portolan is `add`. Stamping only at `push` would leave `init` + `add` still failing `check`, which is the bug in the issue.

## Verification on real data

NWI wetlands and a RapidAI4EO scene from `tests/fixtures/realdata/`, published as a mirror of the US Fish and Wildlife Service:

```
$ uv run portolan add --portolan-dir "$DEMO" \
    "$DEMO/wetlands/nwi-wetlands.parquet"
✓ Added 1 file to 1 collection

$ jq '.providers, .updated, [.links[]|select(.rel=="via")]' \
    wetlands/collection.json
[
  {"name": "US Fish and Wildlife Service",
   "roles": ["producer", "licensor"],
   "url": "https://www.fws.gov/program/national-wetlands-inventory"},
  {"name": "Example City GIS",
   "roles": ["host"],
   "url": "https://gis.example.org/contact"}
]
"2026-07-30T10:15:49Z"
[{"rel": "via",
  "href": "https://www.fws.gov/wetlands/data/Data-Download.html",
  "type": "text/html", "title": "Original source"}]

$ jq .updated catalog.json          # all-mirror tree
"2026-07-30T10:16:00Z"
```

`portolan check` on that catalog reports no PTL-PRV finding and no PTL-PRO error. PTL-PRO-002 stays as 2 INFO rows, which is what the rule is for: whether the upstream publishes STAC is unknowable from the mirror's metadata. The 11 remaining errors are unrelated and pre-existing (projected bbox, `PTL-COL-001`, `PTL-DAT-*`, `PTL-VIZ-001`).

## Gates

`PTL-PRV-001` leaves `KNOWN_GAPS` and `GENERATION_GAPS`, and `test_known_gaps_are_still_real` passes with the rule enabled rather than disabled. Their fixtures now supply providers: the conformance gate is a mirror, the demanding shape that owes a via link and two `updated` stamps; the roundtrip is official, which must carry neither.

5080 unit tests pass. All pre-commit hooks pass, including mypy, xenon, import-linter, and duplicate-code.

## Deliberate non-goal

`extract` still seeds no providers. WFS hands us a `provider_name` and it would be cheap to map, but that name is the service operator, which is not reliably the producer — writing it in would put a false authorship claim in metadata.yaml. Authorship stays a human fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
