### PR TITLE
fix(styles): mark the default style with the default role

### DIFF
--- a/.claude/rules/conversion-and-visualization.md
+++ b/.claude/rules/conversion-and-visualization.md
@@ -136,9 +136,15 @@ render paths.
 - The style JSON MUST have `version == 8`, `sources`, `layers` (Mapbox GL spec; rashid checks the media type via PTL-VIZ-005).
   `sources.data.url` is a **relative** path to the PMTiles (`../file.pmtiles`),
   `layers[].source` is always `"data"`.
-- `portolan:styles` is an ordered array of asset keys (first = default), and
-  every entry MUST reference an existing asset. Vary default colors
-  across a catalog so it is not monotone.
+- **Roles carry the whole manifest.** A client finds the styles by filtering
+  assets on `"style"` and the default by `"default"`, so exactly one style asset
+  carries `["style", "default"]` (rashid PTL-VIZ-006). The old
+  `portolan:styles` array is removed; `register_style_assets` strips it on
+  every run and `check` reports a collection that still has one (issue #739).
+- `select_default_style_key` picks the default: a mark a publisher already made
+  wins, then `styles/default`, then a lone style. Several unmarked styles get no
+  default, because choosing one is cartography, not bookkeeping.
+- Vary default colors across a catalog so it is not monotone.
 
 ## Partitioning: let geoparquet-io name things, detect Hive by pattern
 

--- a/.claude/rules/stac-assets.md
+++ b/.claude/rules/stac-assets.md
@@ -118,7 +118,7 @@ or double-count machine metadata. This caused repeated data-loss bugs.
 
 - **Preserve human-enrichable fields**: `asset.title`, `asset.description`,
   `table:columns[].description`, collection `description`, `providers`,
-  `license`, `links`, `portolan:styles`.
+  `license`, `links`.
 - **Only update machine-derivable fields**: `href`, `type` (media type),
   `roles`, `table:row_count`, column `name`/`type`, `proj:epsg`,
   `extent.bbox`, summaries. These travel under known prefixes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions are recorded where they apply (see `.claude/rules/documentation.md`)
 - **NO** new dependencies without discussion
 
-<!-- freshness: last-verified: 2026-08-12 -->
+<!-- freshness: last-verified: 2026-08-13 -->
 ## Design Principles
 
 | Principle | Meaning |

--- a/portolan_cli/constants.py
+++ b/portolan_cli/constants.py
@@ -31,6 +31,14 @@ PORTOLAN_SCHEMA_URI: str = (
     f"https://schemas.portolan-sdi.org/portolan/v{PORTOLAN_SPEC_VERSION}/schema.json"
 )
 
+# The collection property that once listed style asset keys in display order.
+# The spec removed it (issue #739): a client filters assets on the ``style``
+# role to find the styles and on ``default`` to find the one to draw first, so
+# a manifest would be a second copy of the same fact. Portolan wrote it through
+# 1.0.0b0, which is why both the generator (viz.style) and `check`
+# (validation.legacy) still name it — one to strip it, the other to report it.
+LEGACY_STYLE_MANIFEST_FIELD: str = "portolan:styles"
+
 # The partition extension a Hive-partitioned collection declares.
 # rashid's PTL-PRT-001 recognizes the incubating URI namespace, so generation
 # and `check --fix` both emit this one; the older github.io URL it replaced was

--- a/portolan_cli/validation/legacy.py
+++ b/portolan_cli/validation/legacy.py
@@ -1,11 +1,20 @@
-"""Detect catalogs generated before Portolan emitted the profile schema URI.
+"""Date a catalog by the markers an older Portolan left in it.
 
-Portolan published catalogs for months without declaring the versioned Portolan
-schema URI, describing itself instead through ``portolan:``-prefixed custom
-fields. Those catalogs are not conformant and never were (decision 1 in the
-rashid migration: acceptable pre-1.0). What matters is that `check` says so in
-one sentence, instead of leaving the user to infer it from a PTL-CNF-001 on
-every object.
+Two generations are detectable, and neither is something rashid can report. A
+rule fires on a spec requirement an object fails; these are properties the spec
+has since removed, so no requirement names them and no rule can. `check` still
+owes the operator a sentence about each, which is what this module writes.
+
+The first marker is a catalog published before the versioned profile schema URI
+existed, when Portolan described itself through ``portolan:``-prefixed custom
+fields instead. Those catalogs are not conformant and never were (decision 1 in
+the rashid migration: acceptable pre-1.0). Saying so in one sentence beats
+leaving the operator to infer it from a PTL-CNF-001 on every object.
+
+The second is the ``portolan:styles`` manifest, written up to 1.0.0b0 and
+removed from the spec in favor of the ``default`` asset role (issue #739). A
+catalog carrying it is otherwise current, so the two detectors are independent
+and a catalog can trip either, both, or neither.
 """
 
 from __future__ import annotations
@@ -14,7 +23,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from portolan_cli.constants import PORTOLAN_SCHEMA_URI
+from portolan_cli.constants import LEGACY_STYLE_MANIFEST_FIELD, PORTOLAN_SCHEMA_URI
 
 #: Custom fields only pre-#654 Portolan emitted. Their presence dates the
 #: catalog; ``stac.py`` stopped writing them when the profile schema landed.
@@ -25,6 +34,13 @@ _MESSAGE = (
     "carries portolan: custom fields. Every object will fail PTL-CNF-001 until it is "
     "regenerated. Run `portolan check --fix` to stamp the schema URI and scaffold what the "
     "current generator emits."
+)
+
+_STYLE_MANIFEST_MESSAGE = (
+    f"A collection still carries {LEGACY_STYLE_MANIFEST_FIELD}, which the spec removed. Clients "
+    "read a collection's styles off the 'style' asset role and its default off the 'default' "
+    "role, so the manifest is a stale second copy nothing reads. Re-run `portolan add --pmtiles` "
+    "on the affected collections to rewrite their style assets, or delete the property."
 )
 
 #: Depth of the collection scan. Collections sit one level below the root
@@ -79,3 +95,46 @@ def detect_legacy_generation(root: Path) -> str | None:
             return _MESSAGE
 
     return None
+
+
+def detect_style_manifest(root: Path) -> str | None:
+    """Return an explanatory note when a collection still lists styles by hand.
+
+    Walks the whole tree rather than the direct children :data:`_SCAN_GLOB`
+    matches, because a collection nests under intermediate catalogs at any
+    depth and a manifest hiding three levels down is the one nobody finds by
+    hand. The message does not name the collection, so the walk returns on the
+    first hit; a current catalog is the case that pays for the full pass, once
+    per `check` run against a tree rashid reads in full anyway.
+
+    Args:
+        root: Catalog root directory.
+
+    Returns:
+        A message naming the remedy, or None when no collection carries the
+        removed property.
+    """
+    for collection_path in root.rglob("collection.json"):
+        collection = _load(collection_path)
+        if collection is not None and LEGACY_STYLE_MANIFEST_FIELD in collection:
+            return _STYLE_MANIFEST_MESSAGE
+    return None
+
+
+def detect_legacy_notes(root: Path) -> str | None:
+    """Every legacy marker `check` found in ``root``, as one note.
+
+    The detectors are independent, so a catalog can trip both. They are joined
+    into the single note the report carries rather than given a channel each:
+    the operator reads one warning block, and the ``legacy_note`` key in the
+    JSON payload keeps the shape agents already parse.
+
+    Args:
+        root: Catalog root directory.
+
+    Returns:
+        The notes separated by a blank line, or None when the catalog is
+        current.
+    """
+    notes = [note for note in (detect_legacy_generation(root), detect_style_manifest(root)) if note]
+    return "\n\n".join(notes) if notes else None

--- a/portolan_cli/validation/runner.py
+++ b/portolan_cli/validation/runner.py
@@ -35,7 +35,7 @@ from rashid import validate
 from rashid.model import Report
 
 from portolan_cli.validation.config import load_public_url, load_rules_config
-from portolan_cli.validation.legacy import detect_legacy_generation
+from portolan_cli.validation.legacy import detect_legacy_notes
 
 #: A structural/schema validator maps one object's raw JSON to schema errors.
 #: Injected by tests to keep them offline and independent of schema churn.
@@ -84,7 +84,10 @@ class CheckOutcome:
         format_report: Source-file convertibility (``scan.check.CheckReport``),
             or None when ``geo_assets=False``. This covers files on disk that
             are not yet catalog assets, which rashid by construction cannot see.
-        legacy_note: Set when the catalog predates the profile schema URI.
+        legacy_note: Set when the catalog carries a marker of an older Portolan
+            generation — no profile schema URI, or a removed property such as
+            ``portolan:styles``. Several markers arrive as one note, blank-line
+            separated (see :mod:`portolan_cli.validation.legacy`).
         live_hint: Set when the catalog is published and ``--live`` was skipped.
         workflow_notice: Unregistered or vanished data files, when there are any.
             A workflow channel, never conformance — see :class:`WorkflowNotice`.
@@ -250,7 +253,7 @@ def run_check(
     return CheckOutcome(
         report=report,
         format_report=format_report,
-        legacy_note=detect_legacy_generation(root),
+        legacy_note=detect_legacy_notes(root),
         live_hint=_live_hint(root, public_url, live=live),
         workflow_notice=notice,
     )

--- a/portolan_cli/viz/style.py
+++ b/portolan_cli/viz/style.py
@@ -15,7 +15,7 @@ Public API:
 - get_vector_style_config: Load vector style config from catalog
 - get_raster_style_config: Load raster style config from catalog
 - discover_styles: Discover style JSON files in styles/ directory
-- build_styles_manifest: Build portolan:styles manifest array
+- select_default_style_key: Pick the style that carries the default role
 - register_style_assets: Register styles as STAC assets in collection.json
 - discover_legends: Discover legend PNG files in legends/ directory
 - build_legends_manifest: Build portolan:legends manifest array
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from portolan_cli.config import load_config
+from portolan_cli.constants import LEGACY_STYLE_MANIFEST_FIELD
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.utils import get_dict, get_list
 
@@ -390,6 +391,18 @@ def enrich_cog_assets(
 # Style Discovery
 # =============================================================================
 
+#: Role every style asset carries. A client discovers a collection's styles by
+#: filtering assets on it, which is why the spec defines no manifest property.
+STYLE_ROLE = "style"
+
+#: Second role marking the style a client should draw first (core.md,
+#: Visualization Styles).
+DEFAULT_ROLE = "default"
+
+#: Asset key :func:`write_default_style` writes. Nothing in STAC reads meaning
+#: into a key, so this only breaks the tie when no style is marked yet.
+GENERATED_DEFAULT_STYLE_KEY = "styles/default"
+
 
 def discover_styles(collection_path: Path) -> list[StyleInfo]:
     """Discover style JSON files in {collection_path}/styles/ directory.
@@ -435,36 +448,68 @@ def discover_styles(collection_path: Path) -> list[StyleInfo]:
     return styles
 
 
-def build_styles_manifest(styles: list[StyleInfo]) -> list[str]:
-    """Build the portolan:styles manifest array.
+def _marks_default(asset: Any) -> bool:
+    """Whether a raw asset already carries the ``default`` role.
 
-    Returns ordered list of asset keys with styles/default first if present,
-    then remaining styles sorted alphabetically.
+    Reads a collection.json that a human may have edited, so it answers False
+    for anything that is not an asset object with a list of roles.
+    """
+    if not isinstance(asset, dict):
+        return False
+    roles = asset.get("roles")
+    return isinstance(roles, list) and DEFAULT_ROLE in roles
+
+
+def select_default_style_key(
+    styles: list[StyleInfo],
+    existing_assets: dict[str, Any],
+) -> str | None:
+    """Choose the style asset key that carries the ``default`` role.
+
+    core.md, Visualization Styles: a client reads the default off a second role,
+    never off a key or a position, and exactly one style asset carries it when a
+    collection registers more than one. Precedence runs from most deliberate to
+    least:
+
+    1. the style a previous run already marked ``default``, because which style
+       leads is cartographic judgment and a human's choice must survive a
+       regeneration;
+    2. ``styles/default``, the key :func:`write_default_style` generates;
+    3. the only style there is, which is the default implicitly and gets the
+       role anyway so a client finds the default the same way everywhere.
 
     Args:
-        styles: List of StyleInfo objects (from discover_styles).
+        styles: Styles discovered on disk (from :func:`discover_styles`).
+        existing_assets: The collection's current ``assets`` object, read for
+            the role a previous run wrote.
 
     Returns:
-        List of style asset keys.
+        The winning asset key, or None when several unmarked styles compete.
+        Portolan does not invent that answer; PTL-VIZ-006 asks the publisher
+        for it.
     """
-    keys = [s.key for s in styles]
-
-    if "styles/default" in keys:
-        # Put default first, sort the rest
-        remaining = [k for k in keys if k != "styles/default"]
-        return ["styles/default"] + sorted(remaining)
-
-    # No default, just sort all
-    return sorted(keys)
+    keys = {style.key for style in styles}
+    marked = [key for key in keys if _marks_default(existing_assets.get(key))]
+    if len(marked) == 1:
+        return marked[0]
+    if GENERATED_DEFAULT_STYLE_KEY in keys:
+        return GENERATED_DEFAULT_STYLE_KEY
+    if len(styles) == 1:
+        return styles[0].key
+    return None
 
 
 def register_style_assets(
     collection_path: Path,
     styles: list[StyleInfo],
 ) -> None:
-    """Register discovered styles as STAC assets and set portolan:styles manifest.
+    """Register discovered styles as STAC assets on the collection.
 
-    Updates collection.json to add/update style assets and remove stale ones.
+    Updates collection.json to add or update style assets and to drop stale
+    ones. Every style asset gets the ``style`` role and the default one also
+    gets ``default`` (see :func:`select_default_style_key`). The removed
+    ``portolan:styles`` manifest is stripped whenever it survives from an older
+    generation, so a re-run migrates the collection.
 
     Args:
         collection_path: Path to the collection directory.
@@ -483,25 +528,27 @@ def register_style_assets(
     for key in stale_keys:
         del assets[key]
 
+    # Read the default off the assets as they stand, before the rewrite below
+    # overwrites the roles a previous run wrote.
+    default_key = select_default_style_key(styles, assets)
+
     # Add/update style assets
     for style_info in styles:
+        roles = [STYLE_ROLE]
+        if style_info.key == default_key:
+            roles.append(DEFAULT_ROLE)
         asset_dict: dict[str, Any] = {
             "href": style_info.href,
             "type": "application/vnd.mapbox.style+json",
             "title": style_info.title,
-            "roles": ["style"],
+            "roles": roles,
         }
         if style_info.description:
             asset_dict["description"] = style_info.description
         assets[style_info.key] = asset_dict
 
     data["assets"] = assets
-
-    # Set or remove portolan:styles manifest
-    if styles:
-        data["portolan:styles"] = build_styles_manifest(styles)
-    else:
-        data.pop("portolan:styles", None)
+    data.pop(LEGACY_STYLE_MANIFEST_FIELD, None)
 
     write_json_atomic(collection_json_path, data)
 

--- a/tests/integration/test_thumbnail_workflow.py
+++ b/tests/integration/test_thumbnail_workflow.py
@@ -165,7 +165,7 @@ styles:
 
     @pytest.mark.integration
     def test_style_registered_as_stac_asset(self, tmp_path: Path) -> None:
-        """Style files are registered as STAC assets with portolan:styles manifest."""
+        """Style files are registered as STAC assets carrying the style role."""
         from portolan_cli.viz.style import (
             VectorStyleConfig,
             discover_styles,
@@ -213,8 +213,8 @@ styles:
         collection = json.loads((collection_path / "collection.json").read_text())
 
         assert "styles/default" in collection["assets"]
-        assert collection["assets"]["styles/default"]["roles"] == ["style"]
-        assert collection["portolan:styles"] == ["styles/default"]
+        assert collection["assets"]["styles/default"]["roles"] == ["style", "default"]
+        assert "portolan:styles" not in collection
 
 
 # =============================================================================

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -322,8 +322,8 @@ class TestDiscoverStyles:
         assert styles[0].title == "custom-theme"
 
 
-class TestBuildStylesManifest:
-    """Tests for build_styles_manifest function."""
+class TestSelectDefaultStyleKey:
+    """Which style asset carries the `default` role (issue #739)."""
 
     @staticmethod
     def _style_info(key: str) -> StyleInfo:
@@ -332,9 +332,9 @@ class TestBuildStylesManifest:
         return StyleInfo(key=key, href="", title="", description="", path=Path())
 
     @pytest.mark.unit
-    def test_default_first(self) -> None:
-        """Default style always first regardless of input order."""
-        from portolan_cli.viz.style import build_styles_manifest
+    def test_generated_default_wins_when_nothing_is_marked(self) -> None:
+        """styles/default is the default until a publisher says otherwise."""
+        from portolan_cli.viz.style import select_default_style_key
 
         styles = [
             self._style_info("styles/zebra"),
@@ -342,60 +342,73 @@ class TestBuildStylesManifest:
             self._style_info("styles/alpha"),
         ]
 
-        manifest = build_styles_manifest(styles)
-
-        assert manifest[0] == "styles/default"
-        assert len(manifest) == 3
+        assert select_default_style_key(styles, {}) == "styles/default"
 
     @pytest.mark.unit
-    def test_alphabetical_after_default(self) -> None:
-        """Non-default styles sorted alphabetically."""
-        from portolan_cli.viz.style import build_styles_manifest
+    def test_existing_mark_beats_the_generated_key(self) -> None:
+        """A publisher's choice outranks the key Portolan generates."""
+        from portolan_cli.viz.style import select_default_style_key
 
-        styles = [
-            self._style_info("styles/zebra"),
-            self._style_info("styles/default"),
-            self._style_info("styles/alpha"),
-            self._style_info("styles/beta"),
-        ]
+        styles = [self._style_info("styles/default"), self._style_info("styles/alpha")]
+        assets = {"styles/alpha": {"roles": ["style", "default"]}}
 
-        manifest = build_styles_manifest(styles)
-
-        assert manifest == ["styles/default", "styles/alpha", "styles/beta", "styles/zebra"]
+        assert select_default_style_key(styles, assets) == "styles/alpha"
 
     @pytest.mark.unit
-    def test_no_default(self) -> None:
-        """Works without a style named 'default'."""
-        from portolan_cli.viz.style import build_styles_manifest
+    def test_two_marked_styles_fall_back_to_the_generated_key(self) -> None:
+        """A catalog marking two defaults is broken; regeneration repairs it."""
+        from portolan_cli.viz.style import select_default_style_key
 
-        styles = [
-            self._style_info("styles/zebra"),
-            self._style_info("styles/alpha"),
-        ]
+        styles = [self._style_info("styles/default"), self._style_info("styles/alpha")]
+        assets = {
+            "styles/alpha": {"roles": ["style", "default"]},
+            "styles/default": {"roles": ["style", "default"]},
+        }
 
-        manifest = build_styles_manifest(styles)
-
-        assert manifest == ["styles/alpha", "styles/zebra"]
-
-    @pytest.mark.unit
-    def test_empty_list(self) -> None:
-        """Empty input returns empty output."""
-        from portolan_cli.viz.style import build_styles_manifest
-
-        manifest = build_styles_manifest([])
-
-        assert manifest == []
+        assert select_default_style_key(styles, assets) == "styles/default"
 
     @pytest.mark.unit
-    def test_single_style(self) -> None:
-        """Single style returns single-element list."""
-        from portolan_cli.viz.style import build_styles_manifest
+    def test_a_mark_on_a_deleted_style_does_not_count(self) -> None:
+        """Only a style still on disk can hold the role."""
+        from portolan_cli.viz.style import select_default_style_key
 
-        styles = [self._style_info("styles/custom")]
+        styles = [self._style_info("styles/alpha"), self._style_info("styles/zebra")]
+        assets = {"styles/gone": {"roles": ["style", "default"]}}
 
-        manifest = build_styles_manifest(styles)
+        assert select_default_style_key(styles, assets) is None
 
-        assert manifest == ["styles/custom"]
+    @pytest.mark.unit
+    def test_lone_style_is_the_default(self) -> None:
+        """One style is the default implicitly, and gets the role anyway."""
+        from portolan_cli.viz.style import select_default_style_key
+
+        assert select_default_style_key([self._style_info("styles/custom")], {}) == "styles/custom"
+
+    @pytest.mark.unit
+    def test_several_unmarked_styles_have_no_default(self) -> None:
+        """Portolan will not invent a cartographic decision (PTL-VIZ-006)."""
+        from portolan_cli.viz.style import select_default_style_key
+
+        styles = [self._style_info("styles/zebra"), self._style_info("styles/alpha")]
+
+        assert select_default_style_key(styles, {}) is None
+
+    @pytest.mark.unit
+    def test_no_styles_have_no_default(self) -> None:
+        """Empty input selects nothing."""
+        from portolan_cli.viz.style import select_default_style_key
+
+        assert select_default_style_key([], {}) is None
+
+    @pytest.mark.unit
+    def test_malformed_roles_are_ignored(self) -> None:
+        """A roles value that is not a list of strings cannot mark a default."""
+        from portolan_cli.viz.style import select_default_style_key
+
+        styles = [self._style_info("styles/alpha"), self._style_info("styles/zebra")]
+        assets = {"styles/alpha": {"roles": "default"}, "styles/zebra": ["not", "an", "asset"]}
+
+        assert select_default_style_key(styles, assets) is None
 
 
 # =============================================================================
@@ -875,14 +888,91 @@ class TestRegisterStyleAssets:
 
         default_asset = updated["assets"]["styles/default"]
         assert default_asset["type"] == "application/vnd.mapbox.style+json"
-        assert default_asset["roles"] == ["style"]
+        assert default_asset["roles"] == ["style", "default"]
         assert default_asset["title"] == "Default"
 
         by_age_asset = updated["assets"]["styles/by-age"]
+        assert by_age_asset["roles"] == ["style"]
         assert by_age_asset["title"] == "By Age"
         assert by_age_asset["description"] == "Buildings colored by construction year"
 
-        assert updated["portolan:styles"] == ["styles/default", "styles/by-age"]
+        assert "portolan:styles" not in updated
+
+    @pytest.mark.unit
+    def test_lone_style_is_the_default(self, tmp_path: Path) -> None:
+        """A collection's only style carries the default role too (issue #739)."""
+        import json
+
+        from portolan_cli.viz.style import discover_styles, register_style_assets
+
+        (tmp_path / "collection.json").write_text(
+            json.dumps({"type": "Collection", "id": "test", "assets": {}})
+        )
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "muted.json").write_text('{"version":8,"name":"Muted","layers":[]}')
+
+        register_style_assets(tmp_path, discover_styles(tmp_path))
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert updated["assets"]["styles/muted"]["roles"] == ["style", "default"]
+
+    @pytest.mark.unit
+    def test_marked_default_survives_regeneration(self, tmp_path: Path) -> None:
+        """A publisher's default choice outlives a re-run (issue #739)."""
+        import json
+
+        from portolan_cli.viz.style import discover_styles, register_style_assets
+
+        (tmp_path / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "test",
+                    "assets": {
+                        "styles/by-age": {
+                            "href": "./styles/by-age.json",
+                            "roles": ["style", "default"],
+                        },
+                        "styles/default": {
+                            "href": "./styles/default.json",
+                            "roles": ["style"],
+                        },
+                    },
+                }
+            )
+        )
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text('{"version":8,"name":"Default","layers":[]}')
+        (styles_dir / "by-age.json").write_text('{"version":8,"name":"By Age","layers":[]}')
+
+        register_style_assets(tmp_path, discover_styles(tmp_path))
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert updated["assets"]["styles/by-age"]["roles"] == ["style", "default"]
+        assert updated["assets"]["styles/default"]["roles"] == ["style"]
+
+    @pytest.mark.unit
+    def test_ambiguous_styles_get_no_default(self, tmp_path: Path) -> None:
+        """Several unmarked styles and no styles/default: PTL-VIZ-006 asks a human."""
+        import json
+
+        from portolan_cli.viz.style import discover_styles, register_style_assets
+
+        (tmp_path / "collection.json").write_text(
+            json.dumps({"type": "Collection", "id": "test", "assets": {}})
+        )
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "muted.json").write_text('{"version":8,"name":"Muted","layers":[]}')
+        (styles_dir / "vivid.json").write_text('{"version":8,"name":"Vivid","layers":[]}')
+
+        register_style_assets(tmp_path, discover_styles(tmp_path))
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        roles = [asset["roles"] for asset in updated["assets"].values()]
+        assert roles == [["style"], ["style"]]
 
     @pytest.mark.unit
     def test_no_styles_no_manifest(self, tmp_path: Path) -> None:
@@ -958,7 +1048,39 @@ class TestRegisterStyleAssets:
 
         updated = json.loads((tmp_path / "collection.json").read_text())
         assert "styles/old" not in updated["assets"]
-        assert updated["portolan:styles"] == ["styles/default"]
+        assert "portolan:styles" not in updated
+
+    @pytest.mark.unit
+    def test_strips_the_removed_manifest(self, tmp_path: Path) -> None:
+        """Registering styles migrates a collection off portolan:styles (issue #739)."""
+        import json
+
+        from portolan_cli.viz.style import discover_styles, register_style_assets
+
+        (tmp_path / "collection.json").write_text(
+            json.dumps(
+                {
+                    "type": "Collection",
+                    "id": "test",
+                    "portolan:styles": ["styles/default"],
+                    "assets": {
+                        "styles/default": {
+                            "href": "./styles/default.json",
+                            "roles": ["style"],
+                        }
+                    },
+                }
+            )
+        )
+        styles_dir = tmp_path / "styles"
+        styles_dir.mkdir()
+        (styles_dir / "default.json").write_text('{"version":8,"name":"Default","layers":[]}')
+
+        register_style_assets(tmp_path, discover_styles(tmp_path))
+
+        updated = json.loads((tmp_path / "collection.json").read_text())
+        assert "portolan:styles" not in updated
+        assert updated["assets"]["styles/default"]["roles"] == ["style", "default"]
 
 
 # =============================================================================

--- a/tests/unit/validation/test_legacy_detection.py
+++ b/tests/unit/validation/test_legacy_detection.py
@@ -15,7 +15,11 @@ from typing import Any
 import pytest
 
 from portolan_cli.constants import PORTOLAN_SCHEMA_URI
-from portolan_cli.validation.legacy import detect_legacy_generation
+from portolan_cli.validation.legacy import (
+    detect_legacy_generation,
+    detect_legacy_notes,
+    detect_style_manifest,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -84,3 +88,91 @@ class TestDetectLegacyGeneration:
         """A plain STAC catalog Portolan never generated is not a legacy catalog."""
         _write(tmp_path / "catalog.json", _catalog())
         assert detect_legacy_generation(tmp_path) is None
+
+
+def _collection(**extra: Any) -> dict[str, Any]:
+    return {
+        "type": "Collection",
+        "stac_version": "1.1.0",
+        "id": "roads",
+        "description": "Roads.",
+        "license": "CC-BY-4.0",
+        "extent": {},
+        "links": [],
+        **extra,
+    }
+
+
+class TestDetectStyleManifest:
+    """The removed portolan:styles property (issue #739).
+
+    No rashid rule can report this: a rule fires on a spec requirement an
+    object fails, and the spec no longer names the property at all.
+    """
+
+    def test_collection_with_the_manifest_is_flagged(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog(stac_extensions=[PORTOLAN_SCHEMA_URI]))
+        _write(
+            tmp_path / "roads" / "collection.json",
+            _collection(**{"portolan:styles": ["styles/default"]}),
+        )
+        note = detect_style_manifest(tmp_path)
+        assert note is not None
+        assert "portolan:styles" in note
+
+    def test_nested_collection_is_found(self, tmp_path: Path) -> None:
+        """Collections nest under intermediate catalogs at any depth."""
+        _write(tmp_path / "catalog.json", _catalog())
+        _write(
+            tmp_path / "transport" / "roads" / "collection.json",
+            _collection(**{"portolan:styles": []}),
+        )
+        assert detect_style_manifest(tmp_path) is not None
+
+    def test_current_collection_is_not_flagged(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog())
+        _write(
+            tmp_path / "roads" / "collection.json",
+            _collection(assets={"styles/default": {"roles": ["style", "default"]}}),
+        )
+        assert detect_style_manifest(tmp_path) is None
+
+    def test_empty_catalog_is_not_flagged(self, tmp_path: Path) -> None:
+        assert detect_style_manifest(tmp_path) is None
+
+    def test_unparseable_collection_is_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "roads").mkdir()
+        (tmp_path / "roads" / "collection.json").write_text("{ not json", encoding="utf-8")
+        assert detect_style_manifest(tmp_path) is None
+
+
+class TestDetectLegacyNotes:
+    """The detectors are independent, and `check` reports them as one note."""
+
+    def test_current_catalog_has_no_note(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog(stac_extensions=[PORTOLAN_SCHEMA_URI]))
+        _write(tmp_path / "roads" / "collection.json", _collection())
+        assert detect_legacy_notes(tmp_path) is None
+
+    def test_style_manifest_alone_is_reported(self, tmp_path: Path) -> None:
+        """A catalog can be current in every other respect and still carry it."""
+        _write(tmp_path / "catalog.json", _catalog(stac_extensions=[PORTOLAN_SCHEMA_URI]))
+        _write(
+            tmp_path / "roads" / "collection.json",
+            _collection(**{"portolan:styles": ["styles/default"]}),
+        )
+        note = detect_legacy_notes(tmp_path)
+        assert note is not None
+        assert "portolan:styles" in note
+        assert "predates" not in note
+
+    def test_both_markers_are_joined(self, tmp_path: Path) -> None:
+        _write(tmp_path / "catalog.json", _catalog(**{"portolan:version": "0.0.9"}))
+        _write(
+            tmp_path / "roads" / "collection.json",
+            _collection(**{"portolan:styles": ["styles/default"]}),
+        )
+        note = detect_legacy_notes(tmp_path)
+        assert note is not None
+        assert "portolan check --fix" in note
+        assert "portolan:styles" in note


### PR DESCRIPTION
## What this changes

`register_style_assets` now uses asset roles to identify styles and the default style.

* Removes the `portolan:styles` manifest.
* Marks the default style with `roles: ["style", "default"]`.
* `select_default_style_key` selects a default in this order:

  1. A default already marked by the publisher.
  2. `styles/default`.
  3. The only style, if there is one.
* If several styles are unmarked, no default is selected. `PTL-VIZ-006` then asks a human to resolve the ambiguity.
* Each registration run removes the old manifest.
* `portolan check` reports collections that still contain the removed manifest.

## Why

Resolves #739.

The spec removed `portolan:styles`. Clients should now find styles through the `style` asset role and find the default through the `default` role.

The CLI previously created style assets without marking any default. The old manifest also cannot be reported by a Rashid rule because it is no longer part of the spec. `portolan check` therefore reports it through the existing legacy-note mechanism used for properties from older schemas.

`portolan-browser` still reads `portolan:styles` and needs a separate fix.

## Verification

Tested with real data in `tests/fixtures/realdata/fieldmaps-boundaries.parquet`.

After `portolan add boundaries/ --pmtiles`, the collection has no manifest and marks `styles/default` as the default:

```console
$ jq '{manifest: has("portolan:styles"), roles: (.assets | map_values(.roles))}' boundaries/collection.json
{
  "manifest": false,
  "roles": {
    "fieldmaps-boundaries": ["data"],
    "fieldmaps-boundaries-tiles": ["visual"],
    "fieldmaps-boundaries-tiles-thumbnail": ["thumbnail"],
    "styles/default": ["style", "default"]
  }
}
```

After manually adding the removed property, `portolan check` reports it:

```console
$ portolan check
⚠ A collection still carries portolan:styles, which the spec removed. Clients read styles
  from the 'style' asset role and the default from the 'default' role. Re-run
  `portolan add --pmtiles` on the affected collections, or delete the property.
```

Re-running registration removes the property:

```console
$ portolan add boundaries/ --pmtiles
✓ All 2 files already tracked (unchanged)

$ jq 'has("portolan:styles")' boundaries/collection.json
false
```

Full test suite:

```console
$ uv run pytest tests/unit tests/integration -q -m "not slow"
6530 passed, 9 skipped, 4 deselected in 417.33s (0:06:57)
```
