### PR TITLE
fix(tests): keep Hypothesis property tests alive across mutmut's repeated sessions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,44 @@ def cleared_environ(**overrides: str) -> Iterator[None]:
         yield
 
 
+# mutmut drives pytest in-process and runs the suite several times per
+# invocation: a stats pass, a clean pass, a forced-fail pass, then one pass per
+# mutant. Hypothesis remembers the instance that ran a @given method and fails
+# HealthCheck.differing_executors the second time that method runs against a
+# fresh instance, so the clean pass dies on the first class-based property test
+# it reaches and takes the night's sweep with it (portolan-sdi/portolan-cli#612).
+# Those 100-odd tests are ordinary pytest methods, not the reused executors the
+# check is aimed at.
+#
+# Dropping the example database answers what the check actually warns about:
+# a failing example recorded while one mutant was live would replay against the
+# next, crediting a kill to the wrong mutant. Outside mutmut the var is absent
+# and the check stays on.
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Keep class-based Hypothesis tests alive across mutmut's repeated sessions."""
+    if _MUTMUT_ENV_KEY not in os.environ:
+        return
+
+    from hypothesis import HealthCheck, settings
+
+    for item in items:
+        obj = getattr(item, "obj", None)
+        func = getattr(obj, "__func__", obj)
+        if not hasattr(func, "hypothesis"):
+            continue
+        current = getattr(func, "_hypothesis_internal_use_settings", None) or settings.default
+        if HealthCheck.differing_executors in current.suppress_health_check:
+            continue
+        func._hypothesis_internal_use_settings = settings(
+            parent=current,
+            suppress_health_check=[
+                *current.suppress_health_check,
+                HealthCheck.differing_executors,
+            ],
+            database=None,
+        )
+
+
 # =============================================================================
 # Fixture Directory Access
 # =============================================================================

--- a/tests/integration/test_mutmut_hypothesis_guard.py
+++ b/tests/integration/test_mutmut_hypothesis_guard.py
@@ -1,0 +1,108 @@
+"""Guard for Hypothesis property tests under mutmut's repeated pytest sessions.
+
+mutmut drives pytest in-process and runs the suite several times per invocation
+(stats, clean, forced-fail, then one pass per mutant). Hypothesis remembers the
+instance that ran a ``@given`` method and fails ``HealthCheck.differing_executors``
+the second time the same method runs against a fresh instance, which sinks the
+clean pass and the whole sweep. See portolan-sdi/portolan-cli#612.
+
+``tests/conftest.py`` suppresses that check when ``MUTANT_UNDER_TEST`` is in the
+environment, which mutmut sets in every phase and nothing else sets.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+# Each case spawns two more pytest sessions. Under mutmut those sessions import
+# the mutated tree, where every call goes through a trampoline, and the pair
+# blows the timeout and takes the sweep's stats phase with it. The guard being
+# tested is what lets that phase run at all, so exercising it there is circular
+# as well as slow.
+pytestmark = pytest.mark.skipif(
+    "MUTANT_UNDER_TEST" in os.environ,
+    reason="nested pytest sessions are too slow against the mutated tree",
+)
+
+
+def _first_class_based_property_test() -> str:
+    """Return the node ID of a class-based ``@given`` test in this suite.
+
+    Found by scanning rather than hardcoded so a rename cannot silently turn
+    this into a test of nothing.
+    """
+    for path in sorted(TESTS_ROOT.rglob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ClassDef):
+                continue
+            for member in node.body:
+                if not isinstance(member, ast.FunctionDef):
+                    continue
+                names = {
+                    getattr(d.func if isinstance(d, ast.Call) else d, "id", None)
+                    for d in member.decorator_list
+                }
+                if "given" in names:
+                    rel = path.relative_to(REPO_ROOT).as_posix()
+                    return f"{rel}::{node.name}::{member.name}"
+    pytest.fail("no class-based @given test found; the guard now protects nothing")
+
+
+TWO_SESSIONS = textwrap.dedent(
+    """
+    import sys
+    import pytest
+
+    args = ["--no-cov", "-q", "-p", "no:cacheprovider", sys.argv[1]]
+    first = pytest.main(args)
+    second = pytest.main(args)
+    print(f"first={first} second={second}")
+    sys.exit(0 if (first, second) == (0, 0) else 1)
+    """
+)
+
+
+def _run_two_sessions(*, under_mutmut: bool) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env.pop("MUTANT_UNDER_TEST", None)
+    if under_mutmut:
+        # mutmut sets this to '' for the clean pass; presence is the signal.
+        env["MUTANT_UNDER_TEST"] = ""
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [sys.executable, "-c", TWO_SESSIONS, _first_class_based_property_test()],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+
+@pytest.mark.integration
+def test_property_test_survives_a_second_session_under_mutmut() -> None:
+    """Two in-process sessions both pass when MUTANT_UNDER_TEST is set."""
+    result = _run_two_sessions(under_mutmut=True)
+
+    assert "first=0 second=0" in result.stdout, result.stdout + result.stderr
+    assert "differing_executors" not in result.stdout
+
+
+@pytest.mark.integration
+def test_health_check_still_fires_outside_mutmut() -> None:
+    """The guard is scoped to mutmut, so an ordinary run keeps the check."""
+    result = _run_two_sessions(under_mutmut=False)
+
+    assert "first=0 second=1" in result.stdout, result.stdout + result.stderr
+    assert "differing_executors" in result.stdout


### PR DESCRIPTION
## What this changes

Fixes #721 by isolating Hypothesis state during `mutmut` runs. `mutmut` runs pytest multiple times in the same process, which causes Hypothesis's `differing_executors` health check to fail when a `@given` test runs against a fresh instance. When `MUTANT_UNDER_TEST` is set, the pytest collection hook now disables that health check and removes the Hypothesis example database before collection. Normal pytest runs are unchanged.

A regression test runs the same test in two in-process pytest sessions and verifies both behaviors: the second session fails without `MUTANT_UNDER_TEST`, while both sessions pass with it set.

## Verification

The regression test passes:

```text
$ uv run pytest tests/integration/test_mutmut_hypothesis_guard.py -q
2 passed in 8.05s
```

The offline unit and integration suite passes:

```text
$ uv run pytest tests/unit tests/integration -q -m "not network and not slow and not benchmark and not e2e"
5949 passed, 9 skipped, 15 deselected, 36 warnings in 395.50s (0:06:35)
```

A real mutation run now gets past the clean test pass and starts testing mutants:

```text
$ uv run mutmut run "portolan_cli.temporal.*"; echo "EXIT=$?"
    done in 34813ms (151 files mutated, 0 ignored, 0 unmodified)
    done          # stats
    done          # clean tests
    done          # forced fail
Running mutation testing
18.85 mutations/second
🎉 portolan_cli.temporal.x_parse_flexible_datetime__mutmut_1
EXIT=0
```

The original failure is reproduced by running the same test in two pytest sessions in one interpreter: on `main`, the second session exits 1 with `FailedHealthCheck`; with `MUTANT_UNDER_TEST` set, both sessions exit 0.

CI: https://github.com/portolan-sdi/portolan-cli/actions/runs/31240192872/job/93059754156
