### PR TITLE
fix(stac-geoparquet): publish file:size and file:checksum on the mirror asset

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -160,7 +160,7 @@ from portolan_cli.stac import (
     update_catalog_provenance,
     update_collection_file_statistics,
 )
-from portolan_cli.sync.checksums import compute_checksum, multihash_sha256
+from portolan_cli.sync.checksums import compute_checksum, file_fields
 from portolan_cli.viz.style import enrich_cog_assets
 
 if TYPE_CHECKING:
@@ -1706,16 +1706,11 @@ def _update_collection_with_asset(
             # Different file with same stem - use full filename to avoid collision
             asset_key = asset_path.name
 
-    # Compute file size and checksum for file extension metadata
-    file_size = asset_path.stat().st_size
-    file_checksum = compute_checksum(asset_path)
-
     assets[asset_key] = {
         "href": f"./{asset_path.name}",
         "type": media_type,
         "roles": [role],
-        "file:size": file_size,
-        "file:checksum": multihash_sha256(file_checksum),
+        **file_fields(asset_path),
     }
 
     # Write updated collection

--- a/portolan_cli/preparation.py
+++ b/portolan_cli/preparation.py
@@ -60,7 +60,7 @@ from portolan_cli.sync.checksums import (
     compute_checksum,
     compute_dir_checksum,
     compute_dir_size,
-    multihash_sha256,
+    file_fields_from,
 )
 from portolan_cli.viz.style import enrich_cog_assets
 
@@ -267,10 +267,9 @@ def _scan_item_assets(
             # Titles should come from metadata.yaml or be preserved from existing
             # metadata via merge strategy. Role-based default titles are NOT
             # auto-detected values, so they shouldn't appear with OVERWRITE.
-            extra_fields={
-                "file:size": file_size,
-                "file:checksum": multihash_sha256(file_checksum),
-            },
+            # file_fields_from, not file_fields: a FileGDB asset is a directory,
+            # already measured above by compute_dir_checksum/compute_dir_size.
+            extra_fields=file_fields_from(file_checksum, file_size),
         )
         asset_files[file_path.name] = (file_path, file_checksum, file_size)
         asset_paths.append(str(file_path))

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -882,13 +882,15 @@ def update_collection_temporal_extent(
 
 
 # STAC Extension schema URLs (v1.1.0 compatible)
-# Note: "file" extension is reserved for future use (checksums, sizes)
-# Currently only table, projection, and raster are actively used
+# "vector" is the only entry still unused; the rest are declared by the writers
+# named beside them.
 EXTENSION_URLS = {
     "table": "https://stac-extensions.github.io/table/v1.2.0/schema.json",
     "projection": "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
     "raster": "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "file": "https://stac-extensions.github.io/file/v2.1.0/schema.json",  # Reserved for future
+    # file:size / file:checksum, declared by update_collection_file_statistics
+    # and by stac_parquet._sync_file_extension.
+    "file": "https://stac-extensions.github.io/file/v2.1.0/schema.json",
     "vector": "https://stac-extensions.github.io/vector/v0.1.0/schema.json",  # Proposal maturity
     "partition": PARTITION_EXTENSION_URI,
 }

--- a/portolan_cli/stac_parquet.py
+++ b/portolan_cli/stac_parquet.py
@@ -30,6 +30,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from rashid.catalog import is_absolute_href
+
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import info, warn
 from portolan_cli.sync.checksums import file_fields
@@ -235,6 +237,18 @@ def generate_items_parquet(collection_path: Path) -> Path:
 _FILE_FIELDS = ("file:size", "file:checksum")
 
 
+def _strip_file_fields(asset: dict[str, Any]) -> bool:
+    """Drop both file fields, reporting whether either was there to drop.
+
+    Tests membership rather than the popped value, so a field written as JSON
+    ``null`` still counts as a change and the caller still writes the file.
+    """
+    present = [name for name in _FILE_FIELDS if name in asset]
+    for name in present:
+        del asset[name]
+    return bool(present)
+
+
 def _stamp_file_fields(asset: dict[str, Any], base_dir: Path) -> bool:
     """Refresh ``file:size``/``file:checksum`` from the bytes the asset points at.
 
@@ -243,6 +257,14 @@ def _stamp_file_fields(asset: dict[str, Any], base_dir: Path) -> bool:
     the bytes the href resolves to, and rashid's data pass reports a mismatch as
     an error. A stale value is therefore worse than no value, which is why a
     vanished file strips the fields instead of leaving them behind.
+
+    Only a relative href that resolves to nothing is proof the claim is false.
+    Everything else is unverifiable rather than wrong, so it is left untouched:
+    an absolute or remote href points at bytes this process cannot read, and a
+    directory (a FileGDB asset) is measured by ``compute_dir_checksum`` elsewhere.
+    Deleting a value on that evidence would destroy metadata the operator
+    supplied. ``_local_asset_path`` in ``validation.fixers`` skips the same hrefs
+    for the same reason.
 
     Reads each asset's own href rather than assuming ``items.parquet``: the caller
     matches by asset key as well as by href, so an asset keyed ``geoparquet-items``
@@ -257,11 +279,14 @@ def _stamp_file_fields(asset: dict[str, Any], base_dir: Path) -> bool:
         there is something to write.
     """
     href = asset.get("href")
-    path = _resolve_href(base_dir, href) if isinstance(href, str) and href else None
+    if not isinstance(href, str) or not href or is_absolute_href(href):
+        return False
 
-    if path is None or not path.is_file():
-        # Pop every field before returning; any() would short-circuit on the first.
-        return len([f for f in _FILE_FIELDS if asset.pop(f, None) is not None]) > 0
+    path = _resolve_href(base_dir, href)
+    if not path.exists():
+        return _strip_file_fields(asset)
+    if not path.is_file():
+        return False
 
     fields = file_fields(path)
     if all(asset.get(name) == value for name, value in fields.items()):
@@ -270,12 +295,19 @@ def _stamp_file_fields(asset: dict[str, Any], base_dir: Path) -> bool:
     return True
 
 
-def _declare_file_extension(data: dict[str, Any], assets: dict[str, Any]) -> bool:
-    """Declare the STAC file extension when any asset publishes ``file:size``.
+def _sync_file_extension(data: dict[str, Any], assets: dict[str, Any]) -> bool:
+    """Declare the STAC file extension while an asset uses it, withdraw it after.
 
     ``update_collection_file_statistics`` does this for the add and finalize paths,
     but it needs a ``pystac.Collection`` and this module works on raw JSON on
     purpose (pystac leaks absolute paths, see known-issues/pystac-absolute-paths.md).
+
+    Withdrawal matters because :func:`_stamp_file_fields` strips the fields when
+    the mirror disappears, which can leave the collection declaring an extension
+    nothing uses. It reads ``portolan:asset_count`` first: that tally covers item
+    assets too, and ``update_collection_file_statistics`` redeclares from the same
+    wider scope, so removing the URI while items still carry ``file:`` fields would
+    make the two writers fight over collection.json on every run.
 
     Args:
         data: Parsed collection.json, mutated in place.
@@ -286,13 +318,32 @@ def _declare_file_extension(data: dict[str, Any], assets: dict[str, Any]) -> boo
     """
     from portolan_cli.stac import EXTENSION_URLS
 
-    if not any("file:size" in asset for asset in assets.values()):
+    extensions = data.get("stac_extensions")
+    if extensions is not None and not isinstance(extensions, list):
+        # Malformed. Schema validation reports it; do not crash on .append here.
         return False
 
-    extensions = data.setdefault("stac_extensions", [])
-    if EXTENSION_URLS["file"] in extensions:
+    url = EXTENSION_URLS["file"]
+    in_use = any(
+        isinstance(asset, dict) and any(key.startswith("file:") for key in asset)
+        for asset in assets.values()
+    )
+
+    if in_use:
+        if extensions is None:
+            extensions = []
+            data["stac_extensions"] = extensions
+        if url in extensions:
+            return False
+        extensions.append(url)
+        return True
+
+    if extensions is None or url not in extensions:
         return False
-    extensions.append(EXTENSION_URLS["file"])
+    count = data.get("portolan:asset_count")
+    if isinstance(count, int) and not isinstance(count, bool) and count > 0:
+        return False
+    extensions.remove(url)
     return True
 
 
@@ -374,7 +425,7 @@ def add_parquet_link_to_collection(collection_path: Path) -> None:
         data["assets"] = assets
         modified = True
 
-    if _declare_file_extension(data, assets):
+    if _sync_file_extension(data, assets):
         modified = True
 
     # Write back only if changes were made

--- a/portolan_cli/stac_parquet.py
+++ b/portolan_cli/stac_parquet.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import info, warn
+from portolan_cli.sync.checksums import file_fields
 
 # Constants
 PARQUET_FILENAME = "items.parquet"
@@ -231,6 +232,70 @@ def generate_items_parquet(collection_path: Path) -> Path:
     return output_path
 
 
+_FILE_FIELDS = ("file:size", "file:checksum")
+
+
+def _stamp_file_fields(asset: dict[str, Any], base_dir: Path) -> bool:
+    """Refresh ``file:size``/``file:checksum`` from the bytes the asset points at.
+
+    PORTO-CORE-028 makes the fields a SHOULD, so their absence is only a
+    PTL-AST-003 warning. PORTO-CORE-030 makes a *published* value a claim about
+    the bytes the href resolves to, and rashid's data pass reports a mismatch as
+    an error. A stale value is therefore worse than no value, which is why a
+    vanished file strips the fields instead of leaving them behind.
+
+    Reads each asset's own href rather than assuming ``items.parquet``: the caller
+    matches by asset key as well as by href, so an asset keyed ``geoparquet-items``
+    may legitimately point somewhere else, and must not inherit another file's digest.
+
+    Args:
+        asset: STAC asset dict, mutated in place.
+        base_dir: Directory holding the collection.json that owns the asset.
+
+    Returns:
+        Whether the asset changed, so the caller writes collection.json only when
+        there is something to write.
+    """
+    href = asset.get("href")
+    path = _resolve_href(base_dir, href) if isinstance(href, str) and href else None
+
+    if path is None or not path.is_file():
+        # Pop every field before returning; any() would short-circuit on the first.
+        return len([f for f in _FILE_FIELDS if asset.pop(f, None) is not None]) > 0
+
+    fields = file_fields(path)
+    if all(asset.get(name) == value for name, value in fields.items()):
+        return False
+    asset.update(fields)
+    return True
+
+
+def _declare_file_extension(data: dict[str, Any], assets: dict[str, Any]) -> bool:
+    """Declare the STAC file extension when any asset publishes ``file:size``.
+
+    ``update_collection_file_statistics`` does this for the add and finalize paths,
+    but it needs a ``pystac.Collection`` and this module works on raw JSON on
+    purpose (pystac leaks absolute paths, see known-issues/pystac-absolute-paths.md).
+
+    Args:
+        data: Parsed collection.json, mutated in place.
+        assets: The collection's asset dicts.
+
+    Returns:
+        Whether the extension list changed.
+    """
+    from portolan_cli.stac import EXTENSION_URLS
+
+    if not any("file:size" in asset for asset in assets.values()):
+        return False
+
+    extensions = data.setdefault("stac_extensions", [])
+    if EXTENSION_URLS["file"] in extensions:
+        return False
+    extensions.append(EXTENSION_URLS["file"])
+    return True
+
+
 def add_parquet_link_to_collection(collection_path: Path) -> None:
     """Add items.parquet link and asset to collection.json.
 
@@ -292,14 +357,24 @@ def add_parquet_link_to_collection(collection_path: Path) -> None:
             if "collection-mirror" not in roles:
                 roles.append("collection-mirror")
                 modified = True
+            # Refresh, do not skip: generate_items_parquet overwrote the bytes
+            # moments ago, so an asset carried over from an earlier run describes
+            # a file that no longer exists in that form.
+            if _stamp_file_fields(asset, collection_path):
+                modified = True
     else:
-        assets[asset_key] = {
+        asset = {
             "href": f"./{PARQUET_FILENAME}",
             "type": PARQUET_MEDIA_TYPE,
             "title": "STAC items as GeoParquet",
             "roles": ["stac-items", "collection-mirror"],
         }
+        _stamp_file_fields(asset, collection_path)
+        assets[asset_key] = asset
         data["assets"] = assets
+        modified = True
+
+    if _declare_file_extension(data, assets):
         modified = True
 
     # Write back only if changes were made

--- a/portolan_cli/sync/checksums.py
+++ b/portolan_cli/sync/checksums.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from pathlib import Path
+from typing import Any
 
 from rashid.api import SHA2_256, encode_multihash
 
@@ -69,6 +70,46 @@ def compute_checksum(path: Path) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             sha256.update(chunk)
     return sha256.hexdigest()
+
+
+def file_fields_from(digest_hex: str, size: int) -> dict[str, Any]:
+    """Build the STAC file-extension fields for bytes that are already measured.
+
+    Takes the digest and the size rather than a path, because a FileGDB asset is
+    a directory: :func:`compute_dir_checksum` and :func:`compute_dir_size` measure
+    it, and :func:`compute_checksum` would reject it as a non-regular file.
+
+    Args:
+        digest_hex: Hex-encoded SHA-256 digest of the asset's bytes.
+        size: Byte count to publish as ``file:size``.
+
+    Returns:
+        The ``file:size`` and ``file:checksum`` pair, ready to merge into an asset.
+
+    Raises:
+        ValueError: If ``digest_hex`` is not a 64-character hex string.
+    """
+    return {"file:size": size, "file:checksum": multihash_sha256(digest_hex)}
+
+
+def file_fields(path: Path) -> dict[str, Any]:
+    """Build the STAC file-extension fields for a regular file, from its bytes.
+
+    PORTO-CORE-030 makes a published ``file:size``/``file:checksum`` a claim about
+    the bytes the asset's href resolves to, so always read them from the file as it
+    stands rather than carrying a value forward from an earlier write.
+
+    Args:
+        path: Path to the asset file.
+
+    Returns:
+        The ``file:size`` and ``file:checksum`` pair, ready to merge into an asset.
+
+    Raises:
+        ValueError: If ``path`` is not a regular file.
+        FileNotFoundError: If ``path`` does not exist.
+    """
+    return file_fields_from(compute_checksum(path), path.stat().st_size)
 
 
 def compute_dir_checksum(path: Path) -> str:

--- a/portolan_cli/validation/fixers.py
+++ b/portolan_cli/validation/fixers.py
@@ -493,7 +493,7 @@ def _fix_checksums(root: Path, dry_run: bool) -> list[FixResult]:
     asset whole: a COG is routinely gigabytes, and the whole point of this fixer
     is that it runs over every asset in the catalog.
     """
-    from portolan_cli.sync.checksums import compute_checksum, multihash_sha256
+    from portolan_cli.sync.checksums import file_fields
 
     results: list[FixResult] = []
     for node in _graph(root).iter("collection", "item"):
@@ -502,14 +502,10 @@ def _fix_checksums(root: Path, dry_run: bool) -> list[FixResult]:
             path = _local_asset_path(node, asset)
             if path is None:
                 continue
-            size = path.stat().st_size
-            checksum = multihash_sha256(compute_checksum(path))
-            if asset.get("file:size") != size:
-                asset["file:size"] = size
-                changed = True
-            if asset.get("file:checksum") != checksum:
-                asset["file:checksum"] = checksum
-                changed = True
+            for name, value in file_fields(path).items():
+                if asset.get(name) != value:
+                    asset[name] = value
+                    changed = True
         if changed:
             _write_node(node, dry_run=dry_run)
             results.append(_updated(node, "Recomputed file:size and file:checksum from the bytes"))

--- a/tests/integration/test_metadata_scan_unification.py
+++ b/tests/integration/test_metadata_scan_unification.py
@@ -30,6 +30,7 @@ from click.testing import CliRunner
 from portolan_cli.cli import cli
 from portolan_cli.metadata.models import MetadataStatus
 from portolan_cli.metadata.scan import scan_catalog_metadata
+from portolan_cli.sync.checksums import file_fields
 
 
 @pytest.fixture
@@ -163,6 +164,7 @@ def _make_raster_collection_with_items_parquet(
                 "type": "application/vnd.apache.parquet",
                 "title": "STAC items as GeoParquet",
                 "roles": ["stac-items"],
+                **file_fields(items_parquet),
             }
         },
     )

--- a/tests/unit/test_multihash_checksum.py
+++ b/tests/unit/test_multihash_checksum.py
@@ -7,10 +7,11 @@ not a bare digest; rashid's PTL-AST-004 rejects anything else.
 from __future__ import annotations
 
 import hashlib
+from pathlib import Path
 
 import pytest
 
-from portolan_cli.sync.checksums import multihash_sha256
+from portolan_cli.sync.checksums import file_fields, file_fields_from, multihash_sha256
 
 pytestmark = pytest.mark.unit
 
@@ -37,3 +38,55 @@ class TestMultihashSha256:
     def test_rejects_a_non_sha256_digest(self) -> None:
         with pytest.raises(ValueError, match="64-character"):
             multihash_sha256("deadbeef")
+
+
+class TestFileFields:
+    """The paired ``file:size``/``file:checksum`` fields the file extension defines.
+
+    Four call sites used to inline the same two lines. These cover the shared
+    helpers they now share.
+    """
+
+    def test_reads_both_fields_from_a_file(self, tmp_path: Path) -> None:
+        payload = b"portolan file fields"
+        path = tmp_path / "asset.bin"
+        path.write_bytes(payload)
+
+        fields = file_fields(path)
+
+        assert fields == {
+            "file:size": len(payload),
+            "file:checksum": f"1220{hashlib.sha256(payload).hexdigest()}",
+        }
+
+    def test_encodes_a_digest_that_was_measured_elsewhere(self) -> None:
+        # FileGDB assets are directories: preparation.py computes the digest and
+        # the size with compute_dir_checksum/compute_dir_size, then hands both here.
+        digest = hashlib.sha256(b"filegdb").hexdigest()
+
+        assert file_fields_from(digest, 4096) == {
+            "file:size": 4096,
+            "file:checksum": f"1220{digest}",
+        }
+
+    def test_size_is_an_int_so_ptl_ast_003_accepts_it(self, tmp_path: Path) -> None:
+        # PTL-AST-003 rejects a bool or a non-int, and bool is a subclass of int.
+        path = tmp_path / "asset.bin"
+        path.write_bytes(b"xy")
+
+        size = file_fields(path)["file:size"]
+
+        assert type(size) is int
+        assert size == 2
+
+    def test_rejects_a_digest_that_is_not_sha256(self) -> None:
+        with pytest.raises(ValueError, match="64-character"):
+            file_fields_from("deadbeef", 1)
+
+    def test_raises_when_the_file_is_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            file_fields(tmp_path / "absent.bin")
+
+    def test_rejects_a_directory(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            file_fields(tmp_path)

--- a/tests/unit/test_stac_parquet.py
+++ b/tests/unit/test_stac_parquet.py
@@ -1067,6 +1067,178 @@ class TestMirrorAssetFileFields:
         assert collection_path.read_text() == before
 
 
+class TestUnverifiableHrefsAreLeftAlone:
+    """Only a missing local file proves a published claim is false.
+
+    A relative href that resolves to nothing is evidence. An absolute or remote
+    href is not: those bytes live somewhere this process cannot read, so the
+    values there may be correct and measured by whoever wrote them. Stripping
+    them would destroy true metadata. ``_local_asset_path`` in
+    ``validation.fixers`` skips the same hrefs.
+    """
+
+    @staticmethod
+    def _write_mirror(collection_dir: Path, asset: dict[str, object]) -> None:
+        collection_path = collection_dir / "collection.json"
+        data = json.loads(collection_path.read_text())
+        data["assets"] = {"geoparquet-items": asset}
+        collection_path.write_text(json.dumps(data, indent=2))
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "href",
+        [
+            "https://data.example.org/imagery/items.parquet",
+            "s3://example-bucket/imagery/items.parquet",
+            "/srv/catalog/imagery/items.parquet",
+        ],
+        ids=["https", "s3", "absolute-local"],
+    )
+    def test_an_unreadable_href_keeps_its_published_claim(
+        self, collection_with_items: Path, href: str
+    ) -> None:
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        claim = f"1220{'ab' * 32}"
+        self._write_mirror(
+            collection_with_items,
+            {
+                "href": href,
+                "type": "application/vnd.apache.parquet",
+                "roles": ["stac-items"],
+                "file:size": 4096,
+                "file:checksum": claim,
+            },
+        )
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        asset = _mirror_asset(collection_with_items)
+        assert asset["file:size"] == 4096
+        assert asset["file:checksum"] == claim
+
+    @pytest.mark.unit
+    def test_a_directory_href_keeps_its_published_claim(self, collection_with_items: Path) -> None:
+        """A FileGDB asset is a directory; compute_checksum rejects one outright."""
+        from portolan_cli.stac_parquet import add_parquet_link_to_collection
+
+        (collection_with_items / "layers.gdb").mkdir()
+        claim = f"1220{'cd' * 32}"
+        self._write_mirror(
+            collection_with_items,
+            {
+                "href": "./layers.gdb",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["stac-items"],
+                "file:size": 8192,
+                "file:checksum": claim,
+            },
+        )
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        asset = _mirror_asset(collection_with_items)
+        assert asset["file:size"] == 8192
+        assert asset["file:checksum"] == claim
+
+    @pytest.mark.unit
+    def test_a_null_valued_field_is_still_removed(self, collection_with_items: Path) -> None:
+        """Membership decides, not the popped value: null is a field, and it must go."""
+        from portolan_cli.stac_parquet import add_parquet_link_to_collection
+
+        self._write_mirror(
+            collection_with_items,
+            {
+                "href": "./items.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["stac-items"],
+                "file:size": None,
+                "file:checksum": None,
+            },
+        )
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        asset = _mirror_asset(collection_with_items)
+        assert "file:size" not in asset
+        assert "file:checksum" not in asset
+
+
+class TestFileExtensionDeclaration:
+    """The declaration follows the fields, in both directions."""
+
+    @pytest.mark.unit
+    def test_it_is_withdrawn_when_the_last_file_field_goes(
+        self, collection_with_items: Path
+    ) -> None:
+        from portolan_cli.stac import EXTENSION_URLS
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+        collection_path = collection_with_items / "collection.json"
+        assert EXTENSION_URLS["file"] in json.loads(collection_path.read_text())["stac_extensions"]
+
+        (collection_with_items / "items.parquet").unlink()
+        add_parquet_link_to_collection(collection_with_items)
+
+        data = json.loads(collection_path.read_text())
+        assert EXTENSION_URLS["file"] not in data["stac_extensions"]
+
+    @pytest.mark.unit
+    def test_it_survives_while_item_assets_still_carry_the_fields(
+        self, collection_with_items: Path
+    ) -> None:
+        """portolan:asset_count covers items, and the statistics writer redeclares
+        from that wider scope. Removing the URI here would start a write war."""
+        from portolan_cli.stac import EXTENSION_URLS
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+        collection_path = collection_with_items / "collection.json"
+        data = json.loads(collection_path.read_text())
+        data["portolan:asset_count"] = 3
+        collection_path.write_text(json.dumps(data, indent=2))
+
+        (collection_with_items / "items.parquet").unlink()
+        add_parquet_link_to_collection(collection_with_items)
+
+        data = json.loads(collection_path.read_text())
+        assert EXTENSION_URLS["file"] in data["stac_extensions"]
+
+    @pytest.mark.unit
+    def test_a_malformed_extension_list_does_not_crash(self, collection_with_items: Path) -> None:
+        """stac_extensions as a string is invalid STAC; report it, do not append to it."""
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        collection_path = collection_with_items / "collection.json"
+        data = json.loads(collection_path.read_text())
+        data["stac_extensions"] = "https://stac-extensions.github.io/file/v2.1.0/schema.json"
+        collection_path.write_text(json.dumps(data, indent=2))
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        data = json.loads(collection_path.read_text())
+        assert data["stac_extensions"] == (
+            "https://stac-extensions.github.io/file/v2.1.0/schema.json"
+        )
+
+
 # =============================================================================
 # Test: generate_or_suggest_parquet (post-add orchestration, issue #620)
 # =============================================================================

--- a/tests/unit/test_stac_parquet.py
+++ b/tests/unit/test_stac_parquet.py
@@ -821,6 +821,253 @@ class TestCollectionLevelAsset:
 
 
 # =============================================================================
+# Test: file:size / file:checksum on the mirror asset (issue #710)
+# =============================================================================
+
+
+def _mirror_asset(collection_dir: Path) -> dict[str, object]:
+    """The geoparquet-items asset as it stands on disk."""
+    data = json.loads((collection_dir / "collection.json").read_text())
+    asset: dict[str, object] = data["assets"]["geoparquet-items"]
+    return asset
+
+
+def _append_item(collection_dir: Path, item_id: str) -> None:
+    """Add one more item so the next items.parquet differs from the last."""
+    item_dir = collection_dir / item_id
+    item_dir.mkdir()
+    item_json = {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "id": item_id,
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [[-121.5, 37.7], [-121.4, 37.7], [-121.4, 37.8], [-121.5, 37.8], [-121.5, 37.7]]
+            ],
+        },
+        "bbox": [-121.5, 37.7, -121.4, 37.8],
+        "properties": {"datetime": "2024-02-01T00:00:00Z", "title": f"Landsat {item_id}"},
+        "assets": {
+            "data": {
+                "href": f"./{item_id}.tif",
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "roles": ["data"],
+            }
+        },
+        "links": [],
+        "collection": "landsat",
+    }
+    (item_dir / f"{item_id}.json").write_text(json.dumps(item_json, indent=2))
+
+    collection_path = collection_dir / "collection.json"
+    data = json.loads(collection_path.read_text())
+    data["links"].append({"rel": "item", "href": f"./{item_id}/{item_id}.json"})
+    collection_path.write_text(json.dumps(data, indent=2))
+
+
+class TestMirrorAssetFileFields:
+    """The mirror asset must publish file:size and file:checksum (issue #710).
+
+    PTL-AST-003 warns on their absence (PORTO-CORE-028 is a SHOULD), and
+    ``portolan check --strict`` escalates that warning to a non-zero exit.
+    PORTO-CORE-030 then makes a published value a claim about the bytes, and
+    rashid's data pass — on by default — reports a mismatch as an ERROR. So a
+    value left stale by a regeneration is worse than one that was never written.
+    """
+
+    @pytest.mark.unit
+    def test_asset_carries_file_size_and_checksum(self, collection_with_items: Path) -> None:
+        import hashlib
+
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+
+        raw = (collection_with_items / "items.parquet").read_bytes()
+        asset = _mirror_asset(collection_with_items)
+        assert asset["file:size"] == len(raw)
+        assert asset["file:checksum"] == f"1220{hashlib.sha256(raw).hexdigest()}"
+
+    @pytest.mark.unit
+    def test_checksum_is_a_well_formed_multihash(self, collection_with_items: Path) -> None:
+        # PORTO-CORE-029 / PTL-AST-004. Assert with rashid's own predicate so the
+        # test cannot drift away from the rule that gates the catalog.
+        from rashid.api import is_well_formed_multihash
+
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+
+        assert is_well_formed_multihash(_mirror_asset(collection_with_items)["file:checksum"])
+
+    @pytest.mark.unit
+    def test_regenerating_the_parquet_refreshes_the_checksum(
+        self, collection_with_items: Path
+    ) -> None:
+        """The PORTO-CORE-030 guard: registration is idempotent by presence.
+
+        Stamping only the creation branch leaves the first run's digest sitting
+        against bytes the second run overwrote, which turns a warning into an error.
+        """
+        import hashlib
+
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+        first = dict(_mirror_asset(collection_with_items))
+
+        _append_item(collection_with_items, "scene-005")
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+
+        raw = (collection_with_items / "items.parquet").read_bytes()
+        asset = _mirror_asset(collection_with_items)
+        assert asset["file:checksum"] != first["file:checksum"]
+        assert asset["file:checksum"] == f"1220{hashlib.sha256(raw).hexdigest()}"
+        assert asset["file:size"] == len(raw)
+
+    @pytest.mark.unit
+    def test_an_older_asset_without_the_fields_is_backfilled(
+        self, collection_with_items: Path
+    ) -> None:
+        """A catalog written before this fix must gain the fields on the next run."""
+        import hashlib
+
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        collection_path = collection_with_items / "collection.json"
+        data = json.loads(collection_path.read_text())
+        data["assets"] = {
+            "geoparquet-items": {
+                "href": "./items.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["stac-items"],
+            }
+        }
+        collection_path.write_text(json.dumps(data, indent=2))
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        raw = (collection_with_items / "items.parquet").read_bytes()
+        asset = _mirror_asset(collection_with_items)
+        assert asset["file:size"] == len(raw)
+        assert asset["file:checksum"] == f"1220{hashlib.sha256(raw).hexdigest()}"
+
+    @pytest.mark.unit
+    def test_fields_are_absent_when_the_parquet_was_never_written(
+        self, collection_with_items: Path
+    ) -> None:
+        """Never fabricate. Registration still happens; the claim does not."""
+        from portolan_cli.stac_parquet import add_parquet_link_to_collection
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        asset = _mirror_asset(collection_with_items)
+        assert "file:size" not in asset
+        assert "file:checksum" not in asset
+
+    @pytest.mark.unit
+    def test_stale_fields_are_stripped_when_the_parquet_disappears(
+        self, collection_with_items: Path
+    ) -> None:
+        """Absence is a PTL-AST-003 warning; a claim about missing bytes is an error."""
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+        assert "file:size" in _mirror_asset(collection_with_items)
+
+        (collection_with_items / "items.parquet").unlink()
+        add_parquet_link_to_collection(collection_with_items)
+
+        asset = _mirror_asset(collection_with_items)
+        assert "file:size" not in asset
+        assert "file:checksum" not in asset
+
+    @pytest.mark.unit
+    def test_a_foreign_href_is_not_stamped_from_items_parquet(
+        self, collection_with_items: Path
+    ) -> None:
+        """The asset matches by key too, so stamp each asset from its own href."""
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        collection_path = collection_with_items / "collection.json"
+        data = json.loads(collection_path.read_text())
+        data["assets"] = {
+            "geoparquet-items": {
+                "href": "./elsewhere.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["stac-items"],
+            }
+        }
+        collection_path.write_text(json.dumps(data, indent=2))
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        asset = _mirror_asset(collection_with_items)
+        assert "file:size" not in asset
+        assert "file:checksum" not in asset
+
+    @pytest.mark.unit
+    def test_the_file_extension_is_declared_once(self, collection_with_items: Path) -> None:
+        from portolan_cli.stac import EXTENSION_URLS
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+
+        data = json.loads((collection_with_items / "collection.json").read_text())
+        assert data["stac_extensions"].count(EXTENSION_URLS["file"]) == 1
+
+    @pytest.mark.unit
+    def test_a_second_call_without_regeneration_rewrites_nothing(
+        self, collection_with_items: Path
+    ) -> None:
+        """Refreshing must not mark the collection modified when nothing moved."""
+        from portolan_cli.stac_parquet import (
+            add_parquet_link_to_collection,
+            generate_items_parquet,
+        )
+
+        generate_items_parquet(collection_with_items)
+        add_parquet_link_to_collection(collection_with_items)
+        collection_path = collection_with_items / "collection.json"
+        before = collection_path.read_text()
+
+        add_parquet_link_to_collection(collection_with_items)
+
+        assert collection_path.read_text() == before
+
+
+# =============================================================================
 # Test: generate_or_suggest_parquet (post-add orchestration, issue #620)
 # =============================================================================
 


### PR DESCRIPTION
## What this changes

`stac-geoparquet` publishes `file:size` and `file:checksum` on the `geoparquet-items` asset.

* Stamps both from the bytes on disk, refreshed on every regeneration.
* Strips them only when a relative href resolves to nothing.
* Declares the STAC file extension while an asset uses it, and withdraws it after.
* Moves the shared `file_fields` and `file_fields_from` helpers into `sync.checksums`.

## Why

Resolves #710.

A collection with `items.parquet` carried no file metadata, so `portolan check --strict` reported two `PTL-AST-003` findings.

The file is rewritten on every run. A value stamped once goes stale, and `PORTO-CORE-030` makes that an error.

Review caught the first draft deleting values it could not read, remote hrefs among them. Only a missing local file disproves a published claim.

## Verification

Catalog: four COG items under `imagery/`, each a copy of `tests/fixtures/raster/valid/rgb.tif`.

The checksum is the sha2-256 multihash prefix `1220` plus the file's digest:

```console
$ portolan stac-geoparquet -c imagery
✓ Generated items.parquet for 'imagery'
      Items: 3

$ jq -c '.assets["geoparquet-items"]' imagery/collection.json
{"href":"./items.parquet","type":"application/vnd.apache.parquet","title":"STAC items as GeoParquet","roles":["stac-items","collection-mirror"],"file:size":21881,"file:checksum":"12205a1efdd66a063d695e0bdf11579e2fced64f4917905a1556de7975bd3c30ceb6"}

$ sha256sum imagery/items.parquet && stat -c%s imagery/items.parquet
5a1efdd66a063d695e0bdf11579e2fced64f4917905a1556de7975bd3c30ceb6  imagery/items.parquet
21881
```

The #710 finding, reproduced by removing both fields, then cleared by regeneration:

```console
$ jq 'del(.assets["geoparquet-items"]["file:size"],
          .assets["geoparquet-items"]["file:checksum"])' \
    imagery/collection.json > /tmp/c.json
$ mv /tmp/c.json imagery/collection.json

$ portolan check --strict 2>&1 | grep PTL-AST-003
⚠ PTL-AST-003 imagery/collection.json: asset 'geoparquet-items' has no file:checksum
⚠ PTL-AST-003 imagery/collection.json: asset 'geoparquet-items' has no file:size

$ portolan stac-geoparquet -c imagery > /dev/null
$ portolan check --strict 2>&1 | grep -c PTL-AST-003
0
```

A fourth item changes the file, and both values follow it:

```console
$ portolan add imagery/ > /dev/null
$ portolan stac-geoparquet -c imagery > /dev/null

$ sha256sum imagery/items.parquet && stat -c%s imagery/items.parquet
b436745e6daeb5132f1c53c8f19557394668843c3f17cb9bd6e501fcd026705c  imagery/items.parquet
21904

$ jq -r '.assets["geoparquet-items"]
         | "\(.["file:size"]) \(.["file:checksum"])"' \
    imagery/collection.json
21904 1220b436745e6daeb5132f1c53c8f19557394668843c3f17cb9bd6e501fcd026705c
```

A remote href keeps its claim, because nothing here can read those bytes:

```console
$ jq '.assets["geoparquet-items"].href =
      "https://data.example.org/imagery/items.parquet"' \
    imagery/collection.json > /tmp/c.json
$ mv /tmp/c.json imagery/collection.json

$ portolan stac-geoparquet -c imagery > /dev/null
$ jq -c '.assets["geoparquet-items"]
         | {href, size: .["file:size"]}' imagery/collection.json
{"href":"https://data.example.org/imagery/items.parquet","size":21904}
```

## Tests

```console
$ uv run pytest tests/unit -q
5663 passed, 6 skipped, 17 warnings in 128.32s (0:02:08)

$ uv run lint-imports && uv run mypy portolan_cli
Contracts: 6 kept, 0 broken.
Success: no issues found in 155 source files
```

`test_regenerating_the_parquet_refreshes_the_checksum` guards `PORTO-CORE-030`.
`TestUnverifiableHrefsAreLeftAlone` guards the hrefs that must not be stripped.
