### PR TITLE
fix(stac): fix parent links in nested STAC collections (#711)

### DIFF
--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -18,8 +18,10 @@ from typing import Any, Literal, overload
 
 from portolan_cli.agents_md import visible_stac_files
 from portolan_cli.errors import CatalogAlreadyExistsError
+from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic, write_text_atomic
 from portolan_cli.models.catalog import CatalogModel
+from portolan_cli.utils import relative_href
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -395,8 +397,6 @@ def init_catalog(
     # Set defaults. Issue #502: title is mandatory and must be human-readable,
     # so derive one from the directory name instead of leaving it empty.
     if not title:
-        from portolan_cli.humanize import humanize_slug
-
         title = humanize_slug(catalog_id)
         warnings.append(f"Derived catalog title '{title}' from directory name")
 
@@ -596,7 +596,7 @@ def create_intermediate_catalogs(collection_id: str, catalog_root: Path) -> None
     # Create catalog.json at each intermediate level (all but the last).
     # intermediate_catalog_ids is the shared source of truth for this walk,
     # also used by push discovery (keeps add/push in lockstep).
-    for i, intermediate_path in enumerate(intermediate_catalog_ids(collection_id)):
+    for intermediate_path in intermediate_catalog_ids(collection_id):
         catalog_dir = catalog_root / intermediate_path
         catalog_file = catalog_dir / "catalog.json"
 
@@ -607,18 +607,28 @@ def create_intermediate_catalogs(collection_id: str, catalog_root: Path) -> None
         # Create directory if needed
         catalog_dir.mkdir(parents=True, exist_ok=True)
 
-        # Calculate relative path depth for links
-        depth = i + 1  # How many levels deep from root
-        parent_href = "../" * depth + "catalog.json"
+        # Root and parent diverge below the first level: the root catalog is
+        # `depth` levels up, while the containing object is always the catalog
+        # one level up. Deriving both from the depth made every intermediate
+        # below the first point past its own parent (issue #711).
+        root_href = relative_href(catalog_dir, catalog_root / "catalog.json")
+        parent_href = relative_href(catalog_dir, catalog_dir.parent / "catalog.json")
+
+        # Titled after its own path segment, not the full id: the title is what
+        # a browser shows and what ensure_link_titles copies onto the parent's
+        # child link, so "Air Quality" reads better than "Env/Air Quality"
+        # (issue #502, rashid PTL-TTL-001 and PTL-TTL-003).
+        title = humanize_slug(catalog_dir.name)
 
         # Create intermediate catalog
         catalog_data = {
             "type": "Catalog",
             "id": intermediate_path,
             "stac_version": "1.1.0",
+            "title": title,
             "description": f"Catalog: {intermediate_path}",
             "links": [
-                {"rel": "root", "href": parent_href, "type": "application/json"},
+                {"rel": "root", "href": root_href, "type": "application/json"},
                 {"rel": "parent", "href": parent_href, "type": "application/json"},
             ],
         }

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import json
 import logging
-import posixpath
 from pathlib import Path, PurePath
 from typing import Any
 
@@ -53,12 +52,12 @@ from portolan_cli.stac import (
     apply_human_titles,
     apply_provenance,
     create_collection,
-    load_catalog,
     update_catalog_file_statistics,
     update_catalog_provenance,
     update_collection_file_statistics,
     update_collection_summaries,
 )
+from portolan_cli.utils import relative_href
 from portolan_cli.versions import (
     Asset,
     VersionsFile,
@@ -103,13 +102,6 @@ def _deduplicate_collection_item_links(collection: pystac.Collection) -> None:
 def relative_root_href(catalog_root: PurePath, collection_dir: PurePath) -> str:
     """The href from ``collection_dir`` to the root ``catalog.json``, in POSIX.
 
-    A STAC href is a relative URL reference, so the separator is ``/`` on every
-    platform. ``os.path.relpath`` returns the *native* one, which on Windows
-    shipped ``..\\catalog.json`` — not a Windows spelling of the parent link but
-    a filename containing backslashes, which resolves nowhere (rashid
-    PTL-LNK-006). Normalizing both sides to POSIX first keeps the computation
-    itself platform-independent.
-
     Args:
         catalog_root: Directory holding the root ``catalog.json``.
         collection_dir: Directory the link will live in.
@@ -117,10 +109,34 @@ def relative_root_href(catalog_root: PurePath, collection_dir: PurePath) -> str:
     Returns:
         A relative POSIX href, e.g. ``../catalog.json``.
     """
-    return posixpath.relpath(
-        posixpath.join(PurePath(catalog_root).as_posix(), "catalog.json"),
-        PurePath(collection_dir).as_posix(),
-    )
+    return relative_href(collection_dir, PurePath(catalog_root) / "catalog.json")
+
+
+def _set_structural_link(
+    links: list[dict[str, Any]],
+    rel: str,
+    href: str,
+    media_type: str = "application/json",
+) -> None:
+    """Point ``rel`` at ``href``, adding the link when it is absent.
+
+    Repointing matters as much as adding. PySTAC writes a ``parent`` link of its
+    own, so a generator that only fills in missing links leaves PySTAC's answer
+    standing, which is how the wrong parent survived to disk (issue #711).
+    """
+    for link in links:
+        if link.get("rel") == rel:
+            # PySTAC stamps the owning object's title on the links it writes, so
+            # a title that survived a repoint would now name the old target.
+            # Titles on child/item links are backfilled from the target by
+            # ensure_link_titles; these structural rels are not, so dropping is
+            # the honest option.
+            if link.get("href") != href:
+                link.pop("title", None)
+            link["href"] = href
+            link["type"] = media_type
+            return
+    links.append({"rel": rel, "href": href, "type": media_type})
 
 
 def _fix_collection_links(
@@ -130,7 +146,13 @@ def _fix_collection_links(
 ) -> None:
     """Fix root/parent links and deduplicate item links in collection JSON.
 
-    PySTAC sets root to self by default; we need to point to catalog root.
+    PySTAC sets root to self by default, so both structural links need
+    repointing: ``root`` at the catalog root, and ``parent`` at whatever catalog
+    contains this collection. Those two coincide only for a single-level id. For
+    a nested id the container is the intermediate ``catalog.json`` that
+    ``create_intermediate_catalogs`` writes one level up, and reusing the root
+    href walked straight past it (rashid PTL-LNK-006, issue #711).
+
     Also deduplicates item links that can occur when add is called
     multiple times on the same collection.
     """
@@ -138,25 +160,12 @@ def _fix_collection_links(
         return
 
     collection_data = json.loads(collection_json_path.read_text(encoding="utf-8"))
-    relative_root = relative_root_href(catalog_root, collection_dir)
+    links: list[dict[str, Any]] = collection_data.setdefault("links", [])
 
-    # Update root link to point to catalog
-    for link in collection_data.get("links", []):
-        if link.get("rel") == "root":
-            link["href"] = relative_root
-            break
-    else:
-        # No root link found, add one
-        collection_data.setdefault("links", []).append(
-            {"rel": "root", "href": relative_root, "type": "application/json"}
-        )
-
-    # Add parent link if missing
-    has_parent = any(link.get("rel") == "parent" for link in collection_data.get("links", []))
-    if not has_parent:
-        collection_data["links"].append(
-            {"rel": "parent", "href": relative_root, "type": "application/json"}
-        )
+    _set_structural_link(links, "root", relative_root_href(catalog_root, collection_dir))
+    _set_structural_link(
+        links, "parent", relative_href(collection_dir, collection_dir.parent / "catalog.json")
+    )
 
     # Deduplicate item links (can occur when add is called multiple times)
     seen_item_hrefs: set[str] = set()
@@ -173,50 +182,77 @@ def _fix_collection_links(
     write_json_atomic(collection_json_path, collection_data)
 
 
-def _update_catalog_links(catalog_root: Path, collection_id: str) -> None:
-    """Ensure catalog has link to collection.
+def _fix_item_links(
+    collection_json_path: Path,
+    catalog_root: Path,
+    collection_dir: Path,
+) -> None:
+    """Repoint the structural links of every item this collection owns.
 
-    For nested collection IDs, delegates to update_catalog_links_for_nested
-    which properly links through the catalog hierarchy.
+    ``Collection.save`` serializes its items, but the collection is loaded
+    standalone and never attached to a parent ``pystac.Catalog``, so PySTAC
+    resolves each item's root to the collection itself and writes
+    ``root -> collection.json``. The spec wants the catalog root there
+    (core.md:262-264, rashid PTL-LNK-006), and until now only ``check --fix``
+    repaired it — generation and repair disagreed.
+
+    ``parent`` and ``collection`` both point at the owning collection, which is
+    what PySTAC already writes; they are set here so a hand-edited or partially
+    written item ends up complete.
+
+    Args:
+        collection_json_path: The saved ``collection.json``, read for item links.
+        catalog_root: Directory holding the root ``catalog.json``.
+        collection_dir: Directory holding ``collection.json``.
+    """
+    if not collection_json_path.exists():
+        return
+
+    collection_data = json.loads(collection_json_path.read_text(encoding="utf-8"))
+    for link in collection_data.get("links", []):
+        if link.get("rel") != "item":
+            continue
+        href = link.get("href", "")
+        if not href:
+            continue
+        item_path = (collection_dir / href).resolve()
+        if not item_path.exists():
+            continue
+
+        item_data = json.loads(item_path.read_text(encoding="utf-8"))
+        item_dir = item_path.parent
+        item_links: list[dict[str, Any]] = item_data.setdefault("links", [])
+        collection_href = relative_href(item_dir, collection_dir / "collection.json")
+
+        _set_structural_link(
+            item_links, "root", relative_href(item_dir, catalog_root / "catalog.json")
+        )
+        _set_structural_link(item_links, "parent", collection_href)
+        _set_structural_link(item_links, "collection", collection_href)
+        write_json_atomic(item_path, item_data)
+
+
+def _update_catalog_links(catalog_root: Path, collection_id: str) -> None:
+    """Ensure the catalog tree has a child link down to this collection.
+
+    ``update_catalog_links_for_nested`` handles both shapes: a flat id gets one
+    child link on the root, a nested id gets one at every level. It edits only
+    the ``links`` arrays it must, which is why the flat case routes here too.
+
+    The flat case used to load the root with PySTAC and call
+    ``save(SELF_CONTAINED)``. That walks and re-serializes every descendant, and
+    ``normalize_hrefs`` lays children out by ``id`` — so an intermediate catalog,
+    whose id is its POSIX path, was relocated from ``env/air/`` to
+    ``env/env/air/`` and its child link followed. Adding a flat collection
+    corrupted the nested half of the catalog (issue #711).
 
     Args:
         catalog_root: Root directory of the catalog.
         collection_id: Collection identifier (may be nested like "climate/hittekaart").
     """
-    # For nested collection IDs, use the nested catalog link updater
-    if "/" in collection_id:
-        from portolan_cli.catalog import update_catalog_links_for_nested
+    from portolan_cli.catalog import update_catalog_links_for_nested
 
-        update_catalog_links_for_nested(catalog_root, collection_id)
-        return
-
-    # For single-level collections, add direct link from root
-    catalog_path = catalog_root / "catalog.json"
-    catalog = load_catalog(catalog_path)
-
-    # Trailing slash required: pystac treats paths with dots in final component as files
-    catalog.normalize_hrefs(f"{catalog_root}/")
-
-    # Extract collection IDs from existing child links
-    # Links are in format: "./{collection_id}/collection.json"
-    existing_collection_ids: set[str] = set()
-    for link in catalog.links:
-        if link.rel != "child":
-            continue
-        href = link.href or ""
-        # Extract collection ID from href pattern: ./{collection_id}/collection.json
-        if href.endswith("/collection.json"):
-            # Parse: ./{collection_id}/collection.json or {collection_id}/collection.json
-            parts = href.replace("./", "").split("/")
-            if len(parts) >= 2:
-                coll_id = parts[0]
-                existing_collection_ids.add(coll_id)
-
-    if collection_id not in existing_collection_ids:
-        collection_href = f"./{collection_id}/collection.json"
-        catalog.add_link(pystac.Link(rel="child", target=collection_href))
-        # Re-save catalog
-        catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
+    update_catalog_links_for_nested(catalog_root, collection_id)
 
 
 def _save_collection_with_links(
@@ -241,6 +277,7 @@ def _save_collection_with_links(
 
     collection_json_path = collection_dir / "collection.json"
     _fix_collection_links(collection_json_path, catalog_root, collection_dir)
+    _fix_item_links(collection_json_path, catalog_root, collection_dir)
     _update_catalog_links(catalog_root, collection_id)
 
     # Scaffold AGENTS.md and add the rel="agents" link (rashid PTL-FIL-002).

--- a/portolan_cli/utils.py
+++ b/portolan_cli/utils.py
@@ -5,7 +5,37 @@ Small helpers used across multiple modules.
 
 from __future__ import annotations
 
+import posixpath
+from pathlib import PurePath
 from typing import Any
+
+
+def relative_href(from_dir: PurePath, to_file: PurePath) -> str:
+    """The POSIX href from a directory to a STAC file.
+
+    A STAC href is a relative URL reference, so its separator is ``/`` on every
+    platform. ``os.path.relpath`` returns the *native* one, and on Windows that
+    shipped ``..\\catalog.json`` — not a Windows spelling of a parent link but a
+    filename containing backslashes, which resolves nowhere (rashid
+    ``PTL-LNK-006``). Normalizing both sides to POSIX first keeps the
+    computation itself platform-independent.
+
+    Both link ends flow through here so that ``root`` and ``parent`` are derived
+    separately rather than sharing one href. Reusing the root href for ``parent``
+    is what made a nested collection point past its own intermediate catalog
+    (issue #711).
+
+    Args:
+        from_dir: Directory the link will live in.
+        to_file: File the link points at.
+
+    Returns:
+        A relative POSIX href, e.g. ``../catalog.json``.
+    """
+    return posixpath.relpath(
+        PurePath(to_file).as_posix(),
+        PurePath(from_dir).as_posix(),
+    )
 
 
 def get_dict(data: dict[str, Any], key: str) -> dict[str, Any]:

--- a/tests/integration/test_generated_catalog_conformance.py
+++ b/tests/integration/test_generated_catalog_conformance.py
@@ -49,6 +49,14 @@ def _build_catalog(root: Path) -> None:
     collection_dir.mkdir(parents=True)
     shutil.copy(FIXTURE, collection_dir / "roads.parquet")
 
+    # A three-level id, so generation has to write two intermediate catalogs and
+    # the deeper one's parent differs from its root. Flat ids alone let #711
+    # ship: root and parent coincide at the top level and the conflation between
+    # them stays invisible.
+    nested_dir = root / "env" / "air" / "quality"
+    nested_dir.mkdir(parents=True)
+    shutil.copy(FIXTURE, nested_dir / "quality.parquet")
+
     # A geometry-less Parquet exercises the tabular path, which writes its
     # collection.json outside finalize_items.
     tabular_dir = root / "demographics"
@@ -115,6 +123,7 @@ def _build_catalog(root: Path) -> None:
             "--portolan-dir",
             str(root),
             str(collection_dir / "roads.parquet"),
+            str(nested_dir / "quality.parquet"),
             str(tabular_dir / "census.parquet"),
         ],
         catch_exceptions=False,

--- a/tests/unit/test_finalization_link_hrefs.py
+++ b/tests/unit/test_finalization_link_hrefs.py
@@ -8,6 +8,11 @@ of every collection were built with ``os.path.relpath``, which returns the nativ
 separator.
 
 ``PureWindowsPath`` inputs reproduce the Windows computation on any host.
+
+The same rule catches a second way a link can point nowhere useful: naming a
+real file that is the wrong object. ``root``, ``parent``, and ``collection`` are
+three different targets, and the classes below hold each to its own (issue
+#711).
 """
 
 from __future__ import annotations
@@ -17,7 +22,11 @@ from pathlib import Path, PureWindowsPath
 
 import pytest
 
-from portolan_cli.finalization import _fix_collection_links, relative_root_href
+from portolan_cli.finalization import (
+    _fix_collection_links,
+    _fix_item_links,
+    relative_root_href,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -42,27 +51,30 @@ class TestRelativeRootHref:
         assert href == "../catalog.json"
 
 
-class TestFixCollectionLinks:
-    @staticmethod
-    def _collection(path: Path, links: list[dict[str, str]]) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(
-            json.dumps(
-                {
-                    "type": "Collection",
-                    "stac_version": "1.1.0",
-                    "id": "roads",
-                    "description": "Roads.",
-                    "links": links,
-                }
-            ),
-            encoding="utf-8",
-        )
+def _write_collection(path: Path, links: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "type": "Collection",
+                "stac_version": "1.1.0",
+                "id": "roads",
+                "description": "Roads.",
+                "links": links,
+            }
+        ),
+        encoding="utf-8",
+    )
 
-    @staticmethod
-    def _hrefs(path: Path, rel: str) -> list[str]:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return [link["href"] for link in data["links"] if link.get("rel") == rel]
+
+def _hrefs(path: Path, rel: str) -> list[str]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return [link["href"] for link in data["links"] if link.get("rel") == rel]
+
+
+class TestFixCollectionLinks:
+    _collection = staticmethod(_write_collection)
+    _hrefs = staticmethod(_hrefs)
 
     def test_root_and_parent_links_are_written_relative(self, tmp_path: Path) -> None:
         collection_dir = tmp_path / "roads"
@@ -82,3 +94,152 @@ class TestFixCollectionLinks:
         _fix_collection_links(collection_json, tmp_path, collection_dir)
 
         assert self._hrefs(collection_json, "root") == ["../../catalog.json"]
+
+
+class TestParentLinkTargetsTheContainingCatalog:
+    """Issue #711: ``parent`` is the immediate container, never the root.
+
+    A nested collection sits under an intermediate ``catalog.json`` that
+    ``create_intermediate_catalogs`` writes for it, so its parent is always one
+    level up. Before the fix ``parent`` was a copy of the root href, which
+    walked past that intermediate catalog to the repository root and made the
+    tree unwalkable upward (rashid ``PTL-LNK-006``).
+    """
+
+    _collection = staticmethod(_write_collection)
+    _hrefs = staticmethod(_hrefs)
+
+    def test_nested_collection_parent_stops_at_the_intermediate_catalog(
+        self, tmp_path: Path
+    ) -> None:
+        collection_dir = tmp_path / "boundaries" / "adm1-attributes"
+        collection_json = collection_dir / "collection.json"
+        self._collection(collection_json, [])
+
+        _fix_collection_links(collection_json, tmp_path, collection_dir)
+
+        # Pre-fix this was "../../catalog.json", the root catalog.
+        assert self._hrefs(collection_json, "parent") == ["../catalog.json"]
+        assert self._hrefs(collection_json, "root") == ["../../catalog.json"]
+
+    def test_parent_is_one_level_up_however_deep_the_collection_sits(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "env" / "air" / "quality"
+        collection_json = collection_dir / "collection.json"
+        self._collection(collection_json, [])
+
+        _fix_collection_links(collection_json, tmp_path, collection_dir)
+
+        # Pre-fix this was "../../../catalog.json".
+        assert self._hrefs(collection_json, "parent") == ["../catalog.json"]
+        assert self._hrefs(collection_json, "root") == ["../../../catalog.json"]
+
+    def test_an_existing_wrong_parent_link_is_repointed(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "boundaries" / "adm1-attributes"
+        collection_json = collection_dir / "collection.json"
+        # PySTAC writes this href when it saves a standalone collection, so the
+        # pre-fix "append only when absent" branch never corrected it.
+        self._collection(collection_json, [{"rel": "parent", "href": "../../catalog.json"}])
+
+        _fix_collection_links(collection_json, tmp_path, collection_dir)
+
+        assert self._hrefs(collection_json, "parent") == ["../catalog.json"]
+
+    def test_a_repointed_parent_link_carries_its_media_type(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "boundaries" / "adm1-attributes"
+        collection_json = collection_dir / "collection.json"
+        self._collection(collection_json, [{"rel": "parent", "href": "../../catalog.json"}])
+
+        _fix_collection_links(collection_json, tmp_path, collection_dir)
+
+        data = json.loads(collection_json.read_text(encoding="utf-8"))
+        parent = next(link for link in data["links"] if link["rel"] == "parent")
+        # PTL-LNK-003: every structural link carries application/json.
+        assert parent["type"] == "application/json"
+
+
+class TestFixItemLinks:
+    """Issue #711: an item's ``root`` is the catalog root, not its collection.
+
+    ``add`` loads the collection standalone, so PySTAC never sees a parent
+    catalog and resolves each item's root to the collection itself. Nothing in
+    the add path repaired that; only ``check --fix`` did.
+    """
+
+    @staticmethod
+    def _write_item(path: Path, links: list[dict[str, str]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "type": "Feature",
+                    "stac_version": "1.1.0",
+                    "id": path.stem,
+                    "geometry": None,
+                    "properties": {"datetime": None},
+                    "assets": {},
+                    "links": links,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_item_root_points_at_the_catalog_root(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "env" / "air"
+        collection_json = collection_dir / "collection.json"
+        _write_collection(collection_json, [{"rel": "item", "href": "./scenes/scenes.json"}])
+        item_json = collection_dir / "scenes" / "scenes.json"
+        # The shape PySTAC emits today.
+        self._write_item(
+            item_json,
+            [
+                {"rel": "root", "href": "../collection.json"},
+                {"rel": "collection", "href": "../collection.json"},
+                {"rel": "parent", "href": "../collection.json"},
+            ],
+        )
+
+        _fix_item_links(collection_json, tmp_path, collection_dir)
+
+        # Pre-fix root was "../collection.json", the collection itself.
+        assert _hrefs(item_json, "root") == ["../../../catalog.json"]
+        assert _hrefs(item_json, "parent") == ["../collection.json"]
+        assert _hrefs(item_json, "collection") == ["../collection.json"]
+
+    def test_missing_structural_links_are_added(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "roads"
+        collection_json = collection_dir / "collection.json"
+        _write_collection(collection_json, [{"rel": "item", "href": "./a/a.json"}])
+        item_json = collection_dir / "a" / "a.json"
+        self._write_item(item_json, [])
+
+        _fix_item_links(collection_json, tmp_path, collection_dir)
+
+        assert _hrefs(item_json, "root") == ["../../catalog.json"]
+        assert _hrefs(item_json, "parent") == ["../collection.json"]
+        assert _hrefs(item_json, "collection") == ["../collection.json"]
+
+    def test_item_links_carry_their_media_types(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "roads"
+        collection_json = collection_dir / "collection.json"
+        _write_collection(collection_json, [{"rel": "item", "href": "./a/a.json"}])
+        item_json = collection_dir / "a" / "a.json"
+        self._write_item(item_json, [])
+
+        _fix_item_links(collection_json, tmp_path, collection_dir)
+
+        data = json.loads(item_json.read_text(encoding="utf-8"))
+        types = {link["rel"]: link["type"] for link in data["links"]}
+        assert types == {
+            "root": "application/json",
+            "parent": "application/json",
+            "collection": "application/json",
+        }
+
+    def test_a_missing_item_file_is_skipped(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "roads"
+        collection_json = collection_dir / "collection.json"
+        _write_collection(collection_json, [{"rel": "item", "href": "./gone/gone.json"}])
+
+        _fix_item_links(collection_json, tmp_path, collection_dir)  # must not raise
+
+        assert not (collection_dir / "gone").exists()

--- a/tests/unit/test_nested_catalog_inference.py
+++ b/tests/unit/test_nested_catalog_inference.py
@@ -297,6 +297,55 @@ class TestCreateIntermediateCatalogs:
         assert "parent" in links_by_rel
         assert links_by_rel["parent"]["href"] == "../catalog.json"
 
+    def test_deep_intermediate_parent_stops_one_level_up(self, tmp_path: Path) -> None:
+        """Issue #711: root and parent diverge below the first level.
+
+        At depth 1 the containing object *is* the root catalog, so one href
+        served both rels and the conflation stayed invisible. At depth 2 the
+        container is ``env/catalog.json`` while the root is two levels up.
+        """
+        import json
+
+        from portolan_cli.catalog import create_intermediate_catalogs
+
+        catalog_root = tmp_path
+        (catalog_root / "catalog.json").write_text(
+            '{"type": "Catalog", "id": "test", "stac_version": "1.1.0", "links": []}'
+        )
+
+        create_intermediate_catalogs("env/air/quality", catalog_root)
+
+        content = json.loads((catalog_root / "env" / "air" / "catalog.json").read_text())
+        links_by_rel = {link["rel"]: link for link in content.get("links", [])}
+
+        assert links_by_rel["root"]["href"] == "../../catalog.json"
+        # Pre-fix this was "../../catalog.json", the root rather than env/.
+        assert links_by_rel["parent"]["href"] == "../catalog.json"
+
+    def test_intermediate_catalogs_carry_a_human_readable_title(self, tmp_path: Path) -> None:
+        """Issue #502 titles apply to intermediate catalogs too (rashid PTL-TTL-001).
+
+        Without a title on the target, ``ensure_link_titles`` also has nothing to
+        copy onto the parent's child link, so PTL-TTL-003 fires alongside it.
+        """
+        import json
+
+        from portolan_cli.catalog import create_intermediate_catalogs
+
+        catalog_root = tmp_path
+        (catalog_root / "catalog.json").write_text(
+            '{"type": "Catalog", "id": "test", "stac_version": "1.1.0", "links": []}'
+        )
+
+        create_intermediate_catalogs("env/air-quality/pm25", catalog_root)
+
+        # Pre-fix neither file carried a title at all.
+        top = json.loads((catalog_root / "env" / "catalog.json").read_text())
+        nested = json.loads((catalog_root / "env" / "air-quality" / "catalog.json").read_text())
+        assert top["title"] == "Env"
+        # Titled after its own segment, not the full "env/air-quality" id.
+        assert nested["title"] == "Air Quality"
+
 
 class TestIntermediateCatalogIds:
     """Test intermediate_catalog_ids() pure path-walk helper (shared by add + push)."""
@@ -335,6 +384,76 @@ class TestIntermediateCatalogIds:
         }
         written = set((tmp_path).glob("*/catalog.json")) | set((tmp_path).glob("*/*/catalog.json"))
         assert written == expected_dirs
+
+
+def _collection_json(collection_id: str) -> str:
+    """A minimal valid collection body, enough for PySTAC to resolve a link."""
+    return (
+        f'{{"type": "Collection", "id": "{collection_id}", "stac_version": "1.1.0", '
+        '"description": "Test.", "license": "proprietary", '
+        '"extent": {"spatial": {"bbox": [[0, 0, 1, 1]]}, '
+        '"temporal": {"interval": [[null, null]]}}, "links": []}'
+    )
+
+
+class TestFlatAddLeavesNestedLinksAlone:
+    """Issue #711: adding a flat collection must not rewrite the nested tree.
+
+    Registering a flat collection used to load the root catalog with PySTAC and
+    call ``save(SELF_CONTAINED)``, which walks and re-serializes every
+    descendant. ``normalize_hrefs`` lays children out by ``id``, and an
+    intermediate catalog's id is its POSIX path, so ``env/air`` was relocated to
+    ``env/env/air/`` and its child href went with it.
+    """
+
+    def test_registering_a_flat_collection_preserves_intermediate_child_hrefs(
+        self, tmp_path: Path
+    ) -> None:
+        import json
+
+        from portolan_cli.catalog import (
+            create_intermediate_catalogs,
+            update_catalog_links_for_nested,
+        )
+        from portolan_cli.finalization import _update_catalog_links
+
+        catalog_root = tmp_path
+        (catalog_root / "catalog.json").write_text(
+            '{"type": "Catalog", "id": "test", "stac_version": "1.1.0", '
+            '"description": "Test", "links": []}'
+        )
+        create_intermediate_catalogs("env/air/quality", catalog_root)
+        leaf = catalog_root / "env" / "air" / "quality"
+        leaf.mkdir(parents=True, exist_ok=True)
+        (leaf / "collection.json").write_text(_collection_json("quality"))
+        update_catalog_links_for_nested(catalog_root, "env/air/quality")
+
+        # A flat collection added afterwards, as in any mixed catalog.
+        (catalog_root / "roads").mkdir()
+        (catalog_root / "roads" / "collection.json").write_text(_collection_json("roads"))
+        _update_catalog_links(catalog_root, "roads")
+
+        intermediate = json.loads((catalog_root / "env" / "catalog.json").read_text())
+        hrefs = [link["href"] for link in intermediate["links"] if link["rel"] == "child"]
+        # Pre-fix this was "./env/air/catalog.json", resolving to env/env/air/.
+        assert hrefs == ["./air/catalog.json"]
+
+    def test_the_flat_collection_still_gets_its_child_link(self, tmp_path: Path) -> None:
+        import json
+
+        from portolan_cli.finalization import _update_catalog_links
+
+        catalog_root = tmp_path
+        (catalog_root / "catalog.json").write_text(
+            '{"type": "Catalog", "id": "test", "stac_version": "1.1.0", '
+            '"description": "Test", "links": []}'
+        )
+
+        _update_catalog_links(catalog_root, "roads")
+
+        content = json.loads((catalog_root / "catalog.json").read_text())
+        hrefs = [link["href"] for link in content["links"] if link["rel"] == "child"]
+        assert hrefs == ["./roads/collection.json"]
 
 
 class TestUpdateCatalogLinksNested:


### PR DESCRIPTION
## What this changes

Fixes the links generated for nested collections. A collection's `parent` link now points to the catalog that contains it, while its `root` link continues to point to the repository root. The same `relative_href` helper now generates these paths consistently for parent, root, and child links. The fix also applies to intermediate catalogs and flat collections, and intermediate catalogs now have a title.

## Why

The code previously used one computed path for both `parent` and `root`. Those links point to the same catalog for a top-level collection, so the mistake was not visible. For a nested collection, however, `parent` must point to the containing catalog rather than the repository root. The same path calculation also affected intermediate catalogs, item `root` links, and flat-collection adds. See #711.

## Verification

The issue data contains a nested collection and a flat sibling. Before the fix, `parent` pointed to the repository root instead of the containing catalog. After the fix, it points to `boundaries/catalog.json`, and the generated child link points back to the nested collection. Rashid reports no link errors.

```console id="f4p8qx"
$ portolan add boundaries/adm1-attributes/adm1.parquet roads/roads.parquet
✓ Added 2 files to 2 collections

$ jq -r '.links[] | select(.rel=="parent") | .href' \
    boundaries/adm1-attributes/collection.json
../catalog.json

$ jq -r '.links[] | select(.rel=="child") | .href' boundaries/catalog.json
./adm1-attributes/collection.json

$ rashid check . | grep -c PTL-LNK
0
```

The conformance gate now includes a three-level collection tree, so generated nested catalogs are checked as part of the test suite.

```console id="m7v2kc"
$ uv run pytest -m unit --no-cov -q
5088 passed, 5 skipped, 1265 deselected

$ uv run pytest tests/integration -m "not network and not slow" --no-cov -q
868 passed, 3 skipped, 13 deselected

$ uv run mypy portolan_cli && uv run lint-imports
Success: no issues found in 154 source files
Contracts: 6 kept, 0 broken.
```

* [ ] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Closes #711.
