### PR TITLE
test: kill 424 surviving mutants in the ESRI converter, COG metadata, and rm

### DIFF
--- a/portolan_cli/extract/common/converters/esri.py
+++ b/portolan_cli/extract/common/converters/esri.py
@@ -371,16 +371,9 @@ def parse_classbreaks_renderer(
             stroke_width=stroke_width,
         )
     else:
-        # Choropleth (color varies by class)
-        cases: list[tuple[float, str]] = []
-        for info in break_infos:
-            max_val = info.get("classMaxValue", 0)
-            symbol = info.get("symbol", {})
-            color = symbol.get("color", [128, 128, 128, 255])
-            cases.append((max_val, esri_color_to_hex(color)))
-
-        # Build step expression for colors
-        # For color, we need the breaks to work correctly
+        # Choropleth (color varies by class). Each class opens at the previous
+        # class's maximum, so the first entry carries minValue as its threshold
+        # and make_step_expression uses its color as the below-first-break value.
         color_breaks: list[tuple[Any, Any]] = []
         for i, info in enumerate(break_infos):
             symbol = info.get("symbol", {})

--- a/portolan_cli/remove.py
+++ b/portolan_cli/remove.py
@@ -28,8 +28,6 @@ def _gather_removable_files(path: Path) -> list[Path]:
         List of candidate file paths to untrack/delete.
     """
     if path.is_dir():
-        if not path.exists():
-            return []
         return [f for f in path.rglob("*") if f.is_file()]
 
     sidecars = get_sidecars(path) if path.exists() else []

--- a/tests/unit/extract/common/converters/test_esri.py
+++ b/tests/unit/extract/common/converters/test_esri.py
@@ -15,6 +15,11 @@ import pytest
 
 from portolan_cli.extract.common.converters.esri import (
     ESRIConverterError,
+    _parse_circle_symbol,
+    _parse_fill_symbol,
+    _parse_line_symbol,
+    _parse_symbol,
+    _symbol_to_layer_type,
     convert_esri_renderer,
     parse_classbreaks_renderer,
     parse_simple_renderer,
@@ -248,3 +253,738 @@ class TestWarningsAndPartialConversion:
         # Falls back to circle
         assert style["layers"][0]["type"] == "circle"
         assert len(warnings) > 0
+
+
+# ESRI's default symbol color when a symbol omits "color", and the values it
+# converts to. Several parsers share this literal, so pin it once.
+DEFAULT_ESRI_COLOR = [128, 128, 128, 255]
+DEFAULT_HEX = "#808080"
+
+
+class TestSymbolToLayerType:
+    """Symbol-type to Mapbox GL layer-type routing (`_symbol_to_layer_type`)."""
+
+    @pytest.mark.parametrize(
+        ("symbol_type", "expected"),
+        [
+            ("esriSFS", "fill"),
+            ("esriSLS", "line"),
+            ("esriSMS", "circle"),
+            ("esriPMS", "circle"),
+        ],
+    )
+    def test_known_symbol_types(self, symbol_type: str, expected: str) -> None:
+        """Each supported ESRI symbol type maps to its Mapbox GL layer type."""
+        assert _symbol_to_layer_type({"type": symbol_type}) == expected
+
+    def test_unknown_symbol_type_defaults_to_fill(self) -> None:
+        """An unrecognized symbol type falls back to fill."""
+        assert _symbol_to_layer_type({"type": "esriTextSymbol"}) == "fill"
+
+    def test_missing_symbol_type_defaults_to_fill(self) -> None:
+        """A symbol with no "type" key falls back to fill."""
+        assert _symbol_to_layer_type({}) == "fill"
+
+
+class TestParseFillSymbol:
+    """esriSFS parsing (`_parse_fill_symbol`)."""
+
+    def test_full_symbol_produces_exact_layer(self) -> None:
+        """Color, alpha, and outline all land in the paint dict."""
+        symbol = {
+            "type": "esriSFS",
+            "color": [255, 0, 0, 128],
+            "outline": {"color": [0, 0, 255, 255], "width": 2},
+        }
+        layer = _parse_fill_symbol(symbol, "my-layer", "src")
+
+        assert layer == {
+            "id": "my-layer",
+            "type": "fill",
+            "source": "data",
+            "source-layer": "src",
+            "paint": {
+                "fill-color": "#ff0000",
+                "fill-opacity": 128 / 255.0,
+                "fill-outline-color": "#0000ff",
+            },
+        }
+
+    def test_missing_color_uses_esri_default_gray(self) -> None:
+        """A symbol with no color renders opaque #808080."""
+        layer = _parse_fill_symbol({"type": "esriSFS"}, "layer-0", "src")
+
+        assert layer["paint"]["fill-color"] == DEFAULT_HEX
+        assert layer["paint"]["fill-opacity"] == 1.0
+
+    def test_outline_without_color_omits_outline(self) -> None:
+        """An outline carrying only a width adds no fill-outline-color.
+
+        Guards the `outline and outline.get("color")` conjunction: reading
+        ``outline["color"]`` on this symbol would raise KeyError.
+        """
+        symbol = {"type": "esriSFS", "color": [1, 2, 3, 255], "outline": {"width": 3}}
+        layer = _parse_fill_symbol(symbol, "layer-0", "src")
+
+        assert "fill-outline-color" not in layer["paint"]
+
+    def test_empty_outline_omits_outline(self) -> None:
+        """An empty outline dict adds no fill-outline-color."""
+        symbol = {"type": "esriSFS", "color": [1, 2, 3, 255], "outline": {}}
+        layer = _parse_fill_symbol(symbol, "layer-0", "src")
+
+        assert "fill-outline-color" not in layer["paint"]
+
+    def test_missing_outline_omits_outline(self) -> None:
+        """A symbol with no outline key adds no fill-outline-color."""
+        layer = _parse_fill_symbol({"type": "esriSFS"}, "layer-0", "src")
+
+        assert "fill-outline-color" not in layer["paint"]
+
+
+class TestParseCircleSymbol:
+    """esriSMS/esriPMS parsing (`_parse_circle_symbol`)."""
+
+    def test_picture_marker_uses_fixed_placeholder(self) -> None:
+        """esriPMS ignores its own paint and renders a fixed grey circle."""
+        symbol = {
+            "type": "esriPMS",
+            "url": "https://example.com/icon.png",
+            "color": [255, 0, 0, 255],
+        }
+        warnings: list[str] = []
+        layer = _parse_circle_symbol(symbol, "pms", "src", warnings)
+
+        assert layer["paint"]["circle-color"] == "#888888"
+        assert layer["paint"]["circle-radius"] == 8
+        assert warnings == [
+            "Picture marker symbol (esriPMS) not fully supported; "
+            "falling back to circle. URL: https://example.com/icon.png"
+        ]
+
+    def test_picture_marker_without_url_reports_unknown(self) -> None:
+        """A picture marker with no url names the URL "unknown" in the warning."""
+        warnings: list[str] = []
+        _parse_circle_symbol({"type": "esriPMS"}, "pms", "src", warnings)
+
+        assert warnings == [
+            "Picture marker symbol (esriPMS) not fully supported; "
+            "falling back to circle. URL: unknown"
+        ]
+
+    def test_picture_marker_without_warning_sink(self) -> None:
+        """warnings=None drops the warning instead of raising."""
+        layer = _parse_circle_symbol({"type": "esriPMS"}, "pms", "src", None)
+
+        assert layer["paint"]["circle-color"] == "#888888"
+
+    def test_default_marker_style_is_silent(self) -> None:
+        """A marker with no style key is treated as a circle and warns nothing."""
+        warnings: list[str] = []
+        _parse_circle_symbol({"type": "esriSMS", "size": 10}, "sms", "src", warnings)
+
+        assert warnings == []
+
+    def test_explicit_circle_style_is_silent(self) -> None:
+        """An explicit esriSMSCircle style warns nothing."""
+        warnings: list[str] = []
+        _parse_circle_symbol(
+            {"type": "esriSMS", "style": "esriSMSCircle", "size": 10}, "sms", "src", warnings
+        )
+
+        assert warnings == []
+
+    def test_non_circle_style_warns_with_style_name(self) -> None:
+        """A non-circle marker style names itself in the warning."""
+        warnings: list[str] = []
+        _parse_circle_symbol(
+            {"type": "esriSMS", "style": "esriSMSCross", "size": 10}, "sms", "src", warnings
+        )
+
+        assert warnings == [
+            "Marker style 'esriSMSCross' not directly supported; falling back to circle."
+        ]
+
+    def test_non_circle_style_without_warning_sink(self) -> None:
+        """warnings=None on an unsupported style still produces a layer."""
+        layer = _parse_circle_symbol({"type": "esriSMS", "style": "esriSMSX"}, "sms", "src", None)
+
+        assert layer["type"] == "circle"
+
+    def test_missing_color_uses_esri_default_gray(self) -> None:
+        """A marker with no color renders opaque #808080."""
+        layer = _parse_circle_symbol({"type": "esriSMS", "size": 10}, "sms", "src")
+
+        assert layer["paint"]["circle-color"] == DEFAULT_HEX
+        assert layer["paint"]["circle-opacity"] == 1.0
+
+    def test_missing_size_uses_default_diameter_of_ten(self) -> None:
+        """A marker with no size gets ESRI's default diameter 10, radius 5."""
+        layer = _parse_circle_symbol({"type": "esriSMS"}, "sms", "src")
+
+        assert layer["paint"]["circle-radius"] == 5.0
+
+    def test_size_is_halved_into_radius(self) -> None:
+        """ESRI size is a diameter; Mapbox circle-radius is half of it."""
+        layer = _parse_circle_symbol({"type": "esriSMS", "size": 18}, "sms", "src")
+
+        assert layer["paint"]["circle-radius"] == 9.0
+
+    def test_alpha_becomes_circle_opacity(self) -> None:
+        """The color's alpha channel drives circle-opacity."""
+        layer = _parse_circle_symbol({"type": "esriSMS", "color": [0, 0, 0, 51]}, "sms", "src")
+
+        assert layer["paint"]["circle-opacity"] == 51 / 255.0
+
+    def test_outline_sets_stroke_color_and_width(self) -> None:
+        """A full outline populates both stroke paint properties."""
+        symbol = {"type": "esriSMS", "size": 10, "outline": {"color": [0, 255, 0, 255], "width": 3}}
+        layer = _parse_circle_symbol(symbol, "sms", "src")
+
+        assert layer["paint"]["circle-stroke-color"] == "#00ff00"
+        assert layer["paint"]["circle-stroke-width"] == 3
+
+    def test_outline_width_only_sets_width_without_color(self) -> None:
+        """An outline with only a width still contributes circle-stroke-width."""
+        symbol = {"type": "esriSMS", "size": 10, "outline": {"width": 4}}
+        layer = _parse_circle_symbol(symbol, "sms", "src")
+
+        assert "circle-stroke-color" not in layer["paint"]
+        assert layer["paint"]["circle-stroke-width"] == 4
+
+    def test_outline_color_only_omits_width(self) -> None:
+        """An outline with only a color contributes no circle-stroke-width."""
+        symbol = {"type": "esriSMS", "size": 10, "outline": {"color": [0, 0, 0, 255]}}
+        layer = _parse_circle_symbol(symbol, "sms", "src")
+
+        assert layer["paint"]["circle-stroke-color"] == "#000000"
+        assert "circle-stroke-width" not in layer["paint"]
+
+    def test_no_outline_omits_both_stroke_properties(self) -> None:
+        """A marker with no outline gets neither stroke property."""
+        layer = _parse_circle_symbol({"type": "esriSMS", "size": 10}, "sms", "src")
+
+        assert "circle-stroke-color" not in layer["paint"]
+        assert "circle-stroke-width" not in layer["paint"]
+
+
+class TestParseLineSymbol:
+    """esriSLS parsing (`_parse_line_symbol`)."""
+
+    def test_full_symbol_produces_exact_layer(self) -> None:
+        """Color, alpha, and width all land in the paint dict."""
+        symbol = {"type": "esriSLS", "color": [0, 128, 255, 204], "width": 2.5}
+        layer = _parse_line_symbol(symbol, "my-line", "src")
+
+        assert layer == {
+            "id": "my-line",
+            "type": "line",
+            "source": "data",
+            "source-layer": "src",
+            "paint": {
+                "line-color": "#0080ff",
+                "line-width": 2.5,
+                "line-opacity": 204 / 255.0,
+            },
+        }
+
+    def test_defaults_when_color_and_width_missing(self) -> None:
+        """A bare esriSLS renders opaque #808080 at width 1."""
+        layer = _parse_line_symbol({"type": "esriSLS"}, "my-line", "src")
+
+        assert layer["paint"]["line-color"] == DEFAULT_HEX
+        assert layer["paint"]["line-width"] == 1
+        assert layer["paint"]["line-opacity"] == 1.0
+
+
+class TestParseSymbolRouting:
+    """Symbol dispatch (`_parse_symbol`)."""
+
+    def test_routes_fill_symbol(self) -> None:
+        """esriSFS produces a fill layer carrying the symbol's color."""
+        layer = _parse_symbol({"type": "esriSFS", "color": [255, 0, 0, 255]}, "l", "src")
+
+        assert layer["type"] == "fill"
+        assert layer["paint"]["fill-color"] == "#ff0000"
+
+    def test_routes_line_symbol(self) -> None:
+        """esriSLS produces a line layer carrying the symbol's color."""
+        layer = _parse_symbol({"type": "esriSLS", "color": [255, 0, 0, 255]}, "l", "src")
+
+        assert layer["type"] == "line"
+        assert layer["paint"]["line-color"] == "#ff0000"
+
+    def test_routes_marker_symbol(self) -> None:
+        """esriSMS produces a circle layer carrying the symbol's color."""
+        layer = _parse_symbol({"type": "esriSMS", "color": [255, 0, 0, 255]}, "l", "src")
+
+        assert layer["type"] == "circle"
+        assert layer["paint"]["circle-color"] == "#ff0000"
+
+    def test_routes_picture_marker_symbol(self) -> None:
+        """esriPMS reaches the circle parser and warns."""
+        warnings: list[str] = []
+        layer = _parse_symbol({"type": "esriPMS"}, "l", "src", warnings)
+
+        assert layer["type"] == "circle"
+        assert len(warnings) == 1
+
+    def test_unknown_type_falls_back_to_grey_fill(self) -> None:
+        """An unrecognized symbol type produces a half-opaque grey fill."""
+        warnings: list[str] = []
+        layer = _parse_symbol({"type": "esriTS"}, "l", "src", warnings)
+
+        assert layer["type"] == "fill"
+        assert layer["paint"]["fill-color"] == "#888888"
+        assert layer["paint"]["fill-opacity"] == 0.5
+        assert warnings == ["Unknown symbol type 'esriTS'; defaulting to fill."]
+
+    def test_missing_type_names_empty_string_in_warning(self) -> None:
+        """A symbol with no type reports an empty type in the warning."""
+        warnings: list[str] = []
+        _parse_symbol({}, "l", "src", warnings)
+
+        assert warnings == ["Unknown symbol type ''; defaulting to fill."]
+
+    def test_unknown_type_without_warning_sink(self) -> None:
+        """warnings=None on an unknown symbol type still produces a layer."""
+        layer = _parse_symbol({"type": "esriTS"}, "l", "src", None)
+
+        assert layer["paint"]["fill-color"] == "#888888"
+
+
+class TestSimpleRendererDetails:
+    """Structural detail of `parse_simple_renderer`."""
+
+    def test_layer_id_and_style_name(self) -> None:
+        """The single layer is id "layer-0" under the "Simple Style" name."""
+        renderer = {"type": "simple", "symbol": {"type": "esriSFS", "color": [1, 2, 3, 255]}}
+        style = parse_simple_renderer(renderer, source_layer="src")
+
+        assert style["name"] == "Simple Style"
+        assert [layer["id"] for layer in style["layers"]] == ["layer-0"]
+        assert style["layers"][0]["source-layer"] == "src"
+
+    def test_missing_symbol_falls_back_to_grey_fill(self) -> None:
+        """A renderer with no symbol takes the unknown-symbol fallback."""
+        warnings: list[str] = []
+        style = parse_simple_renderer({"type": "simple"}, source_layer="src", warnings=warnings)
+
+        assert style["layers"][0]["paint"]["fill-color"] == "#888888"
+        assert warnings == ["Unknown symbol type ''; defaulting to fill."]
+
+
+class TestUniqueValueRendererDetails:
+    """Field resolution, layer typing, and defaults in `parse_uniquevalue_renderer`."""
+
+    @staticmethod
+    def _renderer(**overrides: Any) -> dict[str, Any]:
+        """A minimal two-class uniqueValue fill renderer."""
+        renderer: dict[str, Any] = {
+            "type": "uniqueValue",
+            "field1": "CLASS",
+            "uniqueValueInfos": [
+                {"value": "a", "symbol": {"type": "esriSFS", "color": [255, 0, 0, 255]}},
+                {"value": "b", "symbol": {"type": "esriSFS", "color": [0, 255, 0, 255]}},
+            ],
+        }
+        renderer.update(overrides)
+        return renderer
+
+    def test_field1_wins_over_field(self) -> None:
+        """field1 is ESRI's primary classification field and takes precedence."""
+        renderer = self._renderer(field="IGNORED")
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][1] == ["get", "CLASS"]
+
+    def test_field_used_when_field1_absent(self) -> None:
+        """Renderers that only carry "field" still classify on it."""
+        renderer = self._renderer()
+        del renderer["field1"]
+        renderer["field"] = "OTHER"
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][1] == ["get", "OTHER"]
+
+    def test_value_field_fallback(self) -> None:
+        """With neither field key, classification falls back to "value"."""
+        renderer = self._renderer()
+        del renderer["field1"]
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][1] == ["get", "value"]
+
+    def test_match_expression_is_exact(self) -> None:
+        """Cases follow input order and end with the #cccccc default."""
+        style = parse_uniquevalue_renderer(self._renderer(), source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"] == [
+            "match",
+            ["get", "CLASS"],
+            "a",
+            "#ff0000",
+            "b",
+            "#00ff00",
+            "#cccccc",
+        ]
+
+    def test_style_name_and_fill_layer_id(self) -> None:
+        """Fill classification is id "categorical-fill" under "Categorical Style"."""
+        style = parse_uniquevalue_renderer(self._renderer(), source_layer="src")
+
+        assert style["name"] == "Categorical Style"
+        assert style["layers"][0]["id"] == "categorical-fill"
+
+    def test_circle_layer_id_and_type(self) -> None:
+        """Marker symbols produce a "categorical-circle" layer."""
+        renderer = self._renderer(
+            uniqueValueInfos=[
+                {"value": "a", "symbol": {"type": "esriSMS", "color": [255, 0, 0, 255]}},
+            ]
+        )
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "categorical-circle"
+        assert style["layers"][0]["type"] == "circle"
+
+    def test_line_layer_id_and_type(self) -> None:
+        """Line symbols produce a "categorical-line" layer."""
+        renderer = self._renderer(
+            uniqueValueInfos=[
+                {"value": "a", "symbol": {"type": "esriSLS", "color": [255, 0, 0, 255]}},
+            ]
+        )
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "categorical-line"
+        assert style["layers"][0]["type"] == "line"
+
+    def test_unknown_symbol_type_produces_fill(self) -> None:
+        """An unrecognized symbol type classifies as fill."""
+        renderer = self._renderer(
+            uniqueValueInfos=[{"value": "a", "symbol": {"type": "esriTS", "color": [1, 2, 3, 255]}}]
+        )
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "categorical-fill"
+
+    def test_first_info_decides_layer_type(self) -> None:
+        """Layer type comes from the first info, not a later one."""
+        renderer = self._renderer(
+            uniqueValueInfos=[
+                {"value": "a", "symbol": {"type": "esriSFS", "color": [255, 0, 0, 255]}},
+                {"value": "b", "symbol": {"type": "esriSMS", "color": [0, 255, 0, 255]}},
+            ]
+        )
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "categorical-fill"
+
+    def test_first_info_decides_opacity(self) -> None:
+        """Opacity comes from the first info's alpha, not a later one."""
+        renderer = self._renderer(
+            uniqueValueInfos=[
+                {"value": "a", "symbol": {"type": "esriSFS", "color": [255, 0, 0, 51]}},
+                {"value": "b", "symbol": {"type": "esriSFS", "color": [0, 255, 0, 255]}},
+            ]
+        )
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-opacity"] == 51 / 255.0
+
+    def test_info_without_color_uses_default_gray(self) -> None:
+        """An info whose symbol omits color contributes #808080."""
+        renderer = self._renderer(uniqueValueInfos=[{"value": "a", "symbol": {"type": "esriSFS"}}])
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][2:] == ["a", DEFAULT_HEX, "#cccccc"]
+
+    def test_info_without_symbol_uses_default_gray(self) -> None:
+        """An info with no symbol at all contributes #808080 at full opacity."""
+        renderer = self._renderer(uniqueValueInfos=[{"value": "a"}])
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][3] == DEFAULT_HEX
+        assert style["layers"][0]["paint"]["fill-opacity"] == 1.0
+
+    def test_info_without_value_maps_none(self) -> None:
+        """A missing "value" is carried through as None rather than dropped."""
+        renderer = self._renderer(
+            uniqueValueInfos=[{"symbol": {"type": "esriSFS", "color": [255, 0, 0, 255]}}]
+        )
+        style = parse_uniquevalue_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][2] is None
+
+    def test_empty_infos_produce_placeholder_style(self) -> None:
+        """No classes yields the grey placeholder style and a warning."""
+        warnings: list[str] = []
+        renderer = {"type": "uniqueValue", "field1": "CLASS", "uniqueValueInfos": []}
+        style = parse_uniquevalue_renderer(renderer, source_layer="src", warnings=warnings)
+
+        assert style["name"] == "Empty UniqueValue Style"
+        assert style["layers"][0]["id"] == "layer-0"
+        assert style["layers"][0]["paint"]["fill-color"] == "#888888"
+        assert style["layers"][0]["paint"]["fill-opacity"] == 0.5
+        assert warnings == ["UniqueValue renderer has no value infos; using default."]
+
+    def test_missing_infos_key_produces_placeholder_style(self) -> None:
+        """A renderer with no uniqueValueInfos key takes the same path."""
+        style = parse_uniquevalue_renderer({"type": "uniqueValue"}, source_layer="src")
+
+        assert style["name"] == "Empty UniqueValue Style"
+
+    def test_empty_infos_without_warning_sink(self) -> None:
+        """warnings=None on an empty renderer still produces a style."""
+        renderer = {"type": "uniqueValue", "uniqueValueInfos": []}
+        style = parse_uniquevalue_renderer(renderer, source_layer="src", warnings=None)
+
+        assert style["name"] == "Empty UniqueValue Style"
+
+
+class TestClassBreaksRendererDetails:
+    """Graduated and choropleth branches of `parse_classbreaks_renderer`."""
+
+    @staticmethod
+    def _graduated() -> dict[str, Any]:
+        """Marker classes whose sizes vary, i.e. a graduated-symbol renderer."""
+        return {
+            "type": "classBreaks",
+            "field": "POP",
+            "classBreakInfos": [
+                {
+                    "classMaxValue": 100,
+                    "symbol": {"type": "esriSMS", "size": 8, "color": [255, 0, 0, 255]},
+                },
+                {
+                    "classMaxValue": 500,
+                    "symbol": {"type": "esriSMS", "size": 16, "color": [0, 255, 0, 255]},
+                },
+                {
+                    "classMaxValue": 900,
+                    "symbol": {"type": "esriSMS", "size": 24, "color": [0, 0, 255, 255]},
+                },
+            ],
+        }
+
+    @staticmethod
+    def _choropleth() -> dict[str, Any]:
+        """Fill classes whose colors vary, i.e. a choropleth renderer."""
+        return {
+            "type": "classBreaks",
+            "field": "DENS",
+            "classBreakInfos": [
+                {"classMaxValue": 10, "symbol": {"type": "esriSFS", "color": [255, 0, 0, 255]}},
+                {"classMaxValue": 20, "symbol": {"type": "esriSFS", "color": [0, 255, 0, 255]}},
+                {"classMaxValue": 30, "symbol": {"type": "esriSFS", "color": [0, 0, 255, 255]}},
+            ],
+        }
+
+    def test_graduated_radius_steps_are_exact(self) -> None:
+        """Radii halve each size and step at the *previous* class maximum."""
+        style = parse_classbreaks_renderer(self._graduated(), source_layer="src")
+
+        assert style["layers"][0]["paint"]["circle-radius"] == [
+            "step",
+            ["get", "POP"],
+            4.0,
+            100,
+            8.0,
+            500,
+            12.0,
+        ]
+
+    def test_graduated_layer_id_name_and_color(self) -> None:
+        """The graduated layer is id "graduated-circle" colored by the first class."""
+        style = parse_classbreaks_renderer(self._graduated(), source_layer="src")
+
+        assert style["name"] == "Graduated Style"
+        assert style["layers"][0]["id"] == "graduated-circle"
+        assert style["layers"][0]["paint"]["circle-color"] == "#ff0000"
+
+    def test_graduated_outline_sets_stroke(self) -> None:
+        """A first-class outline supplies both graduated stroke properties."""
+        renderer = self._graduated()
+        renderer["classBreakInfos"][0]["symbol"]["outline"] = {
+            "color": [0, 0, 0, 255],
+            "width": 2,
+        }
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["circle-stroke-color"] == "#000000"
+        assert style["layers"][0]["paint"]["circle-stroke-width"] == 2
+
+    def test_graduated_outline_without_color_sets_no_stroke(self) -> None:
+        """Unlike simple markers, a colorless outline here contributes no width."""
+        renderer = self._graduated()
+        renderer["classBreakInfos"][0]["symbol"]["outline"] = {"width": 2}
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert "circle-stroke-color" not in style["layers"][0]["paint"]
+        assert "circle-stroke-width" not in style["layers"][0]["paint"]
+
+    def test_graduated_break_without_class_max_value_steps_at_zero(self) -> None:
+        """A class missing classMaxValue contributes a 0 threshold."""
+        renderer = self._graduated()
+        del renderer["classBreakInfos"][0]["classMaxValue"]
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["circle-radius"][3] == 0
+
+    def test_graduated_break_without_size_uses_default_diameter(self) -> None:
+        """A class missing size falls back to diameter 10, radius 5."""
+        renderer = self._graduated()
+        del renderer["classBreakInfos"][1]["symbol"]["size"]
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["circle-radius"][4] == 5.0
+
+    def test_uniform_marker_sizes_are_not_graduated(self) -> None:
+        """Same-size markers are treated as color-varying, not size-varying.
+
+        Sizes must actually differ for the graduated-symbol branch. With one
+        distinct size the renderer falls through to the color branch, and
+        because the layer type is not fill it emits a line layer.
+        """
+        renderer = self._graduated()
+        for info in renderer["classBreakInfos"]:
+            info["symbol"]["size"] = 8
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "graduated-line"
+        assert style["layers"][0]["type"] == "line"
+
+    def test_sizeless_markers_are_not_graduated(self) -> None:
+        """Markers with no size at all cannot be graduated by size."""
+        renderer = self._graduated()
+        for info in renderer["classBreakInfos"]:
+            del info["symbol"]["size"]
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "graduated-line"
+
+    def test_choropleth_color_steps_are_exact(self) -> None:
+        """Colors step at the previous class maximum, opening at minValue."""
+        style = parse_classbreaks_renderer(self._choropleth(), source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"] == [
+            "step",
+            ["get", "DENS"],
+            "#ff0000",
+            10,
+            "#00ff00",
+            20,
+            "#0000ff",
+        ]
+
+    def test_choropleth_layer_id_and_opacity(self) -> None:
+        """The choropleth layer is id "choropleth-fill" at fixed 0.7 opacity."""
+        style = parse_classbreaks_renderer(self._choropleth(), source_layer="src")
+
+        assert style["layers"][0]["id"] == "choropleth-fill"
+        assert style["layers"][0]["paint"]["fill-opacity"] == 0.7
+
+    def test_choropleth_class_without_color_uses_default_gray(self) -> None:
+        """A class whose symbol omits color contributes #808080."""
+        renderer = self._choropleth()
+        del renderer["classBreakInfos"][1]["symbol"]["color"]
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][4] == DEFAULT_HEX
+
+    def test_choropleth_class_without_symbol_uses_default_gray(self) -> None:
+        """A class with no symbol contributes #808080."""
+        renderer = self._choropleth()
+        del renderer["classBreakInfos"][1]["symbol"]
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][4] == DEFAULT_HEX
+
+    def test_line_classes_produce_graduated_line(self) -> None:
+        """Line symbols produce a "graduated-line" layer colored by step."""
+        renderer = self._choropleth()
+        for info in renderer["classBreakInfos"]:
+            info["symbol"]["type"] = "esriSLS"
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["id"] == "graduated-line"
+        assert style["layers"][0]["paint"]["line-color"][0] == "step"
+
+    def test_field_fallback(self) -> None:
+        """With no field key, classification falls back to "value"."""
+        renderer = self._choropleth()
+        del renderer["field"]
+        style = parse_classbreaks_renderer(renderer, source_layer="src")
+
+        assert style["layers"][0]["paint"]["fill-color"][1] == ["get", "value"]
+
+    def test_empty_break_infos_produce_placeholder_style(self) -> None:
+        """No classes yields the grey placeholder style and a warning."""
+        warnings: list[str] = []
+        renderer = {"type": "classBreaks", "field": "POP", "classBreakInfos": []}
+        style = parse_classbreaks_renderer(renderer, source_layer="src", warnings=warnings)
+
+        assert style["name"] == "Empty ClassBreaks Style"
+        assert style["layers"][0]["id"] == "layer-0"
+        assert style["layers"][0]["paint"]["fill-color"] == "#888888"
+        assert style["layers"][0]["paint"]["fill-opacity"] == 0.5
+        assert warnings == ["ClassBreaks renderer has no break infos; using default."]
+
+    def test_missing_break_infos_key_produces_placeholder_style(self) -> None:
+        """A renderer with no classBreakInfos key takes the same path."""
+        style = parse_classbreaks_renderer({"type": "classBreaks"}, source_layer="src")
+
+        assert style["name"] == "Empty ClassBreaks Style"
+
+    def test_empty_break_infos_without_warning_sink(self) -> None:
+        """warnings=None on an empty renderer still produces a style."""
+        renderer = {"type": "classBreaks", "classBreakInfos": []}
+        style = parse_classbreaks_renderer(renderer, source_layer="src", warnings=None)
+
+        assert style["name"] == "Empty ClassBreaks Style"
+
+
+class TestConvertESRIRendererContract:
+    """Return shape and error text of `convert_esri_renderer`."""
+
+    def test_default_return_is_a_bare_style(self) -> None:
+        """Without return_warnings the result is the style dict itself."""
+        renderer = {"type": "simple", "symbol": {"type": "esriSFS", "color": [1, 2, 3, 255]}}
+        result = convert_esri_renderer(renderer, source_layer="src")
+
+        assert isinstance(result, dict)
+        assert result["name"] == "Simple Style"
+
+    def test_return_warnings_yields_style_and_warnings(self) -> None:
+        """With return_warnings the result is a (style, warnings) pair."""
+        renderer = {"type": "simple", "symbol": {"type": "esriSFS", "color": [1, 2, 3, 255]}}
+        result = convert_esri_renderer(renderer, source_layer="src", return_warnings=True)
+
+        style, warnings = result
+        assert style["name"] == "Simple Style"
+        assert warnings == []
+
+    def test_warnings_propagate_from_nested_parser(self) -> None:
+        """Warnings raised deep in symbol parsing reach the caller."""
+        renderer = {"type": "simple", "symbol": {"type": "esriTS"}}
+        _, warnings = convert_esri_renderer(renderer, source_layer="src", return_warnings=True)
+
+        assert warnings == ["Unknown symbol type 'esriTS'; defaulting to fill."]
+
+    def test_unsupported_type_error_message_is_exact(self) -> None:
+        """The error names the offending type and the supported set."""
+        with pytest.raises(ESRIConverterError) as excinfo:
+            convert_esri_renderer({"type": "heatmap"}, source_layer="src")
+
+        assert str(excinfo.value) == (
+            "Unsupported ESRI renderer type: 'heatmap'. "
+            "Supported types: simple, uniqueValue, classBreaks."
+        )
+
+    def test_missing_type_reports_empty_string(self) -> None:
+        """A renderer with no type key reports an empty type."""
+        with pytest.raises(ESRIConverterError) as excinfo:
+            convert_esri_renderer({}, source_layer="src")
+
+        assert "renderer type: ''." in str(excinfo.value)

--- a/tests/unit/test_metadata_cog.py
+++ b/tests/unit/test_metadata_cog.py
@@ -12,6 +12,7 @@ correct answer:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -151,7 +152,7 @@ class TestExtractCOGMetadata:
     def test_raises_for_nonexistent_file(self, tmp_path: Path) -> None:
         """Should raise FileNotFoundError for missing file."""
         missing = tmp_path / "missing.tif"
-        with pytest.raises(FileNotFoundError, match=str(missing)):
+        with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
             extract_cog_metadata(missing)
 
     @pytest.mark.unit
@@ -426,7 +427,7 @@ class TestExtractSchemaFromCOG:
     def test_raises_for_nonexistent_file(self, tmp_path: Path) -> None:
         """A missing path fails before rasterio is reached."""
         missing = tmp_path / "missing.tif"
-        with pytest.raises(FileNotFoundError, match=str(missing)):
+        with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
             extract_schema_from_cog(missing)
 
 

--- a/tests/unit/test_metadata_cog.py
+++ b/tests/unit/test_metadata_cog.py
@@ -1,4 +1,14 @@
-"""Tests for COG metadata extraction."""
+"""Tests for COG metadata extraction.
+
+Assertions here pin exact values rather than "is not None". The fixtures are
+committed and their georeferencing is fixed, so every extracted field has one
+correct answer:
+
+- ``raster/valid/singleband.tif``   64x64, 1 band uint8, EPSG:4326, no nodata
+- ``raster/valid/nodata.tif``       same, nodata 255
+- ``raster/valid/float32.tif``      same, float32
+- ``realdata/rapidai4eo-sample.tif`` 200x200, 4 bands int16, EPSG:32633, 3 m
+"""
 
 from __future__ import annotations
 
@@ -6,7 +16,29 @@ from pathlib import Path
 
 import pytest
 
-from portolan_cli.metadata.cog import COGMetadata, extract_cog_metadata
+from portolan_cli.metadata.cog import COGMetadata, extract_cog_metadata, extract_schema_from_cog
+from portolan_cli.models.schema import BandSchema, SchemaModel
+
+
+def bands_of(schema: SchemaModel) -> list[BandSchema]:
+    """Return a COG schema's columns, asserting each one is a BandSchema.
+
+    `SchemaModel.columns` is a union covering vector and raster schemas, so a
+    raster assertion has to narrow it. Doing that here keeps the narrowing (and
+    the check that COG extraction really produces bands) in one place.
+    """
+    assert all(isinstance(column, BandSchema) for column in schema.columns)
+    return [column for column in schema.columns if isinstance(column, BandSchema)]
+
+
+# Georeferencing shared by the three synthetic 64x64 fixtures.
+SYNTHETIC_BOUNDS = (-122.5, 37.7, -122.35, 37.85)
+SYNTHETIC_PIXEL = 0.15 / 64
+
+# The RapidAI4EO sample sits in UTM 33N on an exact 3 m grid, which makes it the
+# fixture to assert resolution and transform against.
+RAPIDAI4EO_BOUNDS = (364800.0, 4823400.0, 365400.0, 4824000.0)
+RAPIDAI4EO_GDAL_TRANSFORM = (364800.0, 3.0, 0.0, 4824000.0, 0.0, -3.0)
 
 
 class TestExtractCOGMetadata:
@@ -19,61 +51,108 @@ class TestExtractCOGMetadata:
         assert isinstance(metadata, COGMetadata)
 
     @pytest.mark.unit
-    def test_extracts_bbox(self, valid_rgb_cog: Path) -> None:
-        """Should extract bounding box as (minx, miny, maxx, maxy)."""
+    def test_bbox_is_left_bottom_right_top(self, valid_rgb_cog: Path) -> None:
+        """bbox follows (minx, miny, maxx, maxy), not rasterio's own ordering."""
         metadata = extract_cog_metadata(valid_rgb_cog)
-        assert metadata.bbox is not None
-        assert len(metadata.bbox) == 4
-        minx, miny, maxx, maxy = metadata.bbox
-        assert minx <= maxx
-        assert miny <= maxy
+        assert metadata.bbox == RAPIDAI4EO_BOUNDS
 
     @pytest.mark.unit
-    def test_extracts_crs(self, valid_rgb_cog: Path) -> None:
-        """Should extract CRS."""
+    def test_bbox_of_geographic_fixture(self, valid_singleband_cog: Path) -> None:
+        """A WGS84 fixture reports its degrees bbox unchanged."""
+        metadata = extract_cog_metadata(valid_singleband_cog)
+        assert metadata.bbox == SYNTHETIC_BOUNDS
+
+    @pytest.mark.unit
+    def test_crs_is_epsg_code_when_available(self, valid_rgb_cog: Path) -> None:
+        """A CRS with an EPSG code is reported in "EPSG:NNNN" form."""
         metadata = extract_cog_metadata(valid_rgb_cog)
-        assert metadata.crs is not None
+        assert metadata.crs == "EPSG:32633"
+
+    @pytest.mark.unit
+    def test_crs_of_geographic_fixture(self, valid_singleband_cog: Path) -> None:
+        """The synthetic fixtures are WGS84."""
+        metadata = extract_cog_metadata(valid_singleband_cog)
+        assert metadata.crs == "EPSG:4326"
 
     @pytest.mark.unit
     def test_extracts_dimensions(self, valid_rgb_cog: Path) -> None:
-        """Should extract width and height."""
+        """Width and height come straight from the raster."""
         metadata = extract_cog_metadata(valid_rgb_cog)
-        assert metadata.width is not None
-        assert metadata.height is not None
-        assert metadata.width > 0
-        assert metadata.height > 0
+        assert (metadata.width, metadata.height) == (200, 200)
 
     @pytest.mark.unit
     def test_extracts_band_count(self, valid_rgb_cog: Path) -> None:
-        """Should extract number of bands."""
+        """The RapidAI4EO sample carries four bands."""
         metadata = extract_cog_metadata(valid_rgb_cog)
-        assert metadata.band_count is not None
-        assert metadata.band_count > 0
+        assert metadata.band_count == 4
 
     @pytest.mark.unit
-    def test_extracts_dtype(self, valid_rgb_cog: Path) -> None:
-        """Should extract data type."""
+    def test_dtype_comes_from_first_band(self, valid_rgb_cog: Path) -> None:
+        """dtype is the first band's type, as a plain string."""
         metadata = extract_cog_metadata(valid_rgb_cog)
-        assert metadata.dtype is not None
+        assert metadata.dtype == "int16"
+
+    @pytest.mark.unit
+    def test_dtype_of_float_fixture(self, valid_float32_cog: Path) -> None:
+        """A float raster reports float32 rather than a default."""
+        metadata = extract_cog_metadata(valid_float32_cog)
+        assert metadata.dtype == "float32"
 
     @pytest.mark.unit
     def test_extracts_nodata(self, valid_nodata_cog: Path) -> None:
-        """Should extract nodata value if present."""
+        """A raster with nodata set reports that exact value."""
         metadata = extract_cog_metadata(valid_nodata_cog)
-        # nodata may or may not be set, just verify it doesn't crash
-        assert hasattr(metadata, "nodata")
+        assert metadata.nodata == 255.0
 
     @pytest.mark.unit
-    def test_extracts_resolution(self, valid_rgb_cog: Path) -> None:
-        """Should extract pixel resolution."""
+    def test_nodata_is_none_when_unset(self, valid_singleband_cog: Path) -> None:
+        """A raster without nodata reports None, not 0."""
+        metadata = extract_cog_metadata(valid_singleband_cog)
+        assert metadata.nodata is None
+
+    @pytest.mark.unit
+    def test_nodatavals_keeps_per_band_none_slots(self, valid_singleband_cog: Path) -> None:
+        """An all-None nodatavals tuple survives; only an empty tuple becomes None.
+
+        rasterio always returns one slot per band, so a raster with no nodata
+        yields ``(None,)`` rather than ``None``. Consumers must read the slots,
+        not test the tuple for truthiness.
+        """
+        metadata = extract_cog_metadata(valid_singleband_cog)
+        assert metadata.nodatavals == (None,)
+
+    @pytest.mark.unit
+    def test_nodatavals_is_per_band_tuple(self, valid_nodata_cog: Path) -> None:
+        """A raster with nodata reports one entry per band."""
+        metadata = extract_cog_metadata(valid_nodata_cog)
+        assert metadata.nodatavals == (255.0,)
+
+    @pytest.mark.unit
+    def test_resolution_is_positive_pixel_size(self, valid_rgb_cog: Path) -> None:
+        """Resolution is the absolute pixel size; the y term is negative in the transform."""
         metadata = extract_cog_metadata(valid_rgb_cog)
-        assert metadata.resolution is not None
+        assert metadata.resolution == (3.0, 3.0)
+
+    @pytest.mark.unit
+    def test_resolution_of_geographic_fixture(self, valid_singleband_cog: Path) -> None:
+        """A degrees-based fixture reports its degree pixel size."""
+        metadata = extract_cog_metadata(valid_singleband_cog)
+        x_res, y_res = metadata.resolution
+        assert x_res == pytest.approx(SYNTHETIC_PIXEL)
+        assert y_res == pytest.approx(SYNTHETIC_PIXEL)
+
+    @pytest.mark.unit
+    def test_transform_is_gdal_ordered(self, valid_rgb_cog: Path) -> None:
+        """transform uses GDAL GeoTransform order, not affine order."""
+        metadata = extract_cog_metadata(valid_rgb_cog)
+        assert metadata.transform == RAPIDAI4EO_GDAL_TRANSFORM
 
     @pytest.mark.unit
     def test_raises_for_nonexistent_file(self, tmp_path: Path) -> None:
         """Should raise FileNotFoundError for missing file."""
-        with pytest.raises(FileNotFoundError):
-            extract_cog_metadata(tmp_path / "missing.tif")
+        missing = tmp_path / "missing.tif"
+        with pytest.raises(FileNotFoundError, match=str(missing)):
+            extract_cog_metadata(missing)
 
     @pytest.mark.unit
     def test_raises_for_non_raster(self, tmp_path: Path) -> None:
@@ -87,62 +166,268 @@ class TestExtractCOGMetadata:
             extract_cog_metadata(fake_file)
 
 
-class TestCOGMetadata:
-    """Tests for COGMetadata dataclass."""
+class TestCOGMetadataToDict:
+    """Tests for COGMetadata.to_dict()."""
+
+    @staticmethod
+    def _metadata(**overrides: object) -> COGMetadata:
+        """A fully-populated COGMetadata, overridable field by field."""
+        kwargs: dict[str, object] = {
+            "bbox": (0.0, 1.0, 2.0, 3.0),
+            "crs": "EPSG:4326",
+            "width": 64,
+            "height": 32,
+            "band_count": 2,
+            "dtype": "uint8",
+            "nodata": 255.0,
+            "resolution": (0.5, 0.25),
+            "nodatavals": (255.0, None),
+            "transform": (0.0, 0.5, 0.0, 3.0, 0.0, -0.25),
+        }
+        kwargs.update(overrides)
+        return COGMetadata(**kwargs)  # type: ignore[arg-type]
 
     @pytest.mark.unit
-    def test_to_dict(self, valid_rgb_cog: Path) -> None:
-        """to_dict() returns complete metadata dict."""
-        metadata = extract_cog_metadata(valid_rgb_cog)
-        d = metadata.to_dict()
-
-        assert "bbox" in d
-        assert "crs" in d
-        assert "width" in d
-        assert "height" in d
-        assert "band_count" in d
-
-    @pytest.mark.unit
-    def test_to_stac_properties(self, valid_rgb_cog: Path) -> None:
-        """to_stac_properties() returns STAC-compatible dict."""
-        metadata = extract_cog_metadata(valid_rgb_cog)
-        props = metadata.to_stac_properties()
-
-        assert isinstance(props, dict)
+    def test_full_metadata_round_trips_every_field(self) -> None:
+        """Every field lands in the dict, with tuples widened to lists."""
+        assert self._metadata().to_dict() == {
+            "bbox": [0.0, 1.0, 2.0, 3.0],
+            "crs": "EPSG:4326",
+            "width": 64,
+            "height": 32,
+            "band_count": 2,
+            "dtype": "uint8",
+            "nodata": 255.0,
+            "resolution": [0.5, 0.25],
+            "nodatavals": [255.0, None],
+            "transform": [0.0, 0.5, 0.0, 3.0, 0.0, -0.25],
+        }
 
     @pytest.mark.unit
-    def test_to_stac_properties_with_nodata(self, valid_nodata_cog: Path) -> None:
-        """to_stac_properties() includes nodata in band info."""
-        metadata = extract_cog_metadata(valid_nodata_cog)
-        props = metadata.to_stac_properties()
-
-        # Check that bands have nodata if the source file has it
-        if metadata.nodata is not None:
-            assert "bands" in props
-            for band in props["bands"]:
-                assert "nodata" in band
-                assert band["nodata"] == metadata.nodata
+    def test_omits_nodatavals_when_absent(self) -> None:
+        """nodatavals is optional and stays out of the dict when unset."""
+        result = self._metadata(nodatavals=None).to_dict()
+        assert "nodatavals" not in result
 
     @pytest.mark.unit
-    def test_to_stac_properties_without_nodata(self) -> None:
-        """to_stac_properties() omits nodata when not set."""
-        # Create metadata without nodata
-        metadata = COGMetadata(
-            bbox=(0.0, 0.0, 1.0, 1.0),
-            crs="EPSG:4326",
-            width=64,
-            height=64,
-            band_count=3,
-            dtype="uint8",
-            nodata=None,
-            resolution=(0.1, 0.1),
-        )
-        props = metadata.to_stac_properties()
+    def test_omits_transform_when_absent(self) -> None:
+        """transform is optional and stays out of the dict when unset."""
+        result = self._metadata(transform=None).to_dict()
+        assert "transform" not in result
 
-        # Bands should not have nodata key
+    @pytest.mark.unit
+    def test_preserves_none_entries_inside_nodatavals(self) -> None:
+        """A band with no nodata keeps its None slot rather than being dropped."""
+        result = self._metadata(nodatavals=(None, None, 7.0)).to_dict()
+        assert result["nodatavals"] == [None, None, 7.0]
+
+    @pytest.mark.unit
+    def test_extracted_metadata_serializes(self, valid_nodata_cog: Path) -> None:
+        """A real extraction produces the same shape."""
+        result = extract_cog_metadata(valid_nodata_cog).to_dict()
+        assert result["bbox"] == list(SYNTHETIC_BOUNDS)
+        assert result["nodatavals"] == [255.0]
+
+
+class TestCOGMetadataToSTACProperties:
+    """Tests for COGMetadata.to_stac_properties()."""
+
+    @staticmethod
+    def _metadata(**overrides: object) -> COGMetadata:
+        """Three-band metadata with no nodata anywhere, overridable."""
+        kwargs: dict[str, object] = {
+            "bbox": (0.0, 0.0, 1.0, 1.0),
+            "crs": "EPSG:4326",
+            "width": 64,
+            "height": 64,
+            "band_count": 3,
+            "dtype": "uint8",
+            "nodata": None,
+            "resolution": (2.0, 4.0),
+            "nodatavals": None,
+            "transform": None,
+        }
+        kwargs.update(overrides)
+        return COGMetadata(**kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.unit
+    def test_bands_are_named_one_based(self) -> None:
+        """Band names count from 1, matching STAC and GDAL conventions."""
+        props = self._metadata().to_stac_properties()
+        assert [band["name"] for band in props["bands"]] == ["band_1", "band_2", "band_3"]
+
+    @pytest.mark.unit
+    def test_every_band_carries_the_data_type(self) -> None:
+        """data_type is repeated on each band entry."""
+        props = self._metadata(dtype="float32").to_stac_properties()
+        assert [band["data_type"] for band in props["bands"]] == ["float32"] * 3
+
+    @pytest.mark.unit
+    def test_uses_unified_bands_key_not_raster_bands(self) -> None:
+        """STAC v1.1.0 uses `bands`; `raster:bands` is the superseded spelling."""
+        props = self._metadata().to_stac_properties()
         assert "bands" in props
-        for band in props["bands"]:
-            assert "nodata" not in band
+        assert "raster:bands" not in props
+
+    @pytest.mark.unit
+    def test_per_band_nodata_wins_over_uniform(self) -> None:
+        """When nodatavals is present it supplies each band's nodata."""
+        metadata = self._metadata(nodatavals=(1.0, 2.0, 3.0), nodata=99.0)
+        props = metadata.to_stac_properties()
+        assert [band["nodata"] for band in props["bands"]] == [1.0, 2.0, 3.0]
+
+    @pytest.mark.unit
+    def test_none_inside_nodatavals_omits_that_band(self) -> None:
+        """A None slot means that band has no nodata, and does not fall back."""
+        metadata = self._metadata(nodatavals=(None, 2.0, None), nodata=99.0)
+        bands = metadata.to_stac_properties()["bands"]
+        assert "nodata" not in bands[0]
+        assert bands[1]["nodata"] == 2.0
+        assert "nodata" not in bands[2]
+
+    @pytest.mark.unit
+    def test_short_nodatavals_falls_back_to_uniform(self) -> None:
+        """Bands past the end of nodatavals use the uniform nodata."""
+        metadata = self._metadata(nodatavals=(1.0,), nodata=99.0)
+        assert [band["nodata"] for band in metadata.to_stac_properties()["bands"]] == [
+            1.0,
+            99.0,
+            99.0,
+        ]
+
+    @pytest.mark.unit
+    def test_uniform_nodata_applies_to_all_bands(self) -> None:
+        """With no per-band values, every band gets the uniform nodata."""
+        props = self._metadata(nodata=7.5).to_stac_properties()
+        assert [band["nodata"] for band in props["bands"]] == [7.5, 7.5, 7.5]
+
+    @pytest.mark.unit
+    def test_omits_nodata_when_unset_everywhere(self) -> None:
+        """No nodata anywhere means no nodata key on any band."""
+        props = self._metadata().to_stac_properties()
+        assert all("nodata" not in band for band in props["bands"])
+
+    @pytest.mark.unit
+    def test_spatial_resolution_averages_the_two_axes(self) -> None:
+        """raster:spatial_resolution is the mean of x and y pixel size."""
+        props = self._metadata(resolution=(2.0, 4.0)).to_stac_properties()
+        assert props["raster:spatial_resolution"] == 3.0
+
+    @pytest.mark.unit
+    def test_band_count_drives_the_band_list_length(self) -> None:
+        """A single-band raster produces exactly one band entry."""
+        props = self._metadata(band_count=1).to_stac_properties()
+        assert len(props["bands"]) == 1
+
+    @pytest.mark.unit
+    def test_extracted_metadata_produces_stac_bands(self, valid_nodata_cog: Path) -> None:
+        """A real extraction yields one nodata-carrying band."""
+        props = extract_cog_metadata(valid_nodata_cog).to_stac_properties()
+        assert props["bands"] == [{"name": "band_1", "data_type": "uint8", "nodata": 255.0}]
+
+
+class TestExtractSchemaFromCOG:
+    """Tests for extract_schema_from_cog()."""
+
+    @pytest.mark.unit
+    def test_schema_header_fields(self, valid_singleband_cog: Path) -> None:
+        """The schema declares version 1.0.0, format cog, and the raster CRS."""
+        schema = extract_schema_from_cog(valid_singleband_cog)
+        assert schema.schema_version == "1.0.0"
+        assert schema.format == "cog"
+        assert schema.crs == "EPSG:4326"
+
+    @pytest.mark.unit
+    def test_one_band_column_per_raster_band(self, valid_rgb_cog: Path) -> None:
+        """Each raster band becomes a one-based BandSchema column."""
+        schema = extract_schema_from_cog(valid_rgb_cog)
+        assert [band.name for band in bands_of(schema)] == [
+            "band_1",
+            "band_2",
+            "band_3",
+            "band_4",
+        ]
+
+    @pytest.mark.unit
+    def test_columns_are_band_schemas_carrying_dtype(self, valid_rgb_cog: Path) -> None:
+        """Columns are BandSchema instances typed from the raster."""
+        schema = extract_schema_from_cog(valid_rgb_cog)
+        assert {band.data_type for band in bands_of(schema)} == {"int16"}
+
+    @pytest.mark.unit
+    def test_band_nodata_is_populated(self, valid_nodata_cog: Path) -> None:
+        """A raster with nodata puts that value on its band."""
+        schema = extract_schema_from_cog(valid_nodata_cog)
+        assert [band.nodata for band in bands_of(schema)] == [255.0]
+
+    @pytest.mark.unit
+    def test_band_nodata_is_none_when_unset(self, valid_singleband_cog: Path) -> None:
+        """A raster without nodata leaves the band's nodata unset."""
+        schema = extract_schema_from_cog(valid_singleband_cog)
+        assert [band.nodata for band in bands_of(schema)] == [None]
+
+    @pytest.mark.unit
+    def test_band_description_defaults_to_none(self, valid_singleband_cog: Path) -> None:
+        """Undescribed bands carry no description."""
+        schema = extract_schema_from_cog(valid_singleband_cog)
+        assert [band.description for band in bands_of(schema)] == [None]
+
+    @pytest.mark.unit
+    def test_band_description_is_read_from_the_raster(self, tmp_path: Path) -> None:
+        """A band description set on the file reaches the schema."""
+        import numpy as np
+        import rasterio
+        from rasterio.transform import from_bounds
+
+        path = tmp_path / "described.tif"
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=8,
+            width=8,
+            count=2,
+            dtype="uint8",
+            crs="EPSG:4326",
+            transform=from_bounds(0, 0, 1, 1, 8, 8),
+        ) as dst:
+            dst.write(np.zeros((8, 8), dtype="uint8"), 1)
+            dst.write(np.zeros((8, 8), dtype="uint8"), 2)
+            dst.set_band_description(1, "red")
+            dst.set_band_description(2, "nir")
+
+        schema = extract_schema_from_cog(path)
+        assert [band.description for band in bands_of(schema)] == ["red", "nir"]
+
+    @pytest.mark.unit
+    def test_no_warnings_when_crs_present(self, valid_singleband_cog: Path) -> None:
+        """A georeferenced raster warns about nothing."""
+        _, warnings = extract_schema_from_cog(valid_singleband_cog, return_warnings=True)
+        assert warnings == []
+
+    @pytest.mark.unit
+    def test_warns_and_leaves_crs_unset_without_crs(
+        self, invalid_not_georeferenced_tif: Path
+    ) -> None:
+        """A raster with no CRS warns once and reports crs=None."""
+        schema, warnings = extract_schema_from_cog(
+            invalid_not_georeferenced_tif, return_warnings=True
+        )
+        assert schema.crs is None
+        assert warnings == ["Raster has no CRS defined. Consider adding CRS metadata."]
+
+    @pytest.mark.unit
+    def test_default_return_is_a_bare_schema(self, valid_singleband_cog: Path) -> None:
+        """Without return_warnings the result is the SchemaModel itself."""
+        result = extract_schema_from_cog(valid_singleband_cog)
+        assert not isinstance(result, tuple)
+
+    @pytest.mark.unit
+    def test_raises_for_nonexistent_file(self, tmp_path: Path) -> None:
+        """A missing path fails before rasterio is reached."""
+        missing = tmp_path / "missing.tif"
+        with pytest.raises(FileNotFoundError, match=str(missing)):
+            extract_schema_from_cog(missing)
 
 
 class TestCOGMetadataEdgeCases:
@@ -158,48 +443,85 @@ class TestCOGMetadataEdgeCases:
 
     @pytest.mark.unit
     def test_extract_crs_wkt_fallback(self, tmp_path: Path) -> None:
-        """Falls back to WKT when no EPSG code available."""
+        """Falls back to WKT when no EPSG code is available.
+
+        The CRS below is a Mercator with a non-standard central meridian, so no
+        EPSG code matches it and ``to_epsg()`` returns None.
+        """
         import numpy as np
         import rasterio
         from rasterio.crs import CRS as RasterioCRS
         from rasterio.transform import from_bounds
 
-        # Create a COG with a custom CRS that has no EPSG code
-        # Using a custom WKT that rasterio won't map to EPSG
         custom_wkt = """PROJCS["Custom_CRS",
             GEOGCS["GCS_WGS_1984",
                 DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],
                 PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],
-            PROJECTION["Mercator"],
-            PARAMETER["central_meridian",0],
+            PROJECTION["Mercator_1SP"],
+            PARAMETER["central_meridian",17.5],
             PARAMETER["scale_factor",1],
             PARAMETER["false_easting",0],
             PARAMETER["false_northing",0],
             UNIT["Meter",1]]"""
 
+        crs = RasterioCRS.from_wkt(custom_wkt)
+        assert crs.to_epsg() is None, "fixture CRS must have no EPSG code"
+
         path = tmp_path / "custom_crs.tif"
-        transform = from_bounds(0, 0, 1, 1, 64, 64)
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=64,
+            width=64,
+            count=1,
+            dtype="uint8",
+            crs=crs,
+            transform=from_bounds(0, 0, 1, 1, 64, 64),
+        ) as dst:
+            dst.write(np.zeros((64, 64), dtype="uint8"), 1)
 
-        try:
-            crs = RasterioCRS.from_wkt(custom_wkt)
-            with rasterio.open(
-                path,
-                "w",
-                driver="GTiff",
-                height=64,
-                width=64,
-                count=1,
-                dtype="uint8",
-                crs=crs,
-                transform=transform,
-            ) as dst:
-                dst.write(np.zeros((64, 64), dtype="uint8"), 1)
+        metadata = extract_cog_metadata(path)
+        assert metadata.crs is not None
+        assert metadata.crs.startswith("PROJCS")
 
-            metadata = extract_cog_metadata(path)
-            # Should return WKT string since no EPSG
-            assert metadata.crs is not None
-            # Could be WKT string
-            assert isinstance(metadata.crs, str)
-        except Exception:
-            # If the custom CRS can't be created, skip the test
-            pytest.skip("Could not create custom CRS for WKT fallback test")
+    @pytest.mark.unit
+    def test_schema_crs_wkt_fallback(self, tmp_path: Path) -> None:
+        """extract_schema_from_cog takes the same WKT fallback."""
+        import numpy as np
+        import rasterio
+        from rasterio.crs import CRS as RasterioCRS
+        from rasterio.transform import from_bounds
+
+        custom_wkt = """PROJCS["Custom_CRS",
+            GEOGCS["GCS_WGS_1984",
+                DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],
+                PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],
+            PROJECTION["Mercator_1SP"],
+            PARAMETER["central_meridian",17.5],
+            PARAMETER["scale_factor",1],
+            PARAMETER["false_easting",0],
+            PARAMETER["false_northing",0],
+            UNIT["Meter",1]]"""
+
+        crs = RasterioCRS.from_wkt(custom_wkt)
+        assert crs.to_epsg() is None, "fixture CRS must have no EPSG code"
+
+        path = tmp_path / "custom_crs_schema.tif"
+        with rasterio.open(
+            path,
+            "w",
+            driver="GTiff",
+            height=8,
+            width=8,
+            count=1,
+            dtype="uint8",
+            crs=crs,
+            transform=from_bounds(0, 0, 1, 1, 8, 8),
+        ) as dst:
+            dst.write(np.zeros((8, 8), dtype="uint8"), 1)
+
+        schema, warnings = extract_schema_from_cog(path, return_warnings=True)
+        assert schema.crs is not None
+        assert schema.crs.startswith("PROJCS")
+        assert warnings == []

--- a/tests/unit/test_remove_files.py
+++ b/tests/unit/test_remove_files.py
@@ -1,0 +1,430 @@
+"""Unit tests for the `portolan rm` file-expansion and deletion helpers.
+
+Covers `_gather_removable_files`, `_remove_one_file`, and `remove_files`.
+Version-tracking behavior lives in `test_remove_versions.py`; these tests build
+catalogs without a `versions.json` unless the assertion needs one, so each one
+isolates the on-disk effect.
+
+The layout under test throughout:
+
+    tmp_path/
+      .portolan/config.yaml      catalog-root sentinel (ADR-0029)
+      mycoll/
+        collection.json          marks the collection dir
+        tunnels.parquet          collection-level asset (ADR-0031)
+        districts/               item dir
+          item.json
+          districts.parquet
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.remove import _gather_removable_files, _remove_one_file, remove_files
+from portolan_cli.versions import (
+    SPEC_VERSION,
+    Asset,
+    Version,
+    VersionsFile,
+    read_versions,
+    write_versions,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> Path:
+    """A managed catalog with one collection holding both asset levels.
+
+    The catalog sits in a subdirectory so `tmp_path` itself stays available as
+    genuinely-outside-the-catalog scratch space.
+    """
+    root = tmp_path / "catalog"
+    portolan_dir = root / ".portolan"
+    portolan_dir.mkdir(parents=True)
+    (portolan_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+    # find_catalog_root needs both the sentinel and catalog.json to call this
+    # an operational catalog.
+    (root / "catalog.json").write_text("{}\n", encoding="utf-8")
+
+    coll_dir = root / "mycoll"
+    coll_dir.mkdir()
+    (coll_dir / "collection.json").write_text("{}\n", encoding="utf-8")
+    (coll_dir / "tunnels.parquet").write_bytes(b"fake")
+
+    item_dir = coll_dir / "districts"
+    item_dir.mkdir()
+    (item_dir / "item.json").write_text("{}\n", encoding="utf-8")
+    (item_dir / "districts.parquet").write_bytes(b"fake")
+
+    return root
+
+
+class TestGatherRemovableFiles:
+    """Expansion of a removal target into concrete files."""
+
+    def test_directory_expands_to_every_file_beneath_it(self, catalog: Path) -> None:
+        """A directory yields all nested files and no directories."""
+        gathered = set(_gather_removable_files(catalog / "mycoll"))
+
+        assert gathered == {
+            catalog / "mycoll" / "collection.json",
+            catalog / "mycoll" / "tunnels.parquet",
+            catalog / "mycoll" / "districts" / "item.json",
+            catalog / "mycoll" / "districts" / "districts.parquet",
+        }
+
+    def test_directory_recurses_past_one_level(self, catalog: Path) -> None:
+        """Files nested two levels down are still gathered."""
+        deep = catalog / "mycoll" / "districts" / "nested"
+        deep.mkdir()
+        (deep / "deep.parquet").write_bytes(b"fake")
+
+        assert deep / "deep.parquet" in _gather_removable_files(catalog / "mycoll")
+
+    def test_empty_directory_yields_nothing(self, tmp_path: Path) -> None:
+        """A directory with no files expands to an empty list."""
+        empty = tmp_path / "empty"
+        empty.mkdir()
+
+        assert _gather_removable_files(empty) == []
+
+    def test_file_is_paired_with_its_sidecars(self, tmp_path: Path) -> None:
+        """A shapefile drags its sidecars along, primary file first."""
+        shp = tmp_path / "roads.shp"
+        shp.write_bytes(b"fake")
+        for ext in (".dbf", ".shx", ".prj"):
+            (tmp_path / f"roads{ext}").write_bytes(b"fake")
+
+        gathered = _gather_removable_files(shp)
+
+        assert gathered[0] == shp
+        assert set(gathered[1:]) == {
+            tmp_path / "roads.dbf",
+            tmp_path / "roads.shx",
+            tmp_path / "roads.prj",
+        }
+
+    def test_file_without_sidecars_yields_only_itself(self, tmp_path: Path) -> None:
+        """A format with no sidecar convention yields a one-element list."""
+        parquet = tmp_path / "data.parquet"
+        parquet.write_bytes(b"fake")
+
+        assert _gather_removable_files(parquet) == [parquet]
+
+    def test_missing_file_still_yields_itself(self, tmp_path: Path) -> None:
+        """A path that does not exist is returned so it can be untracked.
+
+        `rm --keep` on an already-deleted file must still reach
+        `_remove_one_file` to drop the versions.json entry.
+        """
+        missing = tmp_path / "gone.parquet"
+
+        assert _gather_removable_files(missing) == [missing]
+
+
+class TestRemoveOneFile:
+    """Guards and deletion behavior of `_remove_one_file`."""
+
+    def test_item_level_asset_removes_the_whole_item_dir(self, catalog: Path) -> None:
+        """An item-level asset takes its item dir, and item.json, with it."""
+        item_dir = catalog / "mycoll" / "districts"
+
+        removed = _remove_one_file(
+            item_dir / "districts.parquet", catalog_root=catalog, keep=False, dry_run=False
+        )
+
+        assert removed is True
+        assert not item_dir.exists()
+
+    def test_collection_level_asset_keeps_the_collection_dir(self, catalog: Path) -> None:
+        """A file beside collection.json is deleted alone, not with its parent."""
+        coll_dir = catalog / "mycoll"
+
+        removed = _remove_one_file(
+            coll_dir / "tunnels.parquet", catalog_root=catalog, keep=False, dry_run=False
+        )
+
+        assert removed is True
+        assert not (coll_dir / "tunnels.parquet").exists()
+        assert (coll_dir / "collection.json").exists()
+        assert (coll_dir / "districts" / "districts.parquet").exists()
+
+    def test_collection_level_asset_takes_its_sidecars(self, catalog: Path) -> None:
+        """Deleting a shapefile beside collection.json removes its sidecars too."""
+        coll_dir = catalog / "mycoll"
+        shp = coll_dir / "roads.shp"
+        shp.write_bytes(b"fake")
+        for ext in (".dbf", ".shx"):
+            (coll_dir / f"roads{ext}").write_bytes(b"fake")
+
+        _remove_one_file(shp, catalog_root=catalog, keep=False, dry_run=False)
+
+        assert not shp.exists()
+        assert not (coll_dir / "roads.dbf").exists()
+        assert not (coll_dir / "roads.shx").exists()
+
+    def test_keep_preserves_the_file_on_disk(self, catalog: Path) -> None:
+        """keep=True untracks without deleting anything."""
+        item_dir = catalog / "mycoll" / "districts"
+
+        removed = _remove_one_file(
+            item_dir / "districts.parquet", catalog_root=catalog, keep=True, dry_run=False
+        )
+
+        assert removed is True
+        assert (item_dir / "districts.parquet").exists()
+        assert (item_dir / "item.json").exists()
+
+    def test_dry_run_mutates_nothing(self, catalog: Path) -> None:
+        """dry_run reports success without touching the filesystem."""
+        item_dir = catalog / "mycoll" / "districts"
+
+        removed = _remove_one_file(
+            item_dir / "districts.parquet", catalog_root=catalog, keep=False, dry_run=True
+        )
+
+        assert removed is True
+        assert (item_dir / "districts.parquet").exists()
+
+    def test_missing_file_is_skipped(self, catalog: Path) -> None:
+        """A file that is already gone is skipped rather than reported removed."""
+        removed = _remove_one_file(
+            catalog / "mycoll" / "gone.parquet",
+            catalog_root=catalog,
+            keep=False,
+            dry_run=False,
+        )
+
+        assert removed is False
+
+    def test_missing_file_is_still_untracked_under_keep(self, catalog: Path) -> None:
+        """keep=True unblocks the missing-file guard so tracking can be dropped."""
+        removed = _remove_one_file(
+            catalog / "mycoll" / "gone.parquet",
+            catalog_root=catalog,
+            keep=True,
+            dry_run=False,
+        )
+
+        assert removed is True
+
+    def test_symlink_is_refused(self, catalog: Path) -> None:
+        """A symlink is left alone rather than followed into a delete.
+
+        The target here is inside the catalog, so nothing but the symlink guard
+        can account for the refusal.
+        """
+        target = catalog / "mycoll" / "tunnels.parquet"
+        link = catalog / "mycoll" / "link.parquet"
+        link.symlink_to(target)
+
+        removed = _remove_one_file(link, catalog_root=catalog, keep=False, dry_run=False)
+
+        assert removed is False
+        assert link.is_symlink()
+        assert target.exists()
+
+    def test_symlink_can_be_untracked_with_keep(self, catalog: Path) -> None:
+        """keep=True untracks a symlink without deleting it or its target."""
+        target = catalog / "mycoll" / "tunnels.parquet"
+        link = catalog / "mycoll" / "link.parquet"
+        link.symlink_to(target)
+
+        removed = _remove_one_file(link, catalog_root=catalog, keep=True, dry_run=False)
+
+        assert removed is True
+        assert link.is_symlink()
+        assert target.exists()
+
+    def test_symlink_pointing_outside_the_catalog_is_skipped(
+        self, catalog: Path, tmp_path: Path
+    ) -> None:
+        """Collection resolution follows the link, so an external target has none."""
+        target = tmp_path / "outside.parquet"
+        target.write_bytes(b"fake")
+        link = catalog / "mycoll" / "link.parquet"
+        link.symlink_to(target)
+
+        removed = _remove_one_file(link, catalog_root=catalog, keep=True, dry_run=False)
+
+        assert removed is False
+        assert target.exists()
+
+    def test_file_outside_catalog_is_skipped(self, catalog: Path, tmp_path: Path) -> None:
+        """A path outside the catalog root is skipped instead of raising."""
+        outside = tmp_path / "elsewhere.parquet"
+        outside.write_bytes(b"fake")
+
+        removed = _remove_one_file(outside, catalog_root=catalog, keep=False, dry_run=False)
+
+        assert removed is False
+        assert outside.exists()
+
+    def test_removal_untracks_the_asset_in_versions_json(self, catalog: Path) -> None:
+        """Deleting a tracked file drops its entry from the collection's versions.json.
+
+        This is the only test that exercises the versions.json lookup by name,
+        so a wrong filename there shows up here rather than as silent no-op
+        untracking.
+        """
+        coll_dir = catalog / "mycoll"
+        versions_path = coll_dir / "versions.json"
+        write_versions(
+            versions_path,
+            VersionsFile(
+                spec_version=SPEC_VERSION,
+                current_version="1.0.0",
+                versions=[
+                    Version(
+                        version="1.0.0",
+                        created=datetime.now(timezone.utc),
+                        breaking=False,
+                        assets={
+                            "tunnels.parquet": Asset(
+                                sha256="abc", size_bytes=1, href="mycoll/tunnels.parquet"
+                            )
+                        },
+                        changes=["tunnels.parquet"],
+                    )
+                ],
+            ),
+        )
+
+        _remove_one_file(
+            coll_dir / "tunnels.parquet", catalog_root=catalog, keep=False, dry_run=False
+        )
+
+        latest = read_versions(versions_path).versions[-1]
+        assert "tunnels.parquet" not in latest.assets
+
+    def test_dry_run_leaves_versions_json_untouched(self, catalog: Path) -> None:
+        """A preview publishes no new version."""
+        coll_dir = catalog / "mycoll"
+        versions_path = coll_dir / "versions.json"
+        write_versions(
+            versions_path,
+            VersionsFile(
+                spec_version=SPEC_VERSION,
+                current_version="1.0.0",
+                versions=[
+                    Version(
+                        version="1.0.0",
+                        created=datetime.now(timezone.utc),
+                        breaking=False,
+                        assets={
+                            "tunnels.parquet": Asset(
+                                sha256="abc", size_bytes=1, href="mycoll/tunnels.parquet"
+                            )
+                        },
+                        changes=["tunnels.parquet"],
+                    )
+                ],
+            ),
+        )
+
+        _remove_one_file(
+            coll_dir / "tunnels.parquet", catalog_root=catalog, keep=True, dry_run=True
+        )
+
+        assert len(read_versions(versions_path).versions) == 1
+
+    def test_file_at_catalog_root_is_skipped(self, catalog: Path) -> None:
+        """A file with no collection directory above it is skipped."""
+        stray = catalog / "stray.parquet"
+        stray.write_bytes(b"fake")
+
+        removed = _remove_one_file(stray, catalog_root=catalog, keep=False, dry_run=False)
+
+        assert removed is False
+        assert stray.exists()
+
+
+class TestRemoveFiles:
+    """The `remove_files` entry point."""
+
+    def test_returns_removed_and_skipped_in_that_order(self, catalog: Path) -> None:
+        """Successes land in the first list, skips in the second."""
+        good = catalog / "mycoll" / "tunnels.parquet"
+        stray = catalog / "stray.parquet"
+        stray.write_bytes(b"fake")
+
+        removed, skipped = remove_files(paths=[good, stray], catalog_root=catalog)
+
+        assert removed == [good]
+        assert skipped == [stray]
+
+    def test_expands_a_directory_argument(self, catalog: Path) -> None:
+        """Passing an item dir accounts for every file inside it and clears the dir.
+
+        The first file removed takes the whole item dir with it (item-level
+        assets own their directory), so the remaining files report as skipped.
+        Which file comes first depends on `rglob` order, so assert the partition
+        covers both files rather than pinning either side.
+        """
+        item_dir = catalog / "mycoll" / "districts"
+        contents = {item_dir / "item.json", item_dir / "districts.parquet"}
+
+        removed, skipped = remove_files(paths=[item_dir], catalog_root=catalog)
+
+        assert set(removed) | set(skipped) == contents
+        assert len(removed) == 1
+        assert not item_dir.exists()
+
+    def test_processes_every_path_argument(self, catalog: Path) -> None:
+        """Multiple targets are all visited, not just the first."""
+        coll_dir = catalog / "mycoll"
+        second = coll_dir / "bridges.parquet"
+        second.write_bytes(b"fake")
+
+        removed, _ = remove_files(
+            paths=[coll_dir / "tunnels.parquet", second], catalog_root=catalog
+        )
+
+        assert set(removed) == {coll_dir / "tunnels.parquet", second}
+        assert not (coll_dir / "tunnels.parquet").exists()
+        assert not second.exists()
+
+    def test_keep_defaults_to_false(self, catalog: Path) -> None:
+        """The default call deletes, git-style."""
+        target = catalog / "mycoll" / "tunnels.parquet"
+
+        remove_files(paths=[target], catalog_root=catalog)
+
+        assert not target.exists()
+
+    def test_dry_run_defaults_to_false(self, catalog: Path) -> None:
+        """The default call is not a preview."""
+        item_dir = catalog / "mycoll" / "districts"
+
+        remove_files(paths=[item_dir / "districts.parquet"], catalog_root=catalog)
+
+        assert not item_dir.exists()
+
+    def test_dry_run_reports_without_deleting(self, catalog: Path) -> None:
+        """dry_run lists what would go without removing it."""
+        target = catalog / "mycoll" / "tunnels.parquet"
+
+        removed, skipped = remove_files(paths=[target], catalog_root=catalog, dry_run=True)
+
+        assert removed == [target]
+        assert skipped == []
+        assert target.exists()
+
+    def test_keep_untracks_without_deleting(self, catalog: Path) -> None:
+        """keep reports removal from tracking while the file stays put."""
+        target = catalog / "mycoll" / "tunnels.parquet"
+
+        removed, _ = remove_files(paths=[target], catalog_root=catalog, keep=True)
+
+        assert removed == [target]
+        assert target.exists()
+
+    def test_no_paths_returns_two_empty_lists(self, catalog: Path) -> None:
+        """An empty request is a no-op."""
+        assert remove_files(paths=[], catalog_root=catalog) == ([], [])

--- a/tests/unit/test_remove_versions.py
+++ b/tests/unit/test_remove_versions.py
@@ -40,6 +40,10 @@ def _catalog_with_assets(tmp_path: Path, asset_keys: list[str]) -> tuple[Path, P
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
     (portolan_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+    # find_catalog_root requires catalog.json alongside the sentinel; without it
+    # the root resolves to None and the caller silently falls back to the
+    # collection's grandparent.
+    (tmp_path / "catalog.json").write_text("{}\n", encoding="utf-8")
 
     coll_dir = tmp_path / "mycoll"
     coll_dir.mkdir()
@@ -154,3 +158,82 @@ def test_remove_source_drops_converted_parquet_asset(tmp_path: Path) -> None:
 
     latest = read_versions(versions_path).versions[-1]
     assert "roads.parquet" not in latest.assets
+
+
+@pytest.mark.unit
+def test_directly_tracked_source_is_matched_without_the_parquet_fallback(
+    tmp_path: Path,
+) -> None:
+    """A non-parquet asset tracked under its own href is dropped by href match.
+
+    The ``.parquet`` suffix swap is a *fallback* for the convert-on-add case. It
+    must not run when the href already matched, or the direct hit is discarded
+    and replaced by a parquet lookup that finds nothing.
+    """
+    coll_dir, versions_path = _catalog_with_assets(tmp_path, ["roads.shp"])
+    file_path = _touch(coll_dir, "roads.shp")
+
+    _remove_from_versions(file_path, versions_path)
+
+    latest = read_versions(versions_path).versions[-1]
+    assert "roads.shp" not in latest.assets
+
+
+@pytest.mark.unit
+def test_new_version_records_the_removed_filename(tmp_path: Path) -> None:
+    """The version published by a removal names the file in its message."""
+    coll_dir, versions_path = _catalog_with_assets(tmp_path, ["tunnels.parquet"])
+    file_path = _touch(coll_dir, "tunnels.parquet")
+
+    _remove_from_versions(file_path, versions_path)
+
+    assert read_versions(versions_path).versions[-1].message == "Removed tunnels.parquet"
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "#723: rm on a collection under a subcatalog (ADR-0032) leaves a "
+        "phantom versions.json entry. JsonFileBackend._versions_path flattens "
+        "a nested collection id through Path(collection).name, so publishing "
+        "'sub/coll' writes {catalog_root}/coll/versions.json. Drop this marker "
+        "with the fix; it is the acceptance criterion."
+    ),
+)
+def test_nested_collection_resolves_the_real_catalog_root(tmp_path: Path) -> None:
+    """Hrefs are resolved against the catalog root, not the collection's grandparent.
+
+    Under a subcatalog (ADR-0032) the collection sits two levels below the root,
+    so ``versions_path.parent.parent`` is the subcatalog rather than the catalog.
+    Computing hrefs against it yields ``coll/x.parquet`` where the tracked href
+    is ``sub/coll/x.parquet``, and nothing matches.
+    """
+    portolan_dir = tmp_path / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "catalog.json").write_text("{}\n", encoding="utf-8")
+
+    coll_dir = tmp_path / "sub" / "coll"
+    coll_dir.mkdir(parents=True)
+
+    key = "tunnels.parquet"
+    assets = {key: Asset(sha256="abc", size_bytes=1, href=f"sub/coll/{key}")}
+    version = Version(
+        version="1.0.0",
+        created=datetime.now(timezone.utc),
+        breaking=False,
+        assets=assets,
+        changes=[key],
+    )
+    versions_path = coll_dir / "versions.json"
+    write_versions(
+        versions_path,
+        VersionsFile(spec_version=SPEC_VERSION, current_version="1.0.0", versions=[version]),
+    )
+    file_path = _touch(coll_dir, key)
+
+    _remove_from_versions(file_path, versions_path)
+
+    latest = read_versions(versions_path).versions[-1]
+    assert key not in latest.assets


### PR DESCRIPTION
## What this changes

Rewrites the assertions covering the ESRI renderer converter, COG metadata, and
`rm` to pin exact output where they checked only shape. Adds
`tests/unit/test_remove_files.py`. Deletes two unreachable blocks whose mutants
no test could kill: a `cases` list nothing read, and a directory guard that
`Path.is_dir()` already rejects.

## Why

Resolves #674. The first complete sweep (#612) left 533 mutants alive here, the
ESRI converter at 37.6%. Testing the nested-collection path also surfaced #723,
whose regression test ships `xfail(strict=True)`.

## Verification

Mutation sweep per module, against the rates recorded in #674:

```console
$ for m in extract.common.converters.esri metadata.cog remove; do
    uv run mutmut run "portolan_cli.${m}.x*" >/dev/null
    uv run mutmut results --all true | grep -F "portolan_cli.${m}." \
      | awk -F': ' '{print $2}' | sort | uniq -c
  done

--- portolan_cli.extract.common.converters.esri ---
    660 killed   92 survived     37.6% -> 87.8%   (was 282 / 467)
--- portolan_cli.metadata.cog ---
     92 killed    8 survived     57.0% -> 92.0%   (was  57 /  43)
--- portolan_cli.remove ---
     88 killed    9 survived     76.5% -> 90.7%   (was  75 /  23)
```

Combined 43.7% -> 88.5%; 424 of 533 survivors killed. The 109 left are
equivalent or unreachable. Full offline suite, reading
`tests/fixtures/styles/esri_*.json`, `tests/fixtures/raster/valid/*.tif`, and
`tests/fixtures/realdata/rapidai4eo-sample.tif`:

```console
$ uv run pytest -m "not network and not slow and not benchmark and not e2e and not e2e_slow"
6347 passed, 9 skipped, 53 deselected, 1 xfailed, 37 warnings in 348.52s
```
