### PR TITLE
fix(license): require a license before writing a collection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions are recorded where they apply (see `.claude/rules/documentation.md`)
 - **NO** new dependencies without discussion
 
-<!-- freshness: last-verified: 2026-07-29 -->
+<!-- freshness: last-verified: 2026-08-12 -->
 ## Design Principles
 
 | Principle | Meaning |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This CLI converts data to cloud-native formats (GeoParquet, COG), generates rich
 ## Quick Start
 
 ```bash
-# Initialize a catalog
+# Initialize a catalog (prompts for a license; --license sets it directly)
 portolan init
 
 # Add files (creates collections from directories)
@@ -47,7 +47,7 @@ portolan sync s3://my-bucket/catalog -c demographics
 ### All Commands
 
 ```bash
-portolan init                               # Initialize catalog
+portolan init                               # Initialize catalog (asks for a license)
 portolan scan <path>                        # Scan for issues (--fix for filenames)
 portolan add <path>                         # Track files
 portolan add-external <url>                 # Reference a remote dataset in place (no download/convert)

--- a/docs/guides/iceberg.md
+++ b/docs/guides/iceberg.md
@@ -23,7 +23,7 @@ pipx install portolan-cli[iceberg]
 
 ```bash
 # Initialize a catalog with the Iceberg backend
-portolan init my-catalog --backend iceberg
+portolan init my-catalog --backend iceberg --license CC-BY-4.0
 
 # Add data (collection is inferred from the parent directory;
 # there is no --collection flag — place files under the collection dir first)
@@ -56,7 +56,7 @@ portolan version prune boundaries --keep 5
 
 ```bash
 # Set during init (persists in config)
-portolan init my-catalog --backend iceberg
+portolan init my-catalog --backend iceberg --license CC-BY-4.0
 
 # Or set in existing catalog
 portolan config set backend iceberg

--- a/docs/guides/licensing.md
+++ b/docs/guides/licensing.md
@@ -1,0 +1,103 @@
+# Licensing
+
+Every collection Portolan writes carries a license. The spec requires one, and
+`portolan check` reports a collection without one as an error, so `portolan add`
+refuses to write the collection instead of publishing a catalog that fails
+validation.
+
+Portolan never picks a license for you. A license is a legal fact about the data,
+and only the person publishing it knows what it is.
+
+## The two accepted shapes
+
+A license is either an SPDX identifier, or the literal `other` alongside a URL
+pointing at the license text:
+
+```yaml
+# .portolan/metadata.yaml
+license: "CC-BY-4.0"
+```
+
+```yaml
+# .portolan/metadata.yaml — for a license with no SPDX identifier
+license: "other"
+license_url: "https://data.example.org/terms"
+```
+
+The second form emits a `rel="license"` link on the collection. Without that link,
+`license: "other"` says only that the license is unknown, which the spec rejects.
+
+The deprecated value `proprietary` is not accepted. Use `other` with a URL.
+
+## Setting it when you create the catalog
+
+`portolan init` asks for the license and writes it into
+`.portolan/metadata.yaml`:
+
+```console
+$ portolan init
+Catalog title (optional, press Enter to skip): Roads
+Catalog description: Municipal road centerlines
+License (SPDX identifier, or 'other'): CC-BY-4.0
+```
+
+Scripts and agents pass it as a flag. With `--auto` or `--json` there is nobody to
+prompt, so the flag is required:
+
+```bash
+portolan init --auto --license CC-BY-4.0
+
+portolan init --auto \
+  --license other \
+  --license-url https://data.example.org/terms
+```
+
+## Where the license lives
+
+`metadata.yaml` files merge from the catalog root down, and the closest file wins.
+The root license therefore acts as the default for every collection, and a
+collection overrides it by setting its own:
+
+```yaml
+# roads/.portolan/metadata.yaml — this collection only
+license: "ODbL-1.0"
+```
+
+A license already written into `collection.json` also counts, so a collection you
+licensed by hand is not asked to repeat itself in `metadata.yaml`.
+
+## Referencing and harvesting data you do not own
+
+`portolan add-external` registers remote data in place. It takes the same two
+shapes as flags:
+
+```bash
+portolan add-external "s3://bucket/roads/*" \
+  --collection roads \
+  --license ODbL-1.0
+```
+
+The `portolan extract` commands harvest a service's own metadata first. When the
+service publishes a license URL, extraction seeds `other` plus that link, which
+needs no flag. When it publishes none, pass `--license` and extraction stops
+before downloading anything rather than after:
+
+```bash
+portolan extract wfs https://example.org/wfs out/ \
+  --license other \
+  --license-url https://example.org/terms
+```
+
+## When Portolan stops
+
+```console
+$ portolan add roads/roads.parquet
+✗ [PRTLN-VAL004] No usable license for collection 'roads': no license is declared
+→ Set 'license:' in .portolan/metadata.yaml to an SPDX identifier such as
+  CC-BY-4.0, or to 'other' with a 'license_url:' pointing at the license text.
+```
+
+Nothing was written. Set the license and run the command again.
+
+Identifier spelling is checked separately, by `portolan check`, against the full
+SPDX list. A typo like `cc-by-4.0` passes `add` and is reported as `PTL-LIC-001`.

--- a/docs/guides/nested-catalogs.md
+++ b/docs/guides/nested-catalogs.md
@@ -12,11 +12,10 @@ cp env-data/*.parquet my-catalog/environment/
 
 # Initialize and add everything
 cd my-catalog
-portolan init --auto --title "My Regional Data"
+portolan init --auto --title "My Regional Data" --license CC-BY-4.0
 portolan add . --workers 4
 
-# Add metadata and generate documentation
-portolan metadata init
+# Fill in the contact fields init left blank
 # Edit .portolan/metadata.yaml with your info
 portolan readme
 ```
@@ -131,9 +130,9 @@ Created with:
 
 ```bash
 portolan init --auto --title "The Hague Open Data" \
-  --description "Municipal open data from Den Haag, Netherlands"
+  --description "Municipal open data from Den Haag, Netherlands" \
+  --license CC-BY-4.0
 portolan add . --workers 4
-portolan metadata init
 # Edit .portolan/metadata.yaml
 portolan readme
 portolan check

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,7 +41,7 @@ backend: iceberg
 Or initialize a new catalog with the Iceberg backend:
 
 ```bash
-portolan init --backend iceberg
+portolan init --backend iceberg --license CC-BY-4.0
 ```
 
 ### Version Management Commands

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,7 @@ nav:
     - Extracting from ArcGIS: guides/extract-arcgis.md
     - Extracting from WFS: guides/extract-wfs.md
     - Iceberg Backend: guides/iceberg.md
+    - Licensing: guides/licensing.md
     - Metadata Defaults: guides/metadata-defaults.md
     - Nested Catalogs: guides/nested-catalogs.md
     - Partitioning: guides/partitioning.md

--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -42,7 +42,7 @@ from portolan_cli.constants import (
 from portolan_cli.conversion_config import get_vector_settings
 from portolan_cli.convert import convert_multilayer_file
 from portolan_cli.discovery import get_sidecars, iter_files_with_sidecars, iter_geospatial_files
-from portolan_cli.errors import NoGeometryError
+from portolan_cli.errors import MissingLicenseError, NoGeometryError
 
 # Batch finalization (STAC-write + backend coordination) was extracted to
 # finalization.py (issue #624). add.py orchestrates on top of it: add_files /
@@ -89,6 +89,7 @@ from portolan_cli.formats import (
 )
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic
+from portolan_cli.licensing import LICENSE_REL, license_gap, resolve_license
 from portolan_cli.preparation import (
     _MEDIA_TYPE_MAP as _MEDIA_TYPE_MAP,  # noqa: PLC0414
 )
@@ -1103,6 +1104,74 @@ def _recompute_stats_for_collections(affected_collections: set[Path]) -> None:
             collection.save_object(include_self_link=False)
 
 
+def _collection_license_on_disk(collection_json_path: Path) -> tuple[str | None, bool]:
+    """Read the license and license-link state off a collection.json already on disk.
+
+    A re-add inherits both: ``apply_human_license`` leaves the license alone when
+    metadata.yaml declares none, and an existing ``rel="license"`` link survives
+    every link rewrite. So a collection a human already licensed by hand stays
+    licensed, and the gate must see that rather than demand metadata.yaml repeat it.
+
+    Args:
+        collection_json_path: Path to the collection.json, which need not exist.
+
+    Returns:
+        Tuple of (license id or None, whether a rel="license" link is present).
+    """
+    try:
+        data = json.loads(collection_json_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None, False
+
+    if not isinstance(data, dict):
+        return None, False
+
+    license_id = data.get("license")
+    links = data.get("links")
+    has_link = isinstance(links, list) and any(
+        isinstance(link, dict) and link.get("rel") == LICENSE_REL for link in links
+    )
+    return (license_id if isinstance(license_id, str) else None), has_link
+
+
+def _require_licenses(catalog_root: Path, collection_ids: set[str]) -> None:
+    """Stop the add when a target collection would end up with no usable license.
+
+    Runs after phase 1, so it costs one metadata read per collection and fires
+    before any conversion work, and long before ``finalize_items`` writes a
+    collection.json. Raising here rather than at the write seam keeps a refused
+    add from leaving converted files behind. Nested catalog scaffolding from phase
+    1 may already exist, which carries no license and is written idempotently.
+
+    The license and the link are predicted exactly as ``apply_human_license``
+    would apply them: metadata.yaml wins over what is on disk, and either source
+    can supply the link.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+        collection_ids: Collections this add will write.
+
+    Raises:
+        MissingLicenseError: When a collection would fail PTL-LIC-001, PTL-LIC-002,
+            or PTL-LIC-003.
+    """
+    for coll_id in sorted(collection_ids):
+        collection_dir = catalog_root / Path(*coll_id.split("/"))
+        on_disk_license, on_disk_link = _collection_license_on_disk(
+            collection_dir / "collection.json"
+        )
+        declared = resolve_license(load_merged_metadata(collection_dir, catalog_root))
+
+        license_id = declared.license_id if declared is not None else on_disk_license
+        has_license_link = on_disk_link or (
+            declared is not None and declared.license_url is not None
+        )
+
+        gap = license_gap(license_id, has_license_link=has_license_link)
+        if gap is not None:
+            raise MissingLicenseError(f"collection '{coll_id}'", gap)
+
+
 def add_files(
     *,
     paths: list[Path],
@@ -1177,6 +1246,10 @@ def add_files(
     )
     if not files_to_process:
         return [], skipped, []
+
+    # Phase 1.5: refuse the add before any GDAL work when a target collection would
+    # end up with no usable license (issue #686).
+    _require_licenses(catalog_root, {coll_id for _, coll_id in files_to_process})
 
     # Issue #465: filenames of every batch item (sources + converted outputs) so a
     # collection-level asset scan can skip siblings that are tracked as their own

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -323,12 +323,59 @@ class CatalogInitError(Exception):
         super().__init__(message)
 
 
+def _seed_root_metadata(
+    portolan_dir: Path,
+    license_id: str | None,
+    license_url: str | None,
+) -> list[str]:
+    """Write the catalog-level metadata.yaml carrying the license (issue #686).
+
+    Every collection inherits this license through the hierarchical merge, which is
+    what lets ``add`` require one without the human editing anything first.
+
+    Args:
+        portolan_dir: The catalog's ``.portolan`` directory.
+        license_id: SPDX identifier, or None to leave metadata.yaml to the caller.
+        license_url: URL of the license text, required alongside "other".
+
+    Returns:
+        Warnings to surface to the user.
+
+    Raises:
+        CatalogInitError: If the file cannot be written.
+    """
+    if license_id is None:
+        return []
+
+    metadata_file = portolan_dir / "metadata.yaml"
+    if metadata_file.exists():
+        # A human who wrote metadata.yaml before running init keeps it. Overwriting
+        # would drop their contact, providers, and source fields.
+        return [
+            f"Kept existing {metadata_file}; the --license value was not written. "
+            "Check that its 'license:' is set."
+        ]
+
+    from portolan_cli.metadata_yaml import generate_metadata_template
+
+    try:
+        write_text_atomic(
+            metadata_file,
+            generate_metadata_template(license_id=license_id, license_url=license_url or ""),
+        )
+    except OSError as e:
+        raise CatalogInitError(f"Cannot write metadata.yaml: {e}") from e
+    return []
+
+
 def init_catalog(
     path: Path,
     *,
     title: str | None = None,
     description: str | None = None,
     backend: str = "file",
+    license_id: str | None,
+    license_url: str | None = None,
 ) -> tuple[Path, list[str]]:
     """Initialize a new Portolan catalog with the v2 file structure.
 
@@ -337,7 +384,8 @@ def init_catalog(
     2. versions.json at ROOT level (file backend only, consumer-visible)
     3. catalog.json at ROOT level (valid STAC catalog via pystac)
     4. Self link in catalog.json
-    5. .portolan/config.yaml — sentinel file, written LAST (per issue #290)
+    5. .portolan/metadata.yaml — seeded with the license
+    6. .portolan/config.yaml — sentinel file, written LAST (per issue #290)
 
     Write order ensures failed runs stay in FRESH state (retry-safe).
     Versions.json is user-visible metadata and lives at the
@@ -347,10 +395,22 @@ def init_catalog(
     Note: state.json was removed per issue #290. config.yaml alone is now
     sufficient for MANAGED state detection.
 
+    ``license_id`` has no default, so every caller states its intent. Passing an
+    identifier seeds metadata.yaml with it, and the hierarchical merge then hands
+    that license to every collection, which is what lets ``add`` require one
+    (issue #686). Passing None writes no metadata.yaml, for callers that own the
+    file themselves: ``extract`` seeds it from harvested service metadata, and
+    ``clone`` copies collections that already carry their own licenses. Callers
+    validate the value with ``licensing.license_gap`` before getting here.
+
     Args:
         path: Directory path for the catalog. Will be created if doesn't exist.
         title: Optional catalog title.
         description: Optional catalog description.
+        backend: Versioning backend name.
+        license_id: SPDX identifier, or "other" alongside license_url. None leaves
+            metadata.yaml to the caller.
+        license_url: URL of the license text. Required when license_id is "other".
 
     Returns:
         Tuple of (catalog_file_path, warnings).
@@ -477,6 +537,13 @@ def init_catalog(
     except OSError as e:
         raise CatalogInitError(f"Cannot write catalog conformance files: {e}") from e
 
+    # Step 4d: metadata.yaml - seed the license the human supplied. Every collection
+    # inherits it through the hierarchical merge, so the gate in add_files passes
+    # without the human editing anything first (issue #686). Skipped when the caller
+    # owns the file: extract seeds it from harvested metadata, and writing here first
+    # would make its O_EXCL create a no-op and silently drop everything harvested.
+    warnings.extend(_seed_root_metadata(portolan_dir, license_id, license_url))
+
     # Step 5: config.yaml - sentinel file per issue #290 (sufficient for MANAGED state)
     # Written LAST for atomicity: if any previous step fails, directory stays FRESH
     # and init can be safely retried. Also serves as user configuration file for
@@ -527,13 +594,16 @@ class Catalog:
         return self.root / self.CATALOG_FILE
 
     @classmethod
-    def init(cls, root: Path) -> Self:
+    def init(cls, root: Path, *, license_id: str | None = None) -> Self:
         """Initialize a new Portolan catalog.
 
         Creates the catalog using the v2 file structure via init_catalog().
 
         Args:
             root: The directory where the catalog should be created.
+            license_id: SPDX identifier to seed into metadata.yaml. Left None, the
+                catalog starts unlicensed and ``add`` will ask for a license before
+                it writes a collection (issue #686).
 
         Returns:
             A Catalog instance for the newly created catalog.
@@ -547,7 +617,7 @@ class Catalog:
             raise CatalogExistsError(portolan_path)
 
         # Use init_catalog for v2 file structure
-        init_catalog(root)
+        init_catalog(root, license_id=license_id)
 
         return cls(root)
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -456,7 +456,7 @@ def init(
         portolan init --backend iceberg --license CC0-1.0
     """
 
-    from portolan_cli.catalog import init_catalog
+    from portolan_cli.catalog import CatalogState, detect_state, init_catalog
     from portolan_cli.errors import CatalogAlreadyExistsError, UnmanagedStacCatalogError
 
     use_json = should_output_json(ctx, json_output)
@@ -483,7 +483,11 @@ def init(
         if license_id.strip() == OTHER_LICENSE and license_url is None:
             license_url = click.prompt("URL of the license text")
 
-    license_id = _validated_cli_license("init", license_id, license_url, use_json=use_json)
+    # Only gate the license on a directory that can actually become a catalog. An
+    # existing catalog is the more fundamental problem and --license cannot fix it,
+    # so let init_catalog report that instead of sending the user after a flag.
+    if detect_state(path) is CatalogState.FRESH:
+        license_id = _validated_cli_license("init", license_id, license_url, use_json=use_json)
 
     try:
         catalog_file, warnings = init_catalog(

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -36,7 +36,14 @@ from portolan_cli.collection_id import resolve_collection_id
 from portolan_cli.convert import ConversionResult
 from portolan_cli.discovery import get_sidecars
 from portolan_cli.emit import emit_error, emit_success
+from portolan_cli.errors import MissingLicenseError
 from portolan_cli.json_output import ErrorDetail, error_envelope, success_envelope
+from portolan_cli.licensing import (
+    CLI_LICENSE_REMEDIATION,
+    METADATA_LICENSE_REMEDIATION,
+    OTHER_LICENSE,
+    license_gap,
+)
 from portolan_cli.metadata.fix import FixReport
 from portolan_cli.output import detail, error, success, warn
 from portolan_cli.output import info as info_output
@@ -117,6 +124,88 @@ def should_output_json(ctx: click.Context, json_flag: bool = False) -> bool:
 
     # Global format takes precedence, but per-command --json also works
     return global_format == "json" or json_flag
+
+
+def _fail_on_add_error(
+    err: Exception,
+    resolved_paths: list[Path],
+    *,
+    use_json: bool,
+) -> NoReturn:
+    """Report a failed add and exit 1, naming the path when there was only one.
+
+    Args:
+        err: The error raised by the library layer.
+        resolved_paths: Paths the add was asked to process.
+        use_json: Whether output goes out as a JSON envelope.
+
+    Raises:
+        SystemExit: Always, with status 1.
+    """
+    path_context = f"{resolved_paths[0]}: " if len(resolved_paths) == 1 else ""
+    emit_error("add", type(err).__name__, f"{path_context}{err}", use_json=use_json)
+    raise SystemExit(1) from err
+
+
+def _fail_on_missing_license(
+    command: str,
+    err: MissingLicenseError,
+    *,
+    use_json: bool,
+) -> NoReturn:
+    """Report an unlicensed collection and exit 1, naming the file to edit.
+
+    Args:
+        command: Command name, for the error envelope.
+        err: The error raised by the library layer.
+        use_json: Whether output goes out as a JSON envelope.
+
+    Raises:
+        SystemExit: Always, with status 1.
+    """
+    emit_error(command, type(err).__name__, str(err), use_json=use_json, code=err.code)
+    if not use_json:
+        info_output(METADATA_LICENSE_REMEDIATION)
+    raise SystemExit(1) from err
+
+
+def _validated_cli_license(
+    command: str,
+    license_id: str | None,
+    license_url: str | None,
+    *,
+    use_json: bool,
+) -> str:
+    """Validate a --license / --license-url pair, or exit 1 naming both flags.
+
+    Shared by ``init`` and ``add-external``, the two commands that take the license
+    as a flag rather than reading it out of metadata.yaml. Validating here means a
+    bad pair fails before either command touches the filesystem (issue #686).
+
+    Args:
+        command: Command name, for the error envelope.
+        license_id: Value of --license, or None when it was not passed.
+        license_url: Value of --license-url, or None.
+        use_json: Whether output goes out as a JSON envelope.
+
+    Returns:
+        The stripped license identifier.
+
+    Raises:
+        SystemExit: Always exits 1 when the pair cannot produce a conformant license.
+    """
+    declared = license_id.strip() if license_id else ""
+    has_link = bool(license_url and license_url.strip())
+
+    gap = license_gap(declared, has_license_link=has_link)
+    if gap is None:
+        return declared
+
+    err = MissingLicenseError(f"'portolan {command}'", gap)
+    emit_error(command, type(err).__name__, str(err), use_json=use_json, code=err.code)
+    if not use_json:
+        info_output(CLI_LICENSE_REMEDIATION)
+    raise SystemExit(1) from err
 
 
 def output_json_envelope(envelope: Any) -> None:
@@ -315,6 +404,19 @@ def cli(ctx: click.Context, output_format: str) -> None:
     default="file",
     help="Versioning backend to use (e.g., 'file', 'iceberg').",
 )
+@click.option(
+    "--license",
+    "license_id",
+    type=str,
+    default=None,
+    help="SPDX license identifier, or 'other' with --license-url. Required.",
+)
+@click.option(
+    "--license-url",
+    type=str,
+    default=None,
+    help="URL of the license text. Required when --license is 'other'.",
+)
 @click.pass_context
 def init(
     ctx: click.Context,
@@ -324,26 +426,34 @@ def init(
     title: str | None,
     description: str | None,
     backend: str,
+    license_id: str | None,
+    license_url: str | None,
 ) -> None:
     """Initialize a new Portolan catalog.
 
     Creates a catalog.json at the root level and a .portolan directory with
-    management files (config.yaml). Also creates versions.json at the root.
+    management files (config.yaml, metadata.yaml). Also creates versions.json at
+    the root.
 
     Auto-extracts the catalog ID from the directory name.
 
     PATH is the directory where the catalog should be created (default: current directory).
+
+    A license is required. Every collection inherits it from the catalog's
+    metadata.yaml, and 'portolan add' refuses to write a collection without one.
+    Pass an SPDX identifier, or 'other' with --license-url when the license has no
+    identifier. Without --auto or --json you are prompted for it.
 
     Use --auto to skip all prompts and use default values. Use --title and
     --description to set catalog metadata directly.
 
     \b
     Examples:
-        portolan init                       # Initialize in current directory
-        portolan init --auto                # Skip prompts, use defaults
-        portolan init --title "My Catalog"  # Set title
-        portolan init /path/to/data --auto  # Initialize in specific directory
-        portolan init --backend iceberg     # Use Iceberg backend
+        portolan init                            # Prompts for the license
+        portolan init --auto --license CC-BY-4.0 # Skip prompts
+        portolan init --title "My Catalog" --license MIT
+        portolan init --license other --license-url https://x.org/terms
+        portolan init --backend iceberg --license CC0-1.0
     """
 
     from portolan_cli.catalog import init_catalog
@@ -368,12 +478,21 @@ def init(
                 default="A Portolan-managed STAC catalog",
             )
 
+        if license_id is None:
+            license_id = click.prompt("License (SPDX identifier, or 'other')")
+        if license_id.strip() == OTHER_LICENSE and license_url is None:
+            license_url = click.prompt("URL of the license text")
+
+    license_id = _validated_cli_license("init", license_id, license_url, use_json=use_json)
+
     try:
         catalog_file, warnings = init_catalog(
             path,
             title=title,
             description=description,
             backend=backend,
+            license_id=license_id,
+            license_url=license_url,
         )
 
         # Read back catalog ID for display
@@ -3114,12 +3233,12 @@ def add_cmd(
                 skip_partitioning=skip_partitioning,
                 merge_strategy=MergeStrategy(merge_strategy),
             )
+    except MissingLicenseError as err:
+        # Issue #686: a collection with no license fails PTL-LIC-001/002 the moment
+        # check reads it, so add refuses the write and names what to supply.
+        _fail_on_missing_license("add", err, use_json=use_json)
     except (ValueError, FileNotFoundError) as err:
-        err_type = type(err).__name__
-        # Include failed path context in error message when there's only one path
-        path_context = f"{resolved_paths[0]}: " if len(resolved_paths) == 1 else ""
-        emit_error("add", err_type, f"{path_context}{err}", use_json=use_json)
-        raise SystemExit(1) from err
+        _fail_on_add_error(err, resolved_paths, use_json=use_json)
 
     # Compute affected collections before any post-processing
     # Include both added AND skipped assets so --pmtiles works on already-tracked files
@@ -3189,8 +3308,13 @@ def add_cmd(
 @click.option(
     "--license",
     "license_id",
-    default="other",
-    help="SPDX license expression, or 'other' for a non-SPDX license (default: other).",
+    default=None,
+    help="SPDX license identifier, or 'other' with --license-url. Required.",
+)
+@click.option(
+    "--license-url",
+    default=None,
+    help="URL of the license text. Required when --license is 'other'.",
 )
 @click.option(
     "--via",
@@ -3226,7 +3350,8 @@ def add_external_cmd(
     title: str | None,
     description: str | None,
     media_type: str | None,
-    license_id: str,
+    license_id: str | None,
+    license_url: str | None,
     via_url: str | None,
     bbox: str | None,
     catalog_path: Path | None,
@@ -3243,6 +3368,11 @@ def add_external_cmd(
     The remote asset is never fetched, and 'portolan check' will not try to
     convert it (the metadata scanner skips scheme-qualified hrefs).
 
+    A license is required. Pass an SPDX identifier, or 'other' with --license-url
+    when the license has no identifier. Referencing someone else's data in place
+    does not make its license unknowable, and a collection without one is an error
+    under 'portolan check'.
+
     \b
     Examples:
         # Overture Maps places — planet-scale GeoParquet on Overture's S3
@@ -3250,9 +3380,11 @@ def add_external_cmd(
             "s3://overturemaps-us-west-2/release/2024-09-18.0/theme=places/type=place/*" \\
             --collection overture-places \\
             --title "Overture Maps — Places" \\
+            --license ODbL-1.0 \\
             --via "https://docs.overturemaps.org/guides/places/"
 
-        portolan add-external "https://example.org/data/buildings.parquet"
+        portolan add-external "https://example.org/data/buildings.parquet" \\
+            --license other --license-url "https://example.org/terms"
     """
     from portolan_cli.external import add_external
 
@@ -3275,6 +3407,10 @@ def add_external_cmd(
             )
             raise SystemExit(1)
 
+    resolved_license = _validated_cli_license(
+        "add-external", license_id, license_url, use_json=use_json
+    )
+
     try:
         result = add_external(
             catalog_root=catalog_root,
@@ -3283,7 +3419,8 @@ def add_external_cmd(
             title=title,
             description=description,
             media_type=media_type,
-            license=license_id,
+            license=resolved_license,
+            license_url=license_url,
             via_url=via_url,
             bbox=parsed_bbox,
             force=force,
@@ -6342,9 +6479,25 @@ def extract() -> None:
     default=None,
     help="[ImageServer] Name for the collection (default: 'tiles').",
 )
+@click.option(
+    "--license",
+    "license_id",
+    type=str,
+    default=None,
+    help="SPDX license identifier, or 'other' with --license-url. Required unless the "
+    "source publishes a license URL of its own.",
+)
+@click.option(
+    "--license-url",
+    type=str,
+    default=None,
+    help="URL of the license text. Required when --license is 'other'.",
+)
 @click.pass_context
 def extract_arcgis_cmd(
     ctx: click.Context,
+    license_id: str | None,
+    license_url: str | None,
     url: str,
     output_dir: Path | None,
     layers: str | None,
@@ -6516,6 +6669,8 @@ def extract_arcgis_cmd(
         raw=raw,
         token=resolved_token,
         recurse=not no_recurse,
+        license=license_id,
+        license_url=license_url,
     )
 
     # Progress callback for text output
@@ -6555,6 +6710,13 @@ def extract_arcgis_cmd(
             options=options,
             on_progress=None if use_json else on_progress,
         )
+    except MissingLicenseError as e:
+        # Raised before the download starts, so the user re-runs the command rather
+        # than the harvest (issue #686).
+        _output_extract_error(use_json, type(e).__name__, str(e), url)
+        if not use_json:
+            info_output(CLI_LICENSE_REMEDIATION)
+        raise SystemExit(1) from None
     except NotImplementedError as e:
         _output_extract_error(use_json, "NotImplementedError", str(e), url)
         raise SystemExit(1) from None
@@ -6662,9 +6824,25 @@ def extract_arcgis_cmd(
     is_flag=True,
     help="Skip auto-init: create only extraction files, no STAC catalog.",
 )
+@click.option(
+    "--license",
+    "license_id",
+    type=str,
+    default=None,
+    help="SPDX license identifier, or 'other' with --license-url. Required unless the "
+    "source publishes a license URL of its own.",
+)
+@click.option(
+    "--license-url",
+    type=str,
+    default=None,
+    help="URL of the license text. Required when --license is 'other'.",
+)
 @click.pass_context
 def extract_wfs_cmd(
     ctx: click.Context,
+    license_id: str | None,
+    license_url: str | None,
     url: str,
     output_dir: Path | None,
     layers: str | None,
@@ -6769,6 +6947,8 @@ def extract_wfs_cmd(
         limit=limit,
         page_size=page_size,
         auto_tile=auto_tile,
+        license=license_id,
+        license_url=license_url,
     )
 
     # Progress callback for text output
@@ -6806,6 +6986,13 @@ def extract_wfs_cmd(
             options=options,
             on_progress=None if use_json else on_progress,
         )
+    except MissingLicenseError as e:
+        # Raised before the download starts, so the user re-runs the command rather
+        # than the harvest (issue #686).
+        _output_extract_error(use_json, type(e).__name__, str(e), url, command="extract-wfs")
+        if not use_json:
+            info_output(CLI_LICENSE_REMEDIATION)
+        raise SystemExit(1) from None
     except Exception as e:
         _output_extract_error(
             use_json, type(e).__name__, f"Extraction failed: {e}", url, command="extract-wfs"
@@ -6910,9 +7097,25 @@ def extract_wfs_cmd(
     is_flag=True,
     help="Skip auto-init: create only extraction files, no STAC catalog.",
 )
+@click.option(
+    "--license",
+    "license_id",
+    type=str,
+    default=None,
+    help="SPDX license identifier, or 'other' with --license-url. Required unless the "
+    "source publishes a license URL of its own.",
+)
+@click.option(
+    "--license-url",
+    type=str,
+    default=None,
+    help="URL of the license text. Required when --license is 'other'.",
+)
 @click.pass_context
 def extract_carto_cmd(
     ctx: click.Context,
+    license_id: str | None,
+    license_url: str | None,
     url: str,
     output_dir: Path | None,
     tables: str | None,
@@ -7005,6 +7208,8 @@ def extract_carto_cmd(
         include_cols=include_cols,
         exclude_cols=exclude_cols,
         api_key=api_key,
+        license=license_id,
+        license_url=license_url,
     )
 
     def on_progress(progress: ExtractionProgress) -> None:
@@ -7039,6 +7244,13 @@ def extract_carto_cmd(
             options=options,
             on_progress=None if use_json else on_progress,
         )
+    except MissingLicenseError as e:
+        # Raised before the download starts, so the user re-runs the command rather
+        # than the harvest (issue #686).
+        _output_extract_error(use_json, type(e).__name__, str(e), url, command="extract-carto")
+        if not use_json:
+            info_output(CLI_LICENSE_REMEDIATION)
+        raise SystemExit(1) from None
     except Exception as e:
         _output_extract_error(
             use_json, type(e).__name__, f"Extraction failed: {e}", url, command="extract-carto"

--- a/portolan_cli/constants.py
+++ b/portolan_cli/constants.py
@@ -66,6 +66,12 @@ MTIME_TOLERANCE_SECONDS: float = 2.0
 # The .portolan directory name (Portolan internal metadata directory)
 PORTOLAN_DIR: str = ".portolan"
 
+# Placeholder metadata_seeding writes for a required field the harvest could not
+# fill. It lives here rather than in metadata_seeding because licensing.py has to
+# recognize it too: a seeded license reaches collection.license verbatim, where
+# rashid reports it as PTL-LIC-001 (issue #686).
+TODO_MARKER: str = "TODO: Add value"
+
 # Maximum depth for catalog root discovery (prevent traversing to filesystem root)
 MAX_CATALOG_SEARCH_DEPTH: int = 20
 

--- a/portolan_cli/errors.py
+++ b/portolan_cli/errors.py
@@ -327,6 +327,23 @@ class InvalidProvidersError(ValidationError):
         super().__init__(f"Invalid providers in metadata.yaml: {reason}", reason=reason)
 
 
+class MissingLicenseError(ValidationError):
+    """Raised when Portolan is about to write a collection with no usable license.
+
+    A license is a legal fact Portolan cannot invent, and a collection without
+    one fails PTL-LIC-001 or PTL-LIC-002 the moment ``portolan check`` reads it.
+    Rather than write a catalog it knows to be non-conformant, generation stops
+    and names what the human has to supply (issue #686).
+
+    Error code: PRTLN-VAL004
+    """
+
+    code = "PRTLN-VAL004"
+
+    def __init__(self, target: str, reason: str) -> None:
+        super().__init__(f"No usable license for {target}: {reason}", target=target, reason=reason)
+
+
 # Conversion Errors (PRTLN-CNV*)
 class ConversionError(PortolanError):
     """Base class for conversion-related errors."""

--- a/portolan_cli/external.py
+++ b/portolan_cli/external.py
@@ -33,9 +33,9 @@ from portolan_cli.finalization import _save_collection_with_links
 from portolan_cli.input_hardening import InputValidationError, validate_remote_url
 from portolan_cli.preparation import _validate_collection_id
 from portolan_cli.stac import (
-    DEFAULT_LICENSE,
     add_asset_to_collection,
     add_via_link,
+    apply_human_license,
     create_collection,
 )
 
@@ -171,7 +171,8 @@ def add_external(
     title: str | None = None,
     description: str | None = None,
     media_type: str | None = None,
-    license: str = DEFAULT_LICENSE,
+    license: str,
+    license_url: str | None = None,
     via_url: str | None = None,
     bbox: list[float] | None = None,
     asset_key: str = "data",
@@ -191,8 +192,12 @@ def add_external(
         title: Optional human-readable collection title.
         description: Optional description (defaults to a generated one).
         media_type: Asset media type. Inferred from the URL when omitted.
-        license: SPDX license expression, or "other" for a non-SPDX license
-            (default: "other"). STAC 1.1 no longer accepts "proprietary".
+        license: SPDX license expression, or "other" alongside license_url. Required
+            rather than defaulted: the old "other" default shipped a collection with
+            no rel="license" link, which is a PTL-LIC-002 error (issue #686). STAC
+            1.1 no longer accepts "proprietary".
+        license_url: URL of the license text, emitted as a rel="license" link.
+            Required when license is "other".
         via_url: Provenance URL for the ``rel:"via"`` link. Defaults to ``url``.
         bbox: Optional WGS84 bbox [min_x, min_y, max_x, max_y]. Global if omitted.
         asset_key: Key for the asset entry in collection.json (default "data").
@@ -245,6 +250,10 @@ def add_external(
         license=license,
         bbox=bbox,
     )
+
+    # Emit the rel="license" link, so a license of "other" is conformant rather than
+    # a PTL-LIC-002 error. Reuses the applier the add path uses (issue #686).
+    apply_human_license(collection, {"license": license, "license_url": license_url})
 
     asset = pystac.Asset(
         href=url,

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -845,8 +845,9 @@ def _auto_init_catalog(
     if not cog_files:
         return False  # Nothing to add
 
-    # Initialize the catalog
-    init_catalog(output_dir, title=service_name)
+    # Initialize the catalog. license_id=None because the ImageServer path seeds
+    # metadata.yaml from the harvested service licenseInfo (issue #686).
+    init_catalog(output_dir, title=service_name, license_id=None)
 
     # Add all COG files - this creates items per raster
     add_files(

--- a/portolan_cli/extract/arcgis/imageserver/metadata.py
+++ b/portolan_cli/extract/arcgis/imageserver/metadata.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from portolan_cli.crs import transform_bbox_to_wgs84
+from portolan_cli.licensing import LICENSE_REL, license_url_from_text
 from portolan_cli.models._stac_version import get_stac_version
 
 if TYPE_CHECKING:
@@ -49,8 +50,13 @@ def create_collection_metadata(
         - id: derived from service name (sanitized)
         - extent: spatial from fullExtent (WGS84), temporal open interval
         - summaries: core v1.1.0 bands array
-        - links: source link to ImageServer, self link
-        - license: "other" (STAC 1.1 default for unknown/non-SPDX sources)
+        - links: source link to ImageServer, self link, and a license link when the
+          service's licenseInfo carries a URL
+        - license: "other" (STAC 1.1 value for unknown/non-SPDX sources)
+
+    A service whose licenseInfo holds no URL yields "other" with no license link,
+    which ``portolan check`` reports as PTL-LIC-002 for a human to resolve. Nothing
+    honest can be written from license text that names no license (issue #686).
     """
     collection_id = _sanitize_id(service_metadata.name)
 
@@ -82,6 +88,19 @@ def create_collection_metadata(
             "title": "Source ImageServer",
         },
     ]
+
+    # PTL-LIC-002: "other" needs a rel="license" link, and the service's own
+    # licenseInfo is where the only honest one can come from (issue #686).
+    harvested_license_url = license_url_from_text(service_metadata.license_info)
+    if harvested_license_url:
+        links.append(
+            {
+                "rel": LICENSE_REL,
+                "href": harvested_license_url,
+                "type": "text/html",
+                "title": "License",
+            }
+        )
 
     # Build providers if copyright available
     providers = []

--- a/portolan_cli/extract/arcgis/imageserver/report.py
+++ b/portolan_cli/extract/arcgis/imageserver/report.py
@@ -275,6 +275,7 @@ class ImageServerMetadataExtracted:
         Returns:
             ExtractedMetadata with fields populated from this instance.
         """
+        from portolan_cli.licensing import license_url_from_text
         from portolan_cli.metadata_extraction import ExtractedMetadata
 
         # Build processing_notes with service description and technical specs
@@ -304,6 +305,7 @@ class ImageServerMetadataExtracted:
             processing_notes="\n".join(processing_notes_parts),
             known_issues=self.access_information,
             license_raw=self.license_info,
+            license_url=license_url_from_text(self.license_info),
         )
 
 

--- a/portolan_cli/extract/arcgis/metadata.py
+++ b/portolan_cli/extract/arcgis/metadata.py
@@ -79,6 +79,7 @@ class ArcGISMetadata:
         Returns:
             ExtractedMetadata instance with mapped fields.
         """
+        from portolan_cli.licensing import license_url_from_text
         from portolan_cli.metadata_extraction import ExtractedMetadata
 
         return ExtractedMetadata(
@@ -90,6 +91,7 @@ class ArcGISMetadata:
             contact_name=self.contact_name,
             contact_email=None,  # ArcGIS doesn't provide email
             license_raw=self.license_info_raw,
+            license_url=license_url_from_text(self.license_info_raw),
             processing_notes=self.processing_notes,
             known_issues=self.known_issues,
         )

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -67,11 +67,13 @@ from portolan_cli.extract.common.report import (
 from portolan_cli.extract.common.resume import ResumeState, get_resume_state, should_process_layer
 from portolan_cli.extract.common.retry import RetryConfig, retry_with_backoff
 from portolan_cli.extract.common.styles import extract_esri_style
+from portolan_cli.licensing import license_url_from_text, resolve_harvest_license
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
     from portolan_cli.extract.arcgis.metadata import ArcGISMetadata
+    from portolan_cli.licensing import ResolvedLicense
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +251,10 @@ class ExtractionOptions:
         no_styles: If True, skip style extraction from ESRI drawingInfo
         token: Optional ArcGIS token for authenticated endpoints
         recurse: Whether to recurse into sub-folders during discovery (default True)
+        license: SPDX identifier for the harvested data, or "other" with
+            license_url. Overrides any license URL found in the source's own
+            license text (issue #686).
+        license_url: URL of the license text.
     """
 
     workers: int = 3
@@ -261,6 +267,8 @@ class ExtractionOptions:
     no_styles: bool = False
     token: str | None = None
     recurse: bool = True
+    license: str | None = None
+    license_url: str | None = None
 
 
 def _extract_single_layer(
@@ -571,6 +579,18 @@ def extract_arcgis_catalog(
     if options.dry_run:
         return _build_dry_run_report(url, discovery_result, layers)
 
+    # Resolve the license before downloading anything, so a harvest that cannot be
+    # licensed costs one command re-run rather than a whole download (issue #686).
+    resolved_license = (
+        None
+        if options.raw
+        else resolve_harvest_license(
+            cli_license=options.license,
+            cli_license_url=options.license_url,
+            harvested_license_url=license_url_from_text(discovery_result.license_info),
+        )
+    )
+
     # Create output directory structure
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / ".portolan").mkdir(exist_ok=True)
@@ -590,12 +610,14 @@ def extract_arcgis_catalog(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, resolved_license)
 
     return report
 
 
-def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
+def _auto_init_catalog(
+    output_dir: Path, report: ExtractionReport, resolved_license: ResolvedLicense | None = None
+) -> None:
     """Initialize a Portolan catalog and add extracted files.
 
     Called automatically after extraction unless raw=True.
@@ -619,6 +641,9 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
         # Per Issue #369: overwrite init_catalog defaults with the rich
         # (unfiltered) service metadata now that catalog.json exists.
         update_stac_metadata(out / "catalog.json", title=title, description=description)
+        # Seed metadata.yaml here, between init_catalog and add_files, so the
+        # harvested license is in place before add checks for one (issue #686).
+        _seed_metadata_from_extraction(out, report, resolved_license)
 
     added = init_extracted_catalog(
         output_dir,
@@ -632,9 +657,6 @@ def _auto_init_catalog(output_dir: Path, report: ExtractionReport) -> None:
 
     # Register extracted styles as STAC assets (Issue #490)
     register_collection_styles(output_dir, report)
-
-    # Seed metadata.yaml from extracted service metadata
-    _seed_metadata_from_extraction(output_dir, report)
 
     # Add via links for provenance tracking (Issue #353)
     _add_via_links_to_collections(output_dir, report)
@@ -665,7 +687,11 @@ def _derive_catalog_titles(report: ExtractionReport) -> tuple[str | None, str | 
     return title, description
 
 
-def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
+def _seed_metadata_from_extraction(
+    output_dir: Path,
+    report: ExtractionReport,
+    resolved_license: ResolvedLicense | None = None,
+) -> None:
     """Seed metadata.yaml from extracted service metadata.
 
     Called after catalog initialization to pre-populate metadata.yaml with
@@ -675,6 +701,8 @@ def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -
     Args:
         output_dir: The catalog output directory.
         report: The extraction report containing metadata.
+        resolved_license: License resolved before the download, which wins over
+            anything the harvest found (issue #686).
     """
     if not report.metadata_extracted:
         return
@@ -682,7 +710,7 @@ def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -
     # Reconstruct ArcGISMetadata from the report data, then serialize to the
     # source-agnostic ExtractedMetadata the shared seeder expects.
     arcgis_metadata = _report_metadata_to_arcgis_metadata(report.metadata_extracted)
-    seed_catalog_metadata(output_dir, arcgis_metadata.to_extracted())
+    seed_catalog_metadata(output_dir, arcgis_metadata.to_extracted(), resolved_license)
 
 
 def _report_metadata_to_arcgis_metadata(
@@ -1004,6 +1032,19 @@ def _extract_services_root(
         dry_report.folder_coverage = coverage
         return dry_report
 
+    # Resolve the license before downloading anything (issue #686). A services root
+    # spans many services with potentially different licenses, and the catalog carries
+    # one metadata.yaml, so nothing harvested can stand in for the human here.
+    resolved_license = (
+        None
+        if options.raw
+        else resolve_harvest_license(
+            cli_license=options.license,
+            cli_license_url=options.license_url,
+            harvested_license_url=None,
+        )
+    )
+
     # Create output directory structure
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / ".portolan").mkdir(exist_ok=True)
@@ -1130,7 +1171,7 @@ def _extract_services_root(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, resolved_license)
 
     return report
 

--- a/portolan_cli/extract/carto/orchestrator.py
+++ b/portolan_cli/extract/carto/orchestrator.py
@@ -57,9 +57,12 @@ from portolan_cli.extract.common.report import (
 )
 from portolan_cli.extract.common.resume import ResumeState, get_resume_state, should_process_layer
 from portolan_cli.extract.common.retry import RetryConfig, retry_with_backoff
+from portolan_cli.licensing import resolve_harvest_license
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from portolan_cli.licensing import ResolvedLicense
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +91,10 @@ class ExtractionOptions:
         include_cols: Comma-separated columns to include.
         exclude_cols: Comma-separated columns to exclude.
         api_key: Carto API key (or set via the CARTO_API_KEY env var).
+        license: SPDX identifier for the harvested data, or "other" with
+            license_url. Carto exposes no license metadata, so this is the only
+            source (issue #686).
+        license_url: URL of the license text.
     """
 
     workers: int = 1
@@ -102,6 +109,8 @@ class ExtractionOptions:
     include_cols: str | None = None
     exclude_cols: str | None = None
     api_key: str | None = None
+    license: str | None = None
+    license_url: str | None = None
 
 
 def _slug_for_table(name: str) -> str:
@@ -461,6 +470,18 @@ def extract_carto_catalog(
     if options.dry_run:
         return _build_dry_run_report(sql_api_url, tables, discovery.account_name)
 
+    # Resolve the license before downloading anything (issue #686). Carto publishes
+    # no license metadata at all, so --license is the only source.
+    resolved_license = (
+        None
+        if options.raw
+        else resolve_harvest_license(
+            cli_license=options.license,
+            cli_license_url=options.license_url,
+            harvested_license_url=None,
+        )
+    )
+
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / ".portolan").mkdir(exist_ok=True)
 
@@ -493,7 +514,7 @@ def extract_carto_catalog(
     save_report(report, report_path)
 
     if not options.raw:
-        _auto_init_catalog(output_dir, report, discovery)
+        _auto_init_catalog(output_dir, report, discovery, resolved_license)
 
     return report
 
@@ -502,6 +523,7 @@ def _auto_init_catalog(
     output_dir: Path,
     report: ExtractionReport,
     discovery: CartoDiscoveryResult,
+    resolved_license: ResolvedLicense | None = None,
 ) -> None:
     """Initialize a Portolan catalog and add extracted tables.
 
@@ -520,6 +542,10 @@ def _auto_init_catalog(
         if any(not is_geoparquet(path) for path in parquet_files):
             set_setting(out, "tabular.enabled", True)
 
+        # Seed metadata.yaml here, between init_catalog and add_files, so the
+        # license is in place before add checks for one (issue #686).
+        _seed_metadata_from_extraction(out, report, discovery.account_name, resolved_license)
+
     added = init_extracted_catalog(
         output_dir,
         report,
@@ -531,7 +557,6 @@ def _auto_init_catalog(
         return
 
     _add_via_links_to_collections(output_dir, report)
-    _seed_metadata_from_extraction(output_dir, report, discovery.account_name)
     _seed_collection_metadata_carto(output_dir, report)
 
 
@@ -546,13 +571,16 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
 
 
 def _seed_metadata_from_extraction(
-    output_dir: Path, report: ExtractionReport, account_name: str | None
+    output_dir: Path,
+    report: ExtractionReport,
+    account_name: str | None,
+    resolved_license: ResolvedLicense | None = None,
 ) -> None:
     """Seed catalog-level metadata.yaml from Carto account metadata."""
     from portolan_cli.extract.carto.metadata import extract_carto_metadata
 
     extracted = extract_carto_metadata(report.source_url, account_name).to_extracted()
-    seed_catalog_metadata(output_dir, extracted)
+    seed_catalog_metadata(output_dir, extracted, resolved_license)
 
 
 def _seed_collection_metadata_carto(output_dir: Path, report: ExtractionReport) -> None:

--- a/portolan_cli/extract/common/metadata_seeding.py
+++ b/portolan_cli/extract/common/metadata_seeding.py
@@ -104,7 +104,9 @@ def seed_collection_metadata(
     )
 
     metadata_path = collection_dir / ".portolan" / "metadata.yaml"
-    seeded = seed_metadata_yaml(extracted, metadata_path)
+    # No placeholder: this is a child file and the merge lets the child win, so a
+    # TODO here would override the catalog's real license (issue #686).
+    seeded = seed_metadata_yaml(extracted, metadata_path, license_placeholder=False)
 
     # Per Issue #369: Also update collection.json with title/description
     # This ensures STAC has meaningful metadata, not generic placeholders

--- a/portolan_cli/extract/common/orchestrator_base.py
+++ b/portolan_cli/extract/common/orchestrator_base.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from portolan_cli.extract.common.report import ExtractionReport, LayerResult
+    from portolan_cli.licensing import ResolvedLicense
     from portolan_cli.metadata_extraction import ExtractedMetadata
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,10 @@ def init_extracted_catalog(
     if not parquet_files:
         return None
 
-    init_catalog(output_dir, title=title, description=description)
+    # license_id=None: extract owns metadata.yaml, seeding it from harvested service
+    # metadata in post_init below. Writing a template here first would make that
+    # seeder's O_EXCL create a no-op and drop everything harvested (issue #686).
+    init_catalog(output_dir, title=title, description=description, license_id=None)
 
     if post_init is not None:
         post_init(output_dir, parquet_files)
@@ -187,6 +191,7 @@ def add_source_links(
 def seed_catalog_metadata(
     output_dir: Path,
     extracted: ExtractedMetadata | None,
+    license_override: ResolvedLicense | None = None,
 ) -> None:
     """Seed the catalog-level ``metadata.yaml`` from harvested service metadata.
 
@@ -197,6 +202,8 @@ def seed_catalog_metadata(
     Args:
         output_dir: The catalog output directory.
         extracted: Source-agnostic metadata to seed, or ``None`` to skip.
+        license_override: License resolved from the command line, which wins over
+            anything harvested (issue #686).
     """
     from portolan_cli.metadata_seeding import seed_metadata_yaml
     from portolan_cli.output import info
@@ -205,5 +212,5 @@ def seed_catalog_metadata(
         return
 
     metadata_path = output_dir / ".portolan" / "metadata.yaml"
-    if seed_metadata_yaml(extracted, metadata_path):
+    if seed_metadata_yaml(extracted, metadata_path, license_override=license_override):
         info(f"Seeded metadata.yaml from {extracted.source_type}")

--- a/portolan_cli/extract/csw/models.py
+++ b/portolan_cli/extract/csw/models.py
@@ -130,6 +130,7 @@ class ISOMetadata:
         Returns:
             ExtractedMetadata compatible with seed_metadata_yaml.
         """
+        from portolan_cli.licensing import license_url_from_text
         from portolan_cli.metadata_extraction import ExtractedMetadata
 
         # Build license info string
@@ -162,4 +163,5 @@ class ISOMetadata:
             processing_notes=processing_notes,
             known_issues=None,
             license_raw=license_raw,
+            license_url=license_url_from_text(license_raw),
         )

--- a/portolan_cli/extract/wfs/metadata.py
+++ b/portolan_cli/extract/wfs/metadata.py
@@ -115,6 +115,7 @@ class WFSMetadata:
         Returns:
             ExtractedMetadata for use with metadata seeding.
         """
+        from portolan_cli.licensing import license_url_from_text
         from portolan_cli.metadata_extraction import ExtractedMetadata
 
         # Use abstract unless it's boilerplate, then fall back to title
@@ -136,6 +137,7 @@ class WFSMetadata:
             processing_notes=None,
             known_issues=None,
             license_raw=self.license_info_raw,
+            license_url=license_url_from_text(self.license_info_raw),
         )
 
 

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -52,12 +52,14 @@ from portolan_cli.extract.common.resume import ResumeState, get_resume_state, sh
 from portolan_cli.extract.common.retry import RetryConfig, retry_with_backoff
 from portolan_cli.extract.common.styles import extract_wms_legend, extract_wms_style
 from portolan_cli.extract.wfs.discovery import LayerInfo, WFSDiscoveryResult, discover_layers
+from portolan_cli.licensing import license_url_from_text, resolve_harvest_license
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from portolan_cli.extract.csw.models import ISOMetadata
     from portolan_cli.extract.wfs.metadata import WFSMetadata
+    from portolan_cli.licensing import ResolvedLicense
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +92,10 @@ class ExtractionOptions:
         auto_tile: When True (default), gpio subdivides the bbox and retries when
             a server caps maxFeatures below the requested page, so capped layers
             extract completely instead of silently truncating (gpio 1.3+).
+        license: SPDX identifier for the harvested data, or "other" with
+            license_url. Overrides any license URL found in the service's own
+            license text (issue #686).
+        license_url: URL of the license text.
     """
 
     workers: int = 1
@@ -105,6 +111,8 @@ class ExtractionOptions:
     limit: int | None = None
     page_size: int = 100000
     auto_tile: bool = True
+    license: str | None = None
+    license_url: str | None = None
 
 
 def _slugify(name: str, disambiguate: bool = False, unique_id: int | None = None) -> str:
@@ -678,6 +686,25 @@ def extract_wfs_catalog(
     if options.dry_run:
         return _build_dry_run_report(url, layers, discovery_result)
 
+    # Resolve the license before downloading anything, so a harvest that cannot be
+    # licensed costs one command re-run rather than a whole download (issue #686).
+    # GetCapabilities carries the licence in Fees and AccessConstraints.
+    resolved_license = (
+        None
+        if options.raw
+        else resolve_harvest_license(
+            cli_license=options.license,
+            cli_license_url=options.license_url,
+            harvested_license_url=license_url_from_text(
+                "; ".join(
+                    part
+                    for part in (discovery_result.fees, discovery_result.access_constraints)
+                    if part
+                )
+            ),
+        )
+    )
+
     # Create output directory structure
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / ".portolan").mkdir(exist_ok=True)
@@ -760,7 +787,7 @@ def extract_wfs_catalog(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report, discovery_result)
+        _auto_init_catalog(output_dir, report, discovery_result, resolved_license)
 
     return report
 
@@ -769,6 +796,7 @@ def _auto_init_catalog(
     output_dir: Path,
     report: ExtractionReport,
     discovery_result: WFSDiscoveryResult | None = None,
+    resolved_license: ResolvedLicense | None = None,
 ) -> None:
     """Initialize a Portolan catalog and add extracted files.
 
@@ -791,6 +819,9 @@ def _auto_init_catalog(
         update_stac_metadata(
             out / "catalog.json", title=filtered_title, description=filtered_description
         )
+        # Seed metadata.yaml here, between init_catalog and add_files, so the
+        # harvested license is in place before add checks for one (issue #686).
+        _seed_metadata_from_extraction(out, report, resolved_license)
 
     added = init_extracted_catalog(
         output_dir,
@@ -807,9 +838,6 @@ def _auto_init_catalog(
 
     # Add via links for provenance tracking
     _add_via_links_to_collections(output_dir, report)
-
-    # Seed catalog-level metadata.yaml from extracted service metadata
-    _seed_metadata_from_extraction(output_dir, report)
 
     # Seed collection-level metadata.yaml with layer-specific info
     # and update collection.json with rich metadata (Issue #369)
@@ -860,7 +888,11 @@ def _add_via_links_to_collections(output_dir: Path, report: ExtractionReport) ->
     )
 
 
-def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -> None:
+def _seed_metadata_from_extraction(
+    output_dir: Path,
+    report: ExtractionReport,
+    resolved_license: ResolvedLicense | None = None,
+) -> None:
     """Seed catalog-level metadata.yaml from extracted WFS service metadata.
 
     Called after catalog initialization to pre-populate metadata.yaml with
@@ -870,12 +902,14 @@ def _seed_metadata_from_extraction(output_dir: Path, report: ExtractionReport) -
     Args:
         output_dir: The catalog output directory.
         report: The extraction report containing metadata.
+        resolved_license: License resolved before the download, which wins over
+            anything the harvest found (issue #686).
     """
     if not report.metadata_extracted:
         return
 
     wfs_metadata = _report_metadata_to_wfs_metadata(report.metadata_extracted)
-    seed_catalog_metadata(output_dir, wfs_metadata.to_extracted())
+    seed_catalog_metadata(output_dir, wfs_metadata.to_extracted(), resolved_license)
 
 
 def _report_metadata_to_wfs_metadata(
@@ -1046,7 +1080,10 @@ def _seed_collection_from_iso(
     )
 
     metadata_path = collection_dir / ".portolan" / "metadata.yaml"
-    seeded = seed_metadata_yaml(extracted, metadata_path)
+    # No placeholder: a child file inherits the catalog's license. An ISO record that
+    # names its own licence URL still writes it, since the layer's licence is the
+    # more specific fact (issue #686).
+    seeded = seed_metadata_yaml(extracted, metadata_path, license_placeholder=False)
 
     # Per Issue #369: Also update collection.json with title/description
     # ISO metadata has rich title and abstract that should appear in STAC

--- a/portolan_cli/licensing.py
+++ b/portolan_cli/licensing.py
@@ -1,0 +1,201 @@
+"""The license a collection must carry before Portolan will write it (issue #686).
+
+A license is a legal fact about someone else's data, so Portolan cannot invent
+one. What it can do is refuse to write a collection it already knows the
+validator will reject. Two of rashid's three license rules describe failures
+generation causes on its own:
+
+- PTL-LIC-001 fires when a collection declares no license, which is what happens
+  when metadata.yaml omits the field and the collection keeps ``DEFAULT_LICENSE``;
+- PTL-LIC-002 fires when the license is ``other`` and no ``rel="license"`` link
+  points at the license text, which is what happens when metadata.yaml writes
+  ``license: other`` and no ``license_url``.
+
+``license_gap`` answers whether either is about to happen, branch for branch
+against ``rashid.rules.license``, so generation and validation never disagree.
+It also catches the seeded TODO placeholder, which reaches ``collection.license``
+verbatim, and the deprecated ``proprietary`` value (PTL-LIC-003).
+
+Spelling is not judged here. rashid keeps its 727-identifier SPDX list in the
+private ``rashid._spdx``, which this package may not import, so an identifier
+this module waves through can still be misspelled. ``portolan check`` owns that
+verdict, and duplicating a list that long would only let the two copies drift.
+
+``license_url_from_text`` reads a license link back out of raw upstream license
+text. ArcGIS ``licenseInfo`` and ISO access constraints usually carry one, and a
+URL the source published is a real license link rather than a guess.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from portolan_cli.constants import TODO_MARKER
+from portolan_cli.errors import MissingLicenseError
+
+#: The link relation that satisfies PTL-LIC-002.
+LICENSE_REL = "license"
+
+#: STAC's escape hatch for a license with no SPDX identifier. Conformant only
+#: alongside a ``rel="license"`` link.
+OTHER_LICENSE = "other"
+
+#: Deprecated by the spec and rejected outright by PTL-LIC-003.
+PROPRIETARY_LICENSE = "proprietary"
+
+#: What to tell a human whose metadata.yaml carries no usable license. Names both
+#: conformant shapes, so fixing the error does not require reading the spec.
+METADATA_LICENSE_REMEDIATION = (
+    "Set 'license:' in .portolan/metadata.yaml to an SPDX identifier such as "
+    "CC-BY-4.0, or to 'other' with a 'license_url:' pointing at the license text."
+)
+
+#: The same advice for a command that takes the license as a flag.
+CLI_LICENSE_REMEDIATION = (
+    "Pass --license with an SPDX identifier such as CC-BY-4.0, or --license other "
+    "together with --license-url pointing at the license text."
+)
+
+_URL_PATTERN = re.compile(r"https?://[^\s<>\"'`)\]}]+")
+
+#: Trailing characters a URL picks up from prose or markup but does not own.
+_URL_TRAILING = ".,;:!?"
+
+
+@dataclass(frozen=True)
+class ResolvedLicense:
+    """A license as metadata.yaml declares it, before anyone judges it."""
+
+    license_id: str
+    license_url: str | None
+
+
+def _text(value: object) -> str | None:
+    """Return a stripped non-empty string, or None for anything else."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def resolve_license(metadata: object) -> ResolvedLicense | None:
+    """Read the license a human wrote in merged metadata.yaml.
+
+    Reading and judging stay separate: a TODO placeholder or ``proprietary``
+    resolves fine here and fails ``license_gap``. That split lets a caller tell
+    "the human wrote nothing, fall back to the existing collection" apart from
+    "the human wrote something unusable, stop".
+
+    Args:
+        metadata: Merged metadata.yaml mapping (other types yield None).
+
+    Returns:
+        The declared license, or None when the metadata declares no license.
+    """
+    if not isinstance(metadata, Mapping):
+        return None
+
+    license_id = _text(metadata.get("license"))
+    if license_id is None:
+        return None
+
+    return ResolvedLicense(license_id=license_id, license_url=_text(metadata.get("license_url")))
+
+
+def license_gap(license_id: str | None, *, has_license_link: bool) -> str | None:
+    """Return why this license fails the validator, or None when it passes.
+
+    Mirrors ``rashid.rules.license`` branch for branch, so a collection this
+    function waves through is a collection ``portolan check`` accepts on the
+    license rules. Identifier spelling is out of scope, per the module docstring.
+
+    Args:
+        license_id: The value headed for ``collection.license``.
+        has_license_link: Whether the collection will carry a ``rel="license"``
+            link, from either ``license_url`` or a link already on disk.
+
+    Returns:
+        A reason phrased to complete "no usable license: ...", or None.
+    """
+    declared = _text(license_id)
+    if declared is None:
+        return "no license is declared"
+
+    if declared.upper().startswith("TODO"):
+        return f"license is still the seeded {TODO_MARKER!r} placeholder"
+
+    if declared == PROPRIETARY_LICENSE:
+        return "'proprietary' is deprecated and must not be used"
+
+    if declared == OTHER_LICENSE and not has_license_link:
+        return "license 'other' needs a license_url pointing at the license text"
+
+    return None
+
+
+def resolve_harvest_license(
+    *,
+    cli_license: str | None,
+    cli_license_url: str | None,
+    harvested_license_url: str | None,
+) -> ResolvedLicense:
+    """Decide the license an extraction will seed, before it downloads anything.
+
+    What the human passed wins, because they can name an SPDX identifier and the
+    harvest never can. Failing that, a licence URL the source published supports
+    ``other`` plus a link, which is conformant and states only what the source
+    states. With neither, there is nothing honest to seed, and stopping here costs
+    the user a re-run of the command rather than a re-run of the download.
+
+    Args:
+        cli_license: Value of --license, or None.
+        cli_license_url: Value of --license-url, or None.
+        harvested_license_url: URL found in the source's own license text, or None.
+
+    Returns:
+        The license to seed into metadata.yaml.
+
+    Raises:
+        MissingLicenseError: When neither source yields a conformant license.
+    """
+    declared = (cli_license or "").strip()
+    if declared:
+        resolved = ResolvedLicense(declared, (cli_license_url or "").strip() or None)
+    elif harvested_license_url:
+        resolved = ResolvedLicense(OTHER_LICENSE, harvested_license_url)
+    else:
+        raise MissingLicenseError(
+            "this extraction",
+            "the source publishes no license URL to link to",
+        )
+
+    gap = license_gap(resolved.license_id, has_license_link=resolved.license_url is not None)
+    if gap is not None:
+        raise MissingLicenseError("this extraction", gap)
+
+    return resolved
+
+
+def license_url_from_text(text: str | None) -> str | None:
+    """Pull the license link out of raw upstream license text.
+
+    Sources describe their licence in prose or in an HTML fragment, and the URL
+    inside it is the license text the spec asks a ``rel="license"`` link to point
+    at. Text with no URL yields None, which leaves the human to supply one rather
+    than inventing a link to a page that says nothing about licensing.
+
+    Args:
+        text: Raw license text as harvested, such as ArcGIS ``licenseInfo``.
+
+    Returns:
+        The first URL in the text, or None when it holds none.
+    """
+    if not text:
+        return None
+
+    match = _URL_PATTERN.search(text)
+    if match is None:
+        return None
+
+    return match.group().rstrip(_URL_TRAILING) or None

--- a/portolan_cli/metadata_extraction.py
+++ b/portolan_cli/metadata_extraction.py
@@ -48,6 +48,7 @@ class ExtractedMetadata:
         contact_name: Name of the data maintainer/author.
         contact_email: Email of the data maintainer (rarely available).
         license_raw: Raw license text (not SPDX identifier).
+        license_url: URL of the license text, read out of license_raw.
         processing_notes: Notes about data processing or updates.
         known_issues: Known limitations or caveats.
     """
@@ -74,6 +75,10 @@ class ExtractedMetadata:
     """Email of the data maintainer (rarely available from extraction)."""
 
     license_raw: str | None = None
+    # Sources publish a licence page but never an SPDX id. When license_raw holds a
+    # URL, seeding uses `other` plus this link, which is conformant without anyone
+    # guessing at an identifier (issue #686).
+    license_url: str | None = None
     """Raw license text (not SPDX identifier, for human review)."""
 
     processing_notes: str | None = None

--- a/portolan_cli/metadata_seeding.py
+++ b/portolan_cli/metadata_seeding.py
@@ -33,13 +33,13 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from portolan_cli.constants import TODO_MARKER
+from portolan_cli.licensing import OTHER_LICENSE, ResolvedLicense
+
 if TYPE_CHECKING:
     from portolan_cli.metadata_extraction import ExtractedMetadata
 
 logger = logging.getLogger(__name__)
-
-# TODO marker for fields that need human input
-TODO_MARKER = "TODO: Add value"
 
 
 def seed_metadata_yaml(
@@ -47,6 +47,8 @@ def seed_metadata_yaml(
     metadata_path: Path,
     *,
     overwrite: bool = False,
+    license_placeholder: bool = True,
+    license_override: ResolvedLicense | None = None,
 ) -> bool:
     """Seed a metadata.yaml file from extracted metadata.
 
@@ -60,6 +62,14 @@ def seed_metadata_yaml(
         extracted: Extracted metadata from a data source.
         metadata_path: Path to write metadata.yaml (usually .portolan/metadata.yaml).
         overwrite: If False (default), skip if file already exists.
+        license_placeholder: Whether a TODO placeholder may stand in for a license
+            the harvest did not find. False for a collection-level file, which
+            inherits the catalog's license through the hierarchical merge: the child
+            wins, so a placeholder there would override the real license the catalog
+            carries (issue #686). A license the harvest did find is written either
+            way, since a layer's own license beats an inherited one.
+        license_override: License to write instead of anything harvested, from a
+            command-line flag. An identifier a human named beats a guess.
 
     Returns:
         True if file was written, False if skipped (file exists and overwrite=False).
@@ -84,7 +94,11 @@ def seed_metadata_yaml(
             os.close(fd)
 
     # Build metadata structure
-    metadata = _build_metadata_dict(extracted)
+    metadata = _build_metadata_dict(
+        extracted,
+        license_placeholder=license_placeholder,
+        license_override=license_override,
+    )
 
     # Write with header comment using atomic write (temp + rename)
     content = _format_metadata_yaml(metadata, extracted.source_type)
@@ -111,7 +125,12 @@ def seed_metadata_yaml(
     return True
 
 
-def _build_metadata_dict(extracted: ExtractedMetadata) -> dict[str, Any]:
+def _build_metadata_dict(
+    extracted: ExtractedMetadata,
+    *,
+    license_placeholder: bool = True,
+    license_override: ResolvedLicense | None = None,
+) -> dict[str, Any]:
     """Build metadata.yaml dictionary from extracted metadata.
 
     Maps extracted fields to metadata.yaml structure, adding TODO markers
@@ -119,6 +138,9 @@ def _build_metadata_dict(extracted: ExtractedMetadata) -> dict[str, Any]:
 
     Args:
         extracted: Extracted metadata from a data source.
+        license_placeholder: Whether a TODO placeholder may stand in for a license
+            the harvest did not find. See ``seed_metadata_yaml``.
+        license_override: License to write instead of anything harvested.
 
     Returns:
         Dictionary ready for YAML serialization.
@@ -133,8 +155,22 @@ def _build_metadata_dict(extracted: ExtractedMetadata) -> dict[str, Any]:
     metadata: dict[str, Any] = {
         # Required fields
         "contact": contact,
-        "license": TODO_MARKER,  # Raw license isn't SPDX, always needs human review
     }
+
+    # A harvested licence is never an SPDX identifier, but when the source published
+    # a licence URL, "other" plus a rel="license" link to it is the second shape the
+    # spec accepts, and it states only what the source itself states. Without a URL
+    # there is nothing honest to write, so the marker stands and 'add' will ask
+    # (issue #686).
+    if license_override is not None:
+        metadata["license"] = license_override.license_id
+        if license_override.license_url:
+            metadata["license_url"] = license_override.license_url
+    elif extracted.license_url:
+        metadata["license"] = OTHER_LICENSE
+        metadata["license_url"] = extracted.license_url
+    elif license_placeholder:
+        metadata["license"] = TODO_MARKER
 
     # Optional fields - only include if we have data
     if extracted.source_url:

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -6,7 +6,13 @@ STAC or other sources.
 
 **Required fields (human-only):**
 - contact.name, contact.email - Accountability
-- license - SPDX identifier
+- license - SPDX identifier, or "other" alongside license_url
+
+``license`` is the one required field generation actually enforces: ``portolan add``
+refuses to write a collection without a usable one, because a collection with no
+license fails PTL-LIC-001 or PTL-LIC-002 under ``portolan check`` (issue #686). The
+predicate lives in ``portolan_cli.licensing``; ``portolan init`` seeds the value so
+the requirement is already met before the first add.
 
 **Auto-filled from STAC (NOT in metadata.yaml):**
 - title, description - From catalog/collection init
@@ -676,7 +682,7 @@ def _validate_defaults(defaults: dict[str, Any]) -> list[str]:
     return errors
 
 
-def generate_metadata_template() -> str:
+def generate_metadata_template(*, license_id: str = "", license_url: str = "") -> str:
     """Generate a metadata.yaml template with comments.
 
     Returns a YAML string with required and optional fields,
@@ -685,10 +691,35 @@ def generate_metadata_template() -> str:
     Note: title and description are auto-derived from the collection id
     (humanized, per Issue #502); the optional keys below override them.
 
+    ``portolan init`` fills the license in, because ``portolan add`` refuses to
+    write a collection without one (issue #686). ``portolan metadata init`` leaves
+    both blank, since a bare template is what that command is for.
+
+    Args:
+        license_id: SPDX identifier, or "other", to write into the template.
+        license_url: URL of the license text, required alongside "other".
+
     Returns:
         YAML template string ready to write to file.
     """
-    return """# .portolan/metadata.yaml
+    # Comments line up at column 37 in this template; keep both license lines there.
+    comment_column = 36
+    license_line = f'license: "{license_id}"'.ljust(comment_column) + (
+        '# SPDX identifier (e.g., "CC-BY-4.0", "MIT")'
+    )
+    license_url_line = f'license_url: "{license_url}"'.ljust(comment_column) + (
+        "# optional - URL to full license text"
+    )
+
+    # Substituted rather than interpolated: an f-string over the whole template
+    # reads to bandit as string-built SQL (B608), and a nosec here would blunt a
+    # check that catches the real thing elsewhere in the tree.
+    return _TEMPLATE.replace("__LICENSE_LINE__", license_line).replace(
+        "__LICENSE_URL_LINE__", license_url_line
+    )
+
+
+_TEMPLATE = """# .portolan/metadata.yaml
 #
 # Human-enrichable metadata that supplements STAC.
 # Columns and bands are auto-extracted from data files.
@@ -713,7 +744,7 @@ contact:
   name: ""                          # Person or team name
   email: ""                         # Contact email
 
-license: ""                         # SPDX identifier (e.g., "CC-BY-4.0", "MIT")
+__LICENSE_LINE__
 
 # -----------------------------------------------------------------------------
 # Providers: who made this data, and who maintains this copy of it
@@ -745,7 +776,7 @@ license: ""                         # SPDX identifier (e.g., "CC-BY-4.0", "MIT")
 # OPTIONAL: Discovery and citation
 # -----------------------------------------------------------------------------
 
-license_url: ""                     # optional - URL to full license text
+__LICENSE_URL_LINE__
 citation: ""                        # optional - Academic citation text
 doi: ""                             # optional - Zenodo/DataCite DOI
 keywords: []                        # optional - Discovery tags

--- a/portolan_cli/sync/core.py
+++ b/portolan_cli/sync/core.py
@@ -496,7 +496,9 @@ def _step_init(
     if state == CatalogState.FRESH:
         info("Initializing catalog...")
         try:
-            init_catalog(catalog_root)
+            # No license here: sync wraps a directory whose collections already
+            # exist, and it never writes a collection.json of its own (issue #686).
+            init_catalog(catalog_root, license_id=None)
             success("Initialized catalog")
             return True, None
         except Exception as e:
@@ -869,6 +871,9 @@ def clone(
             local_path,
             title=f"Clone of {remote_url}",
             description=f"Cloned from {remote_url}",
+            # No license here: each cloned collection.json arrives carrying the
+            # license the publisher set, and a local default would misstate it.
+            license_id=None,
         )
     except Exception as e:
         error_msg = f"Failed to initialize catalog: {e}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -549,7 +549,17 @@ def _init_catalog(
     root.mkdir(parents=True, exist_ok=True)
     result = CliRunner().invoke(
         cli,
-        ["init", str(root), "--auto", "--title", title, "--description", description],
+        [
+            "init",
+            str(root),
+            "--auto",
+            "--title",
+            title,
+            "--description",
+            description,
+            "--license",
+            "CC-BY-4.0",
+        ],
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -340,6 +340,7 @@ def catalog_with_versions_for_dry_run(tmp_path: Path) -> Path:
     portolan_dir = catalog_dir / ".portolan"
     portolan_dir.mkdir()
     (portolan_dir / "config.yaml").write_text("{}\n")
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     # Versions.json at <catalog_root>/<collection>/versions.json
     collection_dir = catalog_dir / "test-collection"
@@ -396,6 +397,7 @@ def fresh_catalog_no_versions(tmp_path: Path) -> Path:
     portolan_dir = catalog_dir / ".portolan"
     portolan_dir.mkdir()
     (portolan_dir / "config.yaml").write_text("{}\n")
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     # Collection directory exists but NO versions.json
     collection_dir = catalog_dir / "test-collection"
@@ -426,6 +428,7 @@ def catalog_with_multiple_versions(tmp_path: Path) -> Path:
     portolan_dir = catalog_dir / ".portolan"
     portolan_dir.mkdir()
     (portolan_dir / "config.yaml").write_text("catalog_id: test-catalog\n")
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     # catalog.json
     catalog_data = {

--- a/tests/docs/conftest.py
+++ b/tests/docs/conftest.py
@@ -69,7 +69,7 @@ def empty_catalog(tmp_path: Path, runner: CliRunner) -> Iterator[Path]:
     Yields a temporary directory with `portolan init --auto` already run.
     Useful for testing workflows that start from a clean catalog.
     """
-    result = runner.invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = runner.invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     yield tmp_path
 

--- a/tests/docs/test_readme_examples.py
+++ b/tests/docs/test_readme_examples.py
@@ -42,7 +42,7 @@ class TestReadmeQuickStart:
     @pytest.mark.integration
     def test_init_creates_catalog(self, runner: CliRunner, tmp_path: Path) -> None:
         """'portolan init' creates a catalog structure."""
-        result = runner.invoke(cli, ["init", str(tmp_path), "--auto"])
+        result = runner.invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
         assert result.exit_code == 0, f"Init failed: {result.output}"
         # Verify catalog.json created
         assert (tmp_path / "catalog.json").exists()
@@ -83,7 +83,7 @@ class TestReadmeQuickStart:
         README quick start shows (minus the push which requires S3).
         """
         # Step 1: Initialize catalog
-        result = runner.invoke(cli, ["init", str(tmp_path), "--auto"])
+        result = runner.invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
         assert result.exit_code == 0, f"init failed: {result.output}"
 
         # Set up: Create demographics directory with data
@@ -260,7 +260,9 @@ class TestReadmeWorkflowEdgeCases:
         self, runner: CliRunner, catalog_with_minimal_data: Path
     ) -> None:
         """Re-running 'portolan init' on existing catalog fails gracefully."""
-        result = runner.invoke(cli, ["init", str(catalog_with_minimal_data), "--auto"])
+        result = runner.invoke(
+            cli, ["init", str(catalog_with_minimal_data), "--auto", "--license", "CC-BY-4.0"]
+        )
         # Should fail or warn - catalog already exists
         # Exit code 1 indicates the expected failure
         assert result.exit_code != 0 or "already" in result.output.lower()

--- a/tests/iceberg/integration/conftest.py
+++ b/tests/iceberg/integration/conftest.py
@@ -90,7 +90,7 @@ def initialized_iceberg_catalog(tmp_path: Path, runner: CliRunner) -> Path:
     with patch("portolan_cli.backends.iceberg.config._get_external_config", return_value=None):
         result = runner.invoke(
             cli,
-            ["init", str(tmp_path), "--auto", "--backend", "iceberg"],
+            ["init", str(tmp_path), "--auto", "--backend", "iceberg", "--license", "CC-BY-4.0"],
             catch_exceptions=False,
         )
     assert result.exit_code == 0, f"Init failed: {result.output}"

--- a/tests/iceberg/integration/test_error_handling.py
+++ b/tests/iceberg/integration/test_error_handling.py
@@ -55,7 +55,7 @@ def test_version_commands_without_iceberg_backend_error(tmp_path, runner):
     # Init with default file backend (not iceberg)
     result = runner.invoke(
         cli,
-        ["init", str(tmp_path), "--auto"],
+        ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"],
         catch_exceptions=False,
     )
     assert result.exit_code == 0

--- a/tests/integration/extract/arcgis/test_orchestrator_live.py
+++ b/tests/integration/extract/arcgis/test_orchestrator_live.py
@@ -65,6 +65,7 @@ class TestLiveExtraction:
             workers=2,  # Lower workers for faster test
             retries=2,
             sort_hilbert=True,
+            license="CC-BY-4.0",
         )
 
         result = extract_arcgis_catalog(

--- a/tests/integration/extract/carto/test_carto_extract.py
+++ b/tests/integration/extract/carto/test_carto_extract.py
@@ -21,11 +21,17 @@ from portolan_cli.extract.common.report import (
     LayerResult,
     MetadataExtracted,
 )
+from portolan_cli.licensing import ResolvedLicense
 
 pytestmark = [pytest.mark.integration]
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent.parent / "fixtures"
 SQL_API_URL = "https://phl.carto.com/api/v2/sql"
+
+
+# Calling _auto_init_catalog directly skips the resolution the orchestrator does
+# before its download, so the license is passed in here (issue #686).
+TEST_LICENSE = ResolvedLicense(license_id="CC-BY-4.0", license_url=None)
 
 
 def _report(output_path: str, name: str) -> ExtractionReport:
@@ -84,7 +90,7 @@ def test_auto_init_builds_catalog_with_via_link_and_metadata(tmp_path: Path) -> 
     shutil.copy(FIXTURES_DIR / "simple.parquet", collection_dir / "vacant_land.parquet")
 
     report = _report("vacant_land/vacant_land.parquet", "vacant_land")
-    _auto_init_catalog(tmp_path, report, _discovery())
+    _auto_init_catalog(tmp_path, report, _discovery(), TEST_LICENSE)
 
     # Catalog + collection STAC created
     assert (tmp_path / "catalog.json").exists()
@@ -125,7 +131,7 @@ def test_auto_init_tracks_non_geo_table_as_tabular_collection(tmp_path: Path) ->
         tables=[CartoTableInfo("lookup", id=0, has_geometry=False)],
         account_name="phl",
     )
-    _auto_init_catalog(tmp_path, report, discovery)
+    _auto_init_catalog(tmp_path, report, discovery, TEST_LICENSE)
 
     # Tabular support auto-enabled because a non-geo output was present.
     assert get_setting("tabular.enabled", catalog_path=tmp_path) is True
@@ -147,5 +153,5 @@ def test_auto_init_skipped_when_no_successful_tables(tmp_path: Path) -> None:
     report.layers[0].status = "failed"
     report.layers[0].output_path = None
 
-    _auto_init_catalog(tmp_path, report, _discovery())
+    _auto_init_catalog(tmp_path, report, _discovery(), TEST_LICENSE)
     assert not (tmp_path / "catalog.json").exists()

--- a/tests/integration/extract/test_extract_auto_init.py
+++ b/tests/integration/extract/test_extract_auto_init.py
@@ -20,6 +20,7 @@ from portolan_cli.extract.arcgis.report import (
     LayerResult,
     MetadataExtracted,
 )
+from portolan_cli.licensing import ResolvedLicense
 
 pytestmark = [pytest.mark.integration]
 
@@ -94,6 +95,11 @@ def make_report(
     )
 
 
+# Calling _auto_init_catalog directly skips the resolution the orchestrator does
+# before its download, so the license is passed in here (issue #686).
+TEST_LICENSE = ResolvedLicense(license_id="CC-BY-4.0", license_url=None)
+
+
 class TestAutoInitCatalog:
     """Tests for automatic catalog initialization after extraction."""
 
@@ -119,7 +125,7 @@ class TestAutoInitCatalog:
             ],
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Should have catalog.json at root
         assert (output_dir / "catalog.json").exists(), "catalog.json should be created"
@@ -145,7 +151,7 @@ class TestAutoInitCatalog:
             ],
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Should have .portolan/config.yaml
         assert (output_dir / ".portolan" / "config.yaml").exists(), "config.yaml should exist"
@@ -178,7 +184,7 @@ class TestAutoInitCatalog:
 
         report = make_report(layers=layers)
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Each layer should have a collection.json
         assert (output_dir / "layer_0" / "collection.json").exists()
@@ -199,7 +205,7 @@ class TestAutoInitCatalog:
             ],
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Should NOT create catalog (no successful extractions)
         assert not (output_dir / "catalog.json").exists()
@@ -229,7 +235,7 @@ class TestAutoInitCatalog:
             source_url="https://services.arcgis.com/abc/arcgis/rest/services/DenHaagHousing/FeatureServer",
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Check catalog title
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
@@ -287,7 +293,7 @@ class TestExtractWithRawFlag:
         assert (output_dir / ".portolan" / "extraction-report.json").exists()
 
     def test_default_extraction_creates_catalog(self, tmp_path: Path) -> None:
-        """ExtractionOptions(raw=False, the default) creates catalog."""
+        """ExtractionOptions(raw=False, the default, license="CC-BY-4.0") creates catalog."""
         from unittest.mock import patch
 
         from portolan_cli.extract.arcgis.discovery import LayerInfo, ServiceDiscoveryResult
@@ -321,7 +327,7 @@ class TestExtractWithRawFlag:
                 extract_arcgis_catalog(
                     url="https://example.com/arcgis/rest/services/Test/FeatureServer",
                     output_dir=output_dir,
-                    options=ExtractionOptions(dry_run=False, raw=False),
+                    options=ExtractionOptions(dry_run=False, raw=False, license="CC-BY-4.0"),
                 )
 
         # Should have catalog.json (default behavior)
@@ -373,7 +379,7 @@ class TestMetadataPropagation:
             license_info_raw=None,
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Check catalog.json has the description
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
@@ -414,7 +420,7 @@ class TestMetadataPropagation:
                 "name": "Buildings",
                 "description": "Building footprints with construction year and height attributes",
             }
-            _auto_init_catalog(output_dir, report)
+            _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         # Check collection.json has the layer description
         collection_json = json.loads((layer_dir / "collection.json").read_text())
@@ -446,7 +452,7 @@ class TestMetadataPropagation:
             source_url="https://example.com/arcgis/rest/services/bu_building_emprise_v2/FeatureServer",
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
         # Catalog should be created
@@ -494,7 +500,7 @@ class TestMetadataPropagation:
                 "name": "Land Parcels",
                 "description": "Municipal land parcel boundaries",
             }
-            _auto_init_catalog(output_dir, report)
+            _auto_init_catalog(output_dir, report, TEST_LICENSE)
 
         collection_json = json.loads((layer_dir / "collection.json").read_text())
         # Title should be present (either from layer name or as set)

--- a/tests/integration/extract/test_featureserver_metadata_seeding.py
+++ b/tests/integration/extract/test_featureserver_metadata_seeding.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
+from portolan_cli.constants import TODO_MARKER
 from portolan_cli.extract.arcgis.discovery import LayerInfo, ServiceDiscoveryResult
 
 # Valid test URL that passes URL parser validation
@@ -102,7 +103,7 @@ class TestFeatureServerMetadataSeeding:
             extract_arcgis_catalog(
                 url=TEST_FEATURE_SERVER_URL,
                 output_dir=output_dir,
-                options=ExtractionOptions(raw=False),
+                options=ExtractionOptions(raw=False, license="CC-BY-4.0"),
             )
 
         # Verify metadata.yaml was created
@@ -151,7 +152,7 @@ class TestFeatureServerMetadataSeeding:
             extract_arcgis_catalog(
                 url=TEST_FEATURE_SERVER_URL,
                 output_dir=output_dir,
-                options=ExtractionOptions(raw=False),
+                options=ExtractionOptions(raw=False, license="CC-BY-4.0"),
             )
 
         metadata_path = output_dir / ".portolan" / "metadata.yaml"
@@ -163,14 +164,12 @@ class TestFeatureServerMetadataSeeding:
         # Load structured content
         metadata = yaml.safe_load(content)
 
-        # contact.email should have a TODO placeholder
-        contact = metadata.get("contact", {})
-        email = contact.get("email", "")
-        assert "TODO" in str(email) or email == "", "contact.email should be TODO or empty"
+        # contact.email has a TODO placeholder: ArcGIS exposes no email.
+        assert metadata["contact"]["email"] == TODO_MARKER
 
-        # license should have a TODO placeholder (since licenseInfo isn't SPDX)
-        license_val = metadata.get("license", "")
-        assert "TODO" in str(license_val) or license_val == "", "license should be TODO or empty"
+        # The license does not, because it can no longer be left for later: the
+        # extraction resolved it from --license before downloading (issue #686).
+        assert metadata["license"] == "CC-BY-4.0"
 
     @pytest.mark.integration
     def test_seeded_metadata_preserves_extracted_fields(
@@ -206,7 +205,7 @@ class TestFeatureServerMetadataSeeding:
             extract_arcgis_catalog(
                 url=TEST_FEATURE_SERVER_URL,
                 output_dir=output_dir,
-                options=ExtractionOptions(raw=False),
+                options=ExtractionOptions(raw=False, license="CC-BY-4.0"),
             )
 
         metadata_path = output_dir / ".portolan" / "metadata.yaml"
@@ -268,7 +267,7 @@ class TestFeatureServerMetadataSeeding:
             extract_arcgis_catalog(
                 url=TEST_FEATURE_SERVER_URL,
                 output_dir=output_dir,
-                options=ExtractionOptions(raw=False),
+                options=ExtractionOptions(raw=False, license="CC-BY-4.0"),
             )
 
         # Verify original content was preserved

--- a/tests/integration/extract/wfs/test_wfs_extract.py
+++ b/tests/integration/extract/wfs/test_wfs_extract.py
@@ -32,6 +32,7 @@ from portolan_cli.extract.wfs.orchestrator import (
     _auto_init_catalog,
     extract_wfs_catalog,
 )
+from portolan_cli.licensing import ResolvedLicense
 
 pytestmark = [pytest.mark.integration]
 
@@ -134,6 +135,11 @@ def make_report(
     )
 
 
+# Calling _auto_init_catalog directly skips the resolution the orchestrator does
+# before its download, so the license is passed in here (issue #686).
+TEST_LICENSE = ResolvedLicense(license_id="CC-BY-4.0", license_url=None)
+
+
 class TestWFSAutoInitCatalog:
     """Tests for automatic catalog initialization after WFS extraction."""
 
@@ -158,7 +164,7 @@ class TestWFSAutoInitCatalog:
             ],
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, None, TEST_LICENSE)
 
         assert (output_dir / "catalog.json").exists(), "catalog.json should be created"
 
@@ -183,7 +189,7 @@ class TestWFSAutoInitCatalog:
             ],
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, None, TEST_LICENSE)
 
         assert (output_dir / ".portolan" / "config.yaml").exists(), "config.yaml should exist"
 
@@ -212,7 +218,7 @@ class TestWFSAutoInitCatalog:
 
         report = make_report(layers=layers)
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, None, TEST_LICENSE)
 
         assert (output_dir / "buildings" / "collection.json").exists()
         assert (output_dir / "roads" / "collection.json").exists()
@@ -232,7 +238,7 @@ class TestWFSAutoInitCatalog:
             ],
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, None, TEST_LICENSE)
 
         assert not (output_dir / "catalog.json").exists()
         assert not (output_dir / ".portolan").exists()
@@ -263,7 +269,7 @@ class TestWFSViaLinks:
             source_url="https://geoserver.example.com/wfs",
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(output_dir, report, None, TEST_LICENSE)
 
         collection_path = output_dir / "parcels" / "collection.json"
         assert collection_path.exists()
@@ -369,7 +375,7 @@ class TestWFSExtractOrchestrator:
                 extract_wfs_catalog(
                     url="https://example.com/wfs",
                     output_dir=output_dir,
-                    options=ExtractionOptions(raw=False),
+                    options=ExtractionOptions(raw=False, license="CC-BY-4.0"),
                 )
 
         assert (output_dir / "catalog.json").exists(), "default extraction should create catalog"
@@ -628,7 +634,7 @@ class TestWFSMetadataPropagation:
             fees=None,
         )
 
-        _auto_init_catalog(output_dir, report, discovery)
+        _auto_init_catalog(output_dir, report, discovery, TEST_LICENSE)
 
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
         assert catalog_json.get("title") == "INSPIRE Buildings Service", (
@@ -671,7 +677,7 @@ class TestWFSMetadataPropagation:
             fees=None,
         )
 
-        _auto_init_catalog(output_dir, report, discovery)
+        _auto_init_catalog(output_dir, report, discovery, TEST_LICENSE)
 
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
         assert "road network" in catalog_json.get("description", "").lower()
@@ -720,7 +726,7 @@ class TestWFSMetadataPropagation:
             fees=None,
         )
 
-        _auto_init_catalog(output_dir, report, discovery)
+        _auto_init_catalog(output_dir, report, discovery, TEST_LICENSE)
 
         collection_json = json.loads((layer_dir / "collection.json").read_text())
         assert collection_json.get("title") == "Land Parcels", (
@@ -764,7 +770,7 @@ class TestWFSMetadataPropagation:
             fees=None,
         )
 
-        _auto_init_catalog(output_dir, report, discovery)
+        _auto_init_catalog(output_dir, report, discovery, TEST_LICENSE)
 
         catalog_json = json.loads((output_dir / "catalog.json").read_text())
         # Technical title should be filtered (Issue #369)

--- a/tests/integration/test_add_catalog_root_integration.py
+++ b/tests/integration/test_add_catalog_root_integration.py
@@ -28,7 +28,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_cloud_native_vectors.py
+++ b/tests/integration/test_add_cloud_native_vectors.py
@@ -31,7 +31,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_file_size.py
+++ b/tests/integration/test_add_file_size.py
@@ -25,7 +25,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_hive_partitions.py
+++ b/tests/integration/test_add_hive_partitions.py
@@ -27,7 +27,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_incremental_accounting.py
+++ b/tests/integration/test_add_incremental_accounting.py
@@ -30,7 +30,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_merge_strategy.py
+++ b/tests/integration/test_add_merge_strategy.py
@@ -29,7 +29,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_multilayer_integration.py
+++ b/tests/integration/test_add_multilayer_integration.py
@@ -31,7 +31,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_add_no_duplicate_nesting.py
+++ b/tests/integration/test_add_no_duplicate_nesting.py
@@ -68,6 +68,7 @@ class TestNoDuplicateNestingIntegration:
             )
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
             # Create collection/item structure
             # Simulating: 2025/26453e204934n/26453E204934N.tif
@@ -124,6 +125,7 @@ class TestNoDuplicateNestingIntegration:
             )
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
             Path("data").mkdir()
             Path("data/myitem").mkdir()
@@ -174,6 +176,7 @@ class TestNoDuplicateNestingIntegration:
             )
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
             # Mimic real-world structure: collection/tile_id/TILE_ID.tif
             Path("aerial").mkdir()
@@ -222,6 +225,7 @@ class TestNoDuplicateNestingIntegration:
             )
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
             Path("collection").mkdir()
             Path("collection/item_dir").mkdir()

--- a/tests/integration/test_add_rm_integration.py
+++ b/tests/integration/test_add_rm_integration.py
@@ -27,7 +27,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_bbox_validation.py
+++ b/tests/integration/test_bbox_validation.py
@@ -96,6 +96,7 @@ class TestBboxValidationIntegration:
             # Initialize catalog by creating .portolan/config.yaml
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             Path("catalog.json").write_text(
                 json.dumps(
                     {
@@ -132,6 +133,7 @@ class TestBboxValidationIntegration:
             # Initialize catalog
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             Path("catalog.json").write_text(
                 json.dumps(
                     {
@@ -197,6 +199,7 @@ class TestBboxValidationIntegration:
             # Initialize catalog
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             Path("catalog.json").write_text(
                 json.dumps(
                     {
@@ -246,6 +249,7 @@ class TestBboxValidationIntegration:
             # Initialize catalog
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             Path("catalog.json").write_text(
                 json.dumps(
                     {
@@ -291,6 +295,7 @@ class TestAntimeridianBboxIntegration:
             # Initialize catalog
             Path(".portolan").mkdir()
             Path(".portolan/config.yaml").write_text("version: 1\n")
+            Path(".portolan/metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             Path("catalog.json").write_text(
                 json.dumps(
                     {

--- a/tests/integration/test_check_command.py
+++ b/tests/integration/test_check_command.py
@@ -410,7 +410,7 @@ def catalog_with_files(
 
     # Initialize the catalog (creates .portolan/ and catalog.json)
     # Use --auto for non-interactive mode
-    result = runner.invoke(cli, ["init", "--auto", str(tmp_path)])
+    result = runner.invoke(cli, ["init", "--auto", str(tmp_path), "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
 
     return tmp_path
@@ -595,7 +595,7 @@ class TestCheckBothFlags:
         import shutil
 
         # Initialize a catalog (use --auto for non-interactive mode)
-        result = runner.invoke(cli, ["init", "--auto", str(tmp_path)])
+        result = runner.invoke(cli, ["init", "--auto", str(tmp_path), "--license", "CC-BY-4.0"])
         assert result.exit_code == 0
 
         # Add a convertible file

--- a/tests/integration/test_clean_integration.py
+++ b/tests/integration/test_clean_integration.py
@@ -37,7 +37,7 @@ class TestCleanFullWorkflow:
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Step 1: Initialize catalog
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Step 2: Create a collection structure with data
@@ -114,7 +114,7 @@ class TestCleanFullWorkflow:
         """Clean on freshly initialized catalog (just .portolan/ and catalog.json)."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Clean
@@ -131,7 +131,7 @@ class TestCleanFullWorkflow:
         """Clean should preserve all common data file formats."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create data files of various formats
@@ -171,7 +171,7 @@ class TestCleanFromSubdirectory:
             catalog_root = Path(td)
 
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create collection structure
@@ -219,7 +219,7 @@ class TestCleanFromSubdirectory:
             catalog_root = Path(td)
 
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create deep directory structure using absolute path
@@ -255,7 +255,7 @@ class TestCleanDryRun:
         """--dry-run should list all files that would be removed."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create collection with metadata
@@ -293,7 +293,7 @@ class TestCleanDryRun:
         """--dry-run should not modify any files."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Run dry-run
@@ -323,7 +323,7 @@ class TestCleanEmptyDirectories:
         """Clean should remove directories that become empty."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create item directory with only metadata (no data)
@@ -374,7 +374,7 @@ class TestCleanEmptyDirectories:
         """Clean should preserve directories that contain data files."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create collection with both metadata and data
@@ -424,7 +424,7 @@ class TestCleanFindCatalogRoot:
         """After clean, find_catalog_root() should return None."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Verify catalog exists
@@ -453,7 +453,7 @@ class TestCleanJsonOutput:
         """portolan --format json clean should output JSON envelope."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Clean with JSON output
@@ -483,7 +483,7 @@ class TestCleanJsonOutput:
         """portolan --format json clean --dry-run should show preview in JSON."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Clean with dry-run and JSON output
@@ -527,7 +527,7 @@ class TestCleanEdgeCases:
         """Clean should handle orphan item.json without collection.json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create orphan item (no parent collection.json)
@@ -559,7 +559,7 @@ class TestCleanEdgeCases:
         """Clean should handle STAC-like JSON that's actually user data."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0
 
             # Create a JSON file that looks like STAC but is user data

--- a/tests/integration/test_cli_json.py
+++ b/tests/integration/test_cli_json.py
@@ -148,7 +148,9 @@ class TestInitJsonOutput:
         target = tmp_path / "new_catalog"
         target.mkdir()
 
-        result = runner.invoke(cli, ["--format=json", "init", str(target)])
+        result = runner.invoke(
+            cli, ["--format=json", "init", str(target), "--license", "CC-BY-4.0"]
+        )
 
         assert result.exit_code == 0
 

--- a/tests/integration/test_cli_progress.py
+++ b/tests/integration/test_cli_progress.py
@@ -24,6 +24,7 @@ def catalog_with_files(tmp_path: Path) -> Path:
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
     (portolan_dir / "config.yaml").write_text("version: 1\n")
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     # Create collection with multiple GeoJSON files
     collection_dir = tmp_path / "test-collection"
@@ -98,6 +99,7 @@ class TestCheckFixProgress:
         portolan_dir = tmp_path / ".portolan"
         portolan_dir.mkdir()
         (portolan_dir / "config.yaml").write_text("version: 1\n")
+        (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
         # Create a simple catalog.json
         (tmp_path / "catalog.json").write_text(

--- a/tests/integration/test_config_command.py
+++ b/tests/integration/test_config_command.py
@@ -42,7 +42,7 @@ class TestConfigWorkflow:
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize catalog
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # 1. Set a value (using non-sensitive setting)
             result = runner.invoke(cli, ["config", "set", "workers", "4"])
@@ -75,7 +75,7 @@ class TestConfigWorkflow:
         Note: Uses 'workers' instead of 'remote' since remote is a sensitive setting (Issue #356).
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             runner.invoke(cli, ["config", "set", "workers", "8"])
 
             # Verify file exists and contains our value
@@ -92,7 +92,7 @@ class TestConfigWorkflow:
         Note: Uses 'workers' instead of 'remote' since remote is a sensitive setting (Issue #356).
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Set value (using non-sensitive setting)
             runner.invoke(cli, ["config", "set", "workers", "16"])
@@ -124,7 +124,7 @@ class TestConfigPrecedence:
         cannot be set in config.yaml (Issue #356).
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             runner.invoke(cli, ["config", "set", "workers", "4"])
 
             # Set env var and verify it takes precedence
@@ -142,7 +142,7 @@ class TestConfigPrecedence:
         Note: Sensitive settings like aws_profile must use env vars (Issue #356).
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             runner.invoke(cli, ["config", "set", "workers", "4"])
 
             with mock.patch.dict(os.environ, {"PORTOLAN_AWS_PROFILE": "env-profile"}):
@@ -170,7 +170,7 @@ class TestConfigCollection:
     def test_set_collection_config(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set --collection should set collection-level config."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(
                 cli,
@@ -188,7 +188,7 @@ class TestConfigCollection:
     def test_get_collection_config(self, runner: CliRunner, tmp_path: Path) -> None:
         """config get --collection should retrieve collection-level config."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Set catalog-level and collection-level (using non-sensitive setting)
             runner.invoke(cli, ["config", "set", "workers", "4"])
@@ -208,7 +208,7 @@ class TestConfigCollection:
     def test_collection_inherits_catalog_config(self, runner: CliRunner, tmp_path: Path) -> None:
         """Collection should inherit unset keys from catalog config."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Set only catalog-level workers (using non-sensitive setting)
             runner.invoke(cli, ["config", "set", "workers", "32"])
@@ -238,7 +238,7 @@ class TestConfigJsonOutput:
     def test_set_json_envelope(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set should output JSON envelope with --format json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["--format", "json", "config", "set", "workers", "8"])
 
@@ -253,7 +253,7 @@ class TestConfigJsonOutput:
     def test_get_json_envelope(self, runner: CliRunner, tmp_path: Path) -> None:
         """config get should output JSON envelope with --format json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             runner.invoke(cli, ["config", "set", "workers", "8"])
 
             result = runner.invoke(cli, ["--format", "json", "config", "get", "workers"])
@@ -270,7 +270,7 @@ class TestConfigJsonOutput:
     def test_list_json_envelope(self, runner: CliRunner, tmp_path: Path) -> None:
         """config list should output JSON envelope with --format json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             runner.invoke(cli, ["config", "set", "workers", "8"])
 
             result = runner.invoke(cli, ["--format", "json", "config", "list"])
@@ -286,7 +286,7 @@ class TestConfigJsonOutput:
     def test_unset_json_envelope(self, runner: CliRunner, tmp_path: Path) -> None:
         """config unset should output JSON envelope with --format json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             runner.invoke(cli, ["config", "set", "workers", "8"])
 
             result = runner.invoke(cli, ["--format", "json", "config", "unset", "workers"])
@@ -341,7 +341,7 @@ class TestConfigErrors:
     def test_config_works_from_subdirectory(self, runner: CliRunner, tmp_path: Path) -> None:
         """config should work from a subdirectory of the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Create and enter a subdirectory
             subdir = Path("data/nested")

--- a/tests/integration/test_crs_change_detection.py
+++ b/tests/integration/test_crs_change_detection.py
@@ -40,7 +40,9 @@ def catalog_with_3857_geoparquet(tmp_path: Path) -> tuple[Path, Path, Path]:
     catalog_root.mkdir()
 
     # Initialize catalog via CLI
-    result = CliRunner().invoke(cli, ["init", str(catalog_root), "--auto"])
+    result = CliRunner().invoke(
+        cli, ["init", str(catalog_root), "--auto", "--license", "CC-BY-4.0"]
+    )
     assert result.exit_code == 0, f"Init failed: {result.output}"
 
     # Create collection directory (file goes directly here, no item subdir)

--- a/tests/integration/test_dotted_path_regression.py
+++ b/tests/integration/test_dotted_path_regression.py
@@ -80,6 +80,7 @@ class TestDottedPathRegression:
         (portolan_dir / "config.yaml").write_text(
             yaml.dump({"version": 1, "statistics": {"enabled": False}})
         )
+        (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
         # Create collection directory with file directly in it
         # (portolan infers collection from directory structure)
@@ -152,6 +153,7 @@ class TestDottedPathRegression:
         (portolan_dir / "config.yaml").write_text(
             yaml.dump({"version": 1, "statistics": {"enabled": False}})
         )
+        (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
         # Create existing collection stub with item
         existing_coll = catalog_root / "existing"

--- a/tests/integration/test_generated_catalog_conformance.py
+++ b/tests/integration/test_generated_catalog_conformance.py
@@ -8,6 +8,7 @@ here, so the gate is the executable form of "Portolan emits conformant catalogs"
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 from typing import Any
@@ -100,6 +101,10 @@ def _build_catalog(root: Path) -> None:
             "Demo Catalog",
             "--description",
             "Roads published for the conformance gate.",
+            # init keeps the metadata.yaml written above, so this only satisfies the
+            # flag's requirement; the license the catalog uses is the one in that file.
+            "--license",
+            "CC-BY-4.0",
         ],
         catch_exceptions=False,
     )
@@ -154,3 +159,67 @@ class TestGeneratedCatalogConformance:
         fired = {f.rule_id for f in report.findings if f.severity is Severity.ERROR}
 
         assert fired == KNOWN_GAPS
+
+
+class TestUnlicensedCatalogIsRefused:
+    """The gate above only ever saw the happy path, which is what hid issue #686.
+
+    A catalog whose metadata.yaml omits the license used to generate collections
+    carrying ``license: "other"`` with no ``rel="license"`` link, a PTL-LIC-002
+    ERROR. Portolan now refuses to write such a collection at all, so the honest
+    assertion is that nothing gets written rather than that the output conforms.
+    """
+
+    def _catalog_without_a_license(self, root: Path) -> Path:
+        """Build a managed catalog whose metadata.yaml declares no license."""
+        collection_dir = root / "roads"
+        collection_dir.mkdir(parents=True)
+        shutil.copy(FIXTURE, collection_dir / "roads.parquet")
+
+        portolan_dir = root / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("# Portolan configuration\n", encoding="utf-8")
+        (portolan_dir / "metadata.yaml").write_text(
+            yaml.dump({"contact": "data@example.org"}), encoding="utf-8"
+        )
+        (root / "catalog.json").write_text(
+            '{"type": "Catalog", "stac_version": "1.1.0", "id": "demo",'
+            ' "description": "No license here", "links": []}',
+            encoding="utf-8",
+        )
+        return collection_dir / "roads.parquet"
+
+    def test_add_refuses_and_writes_no_collection(self, tmp_path: Path) -> None:
+        root = tmp_path / "unlicensed"
+        source = self._catalog_without_a_license(root)
+
+        result = CliRunner().invoke(cli, ["add", "--portolan-dir", str(root), str(source)])
+
+        assert result.exit_code == 1, result.output
+        assert "PRTLN-VAL004" in result.output
+        assert list(root.rglob("collection.json")) == []
+
+    def test_the_violation_it_prevents_is_real(self, tmp_path: Path) -> None:
+        """Prove PTL-LIC-002 is what the gate averts, not a rule we assume exists.
+
+        Takes a conformant generated catalog and puts back exactly what the old
+        code emitted: ``license: "other"`` and no ``rel="license"`` link. Without
+        this, the test above would keep passing even if the rule it protects
+        against were renamed or dropped upstream.
+        """
+        root = tmp_path / "damaged-catalog"
+        _build_catalog(root)
+        collection_path = root / "roads" / "collection.json"
+
+        collection = json.loads(collection_path.read_text(encoding="utf-8"))
+        collection["license"] = "other"
+        collection["links"] = [link for link in collection["links"] if link.get("rel") != "license"]
+        collection_path.write_text(json.dumps(collection, indent=2), encoding="utf-8")
+
+        fired = {
+            f.rule_id
+            for f in _validate(root, config=RulesConfig(disabled=KNOWN_GAPS)).findings
+            if f.severity is Severity.ERROR
+        }
+
+        assert fired == {"PTL-LIC-002"}

--- a/tests/integration/test_init_command.py
+++ b/tests/integration/test_init_command.py
@@ -32,7 +32,7 @@ class TestInitCommandAutoMode:
     def test_init_auto_creates_catalog_json(self, runner: CliRunner, tmp_path: Path) -> None:
         """portolan init --auto should create catalog.json at ROOT with auto-extracted fields."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             # New structure: catalog.json at root
@@ -51,7 +51,7 @@ class TestInitCommandAutoMode:
         catalog_dir = tmp_path / "my-cool-catalog"
         catalog_dir.mkdir()
 
-        result = runner.invoke(cli, ["init", "--auto", str(catalog_dir)])
+        result = runner.invoke(cli, ["init", "--auto", str(catalog_dir), "--license", "CC-BY-4.0"])
 
         assert result.exit_code == 0
         catalog_file = catalog_dir / "catalog.json"
@@ -64,7 +64,7 @@ class TestInitCommandAutoMode:
     def test_init_auto_emits_warnings(self, runner: CliRunner, tmp_path: Path) -> None:
         """portolan init --auto should emit warnings for missing best-practice fields."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             # Should warn about missing title (best practice)
@@ -76,7 +76,9 @@ class TestInitCommandAutoMode:
         """portolan init --auto should complete without waiting for input."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Use a short timeout - if it prompts, it would hang
-            result = runner.invoke(cli, ["init", "--auto"], catch_exceptions=False)
+            result = runner.invoke(
+                cli, ["init", "--auto", "--license", "CC-BY-4.0"], catch_exceptions=False
+            )
 
             # If we get here without timeout, no prompt was issued
             assert result.exit_code == 0
@@ -89,7 +91,7 @@ class TestInitCommandAutoMode:
         Per issue #290: config.yaml alone is sufficient (state.json removed).
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             # Internal tooling state: lives in .portolan/
@@ -119,7 +121,7 @@ class TestInitCommandErrors:
             (portolan / "config.yaml").write_text("{}")
 
             # Use --auto to skip interactive prompts and test error path
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             assert "already" in result.output.lower()
@@ -132,7 +134,7 @@ class TestInitCommandErrors:
             Path("catalog.json").write_text('{"type": "Catalog"}')
 
             # Use --auto to skip interactive prompts and test error path
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             output_lower = result.output.lower()

--- a/tests/integration/test_init_command.py
+++ b/tests/integration/test_init_command.py
@@ -149,7 +149,7 @@ class TestInitCommandErrors:
             portolan.mkdir()
             (portolan / "config.yaml").write_text("{}")
 
-            result = runner.invoke(cli, ["--format", "json", "init"])
+            result = runner.invoke(cli, ["--format", "json", "init", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             data = json.loads(result.output)
@@ -170,7 +170,9 @@ class TestInitCommandJsonOutput:
     def test_init_json_output_success(self, runner: CliRunner, tmp_path: Path) -> None:
         """portolan --format json init should output JSON envelope."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["--format", "json", "init", "--auto"])
+            result = runner.invoke(
+                cli, ["--format", "json", "init", "--auto", "--license", "CC-BY-4.0"]
+            )
 
             assert result.exit_code == 0
             data = json.loads(result.output)
@@ -187,7 +189,7 @@ class TestInitCommandJsonOutput:
             portolan.mkdir()
             (portolan / "config.yaml").write_text("{}")
 
-            result = runner.invoke(cli, ["--format", "json", "init"])
+            result = runner.invoke(cli, ["--format", "json", "init", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             data = json.loads(result.output)

--- a/tests/integration/test_init_v2.py
+++ b/tests/integration/test_init_v2.py
@@ -339,6 +339,8 @@ class TestInitFlags:
                     "Combined Test",
                     "--description",
                     "Testing all flags",
+                    "--license",
+                    "CC-BY-4.0",
                 ],
             )
 
@@ -360,7 +362,9 @@ class TestInitJsonOutput:
     def test_json_output_on_success(self, runner: CliRunner, tmp_path: Path) -> None:
         """JSON output should indicate success with envelope."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["--format", "json", "init", "--auto"])
+            result = runner.invoke(
+                cli, ["--format", "json", "init", "--auto", "--license", "CC-BY-4.0"]
+            )
 
             assert result.exit_code == 0
             data = json.loads(result.output)
@@ -375,7 +379,7 @@ class TestInitJsonOutput:
             portolan.mkdir()
             (portolan / "config.yaml").write_text("{}")
 
-            result = runner.invoke(cli, ["--format", "json", "init"])
+            result = runner.invoke(cli, ["--format", "json", "init", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             data = json.loads(result.output)
@@ -395,7 +399,7 @@ class TestInitJsonOutput:
             }
             Path("catalog.json").write_text(json.dumps(catalog_data))
 
-            result = runner.invoke(cli, ["--format", "json", "init"])
+            result = runner.invoke(cli, ["--format", "json", "init", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             data = json.loads(result.output)

--- a/tests/integration/test_init_v2.py
+++ b/tests/integration/test_init_v2.py
@@ -36,7 +36,7 @@ class TestInitCreatesRequiredFiles:
     def test_init_creates_root_catalog_json(self, runner: CliRunner, tmp_path: Path) -> None:
         """Init should create catalog.json at ROOT level (not inside .portolan)."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             assert Path("catalog.json").exists(), "catalog.json should be at root"
@@ -47,7 +47,7 @@ class TestInitCreatesRequiredFiles:
         import yaml
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             config_file = Path(".portolan/config.yaml")
@@ -67,7 +67,7 @@ class TestInitCreatesRequiredFiles:
         at the catalog root alongside STAC files, not inside .portolan/.
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             # Versions.json is at root, NOT inside .portolan/
@@ -94,7 +94,7 @@ class TestInitCreatesRequiredFiles:
         Note: state.json was removed per issue #290.
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             # Root level: STAC catalog + consumer-visible versioning
@@ -122,7 +122,7 @@ class TestInitCreatesRequiredFiles:
         target_dir = tmp_path / "my.catalog"
         target_dir.mkdir()
 
-        result = runner.invoke(cli, ["init", str(target_dir), "--auto"])
+        result = runner.invoke(cli, ["init", str(target_dir), "--auto", "--license", "CC-BY-4.0"])
 
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert (target_dir / "catalog.json").exists(), "catalog.json should be in target directory"
@@ -150,7 +150,7 @@ class TestCatalogJsonValidity:
     def test_catalog_json_is_valid_stac(self, runner: CliRunner, tmp_path: Path) -> None:
         """catalog.json should be loadable by pystac."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # pystac should be able to read it
             catalog = pystac.Catalog.from_file("catalog.json")
@@ -163,7 +163,7 @@ class TestCatalogJsonValidity:
     def test_catalog_json_has_required_stac_fields(self, runner: CliRunner, tmp_path: Path) -> None:
         """catalog.json must have required STAC Catalog fields."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             data = json.loads(Path("catalog.json").read_text())
             assert data["type"] == "Catalog"
@@ -179,7 +179,7 @@ class TestCatalogJsonValidity:
         catalog_dir = tmp_path / "my-geospatial-catalog"
         catalog_dir.mkdir()
 
-        result = runner.invoke(cli, ["init", "--auto", str(catalog_dir)])
+        result = runner.invoke(cli, ["init", "--auto", str(catalog_dir), "--license", "CC-BY-4.0"])
 
         assert result.exit_code == 0
         data = json.loads((catalog_dir / "catalog.json").read_text())
@@ -204,7 +204,7 @@ class TestInitErrorCases:
             (portolan / "config.yaml").write_text("{}")
 
             # Use --auto to skip interactive prompts and test error path
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             assert "already" in result.output.lower()
@@ -224,7 +224,7 @@ class TestInitErrorCases:
             Path("catalog.json").write_text(json.dumps(catalog_data))
 
             # Use --auto to skip interactive prompts and test error path
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             output_lower = result.output.lower()
@@ -250,7 +250,7 @@ class TestInitPartialState:
         with runner.isolated_filesystem(temp_dir=tmp_path):
             Path(".portolan").mkdir()
 
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             assert Path("catalog.json").exists()
@@ -266,7 +266,7 @@ class TestInitPartialState:
             portolan.mkdir()
             (portolan / "config.yaml").write_text("{}")
 
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Should fail because config.yaml exists = MANAGED state
             assert result.exit_code == 1
@@ -285,7 +285,9 @@ class TestInitFlags:
     def test_title_flag_sets_catalog_title(self, runner: CliRunner, tmp_path: Path) -> None:
         """--title flag should set catalog title."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto", "--title", "My Awesome Catalog"])
+            result = runner.invoke(
+                cli, ["init", "--auto", "--title", "My Awesome Catalog", "--license", "CC-BY-4.0"]
+            )
 
             assert result.exit_code == 0
             data = json.loads(Path("catalog.json").read_text())
@@ -298,7 +300,15 @@ class TestInitFlags:
         """--description flag should set catalog description."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             result = runner.invoke(
-                cli, ["init", "--auto", "--description", "A test catalog for unit tests"]
+                cli,
+                [
+                    "init",
+                    "--auto",
+                    "--description",
+                    "A test catalog for unit tests",
+                    "--license",
+                    "CC-BY-4.0",
+                ],
             )
 
             assert result.exit_code == 0
@@ -310,7 +320,9 @@ class TestInitFlags:
         """--auto flag should complete without any prompts."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # If this blocks for input, the test will timeout
-            result = runner.invoke(cli, ["init", "--auto"], catch_exceptions=False)
+            result = runner.invoke(
+                cli, ["init", "--auto", "--license", "CC-BY-4.0"], catch_exceptions=False
+            )
 
             assert result.exit_code == 0
 

--- a/tests/integration/test_list_status_integration.py
+++ b/tests/integration/test_list_status_integration.py
@@ -25,7 +25,9 @@ def init_catalog(catalog_dir: Path) -> None:
     """Initialize a catalog using the CLI."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["init", "--title", "Test Catalog", "--auto"], catch_exceptions=False
+        cli,
+        ["init", "--title", "Test Catalog", "--auto", "--license", "CC-BY-4.0"],
+        catch_exceptions=False,
     )
     assert result.exit_code == 0, f"init failed: {result.output}"
 

--- a/tests/integration/test_mandatory_titles_add.py
+++ b/tests/integration/test_mandatory_titles_add.py
@@ -40,6 +40,7 @@ def _init_catalog(root: Path) -> None:
     (portolan_dir / "config.yaml").write_text(
         yaml.dump({"version": 1, "statistics": {"enabled": False}})
     )
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
 
 def _add_slug_collection(root: Path, *, metadata_yaml: dict | None = None) -> Path:

--- a/tests/integration/test_partition_paths.py
+++ b/tests/integration/test_partition_paths.py
@@ -30,7 +30,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_provider_generation.py
+++ b/tests/integration/test_provider_generation.py
@@ -72,6 +72,8 @@ def _build_catalog(root: Path, metadata: dict[str, Any], *, tabular: bool = Fals
             "Provider Catalog",
             "--description",
             "Roads published to exercise the provider model.",
+            "--license",
+            "CC-BY-4.0",
         ],
         catch_exceptions=False,
     )

--- a/tests/integration/test_rashid_roundtrip.py
+++ b/tests/integration/test_rashid_roundtrip.py
@@ -92,6 +92,8 @@ def _build_catalog(root: Path) -> None:
             "Roundtrip Catalog",
             "--description",
             "Roads published for the remediation roundtrip.",
+            "--license",
+            "CC-BY-4.0",
         ],
         catch_exceptions=False,
     )

--- a/tests/integration/test_raster_bands_placement.py
+++ b/tests/integration/test_raster_bands_placement.py
@@ -49,6 +49,7 @@ def raster_catalog(tmp_path: Path) -> Path:
     (portolan_dir / "config.yaml").write_text(
         yaml.dump({"version": 1, "statistics": {"enabled": True}})
     )
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
     (catalog_root / "imagery").mkdir()
     return catalog_root
 

--- a/tests/integration/test_rm_item_dir_cleanup.py
+++ b/tests/integration/test_rm_item_dir_cleanup.py
@@ -27,7 +27,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 

--- a/tests/integration/test_versioning_stress.py
+++ b/tests/integration/test_versioning_stress.py
@@ -47,7 +47,7 @@ def runner() -> CliRunner:
 @pytest.fixture
 def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto"])
+    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
     assert result.exit_code == 0, f"Init failed: {result.output}"
     return tmp_path
 
@@ -1196,7 +1196,9 @@ class TestScaleAt1000Files:
     def catalog_with_1000_files(self, tmp_path: Path) -> tuple[Path, Path]:
         """Catalog with 1000 files matching #339 scale."""
         catalog_root = tmp_path / "scale-1000"
-        result = CliRunner().invoke(cli, ["init", str(catalog_root), "--auto"])
+        result = CliRunner().invoke(
+            cli, ["init", str(catalog_root), "--auto", "--license", "CC-BY-4.0"]
+        )
         assert result.exit_code == 0
 
         collection_dir = catalog_root / "large-collection"

--- a/tests/unit/extract/common/test_orchestrator_base.py
+++ b/tests/unit/extract/common/test_orchestrator_base.py
@@ -117,8 +117,17 @@ class TestInitExtractedCatalog:
 
         import portolan_cli.catalog as catalog_mod
 
-        def _fake_init(output_dir: Path, *, title: str | None, description: str | None) -> None:
+        def _fake_init(
+            output_dir: Path,
+            *,
+            title: str | None,
+            description: str | None,
+            license_id: str | None,
+        ) -> None:
             events.append("init")
+            # Issue #686: extract seeds metadata.yaml itself, in post_init, so
+            # init_catalog must not write a template over it.
+            assert license_id is None
 
         def _fake_add(*, paths: list[Path], catalog_root: Path) -> None:
             events.append("add")

--- a/tests/unit/extract/wfs/test_orchestrator.py
+++ b/tests/unit/extract/wfs/test_orchestrator.py
@@ -825,7 +825,8 @@ class TestExtractionProgressError:
                 attempts=3,
             )
 
-            options = ExtractionOptions(workers=1, retries=1)
+            # A non-raw extraction builds a catalog, which needs a license (issue #686).
+            options = ExtractionOptions(workers=1, retries=1, license="CC-BY-4.0")
             extract_wfs_catalog(
                 url="https://example.com/wfs",
                 output_dir=tmp_path,

--- a/tests/unit/test_add_continue_on_errors.py
+++ b/tests/unit/test_add_continue_on_errors.py
@@ -39,6 +39,7 @@ def setup_catalog(path: Path) -> None:
     """Create an initialized Portolan catalog ."""
     portolan_dir = path / ".portolan"
     portolan_dir.mkdir()
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
     (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
     catalog_data = {
         "type": "Catalog",

--- a/tests/unit/test_add_external.py
+++ b/tests/unit/test_add_external.py
@@ -127,39 +127,56 @@ class TestADR0030URLValidation:
         """file:// URLs are local paths disguised as URIs — must reject."""
         setup_catalog(tmp_path)
         with pytest.raises(InputValidationError, match="Unsupported URL scheme"):
-            add_external(catalog_root=tmp_path, url="file:///etc/passwd", collection_id="x")
+            add_external(
+                license="CC-BY-4.0",
+                catalog_root=tmp_path,
+                url="file:///etc/passwd",
+                collection_id="x",
+            )
 
     def test_rejects_path_traversal(self, tmp_path: Path) -> None:
         """Path traversals in URLs must be rejected."""
         setup_catalog(tmp_path)
         with pytest.raises(InputValidationError, match="traversal"):
-            add_external(catalog_root=tmp_path, url="s3://bucket/../etc/passwd", collection_id="x")
+            add_external(
+                license="CC-BY-4.0",
+                catalog_root=tmp_path,
+                url="s3://bucket/../etc/passwd",
+                collection_id="x",
+            )
 
     def test_rejects_control_characters(self, tmp_path: Path) -> None:
         """Control characters in URLs must be rejected."""
         setup_catalog(tmp_path)
         with pytest.raises(InputValidationError, match="Control characters"):
             add_external(
-                catalog_root=tmp_path, url="s3://bucket/key\x00.parquet", collection_id="x"
+                license="CC-BY-4.0",
+                catalog_root=tmp_path,
+                url="s3://bucket/key\x00.parquet",
+                collection_id="x",
             )
 
     def test_rejects_empty_host(self, tmp_path: Path) -> None:
         """URLs without host/bucket must be rejected."""
         setup_catalog(tmp_path)
         with pytest.raises(InputValidationError, match="missing host"):
-            add_external(catalog_root=tmp_path, url="s3://", collection_id="x")
+            add_external(license="CC-BY-4.0", catalog_root=tmp_path, url="s3://", collection_id="x")
 
     def test_rejects_unsupported_scheme(self, tmp_path: Path) -> None:
         """Only s3, gs, az, http, https are allowed."""
         setup_catalog(tmp_path)
         with pytest.raises(InputValidationError, match="Unsupported URL scheme"):
             add_external(
-                catalog_root=tmp_path, url="ftp://example.org/data.parquet", collection_id="x"
+                license="CC-BY-4.0",
+                catalog_root=tmp_path,
+                url="ftp://example.org/data.parquet",
+                collection_id="x",
             )
 
     def test_accepts_valid_s3_url(self, tmp_path: Path) -> None:
         setup_catalog(tmp_path)
         result = add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url="s3://bucket/path/to/data.parquet",
             collection_id="test",
@@ -169,6 +186,7 @@ class TestADR0030URLValidation:
     def test_accepts_valid_https_url(self, tmp_path: Path) -> None:
         setup_catalog(tmp_path)
         result = add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url="https://example.org/data.parquet",
             collection_id="test",
@@ -178,6 +196,7 @@ class TestADR0030URLValidation:
     def test_accepts_valid_gs_url(self, tmp_path: Path) -> None:
         setup_catalog(tmp_path)
         result = add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url="gs://bucket/path/data.parquet",
             collection_id="test",
@@ -187,6 +206,7 @@ class TestADR0030URLValidation:
     def test_accepts_valid_az_url(self, tmp_path: Path) -> None:
         setup_catalog(tmp_path)
         result = add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url="az://container/blob.parquet",
             collection_id="test",
@@ -200,20 +220,26 @@ class TestOverwriteProtection:
     def test_rejects_overwrite_without_force(self, tmp_path: Path) -> None:
         """Existing collections must not be overwritten without --force."""
         setup_catalog(tmp_path)
-        add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="test")
+        add_external(
+            license="CC-BY-4.0", catalog_root=tmp_path, url=OVERTURE_URL, collection_id="test"
+        )
         with pytest.raises(FileExistsError, match="already exists"):
-            add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="test")
+            add_external(
+                license="CC-BY-4.0", catalog_root=tmp_path, url=OVERTURE_URL, collection_id="test"
+            )
 
     def test_allows_overwrite_with_force(self, tmp_path: Path) -> None:
         """With force=True, existing collections can be overwritten."""
         setup_catalog(tmp_path)
         add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url=OVERTURE_URL,
             collection_id="test",
             title="Original",
         )
         result = add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url=OVERTURE_URL,
             collection_id="test",
@@ -232,6 +258,7 @@ class TestAddExternal:
         setup_catalog(tmp_path)
 
         result = add_external(
+            license="CC-BY-4.0",
             catalog_root=tmp_path,
             url=OVERTURE_URL,
             collection_id="overture-places",
@@ -268,14 +295,24 @@ class TestAddExternal:
         metadata, not downloaded data, so the "no local data file" invariant holds.
         """
         setup_catalog(tmp_path)
-        add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="overture-places")
+        add_external(
+            license="CC-BY-4.0",
+            catalog_root=tmp_path,
+            url=OVERTURE_URL,
+            collection_id="overture-places",
+        )
         collection_dir = tmp_path / "overture-places"
         files = sorted(p.name for p in collection_dir.iterdir())
         assert files == ["AGENTS.md", "collection.json"]
 
     def test_links_collection_into_root_catalog(self, tmp_path: Path) -> None:
         setup_catalog(tmp_path)
-        add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="overture-places")
+        add_external(
+            license="CC-BY-4.0",
+            catalog_root=tmp_path,
+            url=OVERTURE_URL,
+            collection_id="overture-places",
+        )
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         child_hrefs = [link["href"] for link in catalog["links"] if link["rel"] == "child"]
         assert "./overture-places/collection.json" in child_hrefs
@@ -283,7 +320,12 @@ class TestAddExternal:
     def test_check_scanner_does_not_flag_remote_asset(self, tmp_path: Path) -> None:
         """The metadata scanner must not report the remote asset as MISSING."""
         setup_catalog(tmp_path)
-        add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="overture-places")
+        add_external(
+            license="CC-BY-4.0",
+            catalog_root=tmp_path,
+            url=OVERTURE_URL,
+            collection_id="overture-places",
+        )
         report = scan_catalog_metadata(tmp_path)
         # No result should reference the external href as a problem.
         assert all(OVERTURE_URL not in str(r.file_path) for r in report.results)
@@ -292,11 +334,18 @@ class TestAddExternal:
         """Local filesystem paths must be rejected (use 'portolan add' instead)."""
         setup_catalog(tmp_path)
         with pytest.raises(InputValidationError, match="Unsupported URL scheme"):
-            add_external(catalog_root=tmp_path, url="/tmp/local.parquet", collection_id="x")
+            add_external(
+                license="CC-BY-4.0",
+                catalog_root=tmp_path,
+                url="/tmp/local.parquet",
+                collection_id="x",
+            )
 
     def test_rejects_uninitialised_catalog(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError, match="Not a Portolan catalog"):
-            add_external(catalog_root=tmp_path, url=OVERTURE_URL, collection_id="x")
+            add_external(
+                license="CC-BY-4.0", catalog_root=tmp_path, url=OVERTURE_URL, collection_id="x"
+            )
 
 
 class TestAddExternalCommand:
@@ -310,6 +359,8 @@ class TestAddExternalCommand:
                 cli,
                 [
                     "add-external",
+                    "--license",
+                    "CC-BY-4.0",
                     OVERTURE_URL,
                     "--collection",
                     "overture-places",
@@ -327,7 +378,15 @@ class TestAddExternalCommand:
             setup_catalog(Path.cwd())
             result = runner.invoke(
                 cli,
-                ["add-external", OVERTURE_URL, "--collection", "overture-places", "--json"],
+                [
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    OVERTURE_URL,
+                    "--collection",
+                    "overture-places",
+                    "--json",
+                ],
             )
             assert result.exit_code == 0, result.output
             payload = json.loads(result.output)
@@ -339,7 +398,17 @@ class TestAddExternalCommand:
     def test_command_rejects_local_path(self, runner: CliRunner) -> None:
         with runner.isolated_filesystem():
             setup_catalog(Path.cwd())
-            result = runner.invoke(cli, ["add-external", "/tmp/local.parquet", "--collection", "x"])
+            result = runner.invoke(
+                cli,
+                [
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    "/tmp/local.parquet",
+                    "--collection",
+                    "x",
+                ],
+            )
             assert result.exit_code == 1
             assert "Unsupported URL scheme" in result.output
 
@@ -347,7 +416,17 @@ class TestAddExternalCommand:
         """file:// URLs must be rejected via CLI."""
         with runner.isolated_filesystem():
             setup_catalog(Path.cwd())
-            result = runner.invoke(cli, ["add-external", "file:///etc/passwd", "--collection", "x"])
+            result = runner.invoke(
+                cli,
+                [
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    "file:///etc/passwd",
+                    "--collection",
+                    "x",
+                ],
+            )
             assert result.exit_code == 1
             assert "Unsupported URL scheme" in result.output
 
@@ -356,7 +435,15 @@ class TestAddExternalCommand:
         with runner.isolated_filesystem():
             setup_catalog(Path.cwd())
             result = runner.invoke(
-                cli, ["add-external", "s3://bucket/../etc/passwd", "--collection", "x"]
+                cli,
+                [
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    "s3://bucket/../etc/passwd",
+                    "--collection",
+                    "x",
+                ],
             )
             assert result.exit_code == 1
             assert "traversal" in result.output
@@ -367,14 +454,29 @@ class TestAddExternalCommand:
             catalog = Path.cwd()
             setup_catalog(catalog)
             # Create initial collection
-            runner.invoke(cli, ["add-external", OVERTURE_URL, "--collection", "test"])
+            runner.invoke(
+                cli,
+                ["add-external", "--license", "CC-BY-4.0", OVERTURE_URL, "--collection", "test"],
+            )
             # Without --force, should fail
-            result = runner.invoke(cli, ["add-external", OVERTURE_URL, "--collection", "test"])
+            result = runner.invoke(
+                cli,
+                ["add-external", "--license", "CC-BY-4.0", OVERTURE_URL, "--collection", "test"],
+            )
             assert result.exit_code == 1
             assert "already exists" in result.output
             # With --force, should succeed
             result = runner.invoke(
-                cli, ["add-external", OVERTURE_URL, "--collection", "test", "--force"]
+                cli,
+                [
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    OVERTURE_URL,
+                    "--collection",
+                    "test",
+                    "--force",
+                ],
             )
             assert result.exit_code == 0
 
@@ -387,6 +489,8 @@ class TestAddExternalCommand:
                 cli,
                 [
                     "add-external",
+                    "--license",
+                    "CC-BY-4.0",
                     OVERTURE_URL,
                     "--collection",
                     "test",
@@ -404,7 +508,16 @@ class TestAddExternalCommand:
             setup_catalog(Path.cwd())
             result = runner.invoke(
                 cli,
-                ["add-external", OVERTURE_URL, "--collection", "test", "--bbox", "-200,0,0,0"],
+                [
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    OVERTURE_URL,
+                    "--collection",
+                    "test",
+                    "--bbox",
+                    "-200,0,0,0",
+                ],
             )
             assert result.exit_code == 1
             assert "Longitude" in result.output
@@ -416,7 +529,14 @@ class TestAddExternalCommand:
             setup_catalog(catalog)
             result = runner.invoke(
                 cli,
-                ["add-external", OVERTURE_URL, "--collection", "test", "--license", "CC-BY-4.0"],
+                [
+                    "add-external",
+                    OVERTURE_URL,
+                    "--collection",
+                    "test",
+                    "--license",
+                    "CC-BY-4.0",
+                ],
             )
             assert result.exit_code == 0, result.output
             data = json.loads((catalog / "test" / "collection.json").read_text())
@@ -431,6 +551,8 @@ class TestAddExternalCommand:
                 cli,
                 [
                     "add-external",
+                    "--license",
+                    "CC-BY-4.0",
                     OVERTURE_URL,
                     "--collection",
                     "test",
@@ -448,9 +570,94 @@ class TestAddExternalCommand:
             setup_catalog(Path.cwd())
             result = runner.invoke(
                 cli,
-                ["--format", "json", "add-external", OVERTURE_URL, "--collection", "test"],
+                [
+                    "--format",
+                    "json",
+                    "add-external",
+                    "--license",
+                    "CC-BY-4.0",
+                    OVERTURE_URL,
+                    "--collection",
+                    "test",
+                ],
             )
             assert result.exit_code == 0, result.output
             payload = json.loads(result.output)
             assert payload["success"] is True
             assert payload["data"]["collection_id"] == "test"
+
+
+class TestAddExternalRequiresALicense:
+    """Issue #686: --license used to default to 'other' with no way to add a link.
+
+    Every external collection therefore shipped a guaranteed PTL-LIC-002 error.
+    Referencing data in place does not make its license unknowable, so the flag is
+    required and 'other' now has a --license-url to pair with.
+    """
+
+    def test_missing_license_fails(self, runner: CliRunner) -> None:
+        with runner.isolated_filesystem():
+            setup_catalog(Path.cwd())
+            result = runner.invoke(cli, ["add-external", OVERTURE_URL, "--collection", "x"])
+
+            assert result.exit_code == 1, result.output
+            assert "PRTLN-VAL004" in result.output
+            assert "--license" in result.output
+
+    def test_other_without_a_url_fails(self, runner: CliRunner) -> None:
+        with runner.isolated_filesystem():
+            setup_catalog(Path.cwd())
+            result = runner.invoke(
+                cli,
+                ["add-external", OVERTURE_URL, "--collection", "x", "--license", "other"],
+            )
+
+            assert result.exit_code == 1, result.output
+            assert "license_url" in result.output
+
+    def test_writes_no_collection_when_it_refuses(self, runner: CliRunner) -> None:
+        """The license is validated before add_external touches the filesystem."""
+        with runner.isolated_filesystem():
+            setup_catalog(Path.cwd())
+            result = runner.invoke(cli, ["add-external", OVERTURE_URL, "--collection", "x"])
+
+            assert result.exit_code == 1
+            assert not (Path.cwd() / "x").exists()
+
+    def test_other_with_a_url_emits_the_license_link(self, runner: CliRunner) -> None:
+        """PTL-LIC-002 is satisfied by the rel='license' link, not by the id alone."""
+        with runner.isolated_filesystem():
+            setup_catalog(Path.cwd())
+            result = runner.invoke(
+                cli,
+                [
+                    "add-external",
+                    OVERTURE_URL,
+                    "--collection",
+                    "x",
+                    "--license",
+                    "other",
+                    "--license-url",
+                    "https://example.org/terms",
+                ],
+            )
+
+            assert result.exit_code == 0, result.output
+            collection = json.loads((Path.cwd() / "x" / "collection.json").read_text())
+            assert collection["license"] == "other"
+            license_links = [link for link in collection["links"] if link["rel"] == "license"]
+            assert len(license_links) == 1
+            assert license_links[0]["href"] == "https://example.org/terms"
+
+    def test_an_spdx_identifier_needs_no_link(self, runner: CliRunner) -> None:
+        with runner.isolated_filesystem():
+            setup_catalog(Path.cwd())
+            result = runner.invoke(
+                cli,
+                ["add-external", OVERTURE_URL, "--collection", "x", "--license", "ODbL-1.0"],
+            )
+
+            assert result.exit_code == 0, result.output
+            collection = json.loads((Path.cwd() / "x" / "collection.json").read_text())
+            assert collection["license"] == "ODbL-1.0"
+            assert [link for link in collection["links"] if link["rel"] == "license"] == []

--- a/tests/unit/test_add_license_gate.py
+++ b/tests/unit/test_add_license_gate.py
@@ -1,0 +1,195 @@
+"""Unit tests for the license gate on ``portolan add`` (issue #686).
+
+Before this gate, an add with no license in metadata.yaml wrote a collection
+carrying ``license: "other"`` and no ``rel="license"`` link, which is a PTL-LIC-002
+ERROR. The gate runs after phase 1 and before any conversion, so a refused add
+leaves no collection.json behind at all.
+
+The catalog here is hand-built rather than created through ``portolan init``,
+because ``init`` now seeds a license of its own and these cases need the state a
+pre-gate catalog is in.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.constants import TODO_MARKER
+
+pytestmark = pytest.mark.unit
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _catalog(root: Path) -> Path:
+    """Hand-build a managed catalog with no metadata.yaml."""
+    portolan_dir = root / ".portolan"
+    portolan_dir.mkdir(parents=True)
+    (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
+    (root / "catalog.json").write_text(
+        json.dumps(
+            {
+                "type": "Catalog",
+                "stac_version": "1.1.0",
+                "id": "demo",
+                "description": "A Portolan-managed STAC catalog",
+                "links": [],
+            },
+            indent=2,
+        )
+    )
+    return root
+
+
+def _write_metadata(root: Path, metadata: dict[str, object]) -> None:
+    (root / ".portolan" / "metadata.yaml").write_text(yaml.dump(metadata, sort_keys=False))
+
+
+def _source(root: Path, name: str = "roads.parquet", collection: str = "roads") -> Path:
+    """Drop a real parquet fixture in a collection dir for add to read."""
+    source = root / collection / name
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_bytes(FIXTURE.read_bytes())
+    return source
+
+
+def _add(runner: CliRunner, root: Path, source: Path) -> object:
+    return runner.invoke(cli, ["add", "--portolan-dir", str(root), str(source)])
+
+
+class TestAddRefusesAnUnlicensedCollection:
+    def test_no_metadata_yaml_at_all(self, runner: CliRunner, tmp_path: Path) -> None:
+        """The plainest form of the defect: nothing declares a license anywhere."""
+        root = _catalog(tmp_path / "catalog")
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 1, result.output
+        assert "PRTLN-VAL004" in result.output
+        assert "no license is declared" in result.output
+
+    def test_metadata_yaml_without_a_license_field(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"contact": {"name": "GIS", "email": "gis@example.org"}})
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 1, result.output
+        assert "PRTLN-VAL004" in result.output
+
+    def test_other_without_a_license_url(self, runner: CliRunner, tmp_path: Path) -> None:
+        """PTL-LIC-002 exactly: 'other' is only conformant beside a license link."""
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"license": "other"})
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 1, result.output
+        assert "license_url" in result.output
+
+    def test_the_seeded_todo_placeholder(self, runner: CliRunner, tmp_path: Path) -> None:
+        """extract seeds this marker, and it used to reach collection.license verbatim."""
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"license": TODO_MARKER})
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 1, result.output
+        assert "placeholder" in result.output
+
+    def test_writes_no_collection_json_when_it_refuses(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """A refused add must not leave a non-conformant collection on disk."""
+        root = _catalog(tmp_path / "catalog")
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 1
+        assert list(root.rglob("collection.json")) == []
+
+    def test_names_the_collection_and_the_remedy(self, runner: CliRunner, tmp_path: Path) -> None:
+        """check must never report an issue without saying who resolves it."""
+        root = _catalog(tmp_path / "catalog")
+
+        result = _add(runner, root, _source(root, "roads.parquet"))
+
+        assert "roads" in result.output
+        assert ".portolan/metadata.yaml" in result.output
+        assert "CC-BY-4.0" in result.output
+
+    def test_reports_the_error_type_in_json_mode(self, runner: CliRunner, tmp_path: Path) -> None:
+        """Agents parse the error class name out of the envelope."""
+        root = _catalog(tmp_path / "catalog")
+
+        result = runner.invoke(
+            cli, ["add", "--portolan-dir", str(root), str(_source(root)), "--json"]
+        )
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["errors"][0]["type"] == "MissingLicenseError"
+        assert payload["errors"][0]["code"] == "PRTLN-VAL004"
+
+
+class TestAddAcceptsALicensedCollection:
+    def test_an_spdx_identifier(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"license": "CC-BY-4.0"})
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 0, result.output
+        collection = json.loads((root / "roads" / "collection.json").read_text())
+        assert collection["license"] == "CC-BY-4.0"
+
+    def test_other_with_a_license_url(self, runner: CliRunner, tmp_path: Path) -> None:
+        """The second conformant shape, and the one extract seeds."""
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"license": "other", "license_url": "https://x.org/terms"})
+
+        result = _add(runner, root, _source(root))
+
+        assert result.exit_code == 0, result.output
+        collection = json.loads((root / "roads" / "collection.json").read_text())
+        assert collection["license"] == "other"
+        assert any(link["rel"] == "license" for link in collection["links"])
+
+    def test_a_license_already_on_the_collection(self, runner: CliRunner, tmp_path: Path) -> None:
+        """A human who licensed collection.json by hand is not asked to repeat it."""
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"license": "CC-BY-4.0"})
+        first = _add(runner, root, _source(root))
+        assert first.exit_code == 0, first.output
+
+        # Strip the license back out of metadata.yaml; the collection keeps its own.
+        _write_metadata(root, {"contact": {"name": "GIS", "email": "gis@example.org"}})
+        second = _add(runner, root, _source(root, "more.parquet"))
+
+        assert second.exit_code == 0, second.output
+
+    def test_a_license_link_already_on_the_collection_rescues_other(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """An existing rel=license link survives every rewrite, so it satisfies the gate."""
+        root = _catalog(tmp_path / "catalog")
+        _write_metadata(root, {"license": "other", "license_url": "https://x.org/terms"})
+        first = _add(runner, root, _source(root))
+        assert first.exit_code == 0, first.output
+
+        _write_metadata(root, {"license": "other"})
+        second = _add(runner, root, _source(root, "more.parquet"))
+
+        assert second.exit_code == 0, second.output

--- a/tests/unit/test_add_rm_hypothesis.py
+++ b/tests/unit/test_add_rm_hypothesis.py
@@ -373,6 +373,7 @@ class TestFindCatalogRootProperties:
             # Create managed catalog with .portolan/config.yaml + catalog.json (per issue #290)
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir()
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             (portolan_dir / "config.yaml").write_text("# Portolan config\n")
             (tmp_path / "catalog.json").write_text('{"type": "Catalog"}')  # Operational file
 
@@ -397,6 +398,7 @@ class TestFindCatalogRootProperties:
             # Create managed catalog with .portolan/config.yaml + catalog.json (per issue #290)
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir()
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             (portolan_dir / "config.yaml").write_text("# Portolan config\n")
             (tmp_path / "catalog.json").write_text('{"type": "Catalog"}')  # Operational file
             (tmp_path / collection).mkdir(exist_ok=True)
@@ -430,6 +432,7 @@ class TestFindCatalogRootProperties:
             tmp_path = Path(tmp_dir)
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir()
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             (portolan_dir / "config.yaml").write_text("# Portolan config\n")
             (tmp_path / "catalog.json").write_text('{"type": "Catalog"}')  # Operational file
 
@@ -821,6 +824,7 @@ class TestAddFilesEdgeCases:
         catalog.mkdir()
         (catalog / "catalog.json").write_text('{"type": "Catalog"}')
         (catalog / ".portolan").mkdir()
+        (catalog / ".portolan" / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
         # Create real file and symlink
         collection = catalog / "data"
@@ -877,6 +881,7 @@ class TestAddFilesEdgeCases:
         catalog.mkdir()
         (catalog / "catalog.json").write_text('{"type": "Catalog"}')
         (catalog / ".portolan").mkdir()
+        (catalog / ".portolan" / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
         collection = catalog / "data"
         collection.mkdir()
@@ -1418,6 +1423,7 @@ def _setup_managed_catalog(catalog_root: Path) -> None:
     # .portolan sentinel
     portolan_dir = catalog_root / ".portolan"
     portolan_dir.mkdir(exist_ok=True)
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
     (portolan_dir / "config.yaml").write_text("# Portolan config\n")
 
 

--- a/tests/unit/test_catalog_model_init.py
+++ b/tests/unit/test_catalog_model_init.py
@@ -306,7 +306,7 @@ class TestInitCatalogBackendOption:
         catalog_dir.mkdir()
 
         with patch("portolan_cli.backends.get_backend", return_value=MagicMock()):
-            init_catalog(catalog_dir, backend="iceberg")
+            init_catalog(catalog_dir, backend="iceberg", license_id="CC-BY-4.0")
 
         config = yaml.safe_load((catalog_dir / ".portolan" / "config.yaml").read_text())
         assert config["backend"] == "iceberg"
@@ -322,7 +322,7 @@ class TestInitCatalogBackendOption:
         catalog_dir.mkdir()
 
         with patch("portolan_cli.backends.get_backend", return_value=MagicMock()):
-            init_catalog(catalog_dir, backend="iceberg")
+            init_catalog(catalog_dir, backend="iceberg", license_id="CC-BY-4.0")
 
         assert not (catalog_dir / "versions.json").exists()
 
@@ -337,7 +337,7 @@ class TestInitCatalogBackendOption:
         catalog_dir.mkdir()
 
         with patch("portolan_cli.backends.get_backend", return_value=MagicMock()):
-            init_catalog(catalog_dir, backend="iceberg")
+            init_catalog(catalog_dir, backend="iceberg", license_id="CC-BY-4.0")
 
         assert not (catalog_dir / ".portolan" / "state.json").exists()
 
@@ -352,7 +352,7 @@ class TestInitCatalogBackendOption:
         catalog_dir.mkdir()
 
         with patch("portolan_cli.backends.get_backend", return_value=MagicMock()):
-            init_catalog(catalog_dir, backend="iceberg")
+            init_catalog(catalog_dir, backend="iceberg", license_id="CC-BY-4.0")
 
         assert (catalog_dir / "catalog.json").exists()
 
@@ -364,7 +364,7 @@ class TestInitCatalogBackendOption:
         catalog_dir = tmp_path / "test"
         catalog_dir.mkdir()
 
-        init_catalog(catalog_dir, backend="file")
+        init_catalog(catalog_dir, backend="file", license_id="CC-BY-4.0")
 
         assert (catalog_dir / "versions.json").exists()
         # state.json was removed per issue #290; config.yaml is the sole sentinel
@@ -379,7 +379,7 @@ class TestInitCatalogBackendOption:
         catalog_dir.mkdir()
 
         with pytest.raises(CatalogInitError, match="Unknown backend"):
-            init_catalog(catalog_dir, backend="nonexistent")
+            init_catalog(catalog_dir, backend="nonexistent", license_id="CC-BY-4.0")
 
 
 class TestInitCatalogFilesystemErrors:
@@ -402,7 +402,7 @@ class TestInitCatalogFilesystemErrors:
 
         with patch.object(Path, "mkdir", failing_mkdir):
             with pytest.raises(CatalogInitError) as exc_info:
-                init_catalog(tmp_path / "nonexistent-parent" / "catalog")
+                init_catalog(tmp_path / "nonexistent-parent" / "catalog", license_id="CC-BY-4.0")
             assert "Cannot create directory" in exc_info.value.message
 
     @pytest.mark.unit
@@ -424,7 +424,7 @@ class TestInitCatalogFilesystemErrors:
 
         with patch.object(Path, "mkdir", failing_mkdir):
             with pytest.raises(CatalogInitError) as exc_info:
-                init_catalog(catalog_dir)
+                init_catalog(catalog_dir, license_id="CC-BY-4.0")
             assert "Cannot create .portolan directory" in exc_info.value.message
 
     @pytest.mark.unit
@@ -438,14 +438,38 @@ class TestInitCatalogFilesystemErrors:
         catalog_dir.mkdir()
 
         # config.yaml is written through the atomic helper, so the failure is
-        # simulated there rather than on Path.write_text.
+        # simulated there rather than on Path.write_text. metadata.yaml goes through
+        # the same helper and is written first, so fail only on config.yaml to keep
+        # this test about the step it names.
         def failing_write_text_atomic(path: Path, content: str) -> None:
-            raise OSError("Disk full")
+            if path.name == "config.yaml":
+                raise OSError("Disk full")
 
         with patch("portolan_cli.catalog.write_text_atomic", failing_write_text_atomic):
             with pytest.raises(CatalogInitError) as exc_info:
-                init_catalog(catalog_dir)
+                init_catalog(catalog_dir, license_id="CC-BY-4.0")
             assert "Cannot write config.yaml" in exc_info.value.message
+
+    @pytest.mark.unit
+    def test_init_catalog_raises_on_metadata_write_failure(self, tmp_path: Path) -> None:
+        """CatalogInitError raised when the seeded metadata.yaml write fails (issue #686)."""
+        from unittest.mock import patch
+
+        from portolan_cli.catalog import CatalogInitError, init_catalog
+
+        catalog_dir = tmp_path / "test"
+        catalog_dir.mkdir()
+
+        def failing_write_text_atomic(path: Path, content: str) -> None:
+            if path.name == "metadata.yaml":
+                raise OSError("Disk full")
+
+        with patch("portolan_cli.catalog.write_text_atomic", failing_write_text_atomic):
+            with pytest.raises(CatalogInitError) as exc_info:
+                init_catalog(catalog_dir, license_id="CC-BY-4.0")
+            assert "Cannot write metadata.yaml" in exc_info.value.message
+        # config.yaml is the sentinel and is written last, so the catalog stays FRESH.
+        assert not (catalog_dir / ".portolan" / "config.yaml").exists()
 
     # Note: test_init_catalog_raises_on_state_write_failure removed per issue #290
     # state.json is no longer created during init
@@ -471,7 +495,7 @@ class TestInitCatalogFilesystemErrors:
 
         with patch("portolan_cli.catalog.write_json_atomic", failing_write_json_atomic):
             with pytest.raises(CatalogInitError) as exc_info:
-                init_catalog(catalog_dir)
+                init_catalog(catalog_dir, license_id="CC-BY-4.0")
             assert "Cannot write versions.json" in exc_info.value.message
 
     @pytest.mark.unit
@@ -491,5 +515,5 @@ class TestInitCatalogFilesystemErrors:
 
         with patch.object(pystac.Catalog, "save", failing_save):
             with pytest.raises(CatalogInitError) as exc_info:
-                init_catalog(catalog_dir)
+                init_catalog(catalog_dir, license_id="CC-BY-4.0")
             assert "Cannot write catalog.json" in exc_info.value.message

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -29,7 +29,7 @@ class TestConfigSet:
         """config set should create .portolan/config.yaml if it doesn't exist."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize catalog first
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "set", "backend", "stac"])
 
@@ -40,7 +40,7 @@ class TestConfigSet:
     def test_set_writes_value(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set should write the value to config file."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "set", "backend", "iceberg"])
 
@@ -52,7 +52,7 @@ class TestConfigSet:
     def test_set_outputs_success_message(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set should output a success message."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "set", "backend", "stac"])
 
@@ -64,7 +64,7 @@ class TestConfigSet:
     def test_set_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set should output JSON envelope with --format json."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["--format", "json", "config", "set", "backend", "stac"])
 
@@ -79,7 +79,7 @@ class TestConfigSet:
     def test_set_collection_level(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set --collection should set collection-level config."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(
                 cli,
@@ -106,7 +106,7 @@ class TestConfigSet:
     def test_set_shows_collection_in_text_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set --collection should mention collection in text output."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(
                 cli,
@@ -120,7 +120,7 @@ class TestConfigSet:
     def test_set_rejects_sensitive_settings(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set should reject sensitive settings (remote, profile, region)."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Test remote
             result = runner.invoke(cli, ["config", "set", "remote", "s3://bucket/"])
@@ -148,7 +148,7 @@ class TestConfigGet:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Use non-sensitive key for testing config read
             save_config(Path("."), {"backend": "iceberg"})
 
@@ -163,7 +163,7 @@ class TestConfigGet:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"backend": "iceberg"})
 
             result = runner.invoke(cli, ["config", "get", "backend"])
@@ -178,7 +178,7 @@ class TestConfigGet:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"remote": "s3://from-config/"})
 
             with mock.patch.dict(os.environ, {"PORTOLAN_REMOTE": "s3://from-env/"}):
@@ -192,7 +192,7 @@ class TestConfigGet:
     def test_get_not_set(self, runner: CliRunner, tmp_path: Path) -> None:
         """config get should indicate when a setting is not set."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "get", "remote"])
 
@@ -217,7 +217,7 @@ class TestConfigGet:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"backend": "iceberg"})
 
             result = runner.invoke(cli, ["--format", "json", "config", "get", "backend"])
@@ -245,7 +245,7 @@ class TestConfigList:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"backend": "iceberg", "statistics.enabled": True})
 
             result = runner.invoke(cli, ["config", "list"])
@@ -260,7 +260,7 @@ class TestConfigList:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"backend": "iceberg"})
 
             with mock.patch.dict(os.environ, {"PORTOLAN_STATISTICS_ENABLED": "true"}):
@@ -277,7 +277,7 @@ class TestConfigList:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"backend": "iceberg"})
 
             result = runner.invoke(cli, ["--format", "json", "config", "list"])
@@ -292,7 +292,7 @@ class TestConfigList:
     def test_list_empty_config(self, runner: CliRunner, tmp_path: Path) -> None:
         """config list should handle empty config gracefully."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "list"])
 
@@ -316,7 +316,7 @@ class TestConfigList:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(
                 Path("."),
                 {"collections": {"demo": {"backend": "iceberg"}}},
@@ -342,7 +342,7 @@ class TestConfigUnset:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"remote": "s3://bucket/"})
 
             result = runner.invoke(cli, ["config", "unset", "remote"])
@@ -355,7 +355,7 @@ class TestConfigUnset:
     def test_unset_nonexistent_key(self, runner: CliRunner, tmp_path: Path) -> None:
         """config unset should warn when key doesn't exist."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "unset", "nonexistent"])
 
@@ -380,7 +380,7 @@ class TestConfigUnset:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(Path("."), {"remote": "s3://bucket/"})
 
             result = runner.invoke(cli, ["--format", "json", "config", "unset", "remote"])
@@ -398,7 +398,7 @@ class TestConfigUnset:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(
                 Path("."),
                 {"collections": {"demographics": {"remote": "s3://collection/"}}},
@@ -426,7 +426,7 @@ class TestConfigErrorMessages:
         # The actual error would be in sync/push commands, not config
         # But we can test that config get shows helpful info
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["config", "get", "remote"])
 
@@ -442,7 +442,7 @@ class TestConfigErrorMessages:
     def test_get_json_output_not_set(self, runner: CliRunner, tmp_path: Path) -> None:
         """config get should output JSON with value=null when not set."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["--format", "json", "config", "get", "remote"])
 
@@ -458,7 +458,7 @@ class TestConfigErrorMessages:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(
                 Path("."),
                 {"collections": {"demo": {"backend": "iceberg"}}},
@@ -478,7 +478,7 @@ class TestConfigErrorMessages:
     def test_set_collection_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """config set --collection should include collection in JSON output."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             # Use non-sensitive key for testing JSON output format
             result = runner.invoke(
@@ -506,7 +506,7 @@ class TestConfigErrorMessages:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Use non-sensitive key (backend) to create collection config
             save_config(
                 Path("."),
@@ -567,7 +567,7 @@ class TestConfigErrorMessages:
         from portolan_cli.config import save_config
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             save_config(
                 Path("."),
                 {"collections": {"demo": {"remote": "s3://col/"}}},

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -28,7 +28,7 @@ class TestCliInit:
     ) -> None:
         """portolan init should create catalog.json at root and .portolan directory."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             # New structure: catalog.json at root
@@ -42,7 +42,7 @@ class TestCliInit:
     def test_init_prints_success_message(self, runner: CliRunner, tmp_path: Path) -> None:
         """portolan init should print a success message."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             assert "Initialized" in result.output or "\u2713" in result.output
@@ -57,7 +57,7 @@ class TestCliInit:
             (portolan / "config.yaml").write_text("# Portolan config\n")
 
             # Use --auto to skip interactive prompts and test error path
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             assert "already" in result.output.lower()
@@ -70,7 +70,7 @@ class TestCliInit:
             Path("catalog.json").write_text('{"type": "Catalog"}')
 
             # Use --auto to skip interactive prompts and test error path
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 1
             output_lower = result.output.lower()
@@ -83,7 +83,7 @@ class TestCliInit:
             target = Path("my-catalog")
             target.mkdir()
 
-            result = runner.invoke(cli, ["init", "--auto", str(target)])
+            result = runner.invoke(cli, ["init", "--auto", str(target), "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0
             assert (target / "catalog.json").exists()
@@ -95,7 +95,9 @@ class TestCliInit:
         import json
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto", "--title", "My Test Catalog"])
+            result = runner.invoke(
+                cli, ["init", "--auto", "--title", "My Test Catalog", "--license", "CC-BY-4.0"]
+            )
 
             assert result.exit_code == 0
             data = json.loads(Path("catalog.json").read_text())
@@ -107,7 +109,10 @@ class TestCliInit:
         import json
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            result = runner.invoke(cli, ["init", "--auto", "--description", "Test description"])
+            result = runner.invoke(
+                cli,
+                ["init", "--auto", "--description", "Test description", "--license", "CC-BY-4.0"],
+            )
 
             assert result.exit_code == 0
             data = json.loads(Path("catalog.json").read_text())
@@ -134,7 +139,7 @@ class TestCliInitInteractive:
             result = runner.invoke(
                 cli,
                 ["init"],
-                input="Interactive Title\nInteractive Description\n",
+                input="Interactive Title\nInteractive Description\nCC-BY-4.0\n",
             )
 
             assert result.exit_code == 0, f"Failed: {result.output}"
@@ -158,7 +163,7 @@ class TestCliInitInteractive:
             result = runner.invoke(
                 cli,
                 ["init"],
-                input="\nCustom Description\n",
+                input="\nCustom Description\nCC-BY-4.0\n",
             )
 
             assert result.exit_code == 0, f"Failed: {result.output}"
@@ -179,7 +184,7 @@ class TestCliInitInteractive:
             result = runner.invoke(
                 cli,
                 ["init"],
-                input="\n\n",
+                input="\n\nCC-BY-4.0\n",
             )
 
             assert result.exit_code == 0, f"Failed: {result.output}"
@@ -193,7 +198,7 @@ class TestCliInitInteractive:
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # JSON mode should not prompt
-            result = runner.invoke(cli, ["--format", "json", "init"])
+            result = runner.invoke(cli, ["--format", "json", "init", "--license", "CC-BY-4.0"])
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             # Verify JSON output

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -27,21 +27,28 @@ class TestMetadataInit:
         return CliRunner()
 
     @pytest.mark.unit
-    def test_creates_metadata_yaml_at_catalog_root(self, runner: CliRunner, tmp_path: Path) -> None:
-        """metadata init --no-recursive should create .portolan/metadata.yaml at catalog root."""
+    def test_leaves_the_catalog_root_metadata_alone(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """`portolan init` seeds the root metadata.yaml, so `metadata init` must not clobber it.
+
+        Overwriting it would drop the license the human supplied at init and leave
+        the catalog unable to accept an add (issue #686).
+        """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["metadata", "init", "--no-recursive"])
 
-            assert result.exit_code == 0, f"Failed: {result.output}"
-            assert Path(".portolan/metadata.yaml").exists()
+            assert result.exit_code == 1
+            assert "already exists" in result.output
+            assert 'license: "CC-BY-4.0"' in Path(".portolan/metadata.yaml").read_text()
 
     @pytest.mark.unit
     def test_creates_metadata_yaml_at_collection(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init PATH --no-recursive should create .portolan/metadata.yaml at collection level."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("demographics").mkdir()
 
             result = runner.invoke(cli, ["metadata", "init", "demographics", "--no-recursive"])
@@ -53,7 +60,7 @@ class TestMetadataInit:
     def test_does_not_overwrite_existing(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init --no-recursive should not overwrite existing metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text("license: CC-BY-4.0\n")
 
             runner.invoke(cli, ["metadata", "init", "--no-recursive"])
@@ -66,7 +73,7 @@ class TestMetadataInit:
     def test_force_overwrites_existing(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init --force --no-recursive should overwrite existing metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text("license: Old\n")
 
             result = runner.invoke(cli, ["metadata", "init", "--force", "--no-recursive"])
@@ -80,9 +87,13 @@ class TestMetadataInit:
     def test_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init --format json --no-recursive should output JSON envelope."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
+            # The root file exists after init, so target a collection to write one.
+            Path("demographics").mkdir()
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "--no-recursive"])
+            result = runner.invoke(
+                cli, ["--format", "json", "metadata", "init", "demographics", "--no-recursive"]
+            )
 
             assert result.exit_code == 0
             output = json.loads(result.output)
@@ -106,7 +117,7 @@ class TestMetadataInit:
         """metadata init (recursive by default) should create templates at all STAC levels."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Set up catalog with subcatalog and collection
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Subcatalog
             Path("climate").mkdir()
             Path("climate/catalog.json").write_text('{"type": "Catalog"}')
@@ -133,7 +144,7 @@ class TestMetadataInit:
     def test_recursive_skips_existing_metadata(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init (recursive by default) should skip directories with existing metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Create collection with existing metadata
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
@@ -153,7 +164,7 @@ class TestMetadataInit:
     def test_recursive_skips_items(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init (recursive by default) should NOT create metadata for items."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Collection with an item
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
@@ -172,7 +183,7 @@ class TestMetadataInit:
     def test_recursive_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init --json (recursive by default) should report created and skipped paths."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
 
@@ -188,7 +199,7 @@ class TestMetadataInit:
     def test_recursive_with_explicit_path(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init PATH (recursive by default) should start from specified path."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Subcatalog with nested collection
             Path("climate").mkdir()
             Path("climate/catalog.json").write_text('{"type": "Catalog"}')
@@ -204,8 +215,8 @@ class TestMetadataInit:
             # climate subtree should have metadata
             assert Path("climate/.portolan/metadata.yaml").exists()
             assert Path("climate/hittekaart/.portolan/metadata.yaml").exists()
-            # Root should NOT have metadata (we started from climate)
-            assert not Path(".portolan/metadata.yaml").exists()
+            # Root was seeded by init and must be untouched (we started from climate)
+            assert 'license: "CC-BY-4.0"' in Path(".portolan/metadata.yaml").read_text()
             # demographics should NOT have metadata
             assert not Path("demographics/.portolan/metadata.yaml").exists()
 
@@ -213,7 +224,7 @@ class TestMetadataInit:
     def test_recursive_nonexistent_path_fails(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init with non-existent path should fail with clear error."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["metadata", "init", "nonexistent"])
 
@@ -226,7 +237,7 @@ class TestMetadataInit:
     ) -> None:
         """metadata init with non-existent path should output JSON error."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["--format", "json", "metadata", "init", "nonexistent"])
 
@@ -239,7 +250,7 @@ class TestMetadataInit:
     def test_recursive_force_overwrites_content(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init --force (recursive by default) should actually overwrite existing content."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
             Path("demographics/.portolan").mkdir()
@@ -258,7 +269,7 @@ class TestMetadataInit:
     def test_recursive_json_output_complete_schema(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init --json (recursive by default) should have complete schema fields."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Create collection with existing metadata (to get skipped paths)
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text('{"type": "Collection"}')
@@ -292,7 +303,7 @@ class TestMetadataInit:
     def test_recursive_skips_symlinks(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata init (recursive by default) should skip symlinks to prevent infinite loops."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("climate").mkdir()
             Path("climate/catalog.json").write_text('{"type": "Catalog"}')
             # Create a symlink that would cause infinite loop
@@ -320,7 +331,7 @@ class TestMetadataValidate:
     def test_passes_for_valid_metadata(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --no-recursive should pass for valid metadata.yaml with contact + license."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Only contact and license are required now
             Path(".portolan/metadata.yaml").write_text(
                 "contact:\n  name: Test User\n  email: test@example.org\nlicense: CC-BY-4.0\n"
@@ -334,7 +345,7 @@ class TestMetadataValidate:
     def test_fails_for_missing_required_fields(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --no-recursive should fail when required fields (contact, license) are missing."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text(
                 "citation: Some citation\n"  # Missing contact and license
             )
@@ -349,7 +360,7 @@ class TestMetadataValidate:
     def test_fails_for_invalid_email(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --no-recursive should fail for invalid email format."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text(
                 "contact:\n  name: Test\n  email: not-an-email\nlicense: MIT\n"
             )
@@ -363,7 +374,7 @@ class TestMetadataValidate:
     def test_validates_collection_level(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate PATH --no-recursive should validate at collection level."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("demographics/.portolan").mkdir(parents=True)
             Path("demographics/.portolan/metadata.yaml").write_text(
                 "contact:\n  name: Team\n  email: team@org.com\nlicense: CC0-1.0\n"
@@ -377,7 +388,7 @@ class TestMetadataValidate:
     def test_json_output_success(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --format json --no-recursive should output JSON on success."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text(
                 "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
             )
@@ -396,7 +407,7 @@ class TestMetadataValidate:
     def test_json_output_failure(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --format json --no-recursive should output errors in JSON."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text("citation: Test\n")  # Incomplete
 
             result = runner.invoke(
@@ -413,7 +424,7 @@ class TestMetadataValidate:
     def test_recursive_validates_all_levels(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate (recursive by default) should validate all STAC levels."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
             # Root metadata
             Path(".portolan/metadata.yaml").write_text(valid_metadata)
@@ -441,7 +452,7 @@ class TestMetadataValidate:
         (not just missing fields, which would inherit from parent).
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
             # Invalid metadata: override with invalid email (can't be fixed by inheritance)
             invalid_email_metadata = "contact:\n  name: Test\n  email: not-an-email\nlicense: MIT\n"
@@ -468,7 +479,7 @@ class TestMetadataValidate:
     def test_recursive_json_output_schema(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --json should have complete recursive schema."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
             invalid_metadata = "citation: Test\n"
             # Root: valid
@@ -501,7 +512,7 @@ class TestMetadataValidate:
         To test actual errors, children must explicitly override with INVALID values.
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
             # Invalid: override with invalid email (can't be fixed by inheritance)
             invalid_email = "contact:\n  name: Test\n  email: not-valid\nlicense: MIT\n"
@@ -521,7 +532,7 @@ class TestMetadataValidate:
     def test_no_recursive_limits_to_single_path(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --no-recursive should only validate target path."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
             invalid_metadata = "citation: Test\n"
             # Root: valid
@@ -543,7 +554,7 @@ class TestMetadataValidate:
     ) -> None:
         """metadata validate should skip STAC levels without metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             valid_metadata = "contact:\n  name: Test\n  email: test@example.org\nlicense: MIT\n"
             # Root: valid
             Path(".portolan/metadata.yaml").write_text(valid_metadata)
@@ -560,7 +571,7 @@ class TestMetadataValidate:
     def test_no_recursive_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate --no-recursive --json should output single-path schema."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path(".portolan/metadata.yaml").write_text(
                 "contact:\n  name: N\n  email: a@b.c\nlicense: MIT\n"
             )
@@ -588,7 +599,7 @@ class TestReadmeGenerate:
     def test_generates_readme_at_catalog_root(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme should generate README.md at catalog root."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             # Create catalog.json with title
             Path("catalog.json").write_text(
                 json.dumps(
@@ -615,7 +626,7 @@ class TestReadmeGenerate:
     def test_generates_readme_at_collection(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme PATH should generate README.md at collection level."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("demographics/.portolan").mkdir(parents=True)
             Path("demographics/collection.json").write_text(
                 json.dumps(
@@ -643,7 +654,7 @@ class TestReadmeGenerate:
         Note: --stdout requires --no-recursive since you can't print multiple READMEs to stdout.
         """
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "My Catalog"})
             )
@@ -665,7 +676,7 @@ class TestReadmeGenerate:
     def test_check_mode_passes_when_fresh(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --check should pass (exit 0) when README is up-to-date."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -683,7 +694,7 @@ class TestReadmeGenerate:
     def test_check_mode_fails_when_stale(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --check should fail (exit 1) when README is stale."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -701,7 +712,7 @@ class TestReadmeGenerate:
     def test_check_mode_fails_when_missing(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --check should fail (exit 1) when README doesn't exist."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -717,7 +728,7 @@ class TestReadmeGenerate:
     def test_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --format json should output JSON envelope."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -736,7 +747,7 @@ class TestReadmeGenerate:
     def test_uses_stac_title_not_metadata(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme should use title from STAC, not metadata.yaml."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps(
                     {
@@ -762,7 +773,7 @@ class TestReadmeGenerate:
     def test_verbose_shows_file_reads(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --verbose should show which files are being read."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("demographics").mkdir()
             Path("demographics/collection.json").write_text(
                 json.dumps({"type": "Collection", "id": "demographics", "title": "Demographics"})
@@ -786,7 +797,7 @@ class TestReadmeGenerate:
     def test_verbose_short_flag(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme -v should work as shorthand for --verbose."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -806,7 +817,7 @@ class TestReadmeGenerate:
     ) -> None:
         """readme --verbose (recursive by default) should show progress for each collection."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "root", "title": "Root"})
             )
@@ -837,7 +848,7 @@ class TestReadmeGenerate:
     ) -> None:
         """readme --check --verbose should show file reads even when README is fresh."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -857,7 +868,7 @@ class TestReadmeGenerate:
     def test_verbose_ignored_with_json_output(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --verbose --json should not include verbose messages in JSON."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -877,7 +888,7 @@ class TestReadmeGenerate:
     def test_default_no_verbose_is_minimal(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme without --verbose should produce minimal output."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             Path("catalog.json").write_text(
                 json.dumps({"type": "Catalog", "id": "test", "title": "Test"})
             )
@@ -908,7 +919,7 @@ class TestPathTraversalHardening:
     ) -> None:
         """metadata init (recursive default) rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["metadata", "init", "../escape"])
 
@@ -921,7 +932,7 @@ class TestPathTraversalHardening:
     ) -> None:
         """metadata init --no-recursive rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["metadata", "init", "../escape", "--no-recursive"])
 
@@ -932,7 +943,7 @@ class TestPathTraversalHardening:
     def test_metadata_validate_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
         """metadata validate rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["metadata", "validate", "../escape"])
 
@@ -945,7 +956,7 @@ class TestPathTraversalHardening:
     ) -> None:
         """metadata validate --no-recursive rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["metadata", "validate", "../escape", "--no-recursive"])
 
@@ -956,7 +967,7 @@ class TestPathTraversalHardening:
     def test_readme_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["readme", "../escape"])
 
@@ -967,7 +978,7 @@ class TestPathTraversalHardening:
     def test_readme_no_recursive_rejects_traversal(self, runner: CliRunner, tmp_path: Path) -> None:
         """readme --no-recursive rejects a PATH escaping the catalog."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["readme", "../escape", "--no-recursive"])
 
@@ -980,7 +991,7 @@ class TestPathTraversalHardening:
     ) -> None:
         """JSON error for a recursive readme traversal must be labeled 'readme'."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["--format", "json", "readme", "../escape"])
 
@@ -994,7 +1005,7 @@ class TestPathTraversalHardening:
     ) -> None:
         """JSON error for a recursive validate traversal must be labeled 'metadata validate'."""
         with runner.isolated_filesystem(temp_dir=tmp_path):
-            runner.invoke(cli, ["init", "--auto"])
+            runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
             result = runner.invoke(cli, ["--format", "json", "metadata", "validate", "../escape"])
 

--- a/tests/unit/test_cli_metadata_readme.py
+++ b/tests/unit/test_cli_metadata_readme.py
@@ -92,7 +92,15 @@ class TestMetadataInit:
             Path("demographics").mkdir()
 
             result = runner.invoke(
-                cli, ["--format", "json", "metadata", "init", "demographics", "--no-recursive"]
+                cli,
+                [
+                    "--format",
+                    "json",
+                    "metadata",
+                    "init",
+                    "demographics",
+                    "--no-recursive",
+                ],
             )
 
             assert result.exit_code == 0
@@ -239,7 +247,10 @@ class TestMetadataInit:
         with runner.isolated_filesystem(temp_dir=tmp_path):
             runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
 
-            result = runner.invoke(cli, ["--format", "json", "metadata", "init", "nonexistent"])
+            result = runner.invoke(
+                cli,
+                ["--format", "json", "metadata", "init", "nonexistent"],
+            )
 
             assert result.exit_code != 0
             output = json.loads(result.output)

--- a/tests/unit/test_csv_skip.py
+++ b/tests/unit/test_csv_skip.py
@@ -38,6 +38,7 @@ def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog structure."""
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     catalog_data = {
         "type": "Catalog",
@@ -445,6 +446,7 @@ class TestCsvSkipHypothesis:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             catalog_data = {
                 "type": "Catalog",
                 "stac_version": "1.0.0",
@@ -497,6 +499,7 @@ class TestCsvSkipHypothesis:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             catalog_data = {
                 "type": "Catalog",
                 "stac_version": "1.0.0",
@@ -575,6 +578,7 @@ class TestCsvSkipHypothesis:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             catalog_data = {
                 "type": "Catalog",
                 "stac_version": "1.0.0",
@@ -1578,6 +1582,7 @@ class TestMixedFormatIntegration:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             catalog_data = {
                 "type": "Catalog",
                 "stac_version": "1.0.0",

--- a/tests/unit/test_init_license.py
+++ b/tests/unit/test_init_license.py
@@ -1,0 +1,194 @@
+"""Unit tests for the license ``portolan init`` acquires (issue #686).
+
+``add`` refuses to write a collection with no license, so ``init`` collects one up
+front and seeds it into ``.portolan/metadata.yaml``. The hierarchical merge then
+hands it to every collection, and the gate in ``add_files`` passes without the
+human editing anything.
+
+Prompting is interactive-only. On ``--auto`` or ``--json`` there is nobody to ask,
+so a missing ``--license`` is an error rather than a silent default, matching how
+``extract`` handles a missing ArcGIS password.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.metadata_yaml import validate_metadata
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _metadata(root: Path) -> dict[str, object]:
+    parsed = yaml.safe_load((root / ".portolan" / "metadata.yaml").read_text())
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+class TestInitRequiresALicense:
+    def test_auto_without_a_license_fails(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--auto"])
+
+        assert result.exit_code == 1, result.output
+        assert "PRTLN-VAL004" in result.output
+        assert "--license" in result.output
+
+    def test_json_without_a_license_fails(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["errors"][0]["type"] == "MissingLicenseError"
+        assert payload["errors"][0]["code"] == "PRTLN-VAL004"
+
+    def test_other_without_a_url_fails(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--auto", "--license", "other"])
+
+        assert result.exit_code == 1, result.output
+        assert "license_url" in result.output
+
+    def test_proprietary_fails(self, runner: CliRunner, tmp_path: Path) -> None:
+        """PTL-LIC-003 rejects it, so init will not write it in the first place."""
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--auto", "--license", "proprietary"])
+
+        assert result.exit_code == 1, result.output
+        assert "deprecated" in result.output
+
+    def test_writes_nothing_when_it_refuses(self, runner: CliRunner, tmp_path: Path) -> None:
+        """The license is validated before init touches the filesystem."""
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--auto"])
+
+        assert result.exit_code == 1
+        assert not (root / "catalog.json").exists()
+        assert not (root / ".portolan").exists()
+
+
+class TestInitSeedsTheLicense:
+    def test_auto_with_a_license_succeeds(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--auto", "--license", "CC-BY-4.0"])
+
+        assert result.exit_code == 0, result.output
+        assert _metadata(root)["license"] == "CC-BY-4.0"
+
+    def test_other_with_a_url_succeeds(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                str(root),
+                "--auto",
+                "--license",
+                "other",
+                "--license-url",
+                "https://x.org/terms",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        metadata = _metadata(root)
+        assert metadata["license"] == "other"
+        assert metadata["license_url"] == "https://x.org/terms"
+
+    def test_the_seeded_metadata_carries_no_license_error(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """The seeded file satisfies the license half of metadata validation.
+
+        Contact stays blank, which is what the two expected errors are. Asserting
+        on them proves the validator ran and simply had nothing to say about the
+        license, rather than the list being empty for some unrelated reason.
+
+        Sorted because ``_validate_contact`` iterates a frozenset, so the two
+        contact errors come back in either order depending on the process.
+        """
+        root = tmp_path / "catalog"
+        init = runner.invoke(cli, ["init", str(root), "--auto", "--license", "MIT"])
+        assert init.exit_code == 0, init.output
+
+        errors = validate_metadata(_metadata(root))
+
+        assert sorted(errors) == [
+            "Field 'contact.email' cannot be empty",
+            "Field 'contact.name' cannot be empty",
+        ]
+
+    def test_the_license_reaches_the_first_collection(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """The point of seeding it: add inherits the license and is not blocked."""
+        root = tmp_path / "catalog"
+        init = runner.invoke(cli, ["init", str(root), "--auto", "--license", "ODbL-1.0"])
+        assert init.exit_code == 0, init.output
+
+        fixture = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
+        source = root / "roads" / "roads.parquet"
+        source.parent.mkdir(parents=True)
+        source.write_bytes(fixture.read_bytes())
+
+        add = runner.invoke(cli, ["add", "--portolan-dir", str(root), str(source)])
+
+        assert add.exit_code == 0, add.output
+        collection = json.loads((root / "roads" / "collection.json").read_text())
+        assert collection["license"] == "ODbL-1.0"
+
+
+class TestInitPrompts:
+    def test_prompts_for_the_license_when_interactive(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root)], input="Demo\nA demo\nCC-BY-4.0\n")
+
+        assert result.exit_code == 0, result.output
+        assert "License" in result.output
+        assert _metadata(root)["license"] == "CC-BY-4.0"
+
+    def test_prompts_for_the_url_when_the_answer_is_other(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """'other' alone is not conformant, so the prompt asks for the link too."""
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(
+            cli, ["init", str(root)], input="Demo\nA demo\nother\nhttps://x.org/terms\n"
+        )
+
+        assert result.exit_code == 0, result.output
+        metadata = _metadata(root)
+        assert metadata["license"] == "other"
+        assert metadata["license_url"] == "https://x.org/terms"
+
+    def test_does_not_ask_when_the_flag_is_given(self, runner: CliRunner, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+
+        result = runner.invoke(cli, ["init", str(root), "--license", "MIT"], input="Demo\nA demo\n")
+
+        assert result.exit_code == 0, result.output
+        assert "License (SPDX" not in result.output
+        assert _metadata(root)["license"] == "MIT"

--- a/tests/unit/test_issue_353_via_link.py
+++ b/tests/unit/test_issue_353_via_link.py
@@ -36,6 +36,7 @@ class TestViaLinkGeneration:
             LayerResult,
             MetadataExtracted,
         )
+        from portolan_cli.licensing import ResolvedLicense
 
         output_dir = tmp_path / "test_catalog"
         output_dir.mkdir()
@@ -91,7 +92,9 @@ class TestViaLinkGeneration:
             ),
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(
+            output_dir, report, ResolvedLicense(license_id="CC-BY-4.0", license_url=None)
+        )
 
         # Verify collection.json has via link
         collection_json_path = output_dir / "test_layer" / "collection.json"
@@ -122,6 +125,7 @@ class TestViaLinkGeneration:
             LayerResult,
             MetadataExtracted,
         )
+        from portolan_cli.licensing import ResolvedLicense
 
         output_dir = tmp_path / "test_catalog"
         output_dir.mkdir()
@@ -179,7 +183,9 @@ class TestViaLinkGeneration:
             ),
         )
 
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(
+            output_dir, report, ResolvedLicense(license_id="CC-BY-4.0", license_url=None)
+        )
 
         # Verify via link points to layer-specific URL
         collection_json_path = output_dir / "census_tracts" / "collection.json"
@@ -202,6 +208,7 @@ class TestViaLinkGeneration:
             LayerResult,
             MetadataExtracted,
         )
+        from portolan_cli.licensing import ResolvedLicense
 
         output_dir = tmp_path / "test_catalog"
         output_dir.mkdir()
@@ -250,7 +257,9 @@ class TestViaLinkGeneration:
         )
 
         # Should not create catalog (no successful extractions)
-        _auto_init_catalog(output_dir, report)
+        _auto_init_catalog(
+            output_dir, report, ResolvedLicense(license_id="CC-BY-4.0", license_url=None)
+        )
 
         # No collection.json should exist
         assert not (output_dir / "failed_layer" / "collection.json").exists()

--- a/tests/unit/test_issue_354_asset_paths.py
+++ b/tests/unit/test_issue_354_asset_paths.py
@@ -324,7 +324,7 @@ class TestAssetPathsInExtraction:
                 extract_arcgis_catalog(
                     url="https://example.com/arcgis/rest/services/Test/FeatureServer",
                     output_dir=output_dir,
-                    options=ExtractionOptions(dry_run=False, raw=False),
+                    options=ExtractionOptions(dry_run=False, raw=False, license="CC-BY-4.0"),
                 )
 
         # Check versions.json in extracted collection

--- a/tests/unit/test_licensing.py
+++ b/tests/unit/test_licensing.py
@@ -1,0 +1,168 @@
+"""Unit tests for the license model a collection must satisfy (issue #686).
+
+A collection with no license, or with ``other`` and no ``rel="license"`` link,
+fails the validator: PTL-LIC-001 and PTL-LIC-002 are both ERROR. ``license_gap``
+answers whether generation is about to produce one of those, branch for branch
+against ``rashid.rules.license``, so ``portolan add`` refuses the write instead
+of shipping a catalog ``portolan check`` then rejects.
+
+Spelling is deliberately out of scope here. rashid keeps its 727-identifier SPDX
+list in a private module, so ``portolan check`` owns that judgment and this
+module never guesses at it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portolan_cli.constants import TODO_MARKER
+from portolan_cli.licensing import (
+    OTHER_LICENSE,
+    PROPRIETARY_LICENSE,
+    license_gap,
+    license_url_from_text,
+    resolve_license,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestLicenseGap:
+    """One branch per rashid license rule."""
+
+    @pytest.mark.parametrize("missing", [None, "", "   ", "\t\n", 42, [], {}])
+    def test_absent_or_blank_is_a_gap(self, missing: object) -> None:
+        """PTL-LIC-001 fires on a collection that declares no license at all."""
+        gap = license_gap(missing, has_license_link=False)  # type: ignore[arg-type]
+
+        assert gap is not None
+        assert "no license is declared" in gap
+
+    def test_a_link_does_not_rescue_a_missing_license(self) -> None:
+        """A license link is not a license. PTL-LIC-001 still fires."""
+        assert license_gap(None, has_license_link=True) is not None
+
+    @pytest.mark.parametrize(
+        "placeholder",
+        [TODO_MARKER, "TODO", "todo: add value", "  TODO: Add value  "],
+    )
+    def test_the_seeded_placeholder_is_a_gap(self, placeholder: str) -> None:
+        """extract seeds a TODO marker, which reaches collection.license verbatim."""
+        gap = license_gap(placeholder, has_license_link=True)
+
+        assert gap is not None
+        assert "placeholder" in gap
+
+    def test_proprietary_is_a_gap(self) -> None:
+        """PTL-LIC-003: 'proprietary' is deprecated and must not be used."""
+        gap = license_gap(PROPRIETARY_LICENSE, has_license_link=True)
+
+        assert gap is not None
+        assert "proprietary" in gap
+
+    def test_other_without_a_link_is_a_gap(self) -> None:
+        """PTL-LIC-002, the defect issue #686 reported."""
+        gap = license_gap(OTHER_LICENSE, has_license_link=False)
+
+        assert gap is not None
+        assert "license_url" in gap
+
+    def test_other_with_a_link_passes(self) -> None:
+        """'other' plus a license link is the second conformant shape."""
+        assert license_gap(OTHER_LICENSE, has_license_link=True) is None
+
+    @pytest.mark.parametrize(
+        "license_id",
+        ["CC-BY-4.0", "MIT", "CC0-1.0", "ODbL-1.0", "EUPL-1.2", "  CC-BY-4.0  "],
+    )
+    def test_an_identifier_passes_without_a_link(self, license_id: str) -> None:
+        """An SPDX identifier needs no link, and spelling is check's job, not ours."""
+        assert license_gap(license_id, has_license_link=False) is None
+
+    def test_spelling_is_not_judged_here(self) -> None:
+        """rashid keeps SPDX_LICENSE_IDS private, so this module cannot and must not check it.
+
+        A misspelled identifier passes the gate and is caught later by
+        PTL-LIC-001 under ``portolan check``. The gate exists to stop the two
+        failures generation itself causes, not to re-implement the SPDX list.
+        """
+        assert license_gap("cc-by-4.0", has_license_link=False) is None
+
+
+class TestResolveLicense:
+    def test_reads_license_and_url(self) -> None:
+        resolved = resolve_license({"license": "other", "license_url": "https://x.org/terms"})
+
+        assert resolved is not None
+        assert resolved.license_id == "other"
+        assert resolved.license_url == "https://x.org/terms"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        resolved = resolve_license({"license": "  MIT  ", "license_url": "  https://x.org  "})
+
+        assert resolved is not None
+        assert resolved.license_id == "MIT"
+        assert resolved.license_url == "https://x.org"
+
+    def test_url_is_none_when_absent_or_blank(self) -> None:
+        assert resolve_license({"license": "MIT"}).license_url is None  # type: ignore[union-attr]
+        assert resolve_license({"license": "MIT", "license_url": ""}).license_url is None  # type: ignore[union-attr]
+
+    @pytest.mark.parametrize("metadata", [{}, {"license": ""}, {"license": None}, "not-a-mapping"])
+    def test_returns_none_when_no_license_is_written(self, metadata: object) -> None:
+        """Nothing declared means the caller falls back to the existing collection."""
+        assert resolve_license(metadata) is None
+
+    def test_does_not_judge_the_value_it_reads(self) -> None:
+        """Reading and judging are separate: license_gap owns the verdict."""
+        resolved = resolve_license({"license": TODO_MARKER})
+
+        assert resolved is not None
+        assert resolved.license_id == TODO_MARKER
+
+
+class TestLicenseUrlFromText:
+    """Harvested license text often carries the license link. Extraction beats invention."""
+
+    def test_pulls_a_bare_url(self) -> None:
+        text = "Open Government Licence, see https://data.example.org/licence for terms"
+
+        assert license_url_from_text(text) == "https://data.example.org/licence"
+
+    def test_pulls_the_href_out_of_arcgis_html(self) -> None:
+        """ArcGIS licenseInfo is usually an HTML fragment."""
+        text = "<a href='https://data.example.org/terms' target='_blank'>Terms of use</a>"
+
+        assert license_url_from_text(text) == "https://data.example.org/terms"
+
+    def test_pulls_the_href_out_of_double_quoted_html(self) -> None:
+        text = '<a href="https://data.example.org/terms">Terms</a>'
+
+        assert license_url_from_text(text) == "https://data.example.org/terms"
+
+    def test_drops_trailing_sentence_punctuation(self) -> None:
+        assert license_url_from_text("See https://x.org/terms.") == "https://x.org/terms"
+        assert license_url_from_text("(https://x.org/terms),") == "https://x.org/terms"
+
+    def test_takes_the_first_url_when_several_appear(self) -> None:
+        text = "Licence: https://x.org/licence. Contact: https://x.org/contact"
+
+        assert license_url_from_text(text) == "https://x.org/licence"
+
+    def test_accepts_plain_http(self) -> None:
+        assert license_url_from_text("http://x.org/terms") == "http://x.org/terms"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            None,
+            "",
+            "   ",
+            "Public domain",
+            "Contact gis@example.org for licensing",
+            "See www.example.org/terms",
+        ],
+    )
+    def test_returns_none_when_there_is_no_url(self, text: str | None) -> None:
+        """No URL means no honest link, so the human has to supply one."""
+        assert license_url_from_text(text) is None

--- a/tests/unit/test_push_default_remote.py
+++ b/tests/unit/test_push_default_remote.py
@@ -539,7 +539,7 @@ class TestPushDefaultRemoteIntegration:
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
             # Initialize catalog
-            result = runner.invoke(cli, ["init", "--auto"])
+            result = runner.invoke(cli, ["init", "--auto", "--license", "CC-BY-4.0"])
             assert result.exit_code == 0, f"Init failed: {result.output}"
 
             # Create a minimal collection for push

--- a/tests/unit/test_scan_bounded_465.py
+++ b/tests/unit/test_scan_bounded_465.py
@@ -29,6 +29,7 @@ def initialized_catalog(tmp_path: Path) -> Path:
     """Minimal initialized catalog."""
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
     (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
     catalog_data = {
         "type": "Catalog",

--- a/tests/unit/test_stac_links_regression.py
+++ b/tests/unit/test_stac_links_regression.py
@@ -55,7 +55,7 @@ def catalog_with_nested_item(tmp_path: Path, valid_parquet: Path) -> tuple[Path,
     catalog_root.mkdir()
 
     # Initialize catalog
-    init_catalog(catalog_root)
+    init_catalog(catalog_root, license_id="CC-BY-4.0")
 
     # Create nested collection structure: collection/item_dir/file.parquet
     collection_id = "test-collection"
@@ -195,7 +195,7 @@ class TestIsCurrentKeyLookup:
         # Arrange: catalog with 2 parquet files in same directory
         catalog_root = tmp_path / "catalog"
         catalog_root.mkdir()
-        init_catalog(catalog_root)
+        init_catalog(catalog_root, license_id="CC-BY-4.0")
 
         collection_id = "multi-file"
         item_dir = catalog_root / collection_id / "data"
@@ -292,7 +292,7 @@ class TestCollectionRootLinks:
         # Arrange: catalog with 2 parquet files in same directory
         catalog_root = tmp_path / "catalog"
         catalog_root.mkdir()
-        init_catalog(catalog_root)
+        init_catalog(catalog_root, license_id="CC-BY-4.0")
 
         collection_id = "multi-file"
         item_dir = catalog_root / collection_id / "data"

--- a/tests/unit/test_tabular_parquet_skip.py
+++ b/tests/unit/test_tabular_parquet_skip.py
@@ -40,6 +40,7 @@ def initialized_catalog(tmp_path: Path) -> Path:
     """Create an initialized Portolan catalog structure."""
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     # Create config.yaml as sentinel
     config_path = portolan_dir / "config.yaml"
@@ -524,6 +525,7 @@ class TestTabularParquetHypothesis:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             config_path = portolan_dir / "config.yaml"
             config_path.write_text("# Portolan config\n")
             catalog_data = {
@@ -577,6 +579,7 @@ class TestTabularParquetHypothesis:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             config_path = portolan_dir / "config.yaml"
             config_path.write_text("# Portolan config\n")
             catalog_data = {
@@ -653,6 +656,7 @@ class TestTabularParquetHypothesis:
             # Set up catalog
             portolan_dir = tmp_path / ".portolan"
             portolan_dir.mkdir(exist_ok=True)
+            (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
             config_path = portolan_dir / "config.yaml"
             config_path.write_text("# Portolan config\n")
             catalog_data = {

--- a/tests/unit/test_tabular_support.py
+++ b/tests/unit/test_tabular_support.py
@@ -230,6 +230,7 @@ def _setup_test_catalog(path: Path) -> None:
     """Create an initialized Portolan catalog for tests."""
     portolan_dir = path / ".portolan"
     portolan_dir.mkdir()
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
     (portolan_dir / "config.yaml").write_text("# Portolan configuration\n")
     catalog_data = {
         "type": "Catalog",


### PR DESCRIPTION
# Require a usable license when creating collections (#686)

## What this changes

Portolan now refuses to create a collection unless it has a usable license. The new `licensing.py` module contains the same license rules that Rashid uses for `PTL-LIC-002`, so Portolan and Rashid apply the same checks.

`add` checks the license before creating or converting the collection, so a failed check does not leave a `collection.json` behind. `init` asks for a license and writes it to `.portolan/metadata.yaml`. `add-external` now requires `--license` and also accepts `--license-url`. `extract` uses a license URL from the harvested metadata when available; otherwise it resolves the license supplied with `--license` before downloading the data.

## Why

Several Portolan commands could create collections with `license: "other"` but no `rel="license"` link. Rashid then rejected those collections with `PTL-LIC-002`. This was especially common with `add-external`, which could produce an invalid collection on every run.

Portolan cannot determine the legal license for data on its own. It should therefore require the user to provide one rather than create a catalog that fails validation.

## Verification

The test uses `tests/fixtures/realdata/nwi-wetlands.parquet`, which contains 1,000 features from the National Wetlands Inventory.

When `init` has no license, it now stops before creating the catalog and explains how to provide one:

```console
$ portolan init "$E" --auto --title "NWI Wetlands" --description "..."
✗ [PRTLN-VAL004] No usable license for 'portolan init': no license is declared
→ Pass --license with an SPDX identifier such as CC-BY-4.0, or --license other
  together with --license-url pointing at the license text.
```

Providing a license allows initialization to continue:

```console
$ portolan init "$E" --auto --title "NWI Wetlands" --description "..." \
    --license CC-BY-4.0
✓ Initialized Portolan catalog in .../evidence

$ portolan add --portolan-dir "$E" "$E/wetlands/nwi-wetlands.parquet"
✓ Added 1 file to 1 collection

$ portolan check "$E" --json | jq '[.data.findings[].rule_id | select(test("LIC"))]'
[]
```

If the catalog metadata has no license, `add` also refuses to create a new collection. It leaves the source file untouched.

```console
$ portolan add --portolan-dir "$E" "$E/buildings/open-buildings.parquet"
✗ [PRTLN-VAL004] No usable license for collection 'buildings': no license is declared
→ Set 'license:' in .portolan/metadata.yaml to an SPDX identifier such as
  CC-BY-4.0, or to 'other' with a 'license_url:' pointing at the license text.

$ ls "$E/buildings/"
open-buildings.parquet
```

## Other fixes

Collection-level metadata could previously add a placeholder license that overrode the real license from the catalog because child metadata wins the merge. That placeholder is no longer written.

`init` also no longer overwrites an existing `metadata.yaml` that was created before initialization.

## Tests

The conformance gate now includes the no-license case from #686. A companion test takes an otherwise conformant catalog, changes its license to `other`, removes the license link, and checks that Rashid reports exactly `PTL-LIC-002`. The test continues to use `check`, as established in #727.

Closes #686.
