### PR TITLE
fix(stac): route every normalize_hrefs call through one href root (#731)

### DIFF
--- a/portolan_cli/backends/iceberg/backend.py
+++ b/portolan_cli/backends/iceberg/backend.py
@@ -24,6 +24,7 @@ from portolan_cli.backends.iceberg.versioning import (
     version_to_snapshot_properties,
 )
 from portolan_cli.backends.protocol import DriftReport, SchemaFingerprint
+from portolan_cli.utils import href_root
 from portolan_cli.versions import Asset, SchemaInfo, Version
 
 if TYPE_CHECKING:
@@ -375,7 +376,7 @@ class IcebergBackend:
                 ),
             )
 
-            collection.normalize_hrefs(str(collection_dir))
+            collection.normalize_hrefs(href_root(collection_dir))
             collection.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
         except Exception:
             logger.warning(

--- a/portolan_cli/backends/json_file.py
+++ b/portolan_cli/backends/json_file.py
@@ -21,7 +21,7 @@ Deferred Features:
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING
 
 from portolan_cli.backends.protocol import DriftReport, SchemaFingerprint
@@ -88,10 +88,18 @@ class JsonFileBackend:
         # than discarding its parts. Validation stays lexical (no `resolve()`) so the
         # returned path keeps the caller's catalog root verbatim, which matters where
         # the root is itself a symlink (macOS `/tmp`).
+        # Judge the id under both path flavors, never just the host's. `pathlib`
+        # splits by platform, and each flavor is blind to the other's escapes.
+        # On Windows `/etc/passwd` is rooted but not absolute, because absolute
+        # there needs a drive, so the guard passed it. On POSIX every backslash
+        # form (`C:\Windows`, `\\server\share`, `climate\..\..\etc`) is a single
+        # filename, so the guard passed those instead. A collection id is a
+        # slash-separated spec string, not a host path, so it must satisfy both.
         candidate = Path(collection)
-        if candidate.is_absolute() or candidate.drive or not candidate.parts:
-            raise ValueError(f"Invalid collection name: {collection!r}")
-        if any(part == ".." for part in candidate.parts):
+        flavors = (PurePosixPath(collection), PureWindowsPath(collection))
+        if not candidate.parts or any(
+            f.is_absolute() or f.root or f.drive or ".." in f.parts for f in flavors
+        ):
             raise ValueError(f"Invalid collection name: {collection!r}")
         # versions.json at collection root
         return self._catalog_root.joinpath(*candidate.parts) / "versions.json"

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -21,7 +21,7 @@ from portolan_cli.errors import CatalogAlreadyExistsError
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic, write_text_atomic
 from portolan_cli.models.catalog import CatalogModel
-from portolan_cli.utils import relative_href
+from portolan_cli.utils import href_root, relative_href
 
 if sys.version_info >= (3, 11):
     from typing import Self
@@ -512,10 +512,7 @@ def init_catalog(
     )
 
     catalog_file = path / "catalog.json"
-    # Absolute path and trailing slash both required: pystac treats a final
-    # component containing a dot (e.g., tmp.xyz) as a file, and it discards the
-    # trailing slash of a relative root while absolutizing it.
-    catalog.normalize_hrefs(f"{path}/")
+    catalog.normalize_hrefs(href_root(path))
     try:
         catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
     except OSError as e:

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -407,6 +407,8 @@ def init_catalog(
 
     Args:
         path: Directory path for the catalog. Will be created if doesn't exist.
+            Resolved before use, so a relative path such as the CLI's "." default
+            is interpreted against the working directory exactly once.
         title: Optional catalog title.
         description: Optional catalog description.
         backend: Versioning backend name.
@@ -415,7 +417,8 @@ def init_catalog(
         license_url: URL of the license text. Required when license_id is "other".
 
     Returns:
-        Tuple of (catalog_file_path, warnings).
+        Tuple of (catalog_file_path, warnings). The path is absolute, so callers
+        can read it back without matching the working directory init ran in.
 
     Raises:
         CatalogAlreadyExistsError: If directory is in MANAGED state.
@@ -426,8 +429,14 @@ def init_catalog(
 
     from portolan_cli.errors import UnmanagedStacCatalogError
 
-    # Ensure path exists
-    path = Path(path)
+    # Ensure path exists. Resolve first: the path argument defaults to "." and
+    # every downstream write, including pystac's, then depends on the working
+    # directory. pystac's normalize_hrefs drops the trailing slash when it
+    # absolutizes a relative root, so a dotted working directory name trips the
+    # file-versus-directory heuristic of issue #401 and catalog.json lands in the
+    # parent. Resolving here keeps the trailing slash meaningful and gives the
+    # caller an absolute path to read back (issue #731).
+    path = Path(path).resolve()
     try:
         path.mkdir(parents=True, exist_ok=True)
     except OSError as e:
@@ -451,8 +460,8 @@ def init_catalog(
 
     warnings: list[str] = []
 
-    # Auto-extract id from directory name
-    catalog_id = _sanitize_id(path.resolve().name)
+    # Auto-extract id from directory name (path is already resolved)
+    catalog_id = _sanitize_id(path.name)
 
     # Set defaults. Issue #502: title is mandatory and must be human-readable,
     # so derive one from the directory name instead of leaving it empty.
@@ -503,7 +512,9 @@ def init_catalog(
     )
 
     catalog_file = path / "catalog.json"
-    # Trailing slash required: pystac treats dotted paths (e.g., tmp.xyz) as files
+    # Absolute path and trailing slash both required: pystac treats a final
+    # component containing a dot (e.g., tmp.xyz) as a file, and it discards the
+    # trailing slash of a relative root while absolutizing it.
     catalog.normalize_hrefs(f"{path}/")
     try:
         catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -57,7 +57,7 @@ from portolan_cli.stac import (
     update_collection_file_statistics,
     update_collection_summaries,
 )
-from portolan_cli.utils import relative_href
+from portolan_cli.utils import href_root, relative_href
 from portolan_cli.versions import (
     Asset,
     VersionsFile,
@@ -271,8 +271,7 @@ def _save_collection_with_links(
     """
     _deduplicate_collection_item_links(collection)
     collection.set_self_href(str(collection_dir / "collection.json"))
-    # Trailing slash required: pystac treats paths with dots in final component as files
-    collection.normalize_hrefs(f"{collection_dir}/", strategy=AsIsLayoutStrategy())
+    collection.normalize_hrefs(href_root(collection_dir), strategy=AsIsLayoutStrategy())
     collection.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
 
     collection_json_path = collection_dir / "collection.json"

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -25,6 +25,7 @@ from portolan_cli.constants import PARTITION_EXTENSION_URI, PORTOLAN_SCHEMA_URI
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.providers import derive_provenance, resolve_providers
+from portolan_cli.utils import href_root
 
 # Any versioned Portolan profile URI, not just the current one: matching the
 # whole family is what lets a stale claim be rewritten rather than duplicated.
@@ -275,8 +276,7 @@ def save_catalog(catalog: pystac.Catalog, dest_dir: Path) -> None:
     """
     dest_dir.mkdir(parents=True, exist_ok=True)
 
-    # Trailing slash required: pystac treats dotted paths (e.g., tmp.xyz) as files
-    catalog.normalize_hrefs(f"{dest_dir}/")
+    catalog.normalize_hrefs(href_root(dest_dir))
 
     # Save as self-contained (relative links)
     catalog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)

--- a/portolan_cli/utils.py
+++ b/portolan_cli/utils.py
@@ -6,8 +6,34 @@ Small helpers used across multiple modules.
 from __future__ import annotations
 
 import posixpath
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Any
+
+
+def href_root(path: Path) -> str:
+    """The root string to hand pystac's ``normalize_hrefs``.
+
+    ``normalize_hrefs`` tells a file from a directory by looking for a dot in
+    the final path component, so a directory named ``tmp.XXXXXX`` reads as a
+    file and the catalog lands in its parent (issue #401). A trailing slash is
+    what settles it.
+
+    The slash alone is not enough. pystac absolutizes a relative root against
+    the working directory and drops the trailing slash on the way, which put the
+    heuristic back in play for ``init``'s ``"."`` default (issue #731).
+    Resolving first keeps the slash meaningful.
+
+    This is the single writer for that string. Every ``normalize_hrefs`` call
+    takes its root from here, and ``tests/unit/test_href_root.py`` fails if one
+    builds it by hand instead.
+
+    Args:
+        path: Directory the catalog or collection is written to.
+
+    Returns:
+        The absolute directory path with exactly one trailing slash.
+    """
+    return f"{path.resolve()}/"
 
 
 def relative_href(from_dir: PurePath, to_file: PurePath) -> str:

--- a/tests/integration/test_dotted_path_regression.py
+++ b/tests/integration/test_dotted_path_regression.py
@@ -6,6 +6,10 @@ and collection.json to be written to the PARENT directory when the path
 contains a dot (e.g., /tmp/tmp.XXXXXX from mktemp -d).
 
 These tests verify the fix works across all affected workflows.
+
+Issue #731 is the same bug reached through the default path argument. Passing
+"." leaves the dotted component in the working directory rather than the
+argument, so absolutizing before the heuristic runs is what keeps it away.
 """
 
 import json
@@ -206,3 +210,93 @@ class TestDottedPathRegression:
         catalog_data = json.loads((catalog_root / "catalog.json").read_text())
         child_hrefs = [link["href"] for link in catalog_data["links"] if link["rel"] == "child"]
         assert "./new-collection/collection.json" in child_hrefs
+
+
+class TestDefaultPathRegression:
+    """Regression tests for `init` with no path argument (issue #731)."""
+
+    @pytest.mark.integration
+    def test_init_no_path_argument_in_dotted_working_directory(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`portolan init` with no path writes catalog.json to the working directory.
+
+        Regression test for issue #731. The path argument defaults to ".", which
+        pystac absolutizes against the working directory. A dotted working
+        directory name, which `mktemp -d` produces, then trips the same
+        file-versus-directory heuristic as issue #401, and catalog.json lands in
+        the parent. `init` went on to read the file back through the same
+        relative path and raised FileNotFoundError instead of a PortolanError.
+        """
+        working_dir = tmp_path / "tmp.ckdIXs70TT"
+        working_dir.mkdir()
+        monkeypatch.chdir(working_dir)
+
+        result = runner.invoke(
+            cli, ["init", "--auto", "--title", "Base test", "--license", "CC-BY-4.0"]
+        )
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert result.exception is None, f"Unhandled exception: {result.exception!r}"
+
+        # Positive assertion: catalog.json lands in the working directory.
+        assert (working_dir / "catalog.json").exists(), (
+            "catalog.json should be in the working directory"
+        )
+        # Negative assertion: it must not leak to the parent.
+        assert not (tmp_path / "catalog.json").exists(), (
+            "catalog.json must NOT leak to the parent directory"
+        )
+
+        # The catalog the CLI reports must be the one on disk.
+        catalog_data = json.loads((working_dir / "catalog.json").read_text())
+        assert catalog_data["id"] == "tmp-ckdIXs70TT"
+        assert catalog_data["title"] == "Base test"
+
+    @pytest.mark.integration
+    def test_init_no_path_reports_catalog_id_as_json(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The JSON envelope holds for `init` with no path (issue #731).
+
+        The crash escaped as a traceback rather than a PortolanError, so the
+        envelope contract in .claude/rules/cli-and-output.md did not hold.
+        """
+        working_dir = tmp_path / "tmp.9Qz.Wm"
+        working_dir.mkdir()
+        monkeypatch.chdir(working_dir)
+
+        result = runner.invoke(cli, ["init", "--auto", "--json", "--license", "CC-BY-4.0"])
+
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["command"] == "init"
+        assert payload["data"]["catalog_id"] == "tmp-9Qz-Wm"
+        assert payload["data"]["path"] == str(working_dir.resolve())
+
+
+class TestInitCatalogReturnValue:
+    """`init_catalog` must return a path its caller can read (issue #731)."""
+
+    @pytest.mark.integration
+    def test_returned_catalog_file_is_absolute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The returned catalog_file resolves without depending on the caller's cwd.
+
+        `init_catalog` returned `path / "catalog.json"`, so a relative path in
+        gave a relative path out. cli.py read it back against whatever working
+        directory it happened to have.
+        """
+        from portolan_cli.catalog import init_catalog
+
+        working_dir = tmp_path / "tmp.relative"
+        working_dir.mkdir()
+        monkeypatch.chdir(working_dir)
+
+        catalog_file, _warnings = init_catalog(Path("."), license_id="CC-BY-4.0")
+
+        assert catalog_file.is_absolute(), f"catalog_file must be absolute, got {catalog_file}"
+        assert catalog_file == working_dir.resolve() / "catalog.json"
+        assert catalog_file.read_text(encoding="utf-8"), "returned path must be readable"

--- a/tests/unit/backends/test_backends.py
+++ b/tests/unit/backends/test_backends.py
@@ -350,14 +350,43 @@ class TestJsonFileBackend:
             backend._versions_path(collection)
 
     @pytest.mark.unit
-    def test_absolute_collection_path_rejected(self, tmp_path: Any) -> None:
-        """An absolute collection id raises instead of escaping the catalog root."""
+    @pytest.mark.parametrize(
+        "collection",
+        [
+            "/etc/passwd",
+            "C:\\Windows\\system32",
+            "C:/Windows/system32",
+            "//server/share",
+            "\\\\server\\share",
+            "climate\\..\\..\\etc",
+        ],
+    )
+    def test_absolute_collection_path_rejected(self, tmp_path: Any, collection: str) -> None:
+        """An absolute collection id raises instead of escaping the catalog root.
+
+        The guard must not depend on the host's path flavor. ``pathlib`` splits
+        by platform, so on Windows ``/etc/passwd`` is rooted but not absolute
+        (absolute needs a drive) and slipped through, while on POSIX every
+        backslash form is one filename and slipped through the other way. A
+        collection id is a slash-separated spec string, so both flavors judge it.
+        """
         from pathlib import Path
 
         backend = JsonFileBackend(catalog_root=Path(tmp_path))
 
         with pytest.raises(ValueError, match="Invalid collection name"):
-            backend._versions_path("/etc/passwd")
+            backend._versions_path(collection)
+
+    @pytest.mark.unit
+    def test_nested_collection_survives_the_flavor_guard(self, tmp_path: Any) -> None:
+        """The cross-flavor guard must not reject a legitimate nested id (#723)."""
+        from pathlib import Path
+
+        backend = JsonFileBackend(catalog_root=Path(tmp_path))
+
+        result = backend._versions_path("climate/hittekaart")
+
+        assert result == Path(tmp_path) / "climate" / "hittekaart" / "versions.json"
 
     @pytest.mark.unit
     def test_dot_collection_rejected(self, tmp_path: Any) -> None:

--- a/tests/unit/test_href_root.py
+++ b/tests/unit/test_href_root.py
@@ -1,0 +1,97 @@
+"""Unit tests for the pystac href-root helper (issues #401, #731).
+
+``normalize_hrefs`` decides between a file and a directory by looking for a dot
+in the final path component, so it needs two things from every caller: a
+trailing slash, and an already-absolute path. Miss either one and pystac writes
+``catalog.json`` or ``collection.json`` into the parent directory.
+
+``href_root`` is the single writer for that string. These tests pin its contract
+and check that no call site bypasses it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.utils import href_root
+
+SOURCE_ROOT = Path(__file__).resolve().parents[2] / "portolan_cli"
+
+
+class TestHrefRoot:
+    """The two properties pystac needs, on every input shape."""
+
+    @pytest.mark.unit
+    def test_ends_with_a_trailing_slash(self, tmp_path: Path) -> None:
+        """Without the slash, pystac reads a dotted directory as a file."""
+        assert href_root(tmp_path / "my.catalog").endswith("/")
+
+    @pytest.mark.unit
+    def test_absolutizes_a_relative_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pystac drops the trailing slash while absolutizing a relative root.
+
+        This is the issue #731 defect. Resolving first is what keeps the slash.
+        """
+        working_dir = tmp_path / "tmp.relative"
+        working_dir.mkdir()
+        monkeypatch.chdir(working_dir)
+
+        assert href_root(Path(".")) == f"{working_dir.resolve()}/"
+
+    @pytest.mark.unit
+    def test_preserves_a_dotted_final_component(self, tmp_path: Path) -> None:
+        """Resolving must not strip the dotted name pystac trips over."""
+        dotted = tmp_path / "tmp.ckdIXs70TT"
+
+        assert href_root(dotted) == f"{dotted.resolve()}/"
+
+    @pytest.mark.unit
+    def test_does_not_double_the_slash(self, tmp_path: Path) -> None:
+        """A caller that already passes a trailing slash gets one, not two."""
+        result = href_root(Path(f"{tmp_path}/"))
+
+        assert result == f"{tmp_path.resolve()}/"
+        assert not result.endswith("//")
+
+
+class TestEveryCallSiteUsesTheHelper:
+    """The 'fix every parallel call site' rule, made executable.
+
+    .claude/rules/stac-assets.md records that the original trailing-slash fix
+    shipped for one call site and missed its twins. This test fails when a new
+    normalize_hrefs call builds its root string by hand.
+    """
+
+    @pytest.mark.unit
+    def test_no_normalize_hrefs_call_bypasses_href_root(self) -> None:
+        offenders: list[str] = []
+
+        for source in SOURCE_ROOT.rglob("*.py"):
+            for lineno, line in enumerate(source.read_text(encoding="utf-8").splitlines(), start=1):
+                if not re.search(r"\.normalize_hrefs\(", line):
+                    continue
+                if "href_root(" not in line:
+                    rel = source.relative_to(SOURCE_ROOT.parent)
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+        assert offenders == [], (
+            "normalize_hrefs must take its root from href_root(), which "
+            "guarantees the absolute path and trailing slash pystac needs:\n" + "\n".join(offenders)
+        )
+
+    @pytest.mark.unit
+    def test_the_guard_sees_the_known_call_sites(self) -> None:
+        """Guard against the scan silently matching nothing (issues #401, #731)."""
+        call_sites = [
+            f"{source.relative_to(SOURCE_ROOT.parent)}:{lineno}"
+            for source in SOURCE_ROOT.rglob("*.py")
+            for lineno, line in enumerate(source.read_text(encoding="utf-8").splitlines(), start=1)
+            if re.search(r"\.normalize_hrefs\(", line)
+        ]
+
+        assert len(call_sites) == 4, f"expected 4 normalize_hrefs call sites, found {call_sites}"

--- a/tests/unit/test_stac.py
+++ b/tests/unit/test_stac.py
@@ -245,6 +245,30 @@ class TestCatalogOperations:
 
         assert (catalog_path / "catalog.json").exists()
 
+    @pytest.mark.unit
+    def test_save_catalog_with_relative_dotted_dest_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A relative dest_dir must not send catalog.json to the parent.
+
+        Same defect as issue #731, reached through this helper instead of init.
+        pystac discards the trailing slash while absolutizing a relative root,
+        so a dotted directory name trips the file-versus-directory heuristic of
+        issue #401. Before the fix this wrote catalog.json to tmp_path.
+        """
+        catalog = pystac.Catalog(id="relative-dest", description="test")
+        dest_dir = tmp_path / "my.catalog"
+        dest_dir.mkdir()
+        monkeypatch.chdir(tmp_path)
+
+        save_catalog(catalog, Path("my.catalog"))
+
+        assert (dest_dir / "catalog.json").exists(), "catalog.json belongs in dest_dir"
+        assert not (tmp_path / "catalog.json").exists(), (
+            "catalog.json must NOT leak to the parent directory"
+        )
+        assert json.loads((dest_dir / "catalog.json").read_text())["id"] == "relative-dest"
+
 
 class TestCollectionManagement:
     """Tests for adding collections to catalogs."""


### PR DESCRIPTION
## What this changes

`utils.href_root` returns the absolute directory with one trailing slash, and
all four `normalize_hrefs` call sites take their root from it. A guard test
fails when a new call builds that string by hand.

## Why

`portolan init` with no path argument crashed and wrote `catalog.json` to
`$TMPDIR` (#731). pystac discards the trailing slash while absolutizing a
relative root, handing the working directory name to the dot heuristic of #401.
`save_catalog` took the same relative dotted path, and the Iceberg backend
passed no trailing slash at all. `.claude/rules/stac-assets.md` records that
patching one site and missing its twins is what keeps this bug alive.

## Verification

The reproduction from #731, against a catalog created at
`/tmp/user/1000/tmp.g2fsjIYl0o`:

```console
$ export T=$(mktemp -d)
$ cd "$T"
$ portolan init --auto --title "Base test" --license CC-BY-4.0
✓ Initialized Portolan catalog in /tmp/user/1000/tmp.g2fsjIYl0o
→ Catalog ID: tmp-g2fsjIYl0o
$ echo "exit=$?"
exit=0
$ find "$T" -maxdepth 1 -name catalog.json
/tmp/user/1000/tmp.g2fsjIYl0o/catalog.json
$ ls /tmp/user/1000/catalog.json 2>/dev/null | wc -l
0
```

Both live defects turn the new tests red when reverted, and the guard names the
offending line:

```console
$ # save_catalog restored to f"{dest_dir}/"
$ uv run pytest tests/unit/test_stac.py -k relative_dotted -q
    assert (dest_dir / "catalog.json").exists(), "catalog.json belongs in dest_dir"
E   assert False
1 failed, 25 deselected in 1.02s

$ # iceberg restored to str(collection_dir)
$ uv run pytest tests/unit/test_href_root.py -k bypasses -q
E     portolan_cli/backends/iceberg/backend.py:379: collection.normalize_hrefs(str(collection_dir))
1 failed, 5 deselected in 1.04s
```

With the fix in place, including the three `test_check_workflow.py` tests the
stray file broke:

```console
$ uv run pytest tests/unit/test_href_root.py tests/unit/test_stac.py \
    tests/integration/test_dotted_path_regression.py \
    tests/integration/test_init_v2.py tests/unit/test_check_workflow.py -q
62 passed, 1 warning in 2.35s

$ uv run lint-imports
Contracts: 6 kept, 0 broken.
```
