### PR TITLE
fix(ci): make mutation selection sandbox-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,11 @@ jobs:
           FILES=()
           while IFS= read -r f; do
             [ -n "$f" ] && FILES+=("$f")
-          done < <(git diff --name-only --diff-filter=d "$BASE_SHA" HEAD -- 'portolan_cli/**/*.py')
+          # `:(glob)` gives `**` its documented zero-or-more-directories
+          # meaning. Without it Git's default pathspec skipped package-root
+          # modules such as portolan_cli/add.py and silently mutated nothing.
+          done < <(git diff --name-only --diff-filter=d "$BASE_SHA" HEAD -- \
+            ':(glob)portolan_cli/**/*.py')
           GLOBS=()
           if [ "${#FILES[@]}" -gt 0 ]; then
             # mutmut filters on mutant names (portolan_cli.foo.x_bar__mutmut_1),

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -170,6 +170,15 @@ falls back to serial when a process pool can't start in the sandbox
 (`convert.py`). (The geoparquet-io #565 CWD guard was evaluated and is **not**
 needed: `isolated_filesystem`/`chdir` tests do not crash the stats phase.)
 
+Static tests that inspect the checked-out Python source use the `source_scan`
+marker. Mutmut instruments the whole source tree before selecting a mutant, so
+those tests otherwise inspect every dormant mutation alternative and fail the
+clean baseline. Ordinary unit CI still runs them; only mutmut excludes them.
+
+The PR changed-file filter uses Git's `:(glob)portolan_cli/**/*.py` pathspec.
+The explicit glob magic matters: default Git pathspec handling treats the same
+text as nested-only and skips package-root modules such as `portolan_cli/add.py`.
+
 Why this matters: AI-generated tests can be tautological — they may pass but not actually verify behavior. Mutation testing injects bugs and checks if tests catch them.
 
 #### `benchmark` — Performance Benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ markers = [
     "slow: Takes > 5 seconds",
     "e2e: End-to-end tests requiring Docker (REST catalog + MinIO)",
     "e2e_slow: Extended E2E tests (concurrency stress, large datasets) - nightly only",
+    "source_scan: Static source-tree guard incompatible with mutmut instrumentation",
 ]
 
 [tool.coverage.run]
@@ -272,7 +273,7 @@ also_copy = ["scripts/", ".pip-audit-ignores", ".mutation-baseline", ".mutation-
 pytest_add_cli_args = [
     "--no-cov",
     "--tb=short",
-    "-m", "not network and not slow and not benchmark and not e2e and not e2e_slow",
+    "-m", "not network and not slow and not benchmark and not e2e and not e2e_slow and not source_scan",
 ]
 
 # ---------- architecture enforcement ----------

--- a/tests/unit/test_href_root.py
+++ b/tests/unit/test_href_root.py
@@ -59,6 +59,7 @@ class TestHrefRoot:
         assert not result.endswith("//")
 
 
+@pytest.mark.source_scan
 class TestEveryCallSiteUsesTheHelper:
     """The 'fix every parallel call site' rule, made executable.
 

--- a/tests/unit/test_json_write_sites.py
+++ b/tests/unit/test_json_write_sites.py
@@ -72,6 +72,7 @@ def _package_files() -> list[Path]:
 
 
 class TestNoInPlaceJsonWrites:
+    @pytest.mark.source_scan
     def test_every_json_write_goes_through_the_atomic_helper(self) -> None:
         offenders: list[str] = []
         for path in _package_files():
@@ -84,6 +85,7 @@ class TestNoInPlaceJsonWrites:
             "Use portolan_cli.json_io.write_json_atomic instead:\n" + "\n".join(offenders)
         )
 
+    @pytest.mark.source_scan
     def test_the_sweep_reads_the_package_it_grades(self) -> None:
         """A sweep over an empty file list would pass forever."""
         files = _package_files()

--- a/tests/unit/test_mutation_ci_config.py
+++ b/tests/unit/test_mutation_ci_config.py
@@ -1,0 +1,51 @@
+"""Regression tests for the PR-scoped mutation-test configuration."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import tomllib
+
+pytestmark = [pytest.mark.unit, pytest.mark.source_scan]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+MUTATION_PATHSPEC = ":(glob)portolan_cli/**/*.py"
+
+
+def test_pr_mutation_pathspec_includes_top_level_and_nested_modules() -> None:
+    """The changed-file filter must reach both package-root and nested modules."""
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    command_pattern = re.compile(
+        r'git diff --name-only --diff-filter=d "\$BASE_SHA" HEAD -- \\\n\s*'
+        + re.escape(f"'{MUTATION_PATHSPEC}'")
+    )
+    assert command_pattern.search(workflow)
+
+    result = subprocess.run(
+        ["git", "ls-files", MUTATION_PATHSPEC],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    matched = set(result.stdout.splitlines())
+
+    assert "portolan_cli/add.py" in matched
+    assert "portolan_cli/metadata/update.py" in matched
+
+
+def test_mutmut_excludes_static_source_scans() -> None:
+    """Instrumented mutation alternatives must not poison source-tree guards."""
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    pytest_config = config["tool"]["pytest"]["ini_options"]
+    mutmut_args = config["tool"]["mutmut"]["pytest_add_cli_args"]
+
+    assert any(str(marker).startswith("source_scan:") for marker in pytest_config["markers"])
+
+    marker_expression = mutmut_args[mutmut_args.index("-m") + 1]
+    assert "not source_scan" in marker_expression

--- a/tests/unit/validation/test_rashid_public_surface.py
+++ b/tests/unit/validation/test_rashid_public_surface.py
@@ -42,6 +42,7 @@ def _python_files() -> list[Path]:
 
 
 class TestRashidImportsArePublic:
+    @pytest.mark.source_scan
     def test_no_import_reaches_a_private_rashid_module(self) -> None:
         private: list[str] = []
         for path in _python_files():
@@ -57,6 +58,7 @@ class TestRashidImportsArePublic:
             + "\n".join(private)
         )
 
+    @pytest.mark.source_scan
     def test_the_sweep_sees_the_imports_it_is_meant_to_grade(self) -> None:
         """A sweep that silently matched nothing would pass forever."""
         found = [module for path in _python_files() for module in _rashid_modules(_parsed(path))]


### PR DESCRIPTION
## What this changes

PR mutation testing now uses Git's explicit glob pathspec, so changed modules at the package root and in nested directories are both selected. Static source-tree guards carry a `source_scan` marker and remain in ordinary CI, while mutmut excludes them from its instrumented sandbox.

## Why

Unblocks #660. Its mutation baseline inspected dormant mutation alternatives in unrelated files and failed the `normalize_hrefs` source guard. #651 exposed the second gap: a change to `portolan_cli/add.py` reported zero changed source files.

## Verification

Repository paths `portolan_cli/add.py` and `portolan_cli/metadata/update.py`:

```console
$ git ls-files ':(glob)portolan_cli/**/*.py' | rg '^portolan_cli/(add|metadata/update)\.py$'
portolan_cli/add.py
portolan_cli/metadata/update.py

$ pytest tests/unit/test_mutation_ci_config.py tests/unit/test_href_root.py tests/unit/test_json_write_sites.py tests/unit/validation/test_rashid_public_surface.py -m source_scan --collect-only -q --no-cov
================= 8/16 tests collected (8 deselected) in 0.49s =================

$ pytest -m unit -q
5428 passed, 9 skipped, 1281 deselected in 93.96s

$ uvx prek run --files <seven changed files>
All hooks passed
```

- [x] This change does not alter behavior (docs, chore, or CI only).

## Related issues

Unblocks #660. Continues the mutation-test hardening tracked in #612.
