### PR TITLE
fix(readme): render the Bands section from the core bands array (#713)

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -5120,7 +5120,11 @@ def _generate_readme_content(
     """
     from portolan_cli.config import load_merged_metadata
     from portolan_cli.errors import ConfigInvalidStructureError
-    from portolan_cli.readme import generate_catalog_readme, generate_readme
+    from portolan_cli.readme import (
+        generate_catalog_readme,
+        generate_readme,
+        load_collection_stac,
+    )
 
     # Compute relative path for display
     try:
@@ -5144,7 +5148,7 @@ def _generate_readme_content(
         _verbose_readme("Generating README.md", verbose, use_json)
         return generate_catalog_readme(target_dir), True
 
-    # Load STAC (collection.json or catalog.json)
+    # Load STAC (collection.json, with its items, or catalog.json)
     stac: dict[str, Any] = {}
     for stac_file in ["collection.json", "catalog.json"]:
         stac_path = target_dir / stac_file
@@ -5152,7 +5156,13 @@ def _generate_readme_content(
             _verbose_readme(
                 f"Reading {stac_file} from {dir_prefix or 'catalog root'}", verbose, use_json
             )
-            stac = json.loads(stac_path.read_text(encoding="utf-8"))
+            # Collections load through load_collection_stac so their items come
+            # too; the README renders band and file metadata that lives only on
+            # item assets (issue #713).
+            if stac_file == "collection.json":
+                stac = load_collection_stac(target_dir)
+            else:
+                stac = json.loads(stac_path.read_text(encoding="utf-8"))
             break
 
     # Load merged metadata

--- a/portolan_cli/readme.py
+++ b/portolan_cli/readme.py
@@ -8,7 +8,7 @@ generated, never hand-edited.
 - Title, description (metadata.yaml override > catalog/collection STAC > id, #534)
 - Spatial/temporal coverage (from extent)
 - Schema/columns (from table:columns)
-- Bands (from eo:bands, raster:bands)
+- Bands (from the unified bands array on the data asset)
 - Files with checksums (from assets)
 - STAC links (from links)
 - Code examples (based on asset types)
@@ -41,6 +41,7 @@ from portolan_cli.agents_md import visible_stac_files as _visible_stac_files
 from portolan_cli.config import load_merged_metadata
 from portolan_cli.errors import ConfigInvalidStructureError
 from portolan_cli.json_io import write_json_atomic
+from portolan_cli.stac_parquet import owned_item_hrefs
 
 # Keyword-badge rendering limits (#515). A junk-dominated list is a machine dump
 # (e.g. WFS layer ids seeded into metadata.yaml at extraction) and is suppressed;
@@ -254,23 +255,86 @@ def _add_schema_section(sections: list[str], stac: dict[str, Any]) -> None:
     sections.append("")
 
 
-def _add_bands_section(sections: list[str], stac: dict[str, Any]) -> None:
-    """Add bands from eo:bands or raster:bands."""
-    summaries = stac.get("summaries", {})
-    bands = summaries.get("eo:bands", []) or summaries.get("raster:bands", [])
+# Statistic keys live inside a band's `statistics` object (STAC v1.1.0
+# Statistics Object), not on the band itself.
+_BAND_STAT_KEYS = frozenset({"minimum", "maximum", "mean", "stddev", "valid_percent"})
 
+# Bands table columns in render order, as (header, band key). A column is
+# dropped when no band carries a value for it, so a bands array without
+# statistics renders as a narrow identity table.
+_BAND_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("Name", "name"),
+    ("Common Name", "eo:common_name"),
+    ("Data Type", "data_type"),
+    ("Unit", "unit"),
+    ("Nodata", "nodata"),
+    ("Min", "minimum"),
+    ("Max", "maximum"),
+    ("Mean", "mean"),
+    ("Std Dev", "stddev"),
+    ("Valid %", "valid_percent"),
+    ("Description", "description"),
+)
+
+
+def _band_field(band: dict[str, Any], key: str) -> Any:
+    """Read one band field, reaching into ``statistics`` for statistic keys."""
+    if key in _BAND_STAT_KEYS:
+        statistics = band.get("statistics")
+        return statistics.get(key) if isinstance(statistics, dict) else None
+    if key == "eo:common_name":
+        # STAC v1.1.0 renamed eo:bands' common_name; read both.
+        return band.get("eo:common_name", band.get("common_name"))
+    return band.get(key)
+
+
+def _find_bands(assets: dict[str, Any], stac: dict[str, Any]) -> list[dict[str, Any]]:
+    """Find the unified bands array, preferring the primary data asset.
+
+    STAC v1.1.0 makes ``bands`` an asset-level field, and the CLI writes it
+    there (``stac._set_bands_on_data_assets``), item-level for rasters. The
+    ``eo:bands`` / ``raster:bands`` summaries are read only as a fallback, for
+    catalogs hand-authored before the v1.1.0 migration (issue #713).
+    """
+    banded = [
+        asset
+        for asset in assets.values()
+        if isinstance(asset, dict) and isinstance(asset.get("bands"), list) and asset["bands"]
+    ]
+    preferred = next((a for a in banded if "data" in (a.get("roles") or [])), None)
+    if preferred is None and banded:
+        preferred = banded[0]
+    if preferred is not None:
+        bands: list[Any] = preferred["bands"]
+    else:
+        summaries = stac.get("summaries", {})
+        bands = summaries.get("eo:bands", []) or summaries.get("raster:bands", [])
+    return [band for band in bands if isinstance(band, dict)]
+
+
+def _add_bands_section(sections: list[str], assets: dict[str, Any], stac: dict[str, Any]) -> None:
+    """Add the bands table from the unified bands array on the data asset."""
+    bands = _find_bands(assets, stac)
     if not bands:
         return
 
+    columns = [
+        (header, key)
+        for header, key in _BAND_COLUMNS
+        if any(_band_field(band, key) is not None for band in bands)
+    ]
+    headers = ["Band", *(header for header, _ in columns)]
+
     sections.append("## Bands")
     sections.append("")
-    sections.append("| Band | Name | Description |")
-    sections.append("|------|------|-------------|")
-    for i, band in enumerate(bands):
-        band_name = band.get("name", f"band_{i + 1}")
-        common_name = band.get("common_name", "")
-        desc = band.get("description", "")
-        sections.append(f"| {i + 1} | {band_name} ({common_name}) | {desc} |")
+    sections.append(f"| {' | '.join(headers)} |")
+    sections.append(f"|{'|'.join('-' * max(len(h) + 2, 6) for h in headers)}|")
+    for index, band in enumerate(bands, start=1):
+        values = [str(index)]
+        for _, key in columns:
+            value = _band_field(band, key)
+            values.append("-" if value is None else str(value))
+        sections.append(f"| {' | '.join(values)} |")
     sections.append("")
 
 
@@ -641,7 +705,7 @@ def generate_readme(
     _add_spatial_section(sections, stac)
     _add_temporal_section(sections, stac)
     _add_schema_section(sections, stac)
-    _add_bands_section(sections, stac)
+    _add_bands_section(sections, assets, stac)
     _add_files_section(sections, assets)
     _add_code_example_section(sections, assets)
     _add_stac_links_section(sections, stac)
@@ -689,6 +753,80 @@ def check_readme_freshness(
     return expected == actual
 
 
+def _collection_relative_href(href: str, item_dir: str) -> str:
+    """Rebase an item-relative asset href onto the collection directory.
+
+    Item assets are written relative to the item JSON (``./scene-a.tif``), but
+    the README sits at the collection root, so the item directory has to be
+    prepended (``scene-a/scene-a.tif``). URLs and absolute paths already
+    resolve on their own and pass through untouched.
+    """
+    if not href or "://" in href or href.startswith("/"):
+        return href
+    cleaned = href[2:] if href.startswith("./") else href
+    if not item_dir or item_dir == ".":
+        return cleaned
+    return f"{item_dir}/{cleaned}"
+
+
+def _read_item(item_path: Path) -> dict[str, Any] | None:
+    """Parse an item JSON, returning None when it is missing or unreadable.
+
+    A stale ``rel="item"`` link is reported by ``portolan check``, so README
+    generation skips the item rather than failing the whole catalog.
+    """
+    try:
+        data = json.loads(item_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _rebase_item_assets(item: dict[str, Any], item_dir: str) -> dict[str, Any]:
+    """Copy an item with its asset hrefs rewritten relative to the collection."""
+    assets = item.get("assets")
+    if not isinstance(assets, dict):
+        return item
+
+    rebased: dict[str, Any] = {}
+    for key, asset in assets.items():
+        if isinstance(asset, dict) and isinstance(asset.get("href"), str):
+            asset = {**asset, "href": _collection_relative_href(asset["href"], item_dir)}
+        rebased[key] = asset
+    return {**item, "assets": rebased}
+
+
+def load_collection_stac(collection_path: Path) -> dict[str, Any]:
+    """Load ``collection.json`` with the collection's items attached.
+
+    STAC keeps items in sibling files behind ``rel="item"`` links, but the
+    README renders asset-level metadata that exists only there: the unified
+    ``bands`` array (issue #713) plus each data file's size and checksum. The
+    items are attached under ``items`` so ``generate_readme`` walks one dict.
+
+    Args:
+        collection_path: Path to the collection directory.
+
+    Returns:
+        The collection dict, empty when there is no collection.json.
+    """
+    collection_json_path = collection_path / "collection.json"
+    if not collection_json_path.exists():
+        return {}
+
+    stac: dict[str, Any] = json.loads(collection_json_path.read_text(encoding="utf-8"))
+
+    items: list[dict[str, Any]] = []
+    for href, item_path in owned_item_hrefs(collection_json_path):
+        item = _read_item(item_path)
+        if item is not None:
+            items.append(_rebase_item_assets(item, str(PurePosixPath(href).parent)))
+    if items:
+        stac["items"] = items
+
+    return stac
+
+
 def generate_readme_for_collection(
     collection_path: Path,
     catalog_root: Path,
@@ -696,7 +834,7 @@ def generate_readme_for_collection(
     """Generate README for a collection by loading STAC and metadata from disk.
 
     High-level function that:
-    1. Loads collection.json (STAC) from collection_path
+    1. Loads collection.json (STAC) and its items from collection_path
     2. Loads merged metadata.yaml from hierarchy
     3. Generates README from both sources
 
@@ -707,11 +845,7 @@ def generate_readme_for_collection(
     Returns:
         README markdown string.
     """
-    # Load STAC collection.json if it exists
-    stac: dict[str, Any] = {}
-    collection_json_path = collection_path / "collection.json"
-    if collection_json_path.exists():
-        stac = json.loads(collection_json_path.read_text(encoding="utf-8"))
+    stac = load_collection_stac(collection_path)
 
     # Load merged metadata from hierarchy
     metadata = load_merged_metadata(collection_path, catalog_root)

--- a/portolan_cli/stac_parquet.py
+++ b/portolan_cli/stac_parquet.py
@@ -47,7 +47,7 @@ def _resolve_href(base_dir: Path, href: str) -> Path:
     return base_dir / href
 
 
-def _owned_item_hrefs(node_json_path: Path) -> list[tuple[str, Path]]:
+def owned_item_hrefs(node_json_path: Path) -> list[tuple[str, Path]]:
     """Every (href, path) pair for the items the object at ``node_json_path`` owns.
 
     A catalog may sit below a collection to organize its items (core.md:168-170),
@@ -75,7 +75,7 @@ def _owned_item_hrefs(node_json_path: Path) -> list[tuple[str, Path]]:
         elif rel == "child":
             child_path = _resolve_href(base_dir, href)
             if child_path.name == "catalog.json":
-                owned.extend(_owned_item_hrefs(child_path))
+                owned.extend(owned_item_hrefs(child_path))
 
     return owned
 
@@ -96,7 +96,7 @@ def count_items(collection_path: Path) -> int:
     if not collection_json_path.exists():
         raise FileNotFoundError(f"collection.json not found in {collection_path}")
 
-    return len(_owned_item_hrefs(collection_json_path))
+    return len(owned_item_hrefs(collection_json_path))
 
 
 def should_suggest_parquet(collection_path: Path, threshold: int = 100) -> bool:
@@ -160,7 +160,7 @@ def _load_item_dicts(collection_path: Path) -> list[dict[str, Any]]:
         ValueError: If no items found.
     """
     collection_json_path = collection_path / "collection.json"
-    owned = _owned_item_hrefs(collection_json_path)
+    owned = owned_item_hrefs(collection_json_path)
 
     if not owned:
         raise ValueError(f"No items found in collection at {collection_path}")

--- a/tests/integration/test_readme_bands_realdata.py
+++ b/tests/integration/test_readme_bands_realdata.py
@@ -1,0 +1,118 @@
+"""End-to-end Bands rendering on a real 4-band COG (issue #713).
+
+`portolan add` writes the unified ``bands`` array onto the item's data asset.
+`portolan readme` has to walk the collection's ``rel="item"`` links to reach it.
+This test drives both commands over ``tests/fixtures/realdata/rapidai4eo-sample.tif``
+and asserts the generated README carries a row per band.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+
+@pytest.fixture
+def raster_catalog(tmp_path: Path) -> Path:
+    """Catalog with statistics enabled, so emitted bands carry a statistics dict."""
+    catalog_root = tmp_path / "catalog"
+    catalog_root.mkdir()
+    (catalog_root / "catalog.json").write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "stac_version": "1.1.0",
+                "id": "test-catalog",
+                "title": "Test Catalog",
+                "description": "Test catalog",
+                "links": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    portolan_dir = catalog_root / ".portolan"
+    portolan_dir.mkdir()
+    (portolan_dir / "config.yaml").write_text(
+        yaml.dump({"version": 1, "statistics": {"enabled": True}}), encoding="utf-8"
+    )
+    (catalog_root / "imagery").mkdir()
+    return catalog_root
+
+
+def _add_and_render(catalog_root: Path, raster: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Add a raster, regenerate READMEs, and return the collection README text."""
+    item_dir = catalog_root / "imagery" / "scene-a"
+    item_dir.mkdir(parents=True)
+    shutil.copy(raster, item_dir / "scene-a.tif")
+
+    runner = CliRunner()
+    added = runner.invoke(
+        cli,
+        ["add", "--portolan-dir", str(catalog_root), str(item_dir / "scene-a.tif")],
+        catch_exceptions=False,
+    )
+    assert added.exit_code == 0, added.output
+
+    # `portolan readme` resolves the catalog from the working directory.
+    monkeypatch.chdir(catalog_root)
+    rendered = runner.invoke(cli, ["readme"], catch_exceptions=False)
+    assert rendered.exit_code == 0, rendered.output
+
+    readme_path = catalog_root / "imagery" / "README.md"
+    assert readme_path.exists(), f"Expected {readme_path}"
+    return readme_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.integration
+@pytest.mark.realdata
+class TestReadmeBandsRealData:
+    """The Bands section must render from the bands `add` actually wrote."""
+
+    def test_readme_has_a_bands_section(
+        self, raster_catalog: Path, rapidai4eo_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Before #713 this heading never appeared for any raster collection."""
+        readme = _add_and_render(raster_catalog, rapidai4eo_path, monkeypatch)
+        assert "## Bands" in readme
+
+    def test_every_band_gets_a_row(
+        self, raster_catalog: Path, rapidai4eo_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """rapidai4eo-sample.tif is 4-band int16, so four numbered rows."""
+        readme = _add_and_render(raster_catalog, rapidai4eo_path, monkeypatch)
+        block = readme.split("## Bands", 1)[1].split("\n## ", 1)[0]
+
+        # The separator line starts with "|-", so this counts header + 4 bands.
+        rows = [line for line in block.splitlines() if line.startswith("| ")]
+        assert len(rows) == 5, block
+        for i in range(1, 5):
+            assert f"| {i} | band_{i} | int16 |" in block
+
+    def test_band_statistics_reach_the_readme(
+        self, raster_catalog: Path, rapidai4eo_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Statistics on the asset must survive into the rendered table."""
+        readme = _add_and_render(raster_catalog, rapidai4eo_path, monkeypatch)
+        block = readme.split("## Bands", 1)[1].split("\n## ", 1)[0]
+
+        item = json.loads(
+            (raster_catalog / "imagery" / "scene-a" / "scene-a.json").read_text(encoding="utf-8")
+        )
+        stats = item["assets"]["data"]["bands"][0]["statistics"]
+
+        assert "| Min | Max | Mean | Std Dev |" in block
+        assert f"| 1 | band_1 | int16 | {stats['minimum']} | {stats['maximum']} |" in block
+
+    def test_cog_reaches_the_files_table(
+        self, raster_catalog: Path, rapidai4eo_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The same dead item walk kept the data file out of Files entirely."""
+        readme = _add_and_render(raster_catalog, rapidai4eo_path, monkeypatch)
+        assert "| scene-a/scene-a.tif |" in readme

--- a/tests/unit/test_readme_bands.py
+++ b/tests/unit/test_readme_bands.py
@@ -1,0 +1,442 @@
+"""Tests for the README Bands section (#713).
+
+The CLI writes the STAC v1.1.0 unified ``bands`` array on the data asset
+(``stac.py:_set_bands_on_data_assets``), item-level for rasters. The Bands
+section used to read ``summaries["eo:bands"]`` / ``["raster:bands"]``, which
+nothing writes, so it never rendered. These tests pin the asset-level read,
+the item walk that reaches it, and the columns that drop when unpopulated.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Band shape the CLI actually writes: name + data_type from metadata/cog.py,
+# statistics merged in by preparation.py.
+CLI_BAND: dict[str, Any] = {
+    "name": "band_1",
+    "data_type": "int16",
+    "nodata": 0,
+    "statistics": {"minimum": 302.0, "maximum": 1015.0, "mean": 512.4, "stddev": 88.1},
+}
+
+# Band shape the portolan-spec reference collection carries: no name, and a
+# valid_percent the CLI does not currently compute.
+SPEC_BAND: dict[str, Any] = {
+    "data_type": "uint8",
+    "statistics": {
+        "minimum": 1.0,
+        "maximum": 255.0,
+        "mean": 44.396,
+        "stddev": 58.4784,
+        "valid_percent": 67.4572,
+    },
+}
+
+
+def _bands_block(readme: str) -> str:
+    """Return the Bands section, from its heading to the next heading."""
+    assert "## Bands" in readme, f"no Bands section in:\n{readme}"
+    after = readme.split("## Bands", 1)[1]
+    return after.split("\n## ", 1)[0]
+
+
+class TestBandsFromAssets:
+    """Bands render from the unified array on the data asset."""
+
+    @pytest.mark.unit
+    def test_collection_level_data_asset_renders(self) -> None:
+        """A single-file raster collection carries bands on collection.assets."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "sample-cog",
+            "assets": {
+                "data": {
+                    "href": "sample-cog.tif",
+                    "roles": ["data"],
+                    "bands": [SPEC_BAND],
+                }
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "| Band | Data Type | Min | Max | Mean | Std Dev | Valid % |" in block
+        assert "| 1 | uint8 | 1.0 | 255.0 | 44.396 | 58.4784 | 67.4572 |" in block
+
+    @pytest.mark.unit
+    def test_item_level_data_asset_renders(self) -> None:
+        """Raster scenes sit on items, so the item walk must reach their bands."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "items": [
+                {
+                    "id": "scene-a",
+                    "assets": {
+                        "data": {
+                            "href": "./scene-a.tif",
+                            "roles": ["data"],
+                            "bands": [CLI_BAND],
+                        }
+                    },
+                }
+            ],
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "| Band | Name | Data Type | Nodata | Min | Max | Mean | Std Dev |" in block
+        assert "| 1 | band_1 | int16 | 0 | 302.0 | 1015.0 | 512.4 | 88.1 |" in block
+
+    @pytest.mark.unit
+    def test_data_role_asset_wins_over_thumbnail(self) -> None:
+        """A thumbnail carrying bands must not shadow the data asset."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {
+                "thumbnail": {
+                    "href": "thumb.png",
+                    "roles": ["thumbnail"],
+                    "bands": [{"name": "rgb", "data_type": "uint8"}],
+                },
+                "data": {
+                    "href": "scene.tif",
+                    "roles": ["data"],
+                    "bands": [CLI_BAND],
+                },
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "band_1" in block
+        assert "rgb" not in block
+
+    @pytest.mark.unit
+    def test_every_band_gets_a_row(self) -> None:
+        """A four-band COG renders four rows, numbered from one."""
+        from portolan_cli.readme import generate_readme
+
+        bands = [dict(CLI_BAND, name=f"band_{i}") for i in range(1, 5)]
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {"data": {"href": "s.tif", "roles": ["data"], "bands": bands}},
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        for i in range(1, 5):
+            assert f"| {i} | band_{i} |" in block
+
+
+class TestBandsColumnSelection:
+    """Columns no band populates are dropped rather than rendered empty."""
+
+    @pytest.mark.unit
+    def test_no_statistics_drops_stat_columns(self) -> None:
+        """Bands without statistics render a narrow identity table."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {
+                "data": {
+                    "href": "s.tif",
+                    "roles": ["data"],
+                    "bands": [{"name": "band_1", "data_type": "int16", "nodata": 0}],
+                }
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "| Band | Name | Data Type | Nodata |" in block
+        assert "Min" not in block
+        assert "Std Dev" not in block
+
+    @pytest.mark.unit
+    def test_no_nodata_drops_nodata_column(self) -> None:
+        """rapidai4eo-sample.tif reports no nodata, so the column must vanish."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {
+                "data": {
+                    "href": "s.tif",
+                    "roles": ["data"],
+                    "bands": [{"name": "band_1", "data_type": "int16"}],
+                }
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "| Band | Name | Data Type |" in block
+        assert "Nodata" not in block
+
+    @pytest.mark.unit
+    def test_zero_nodata_keeps_the_column(self) -> None:
+        """nodata=0 is a real value, so falsiness must not drop the column."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {
+                "data": {
+                    "href": "s.tif",
+                    "roles": ["data"],
+                    "bands": [{"name": "band_1", "data_type": "int16", "nodata": 0}],
+                }
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "Nodata" in block
+        assert "| 1 | band_1 | int16 | 0 |" in block
+
+    @pytest.mark.unit
+    def test_partial_column_renders_dash_for_missing(self) -> None:
+        """One band with nodata keeps the column; the other shows a dash."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {
+                "data": {
+                    "href": "s.tif",
+                    "roles": ["data"],
+                    "bands": [
+                        {"name": "band_1", "data_type": "int16", "nodata": -9999},
+                        {"name": "band_2", "data_type": "int16"},
+                    ],
+                }
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "| 1 | band_1 | int16 | -9999 |" in block
+        assert "| 2 | band_2 | int16 | - |" in block
+
+
+class TestBandsAbsentAndLegacy:
+    """No bands means no section; legacy summaries still render."""
+
+    @pytest.mark.unit
+    def test_no_bands_omits_section(self) -> None:
+        """A vector collection gets no Bands heading."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "boundaries",
+            "assets": {"data": {"href": "b.parquet", "roles": ["data"]}},
+        }
+
+        assert "## Bands" not in generate_readme(stac=stac, metadata={})
+
+    @pytest.mark.unit
+    def test_empty_bands_array_omits_section(self) -> None:
+        """An empty array is not a band list."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {"data": {"href": "s.tif", "roles": ["data"], "bands": []}},
+        }
+
+        assert "## Bands" not in generate_readme(stac=stac, metadata={})
+
+    @pytest.mark.unit
+    def test_legacy_eo_bands_summaries_still_render(self) -> None:
+        """Hand-authored catalogs predating STAC 1.1.0 keep working."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "summaries": {
+                "eo:bands": [
+                    {"name": "B04", "common_name": "red", "description": "Red band"},
+                ]
+            },
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "| 1 | B04 | red | Red band |" in block
+
+    @pytest.mark.unit
+    def test_asset_bands_win_over_legacy_summaries(self) -> None:
+        """The array the CLI writes takes precedence over a stale summary."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "imagery",
+            "summaries": {"raster:bands": [{"name": "stale"}]},
+            "assets": {"data": {"href": "s.tif", "roles": ["data"], "bands": [CLI_BAND]}},
+        }
+
+        block = _bands_block(generate_readme(stac=stac, metadata={}))
+
+        assert "band_1" in block
+        assert "stale" not in block
+
+
+class TestItemAssetHrefs:
+    """Item asset hrefs are rebased onto the collection the README sits in."""
+
+    @pytest.mark.unit
+    def test_item_relative_href_gains_the_item_directory(self) -> None:
+        """An item's ./scene-a.tif must render as scene-a/scene-a.tif."""
+        from portolan_cli.readme import _collection_relative_href
+
+        assert _collection_relative_href("./scene-a.tif", "scene-a") == "scene-a/scene-a.tif"
+
+    @pytest.mark.unit
+    def test_flat_layout_keeps_the_bare_name(self) -> None:
+        """An item JSON beside collection.json has no directory to prepend."""
+        from portolan_cli.readme import _collection_relative_href
+
+        assert _collection_relative_href("./scene-a.tif", ".") == "scene-a.tif"
+
+    @pytest.mark.unit
+    def test_url_is_untouched(self) -> None:
+        """A remote href already resolves and must not be prefixed."""
+        from portolan_cli.readme import _collection_relative_href
+
+        url = "https://data.example.org/scene-a.tif"
+        assert _collection_relative_href(url, "scene-a") == url
+
+    @pytest.mark.unit
+    def test_absolute_path_is_untouched(self) -> None:
+        """An absolute path must not be turned into a relative one."""
+        from portolan_cli.readme import _collection_relative_href
+
+        assert _collection_relative_href("/data/scene-a.tif", "scene-a") == "/data/scene-a.tif"
+
+    @pytest.mark.unit
+    def test_collection_asset_href_is_untouched(self) -> None:
+        """Collection-level hrefs are already collection-relative."""
+        from portolan_cli.readme import generate_readme
+
+        stac = {
+            "type": "Collection",
+            "id": "boundaries",
+            "assets": {"data": {"href": "boundaries.parquet", "file:size": 10}},
+        }
+
+        readme = generate_readme(stac=stac, metadata={})
+
+        assert "| boundaries.parquet |" in readme
+
+
+def _write_raster_collection(catalog_root: Path) -> Path:
+    """Write a catalog whose one collection holds a banded scene item on disk."""
+    catalog_root.mkdir(parents=True, exist_ok=True)
+    (catalog_root / ".portolan").mkdir(exist_ok=True)
+    (catalog_root / ".portolan" / "config.yaml").write_text("version: 1\n", encoding="utf-8")
+    (catalog_root / "catalog.json").write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "stac_version": "1.1.0",
+                "id": "test-catalog",
+                "description": "Test catalog",
+                "links": [{"rel": "child", "href": "./imagery/collection.json"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    collection_dir = catalog_root / "imagery"
+    item_dir = collection_dir / "scene-a"
+    item_dir.mkdir(parents=True)
+    (item_dir / "scene-a.json").write_text(
+        json.dumps(
+            {
+                "type": "Feature",
+                "stac_version": "1.1.0",
+                "id": "scene-a",
+                "properties": {"datetime": "2024-01-01T00:00:00Z"},
+                "assets": {
+                    "data": {
+                        "href": "./scene-a.tif",
+                        "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                        "roles": ["data"],
+                        "file:size": 205061,
+                        "bands": [CLI_BAND],
+                    }
+                },
+                "links": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (collection_dir / "collection.json").write_text(
+        json.dumps(
+            {
+                "type": "Collection",
+                "stac_version": "1.1.0",
+                "id": "imagery",
+                "description": "Raster imagery",
+                "license": "CC0-1.0",
+                "extent": {
+                    "spatial": {"bbox": [[-1.0, -1.0, 1.0, 1.0]]},
+                    "temporal": {"interval": [["2024-01-01T00:00:00Z", None]]},
+                },
+                "links": [{"rel": "item", "href": "./scene-a/scene-a.json"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return collection_dir
+
+
+class TestBandsFromDisk:
+    """generate_readme_for_collection must load items off disk to see bands."""
+
+    @pytest.mark.unit
+    def test_item_bands_render_from_disk(self, tmp_path: Path) -> None:
+        """The regression: bands on disk reached no README before #713."""
+        from portolan_cli.readme import generate_readme_for_collection
+
+        catalog_root = tmp_path / "catalog"
+        collection_dir = _write_raster_collection(catalog_root)
+
+        readme = generate_readme_for_collection(collection_dir, catalog_root)
+
+        assert "| 1 | band_1 | int16 | 0 | 302.0 | 1015.0 | 512.4 | 88.1 |" in _bands_block(readme)
+
+    @pytest.mark.unit
+    def test_item_data_file_reaches_files_table(self, tmp_path: Path) -> None:
+        """The same dead item walk kept the COG out of the Files table."""
+        from portolan_cli.readme import generate_readme_for_collection
+
+        catalog_root = tmp_path / "catalog"
+        collection_dir = _write_raster_collection(catalog_root)
+
+        readme = generate_readme_for_collection(collection_dir, catalog_root)
+
+        assert "| scene-a/scene-a.tif | 200.3 KB |" in readme

--- a/tests/unit/test_stac_parquet.py
+++ b/tests/unit/test_stac_parquet.py
@@ -298,6 +298,41 @@ def collection_with_many_items(tmp_path: Path) -> Path:
 
 
 # =============================================================================
+# Test: Item Traversal
+# =============================================================================
+
+
+class TestOwnedItemHrefs:
+    """The item walker is public so README generation can reuse it (#713)."""
+
+    @pytest.mark.unit
+    def test_returns_href_and_resolved_path_pairs(self, collection_with_items: Path) -> None:
+        """Each pair carries the written href and the file it resolves to."""
+        from portolan_cli.stac_parquet import owned_item_hrefs
+
+        owned = owned_item_hrefs(collection_with_items / "collection.json")
+
+        assert [href for href, _ in owned] == [
+            f"./scene-{i:03d}/scene-{i:03d}.json" for i in range(5)
+        ]
+        assert all(path.exists() for _, path in owned)
+
+    @pytest.mark.unit
+    def test_descends_organizing_catalogs(self, collection_with_organizing_catalogs: Path) -> None:
+        """Items behind an organizing catalog still belong to the collection."""
+        from portolan_cli.stac_parquet import owned_item_hrefs
+
+        assert len(owned_item_hrefs(collection_with_organizing_catalogs / "collection.json")) == 2
+
+    @pytest.mark.unit
+    def test_missing_node_returns_empty(self, tmp_path: Path) -> None:
+        """A collection with no collection.json owns nothing."""
+        from portolan_cli.stac_parquet import owned_item_hrefs
+
+        assert owned_item_hrefs(tmp_path / "collection.json") == []
+
+
+# =============================================================================
 # Test: Item Count and Threshold
 # =============================================================================
 


### PR DESCRIPTION
# Read band metadata from STAC 1.1.0 assets

## What this changes

The README generator now reads band metadata from the unified STAC 1.1.0 `bands` array on each data asset. This is where the CLI writes band metadata. `load_collection_stac` now loads the collection's items so the README generator can access the asset data. This also adds item data files to the Files table.

The old `summaries["eo:bands"]` and `summaries["raster:bands"]` fields remain supported as a fallback. The change only affects README generation; it does not change the generated STAC JSON or any `PTL-*` conformance rules.

## Why

The band section still read `summaries["eo:bands"]` and `summaries["raster:bands"]`, but STAC 1.1.0 moved band metadata to the unified asset-level array. The CLI no longer writes the old summary fields, so raster collections never showed a Bands section.

The README generator also expected `stac["items"]` to be populated, but no caller supplied the collection's items. As a result, the Files table could not include the item data files. The new item loading and README layout match the reference collection in `portolan-spec`.

## Verification

Using `tests/fixtures/realdata/rapidai4eo-sample.tif`, a four-band int16 COG, `portolan add` followed by `portolan readme` now produces the expected Bands section:

```console id="v6nq4c"
$ grep -A7 '^## Bands' imagery/README.md
| Band | Name | Data Type | Min | Max | Mean | Std Dev |
|------|------|-----------|------|------|------|---------|
| 1 | band_1 | int16 | 302.0 | 1015.0 | 460.38215000000383 | 51.76964613919496 |
| 2 | band_2 | int16 | 379.0 | 1440.0 | 655.824725 | 96.180207702388 |
| 3 | band_3 | int16 | 364.0 | 1989.0 | 761.19754999999 | 160.50745052488 |
| 4 | band_4 | int16 | 814.0 | 3299.0 | 1642.9033 | 306.44129967925 |
```

These values match `assets.data.bands` in the generated item JSON. Compared with the same catalog built from the unpatched `release/v1.0.0b0`, the branch now has one Bands section and includes the item data files in the Files table. The strict check reports the same nine findings in both versions.

```text
                     b0          this branch
Bands headings       0           1
Files rows           0 absent    scene-a/scene-a.tif, scene-a.thumb.jpg
check --strict       9 findings  9 findings (identical rules and counts)
```

The full test suite passes: 6,162 tests, including 5,102 unit tests and 1,060 integration tests. Twenty-seven tests cover Rashid conformance and roundtrips, and 23 new tests fail against the unpatched `release/v1.0.0b0`.

`ruff`, `mypy --strict`, `lint-imports`, `xenon`, and `vulture` are clean.
