### PR TITLE
fix(ci): skip mutation shards that hold no mutable code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,10 +432,15 @@ jobs:
                    "changed files; refusing to report an untested PR as passing."
               exit 1
             fi
+            # Files mutmut generates no mutants for (re-export __init__.py,
+            # constant tables, protocol stubs) are dropped here: their globs are
+            # as unmatchable as a file path and fail the whole run. See #716.
             mapfile -t GLOBS < globs.txt
           fi
-          echo "Changed source files: ${#GLOBS[@]}"
-          printf '  %s\n' "${GLOBS[@]}"
+          echo "Changed source files: ${#FILES[@]}, with mutants: ${#GLOBS[@]}"
+          if [ "${#GLOBS[@]}" -gt 0 ]; then
+            printf '  %s\n' "${GLOBS[@]}"
+          fi
           {
             echo 'globs<<GLOBS_EOF'
             printf '%s\n' "${GLOBS[@]}"
@@ -450,7 +455,8 @@ jobs:
           GLOBS=()
           for g in "${RAW[@]}"; do [ -n "$g" ] && GLOBS+=("$g"); done
           if [ "${#GLOBS[@]}" -eq 0 ]; then
-            echo "No mutable source changes (only deletions?); nothing to run."
+            echo "No mutable source changes (deletions, or only mutant-free" \
+                 "modules); nothing to run."
             exit 0
           fi
           # Surviving mutants do NOT fail mutmut — `_run` returns normally after
@@ -487,8 +493,9 @@ jobs:
           # branch below would then wave the PR through untested (#612).
           uv run mutmut export-cicd-stats
           if [ ! -f mutants/mutmut-cicd-stats.json ]; then
-            # Reachable only after a successful run, so the filter did match —
-            # these files genuinely contain no mutable code (constants, imports).
+            # No stats means no run happened, which mutant_globs.py already
+            # explained: the changed files genuinely contain no mutable code
+            # (constants, imports, protocol stubs).
             echo "No mutants in changed files; nothing to score."
             exit 0
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,8 +87,20 @@ jobs:
             exit 1
           fi
           mapfile -t GLOBS < globs.txt
-          echo "Shard ${SHARD} of ${NUM_SHARDS}: ${#GLOBS[@]} file(s)"
-          printf '  %s\n' "${GLOBS[@]}"
+          echo "Shard ${SHARD} of ${NUM_SHARDS}: ${#SHARD_FILES[@]} file(s)," \
+               "${#GLOBS[@]} with mutants"
+          if [ "${#GLOBS[@]}" -gt 0 ]; then
+            printf '  %s\n' "${GLOBS[@]}"
+            echo "has_globs=true" >> "$GITHUB_OUTPUT"
+          else
+            # Every file in this shard is mutant-free (re-export __init__.py,
+            # constant tables, protocol stubs). mutant_globs.py listed them on
+            # stderr above. Handing mutmut their globs is what failed run
+            # 30735881276, so the run and floor steps sit this night out.
+            echo "::notice::Shard ${SHARD} of ${NUM_SHARDS} holds no mutable" \
+                 "code; skipping the sweep. See portolan-sdi/portolan-cli#716."
+            echo "has_globs=false" >> "$GITHUB_OUTPUT"
+          fi
           {
             echo 'globs<<GLOBS_EOF'
             printf '%s\n' "${GLOBS[@]}"
@@ -96,6 +108,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run mutation testing (rotating shard)
+        if: steps.shard.outputs.has_globs == 'true'
         env:
           GLOBS_RAW: ${{ steps.shard.outputs.globs }}
         run: |
@@ -107,11 +120,12 @@ jobs:
           GLOBS=()
           for g in "${RAW[@]}"; do [ -n "$g" ] && GLOBS+=("$g"); done
           if [ "${#GLOBS[@]}" -eq 0 ]; then
-            # An empty shard means no source files — the floor check below (no
-            # --allow-empty) is the authoritative #612 silent-green guard, so let
-            # it fail on zero mutants rather than running mutmut with an empty glob.
-            echo "No files in this shard; nothing to run."
-            exit 0
+            # Unreachable: the step only runs when has_globs is true. Empty here
+            # means the globs output was lost between steps, and mutating nothing
+            # must never report as a passing sweep (#612).
+            echo "::error::has_globs was true but no globs arrived; refusing to" \
+                 "report an unmutated sweep as passing."
+            exit 1
           fi
           # pipefail keeps `tee` from reporting success on mutmut's behalf;
           # `|| STATUS=$?` keeps `set -e` from killing the step before the
@@ -131,6 +145,7 @@ jobs:
           fi
 
       - name: Enforce mutation floor
+        if: steps.shard.outputs.has_globs == 'true'
         env:
           SHARD: ${{ steps.shard.outputs.shard }}
           NUM_SHARDS: ${{ steps.shard.outputs.num_shards }}
@@ -152,7 +167,7 @@ jobs:
             --label "nightly shard ${SHARD}"
 
       - name: Generate mutation report
-        if: always()
+        if: always() && steps.shard.outputs.has_globs == 'true'
         run: |
           # Generate text report for artifact (mutmut 3.x has no HTML export)
           # Note: JSON stats only have aggregates, not individual mutations

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -159,9 +159,22 @@ tightens the gate, so do it when a sweep surfaces one. The score counts
 testable (`no_tests` excluded). **Lowering either floor requires a justification
 in the PR that does so.**
 
+**Mutant-free files are filtered out before mutmut sees them**
+(`scripts/mutant_globs.py`). About a fifth of `portolan_cli` generates no
+mutants: re-export `__init__.py` files, constant tables, protocol stubs, model
+declarations. A glob for one of those is as unmatchable as a file path, so
+mutmut raises `Filtered for specific mutants, but nothing matches` and fails the
+whole run — which is what killed the 2026-08-02 nightly, whose shard held two
+re-export packages and nothing else. Emptiness comes from mutmut's own mutation
+pass, because nine of those files do define functions and a "has a `def`" test
+would still pass them through. Both scopes skip cleanly when the filter leaves
+nothing, and the skipped files are named in the log.
+
 **Fails loud, never silent.** On the nightly sweep, zero testable mutants means
 mutation testing is broken, not passing — the scorer hard-fails (it used to
-`exit 0` and report a green nightly, hiding a broken setup). `[tool.mutmut]` in
+`exit 0` and report a green nightly, hiding a broken setup). The one exception is
+a shard the filter empties, where the run and floor steps are skipped outright
+rather than scored against absent stats. `[tool.mutmut]` in
 `pyproject.toml` copies the `scripts/` package, `spec/` schemas, and data files
 into the mutants sandbox and scopes the stats run to the fast, offline suite with
 `--no-cov`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,7 @@ strict = true  # Enables all strict flags at once
 untyped_calls_exclude = ["pyarrow"]
 
 [[tool.mypy.overrides]]
-module = ["pyarrow.*", "rasterio.*", "gitingest.*", "matplotlib.*", "pyiceberg.*", "shapely.*", "pygeohash.*"]
+module = ["pyarrow.*", "rasterio.*", "gitingest.*", "matplotlib.*", "pyiceberg.*", "shapely.*", "pygeohash.*", "mutmut.*"]
 ignore_missing_imports = true
 
 # ---------- security ----------

--- a/scripts/mutant_globs.py
+++ b/scripts/mutant_globs.py
@@ -16,17 +16,30 @@ Mangled names all begin with ``x_`` or ``xǁ``, so the emitted pattern ends in
 ``.x*``. That anchors the glob to one module — a bare ``package.*`` would also
 match every submodule beneath it and silently inflate a shard.
 
+Files mutmut generates no mutants for are dropped, because a glob for one is
+just as unmatchable as a file path: mutmut raises the same assertion and fails
+the whole run over a module that was never going to be tested. About a fifth of
+``portolan_cli`` is mutant-free — re-export ``__init__.py`` files, constant
+tables, protocol stubs, model declarations — so a small shard can hold nothing
+else, which is what broke nightly run 30735881276. See
+portolan-sdi/portolan-cli#716.
+
+Emptiness is decided by mutmut's own mutation pass, not by a heuristic. Nine
+mutant-free modules do define functions, so "has a ``def``" would still emit
+unmatchable globs for them.
+
 Usage:
     python scripts/mutant_globs.py portolan_cli/readme.py portolan_cli/sync/upload.py
 
-Exit codes: 0 = globs written to stdout, one per line; 1 = no paths given.
+Exit codes: 0 = globs written to stdout, one per line (possibly none, when no
+input file has mutants); 1 = no paths given.
 """
 
 from __future__ import annotations
 
 import sys
-from collections.abc import Sequence
-from pathlib import PurePosixPath
+from collections.abc import Callable, Sequence
+from pathlib import Path, PurePosixPath
 
 # Every name mutmut mangles starts with one of these (function: ``x_name``,
 # method: ``xǁClassǁname``), so this suffix selects a module's mutants without
@@ -61,15 +74,48 @@ def mutant_glob(path: str | PurePosixPath) -> str:
     return f"{module}.{_MANGLE_GLOB}"
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Print one mutant-name glob per source path given on the command line."""
+def has_mutants(path: str | Path) -> bool:
+    """Return whether mutmut generates at least one mutant for ``path``.
+
+    Asks mutmut to mutate the file and reports whether it named anything. The
+    import is local because ``mutmut.__main__`` sets the multiprocessing start
+    method at module scope, which raises in a process that already has one.
+
+    Raises:
+        OSError: ``path`` cannot be read.
+    """
+    from mutmut.__main__ import mutate_file_contents
+
+    source = Path(path).read_text(encoding="utf-8")
+    _mutated, names = mutate_file_contents(str(path), source)
+    return bool(names)
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    probe: Callable[[str], bool] = has_mutants,
+) -> int:
+    """Print one mutant-name glob per source path that has mutants to test.
+
+    Args:
+        argv: Source paths. Defaults to the command line.
+        probe: Decides whether a path has mutants. Injected by the tests, which
+            cannot import mutmut in-process.
+    """
     paths = list(sys.argv[1:] if argv is None else argv)
     if not paths:
         print("error: no source paths given; nothing to mutate", file=sys.stderr)
         return 1
 
     for path in paths:
-        print(mutant_glob(path))
+        glob = mutant_glob(path)
+        if not probe(path):
+            # Reported, not counted: a shard that mutates nothing is legitimate,
+            # but it should be legible in the log rather than look like a sweep.
+            print(f"skipping {path}: mutmut generates no mutants for it", file=sys.stderr)
+            continue
+        print(glob)
     return 0
 
 

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -59,6 +59,30 @@ def real_mutant_name(path: str, mangled: str) -> str:
     return result.stdout.strip()
 
 
+def real_has_mutants(path: Path) -> bool:
+    """Return ``mutant_globs.has_mutants(path)`` computed in a fresh interpreter.
+
+    Same reason as ``real_mutant_name``: importing ``mutmut.__main__`` sets the
+    multiprocessing start method at module scope, so an in-process import fails
+    once any earlier test has started a pool.
+    """
+    scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+    source = (
+        "import sys;"
+        f"sys.path.insert(0, {str(scripts_dir)!r});"
+        "from mutant_globs import has_mutants;"
+        f"print(has_mutants({str(path)!r}))"
+    )
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    )
+    return result.stdout.strip() == "True"
+
+
 # Add scripts directory to path for imports
 @pytest.fixture(autouse=True)
 def _add_scripts_to_path() -> None:
@@ -292,7 +316,10 @@ class TestMutantGlobs:
         """The CLI shim emits one glob per argument for the workflow to consume."""
         from mutant_globs import main
 
-        code = main(["portolan_cli/readme.py", "portolan_cli/extract/__init__.py"])
+        code = main(
+            ["portolan_cli/readme.py", "portolan_cli/extract/__init__.py"],
+            probe=lambda _path: True,
+        )
         assert code == 0
         assert capsys.readouterr().out == "portolan_cli.readme.x*\nportolan_cli.extract.x*\n"
 
@@ -303,6 +330,98 @@ class TestMutantGlobs:
 
         assert main([]) == 1
         assert "no source paths" in capsys.readouterr().err
+
+    @pytest.mark.unit
+    def test_main_drops_paths_with_no_mutants(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A mutant-free module must not reach the filter.
+
+        Emitting its glob is what broke the nightly sweep: mutmut asserts
+        ``Filtered for specific mutants, but nothing matches`` and exits
+        non-zero for the whole shard. See #612.
+        """
+        from mutant_globs import main
+
+        code = main(
+            ["portolan_cli/readme.py", "portolan_cli/extract/carto/__init__.py"],
+            probe=lambda path: "carto" not in path,
+        )
+        assert code == 0
+        captured = capsys.readouterr()
+        assert captured.out == "portolan_cli.readme.x*\n"
+        assert "portolan_cli/extract/carto/__init__.py" in captured.err
+
+    @pytest.mark.unit
+    def test_main_succeeds_when_every_path_is_mutant_free(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A shard of re-export packages has nothing to mutate, and that is not an error."""
+        from mutant_globs import main
+
+        code = main(
+            ["portolan_cli/extract/carto/__init__.py", "portolan_cli/constants.py"],
+            probe=lambda _path: False,
+        )
+        assert code == 0
+        assert capsys.readouterr().out == ""
+
+    @pytest.mark.integration  # Spawns an interpreter per call to import mutmut
+    @requires_mutmut_import
+    def test_has_mutants_rejects_a_function_mutmut_cannot_mutate(self, tmp_path: Path) -> None:
+        """Contract test: a ``def`` is not proof of a mutant.
+
+        Nine modules under ``portolan_cli`` define functions yet yield zero
+        mutants (protocol stubs, model declarations), so filtering on "has a
+        function definition" would still hand mutmut an unmatchable glob.
+        """
+        stub = tmp_path / "stub.py"
+        stub.write_text("def f() -> None:\n    pass\n", encoding="utf-8")
+        assert real_has_mutants(stub) is False
+
+    @pytest.mark.integration  # Spawns an interpreter per call to import mutmut
+    @requires_mutmut_import
+    def test_has_mutants_accepts_a_mutable_function(self, tmp_path: Path) -> None:
+        """The filter must keep files mutmut can actually mutate."""
+        mutable = tmp_path / "mutable.py"
+        mutable.write_text("def f(a: int, b: int) -> int:\n    return a + b\n", encoding="utf-8")
+        assert real_has_mutants(mutable) is True
+
+    @pytest.mark.integration  # Spawns an interpreter to import mutmut
+    @requires_mutmut_import
+    def test_reexport_package_is_filtered_out_end_to_end(self, tmp_path: Path) -> None:
+        """Regression for nightly run 30735881276.
+
+        Shard 14 held only ``extract/arcgis/__init__.py`` and
+        ``extract/carto/__init__.py``. Both re-export their submodules and
+        define nothing, so mutmut matched no mutants and the sweep failed.
+
+        Modelled on those files rather than reading them: mutmut runs the suite
+        from a copied ``mutants/`` tree whose ``__init__.py`` files carry its
+        injected trampoline, which is itself mutable, so the real ones are
+        mutant-free only outside the sandbox.
+        """
+        package = tmp_path / "pkg"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            'from pkg.thing import Thing\n\n__all__ = ["Thing"]\n', encoding="utf-8"
+        )
+        (package / "thing.py").write_text(
+            "def normalize(name: str) -> str:\n    return name.strip().lower()\n", encoding="utf-8"
+        )
+        result = subprocess.run(  # noqa: S603 - fixed argv, no shell, no user input
+            [
+                sys.executable,
+                str(Path(__file__).parent.parent.parent / "scripts" / "mutant_globs.py"),
+                "pkg/__init__.py",
+                "pkg/thing.py",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            timeout=120,
+        )
+        assert result.returncode == 0
+        assert result.stdout == "pkg.thing.x*\n"
+        assert "skipping pkg/__init__.py" in result.stderr
 
 
 class TestMutationScore:


### PR DESCRIPTION
## What this changes

Mutation-testing shards that contain no mutable code are now skipped instead of failing.

`scripts/mutant_globs.py` asks mutmut whether each file can produce mutants and drops the ones that cannot, naming them on stderr. The nightly run, floor, and reporting steps are gated on a `has_globs` output, so an empty shard exits cleanly instead of being scored against missing statistics.

## Why

Fixes #716. mutmut asserts when its filter matches no mutants, so one mutant-free file fails the whole shard. Shard 14 holds two re-export packages and nothing else.

Only mutmut can decide this. Of the 31 mutant-free files under `portolan_cli`, nine contain functions, so a "contains a `def`" heuristic would still build invalid filters.

## Verification

The failing shard now produces no globs and exits zero. A shard with mutable code still matches real mutants. Data read: this repository's source tree.

```console
$ uv run python scripts/shard_select.py --root portolan_cli --num-shards 25 --shard 14
portolan_cli/extract/arcgis/__init__.py
portolan_cli/extract/carto/__init__.py

$ uv run python scripts/mutant_globs.py portolan_cli/extract/arcgis/__init__.py portolan_cli/extract/carto/__init__.py
skipping portolan_cli/extract/arcgis/__init__.py: mutmut generates no mutants for it
skipping portolan_cli/extract/carto/__init__.py: mutmut generates no mutants for it
$ echo $?
0

$ uv run mutmut run "portolan_cli.viz.pmtiles_links.x*"
🎉 portolan_cli.viz.pmtiles_links.x_pmtiles_link_hrefs__mutmut_9
$ echo $?
0

$ uv run pytest tests/unit -q
5125 passed, 6 skipped, 19 warnings in 213.87s (0:03:33)
```

The `mutmut` run is load-bearing: it exercises the sandbox suite, where an earlier end-to-end test failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mutation testing now skips files and shards without testable mutants while clearly reporting what was skipped.
  * CI distinguishes changed files from generated mutant scopes and provides clearer mutation-floor messages.
* **Documentation**
  * CI guidance now covers mutant-free filtering and intentionally empty shards.
* **Tests**
  * Expanded coverage for mixed, non-mutable, mutant-free, and re-export-only inputs.
* **Chores**
  * Improved nightly workflow reporting for shard file and mutation-scope counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
