### PR TITLE
feat(viz): emit a collection thumbnail on every add (#683)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -405,16 +405,44 @@ These are complementary. Use `conversion.vector` for consistent spatial optimiza
 
 Configure automatic thumbnail generation for preview images. Thumbnails are registered as STAC assets with `roles: ["thumbnail"]`.
 
+Every `portolan add` gives each affected geospatial collection a thumbnail asset, because `PTL-VIZ-001` makes one mandatory. `add` takes the first of these it finds, so it never overwrites a picture you chose:
+
+1. A `thumbnail`-role asset already in `collection.json`.
+2. A conventionally named image in the collection directory: `*.thumb.jpg`, `thumbnail.*`, or `preview.*`, in PNG, JPEG, or WebP. Drop one in to use your own.
+3. For rasters, the sidecar `add` generated beside a converted COG.
+4. Otherwise, a rendered thumbnail.
+
 ```yaml
 # .portolan/config.yaml
 thumbnails:
   enabled: true # Auto-generate thumbnails (default: true)
   max_size: 512 # Max dimension in pixels (default: 512)
   quality: 75 # JPEG quality 1-100 (default: 75)
+  max_features: 100000 # Feature ceiling per render (default: 100000)
   basemap:
     provider: CartoDB.Positron # Basemap tile provider (default)
     opacity: 1.0 # Basemap opacity 0-1 (default: 1.0)
     zoom_adjust: 0 # Zoom level adjustment (default: 0)
+```
+
+### Bounding Render Cost
+
+Above `max_features`, the renderer samples rather than drawing every feature, so one collection cannot spend unbounded time. Samples are spread across the file rather than taken from the front, because GeoParquet output is spatially sorted and a leading sample would draw one corner of the extent. The frame is unaffected: it comes from the file's bbox metadata, so a sampled thumbnail still spans the whole extent at lower feature density.
+
+Raise `max_features` for denser output on large layers, at the cost of a slower `add`.
+
+### Opting Out
+
+Set `enabled: false` to stop generating thumbnails, or pass `--no-thumbnails` to skip a single `add`.
+
+Neither silences `PTL-VIZ-001`, which rashid raises as an error. If your catalog ships thumbnails from elsewhere, or ships none by policy, disable the rule as well:
+
+```yaml
+thumbnails:
+  enabled: false
+check:
+  disabled:
+    - PTL-VIZ-001 # thumbnails are generated out of band
 ```
 
 ### Vector vs Raster Thumbnails

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -431,9 +431,19 @@ Above `max_features`, the renderer samples rather than drawing every feature, so
 
 Raise `max_features` for denser output on large layers, at the cost of a slower `add`.
 
+### Refreshing a Thumbnail
+
+`add` leaves a registered thumbnail alone, so growing a collection does not silently redraw its preview. That also means the extent a thumbnail shows is fixed at first render. Pass `--force-thumbnails` to redraw one:
+
+```bash
+portolan add roads/ --force-thumbnails
+```
+
+A `thumbnail.png` or `preview.png` you supplied survives the force. Only the `*.thumb.jpg` that `add` rendered is replaced.
+
 ### Opting Out
 
-Set `enabled: false` to stop generating thumbnails, or pass `--no-thumbnails` to skip a single `add`.
+Set `enabled: false` to stop generating thumbnails, or pass `--no-thumbnails` to skip a single `add`. Both bind `check --fix` as well, so a repair pass cannot reinstate what you turned off.
 
 Neither silences `PTL-VIZ-001`, which rashid raises as an error. If your catalog ships thumbnails from elsewhere, or ships none by policy, disable the rule as well:
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3058,6 +3058,17 @@ def _check_partition_prompt(
     help="Regenerate PMTiles even if they exist and are up-to-date.",
 )
 @click.option(
+    "--thumbnails/--no-thumbnails",
+    "generate_thumbnails",
+    default=None,
+    help=(
+        "Generate a thumbnail asset for each affected collection. "
+        "Defaults to the catalog's thumbnails.enabled setting. "
+        "Opting out leaves PTL-VIZ-001 firing, so pair --no-thumbnails with "
+        "check.disabled in config.yaml if the catalog never ships thumbnails."
+    ),
+)
+@click.option(
     "--force",
     is_flag=True,
     help="Re-process all files, ignoring change detection.",
@@ -3094,6 +3105,7 @@ def add_cmd(
     generate_parquet: bool,
     generate_pmtiles: bool,
     force_pmtiles: bool,
+    generate_thumbnails: bool | None,
     force: bool,
     reconvert: bool,
     merge_strategy: str,
@@ -3284,6 +3296,18 @@ def add_cmd(
         force=force_pmtiles,
         verbose=verbose,
         use_json=use_json,
+    )
+
+    # Thumbnails last, so a higher-fidelity render from the PMTiles above is
+    # adopted rather than replaced. Every geospatial collection needs a
+    # thumbnail asset to satisfy PTL-VIZ-001 (Issue #683).
+    from portolan_cli.collection_thumbnail import ensure_collection_thumbnails
+
+    ensure_collection_thumbnails(
+        catalog_root,
+        affected,
+        generate=generate_thumbnails,
+        verbose=verbose,
     )
 
     # Output combined results (after all processing complete)

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3069,6 +3069,16 @@ def _check_partition_prompt(
     ),
 )
 @click.option(
+    "--force-thumbnails",
+    "force_thumbnails",
+    is_flag=True,
+    help=(
+        "Redraw the thumbnail even if one is registered. Use after a collection "
+        "grows, since the extent it draws is otherwise fixed at first render. "
+        "A thumbnail.png or preview.png you supplied still wins."
+    ),
+)
+@click.option(
     "--force",
     is_flag=True,
     help="Re-process all files, ignoring change detection.",
@@ -3106,6 +3116,7 @@ def add_cmd(
     generate_pmtiles: bool,
     force_pmtiles: bool,
     generate_thumbnails: bool | None,
+    force_thumbnails: bool,
     force: bool,
     reconvert: bool,
     merge_strategy: str,
@@ -3307,6 +3318,7 @@ def add_cmd(
         catalog_root,
         affected,
         generate=generate_thumbnails,
+        force=force_thumbnails,
         verbose=verbose,
     )
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3271,9 +3271,15 @@ def add_cmd(
     # Include both added AND skipped assets so --pmtiles works on already-tracked files
     # Note: all_added contains ItemInfo objects, all_skipped contains Path objects
     affected: set[str] = set()
+    # Collections this run actually wrote a version for. A side-step's derived
+    # asset folds into that snapshot instead of bumping a second version, so one
+    # `add` stays one version. A skipped collection is absent, so its backfill
+    # gets a version of its own rather than editing a published snapshot.
+    versioned: set[str] = set()
     for a in all_added:
         if hasattr(a, "collection_id") and a.collection_id:
             affected.add(a.collection_id)
+            versioned.add(a.collection_id)
     for p in all_skipped:
         # Extract collection_id from path relative to catalog_root
         try:
@@ -3319,6 +3325,7 @@ def add_cmd(
         affected,
         generate=generate_thumbnails,
         force=force_thumbnails,
+        versioned_collections=versioned,
         verbose=verbose,
     )
 

--- a/portolan_cli/collection_thumbnail.py
+++ b/portolan_cli/collection_thumbnail.py
@@ -366,6 +366,7 @@ def ensure_collection_thumbnail(
     *,
     generate: bool | None = None,
     force: bool = False,
+    amend_latest: bool = False,
     verbose: bool = False,
 ) -> Path | None:
     """Give one collection a thumbnail asset, if it needs and can have one.
@@ -381,6 +382,9 @@ def ensure_collection_thumbnail(
             for a catalog that set ``enabled: false``.
         force: Re-resolve and re-render even when a thumbnail asset is already
             registered. Refreshes ``file:size`` and ``file:checksum`` too.
+        amend_latest: Fold the thumbnail into the version the caller just wrote
+            instead of bumping. ``add`` sets this for collections it versioned
+            this run, so one add stays one version.
         verbose: Emit a line per collection touched.
 
     Returns:
@@ -419,6 +423,7 @@ def ensure_collection_thumbnail(
             catalog_root,
             message=f"{'Generated' if was_rendered else 'Registered'} thumbnail: {thumbnail.name}",
             only_if_missing=not force,
+            amend_latest=amend_latest,
         )
     except Exception as exc:
         warn(f"Failed to track {thumbnail.name} in versions.json: {exc}")
@@ -435,6 +440,7 @@ def ensure_collection_thumbnails(
     *,
     generate: bool | None = None,
     force: bool = False,
+    versioned_collections: set[str] | None = None,
     verbose: bool = False,
 ) -> None:
     """Ensure every affected collection carries a thumbnail asset.
@@ -448,6 +454,11 @@ def ensure_collection_thumbnails(
         generate: ``--thumbnails/--no-thumbnails``. None defers to the
             ``thumbnails.enabled`` catalog setting.
         force: ``--force-thumbnails``. Redraw even when one is registered.
+        versioned_collections: Collections whose versions.json this ``add`` just
+            wrote. Their thumbnail is folded into that snapshot rather than
+            bumping a second version. A collection that was skipped is absent,
+            so its backfilled thumbnail gets its own version instead of editing
+            a snapshot that may already be published.
         verbose: Emit a line per collection touched.
     """
     if not affected_collections:
@@ -462,7 +473,12 @@ def ensure_collection_thumbnails(
         if not (collection_path / "collection.json").exists():
             continue
         ensure_collection_thumbnail(
-            collection_path, catalog_root, generate=True, force=force, verbose=verbose
+            collection_path,
+            catalog_root,
+            generate=True,
+            force=force,
+            amend_latest=collection_id in (versioned_collections or set()),
+            verbose=verbose,
         )
 
 

--- a/portolan_cli/collection_thumbnail.py
+++ b/portolan_cli/collection_thumbnail.py
@@ -1,0 +1,377 @@
+"""Collection-level thumbnail assets (Issue #683).
+
+rashid's ``PTL-VIZ-001`` (spec ``PORTO-CORE-067`` / ``PORTO-FMT-033``) requires
+every geospatial collection to carry an asset with the ``thumbnail`` role. Until
+this module existed, ``portolan init`` followed by ``portolan add`` produced a
+catalog that failed its own ``portolan check``: vector rendering ran only inside
+the PMTiles side-step, which is gated on ``--pmtiles``, and rasters got an
+item-level sidecar that no collection asset ever pointed at.
+
+This is the orchestrator, not a renderer. It decides *whether* a collection
+needs a thumbnail and *where* one comes from, then delegates the drawing to
+``viz.thumbnail``. It lives at the package root rather than under ``viz/``
+because it reads STAC metadata and writes versions.json, and ``viz`` is a leaf
+that may not reach the sync layer (see the ``viz-is-a-leaf`` import contract).
+
+The ladder, cheapest rung first:
+
+1. Opt-out, via ``thumbnails.enabled`` or ``--no-thumbnails``.
+2. A ``thumbnail``-role asset is already registered.
+3. The collection is not geospatial, so the rule does not apply.
+4. A conventionally named image is on disk; adopt it.
+5. A raster item already carries a sidecar; point at it.
+6. Render from the collection's GeoParquet.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path, PurePath
+from typing import Any
+
+from portolan_cli import extension_registry as _reg
+from portolan_cli.formats import is_geoparquet
+from portolan_cli.json_io import write_json_atomic
+from portolan_cli.output import detail, warn
+from portolan_cli.sync.checksums import compute_checksum, multihash_sha256
+from portolan_cli.versions import track_generated_assets
+from portolan_cli.viz.thumbnail import generate_vector_thumbnail, get_thumbnail_config
+
+logger = logging.getLogger(__name__)
+
+#: The canonical asset key. STAC consumers find a thumbnail by role, but a
+#: well-known key keeps collection.json readable and matches the item-level
+#: convention in ``preparation._ROLE_KEYS``.
+THUMBNAIL_ASSET_KEY = "thumbnail"
+
+#: Extensions that may serve as a thumbnail, per rashid's ``_THUMBNAIL_TYPES``.
+#: Sourced from the extension registry so media types stay single-sourced.
+_MEDIA_TYPE_MAP: dict[str, str] = _reg.field_map("media_type")
+_THUMBNAIL_SUFFIXES = (".png", ".jpg", ".jpeg", ".webp")
+
+#: Filenames we are willing to adopt. Deliberately a short list of conventions
+#: rather than "any image": a legend or a logo dropped in a collection directory
+#: must never be promoted to the collection's thumbnail.
+_ADOPTABLE_STEMS = ("thumbnail", "preview")
+
+#: Media types that make a collection geospatial on sight. A ``.parquet`` needs
+#: a schema read instead, because a tabular Parquet carries no geometry and
+#: ``PTL-VIZ-001`` skips it.
+_SPATIAL_SUFFIXES = (".pmtiles", ".fgb", ".gpkg", ".shp", ".gdb", ".tif", ".tiff", ".copc.laz")
+
+
+def _load_collection(collection_path: Path) -> dict[str, Any] | None:
+    """Read collection.json, or None when it is absent or unreadable."""
+    collection_json = collection_path / "collection.json"
+    if not collection_json.exists():
+        return None
+    try:
+        data: dict[str, Any] = json.loads(collection_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("Cannot read %s: %s", collection_json, exc)
+        return None
+    return data
+
+
+def _media_type_for(path: Path) -> str:
+    return _MEDIA_TYPE_MAP.get(path.suffix.lower(), "application/octet-stream")
+
+
+def register_collection_thumbnail(
+    collection_path: Path,
+    thumbnail_path: Path,
+    *,
+    title: str | None = None,
+) -> None:
+    """Register ``thumbnail_path`` as the collection's thumbnail asset.
+
+    The single writer of this asset. Emits ``file:size`` and ``file:checksum``
+    so the result does not trip ``PTL-AST-003``; the checksum is a hex multihash,
+    not a bare digest (Issue #654).
+
+    Args:
+        collection_path: Path to the collection directory.
+        thumbnail_path: Path to the image, inside the collection directory or one
+            of its item directories.
+        title: Optional human-facing title.
+    """
+    collection_json = collection_path / "collection.json"
+    data = _load_collection(collection_path)
+    if data is None:
+        return
+
+    try:
+        href = PurePath(thumbnail_path.relative_to(collection_path)).as_posix()
+    except ValueError:
+        logger.debug("%s is outside %s; not registering", thumbnail_path, collection_path)
+        return
+
+    asset: dict[str, Any] = {
+        "href": f"./{href}",
+        "type": _media_type_for(thumbnail_path),
+        "roles": ["thumbnail"],
+    }
+    if title:
+        asset["title"] = title
+    try:
+        asset["file:size"] = thumbnail_path.stat().st_size
+        asset["file:checksum"] = multihash_sha256(compute_checksum(thumbnail_path))
+    except (OSError, ValueError) as exc:
+        # Size and checksum are a PTL-AST-003 warning, not an error. Registering
+        # the asset without them beats registering nothing.
+        logger.debug("Cannot stat or checksum %s: %s", thumbnail_path, exc)
+
+    data.setdefault("assets", {})[THUMBNAIL_ASSET_KEY] = asset
+    write_json_atomic(collection_json, data)
+
+
+def _has_thumbnail_asset(data: dict[str, Any]) -> bool:
+    return any("thumbnail" in asset.get("roles", []) for asset in data.get("assets", {}).values())
+
+
+def _claimed_hrefs(data: dict[str, Any]) -> set[str]:
+    """Every href already spoken for by an asset, normalized to a bare name."""
+    claimed: set[str] = set()
+    for asset in data.get("assets", {}).values():
+        href = asset.get("href", "")
+        if href:
+            claimed.add(PurePath(href.removeprefix("./")).as_posix())
+    return claimed
+
+
+def _is_adoptable(path: Path) -> bool:
+    """True for the filenames the CLI, a human, or the MapLibre skill produce."""
+    if path.suffix.lower() not in _THUMBNAIL_SUFFIXES:
+        return False
+    stem = path.stem.lower()
+    # `data.thumb.jpg` — the convention `thumbnail_path_for` writes.
+    if stem.endswith(".thumb"):
+        return True
+    return stem in _ADOPTABLE_STEMS
+
+
+def _find_adoptable_image(collection_path: Path, data: dict[str, Any]) -> Path | None:
+    claimed = _claimed_hrefs(data)
+    candidates = sorted(
+        p
+        for p in collection_path.iterdir()
+        if p.is_file() and _is_adoptable(p) and p.name not in claimed
+    )
+    return candidates[0] if candidates else None
+
+
+def _item_paths(collection_path: Path, data: dict[str, Any]) -> list[Path]:
+    """Resolve the collection's item links to paths on disk."""
+    items: list[Path] = []
+    for link in data.get("links", []):
+        if link.get("rel") != "item":
+            continue
+        href = link.get("href", "")
+        if not href:
+            continue
+        candidate = (collection_path / href.removeprefix("./")).resolve()
+        if candidate.exists():
+            items.append(candidate)
+    return items
+
+
+def _find_item_thumbnail(collection_path: Path, data: dict[str, Any]) -> Path | None:
+    """The sidecar `add` already writes beside a converted COG (Issue #657)."""
+    for item_json in _item_paths(collection_path, data):
+        try:
+            item: dict[str, Any] = json.loads(item_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        for asset in item.get("assets", {}).values():
+            if "thumbnail" not in asset.get("roles", []):
+                continue
+            href = str(asset.get("href", "")).removeprefix("./")
+            candidate = item_json.parent / href
+            if candidate.exists():
+                return candidate
+    return None
+
+
+def _collection_data_assets(collection_path: Path, data: dict[str, Any]) -> list[Path]:
+    paths: list[Path] = []
+    for asset in data.get("assets", {}).values():
+        roles = asset.get("roles", [])
+        if roles and "data" not in roles:
+            continue
+        href = asset.get("href", "").removeprefix("./")
+        if not href:
+            continue
+        candidate = collection_path / href
+        if candidate.exists():
+            paths.append(candidate)
+    return paths
+
+
+def _find_geoparquet(collection_path: Path, data: dict[str, Any]) -> Path | None:
+    """The GeoParquet to draw, preferring a collection-level asset over an item."""
+    for path in _collection_data_assets(collection_path, data):
+        if path.suffix.lower() == ".parquet" and is_geoparquet(path):
+            return path
+    for item_json in _item_paths(collection_path, data):
+        try:
+            item: dict[str, Any] = json.loads(item_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        for asset in item.get("assets", {}).values():
+            href = str(asset.get("href", "")).removeprefix("./")
+            candidate = item_json.parent / href
+            if candidate.suffix.lower() == ".parquet" and candidate.exists():
+                if is_geoparquet(candidate):
+                    return candidate
+    return None
+
+
+def _is_geospatial(collection_path: Path, data: dict[str, Any]) -> bool:
+    """Mirror rashid's positive-signal test, cheaply and from disk.
+
+    A tabular collection — Parquet with no ``geo`` schema metadata — is not
+    geospatial, and ``PTL-VIZ-001`` skips it. Derive that status, never flag it.
+    """
+    for path in _collection_data_assets(collection_path, data):
+        suffix = path.suffix.lower()
+        if suffix == ".parquet":
+            if is_geoparquet(path):
+                return True
+        elif suffix in _SPATIAL_SUFFIXES:
+            return True
+    for item_json in _item_paths(collection_path, data):
+        try:
+            item: dict[str, Any] = json.loads(item_json.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if item.get("geometry") is not None:
+            return True
+    return False
+
+
+def _resolve_for_collection(
+    collection_path: Path, catalog_root: Path, data: dict[str, Any]
+) -> tuple[Path, bool] | None:
+    """Return (thumbnail path, was_rendered), or None when there is nothing to do."""
+    adopted = _find_adoptable_image(collection_path, data)
+    if adopted is not None:
+        return adopted, False
+
+    item_thumb = _find_item_thumbnail(collection_path, data)
+    if item_thumb is not None:
+        return item_thumb, False
+
+    geoparquet = _find_geoparquet(collection_path, data)
+    if geoparquet is None:
+        return None
+
+    from portolan_cli.viz.pmtiles import _discover_style_for_thumbnail
+
+    rendered = generate_vector_thumbnail(
+        pmtiles_path=None,
+        geoparquet_path=geoparquet,
+        config=get_thumbnail_config(catalog_root),
+        style_path=_discover_style_for_thumbnail(collection_path),
+    )
+    if rendered is None:
+        return None
+    return rendered, True
+
+
+def ensure_collection_thumbnail(
+    collection_path: Path,
+    catalog_root: Path,
+    *,
+    verbose: bool = False,
+) -> Path | None:
+    """Give one collection a thumbnail asset, if it needs and can have one.
+
+    Never raises: a thumbnail is worth a warning, never a failed ``add``.
+
+    Args:
+        collection_path: Path to the collection directory.
+        catalog_root: Path to the catalog root.
+        verbose: Emit a line per collection touched.
+
+    Returns:
+        The registered thumbnail path, or None when nothing was registered.
+    """
+    data = _load_collection(collection_path)
+    if data is None:
+        return None
+    if _has_thumbnail_asset(data):
+        return None
+    if not _is_geospatial(collection_path, data):
+        return None
+
+    try:
+        resolved = _resolve_for_collection(collection_path, catalog_root, data)
+    except Exception as exc:
+        warn(f"Thumbnail generation failed for {collection_path.name}: {exc}")
+        return None
+    if resolved is None:
+        return None
+
+    thumbnail, was_rendered = resolved
+    register_collection_thumbnail(collection_path, thumbnail)
+
+    if was_rendered:
+        # Only track what we wrote. An adopted file is either already tracked or
+        # is the user's to manage.
+        try:
+            track_generated_assets(
+                collection_path,
+                [thumbnail],
+                catalog_root,
+                message=f"Generated thumbnail: {thumbnail.name}",
+                only_if_missing=True,
+            )
+        except Exception as exc:
+            warn(f"Failed to track {thumbnail.name} in versions.json: {exc}")
+
+    if verbose:
+        verb = "Rendered" if was_rendered else "Registered existing"
+        detail(f"{verb} thumbnail for {collection_path.name}: {thumbnail.name}")
+    return thumbnail
+
+
+def ensure_collection_thumbnails(
+    catalog_root: Path,
+    affected_collections: set[str],
+    *,
+    generate: bool | None = None,
+    verbose: bool = False,
+) -> None:
+    """Ensure every affected collection carries a thumbnail asset.
+
+    Runs after the PMTiles side-step, so a higher-fidelity thumbnail rendered
+    from tiles is adopted rather than replaced.
+
+    Args:
+        catalog_root: Path to the catalog root.
+        affected_collections: Collection IDs touched by the command.
+        generate: ``--thumbnails/--no-thumbnails``. None defers to the
+            ``thumbnails.enabled`` catalog setting.
+        verbose: Emit a line per collection touched.
+    """
+    if not affected_collections:
+        return
+    if generate is False:
+        return
+    if generate is None and not get_thumbnail_config(catalog_root).enabled:
+        return
+
+    for collection_id in sorted(affected_collections):
+        collection_path = catalog_root / collection_id
+        if not (collection_path / "collection.json").exists():
+            continue
+        ensure_collection_thumbnail(collection_path, catalog_root, verbose=verbose)
+
+
+__all__ = [
+    "THUMBNAIL_ASSET_KEY",
+    "ensure_collection_thumbnail",
+    "ensure_collection_thumbnails",
+    "register_collection_thumbnail",
+]

--- a/portolan_cli/collection_thumbnail.py
+++ b/portolan_cli/collection_thumbnail.py
@@ -83,7 +83,7 @@ def register_collection_thumbnail(
     thumbnail_path: Path,
     *,
     title: str | None = None,
-) -> None:
+) -> bool:
     """Register ``thumbnail_path`` as the collection's thumbnail asset.
 
     The single writer of this asset. Emits ``file:size`` and ``file:checksum``
@@ -95,17 +95,25 @@ def register_collection_thumbnail(
         thumbnail_path: Path to the image, inside the collection directory or one
             of its item directories.
         title: Optional human-facing title.
+
+    Returns:
+        True when collection.json was rewritten, False when nothing was written.
     """
     collection_json = collection_path / "collection.json"
     data = _load_collection(collection_path)
     if data is None:
-        return
+        return False
 
+    # Resolve BOTH sides. `_item_paths` resolves its candidates, so comparing one
+    # resolved path against an unresolved collection directory raised ValueError
+    # for every catalog reached through a symlink — macOS `/var` -> `/private/var`
+    # among them — and silently dropped the raster branch. Resolving both keeps
+    # the containment check that rejects an href escaping the collection.
     try:
-        href = PurePath(thumbnail_path.relative_to(collection_path)).as_posix()
-    except ValueError:
+        href = PurePath(thumbnail_path.resolve().relative_to(collection_path.resolve())).as_posix()
+    except (OSError, ValueError):
         logger.debug("%s is outside %s; not registering", thumbnail_path, collection_path)
-        return
+        return False
 
     asset: dict[str, Any] = {
         "href": f"./{href}",
@@ -124,6 +132,7 @@ def register_collection_thumbnail(
 
     data.setdefault("assets", {})[THUMBNAIL_ASSET_KEY] = asset
     write_json_atomic(collection_json, data)
+    return True
 
 
 def _has_thumbnail_asset(data: dict[str, Any]) -> bool:
@@ -131,32 +140,57 @@ def _has_thumbnail_asset(data: dict[str, Any]) -> bool:
 
 
 def _claimed_hrefs(data: dict[str, Any]) -> set[str]:
-    """Every href already spoken for by an asset, normalized to a bare name."""
+    """Every href spoken for by a non-thumbnail asset, collection-relative.
+
+    A thumbnail-role asset is excluded on purpose. It points at the very file
+    this module is deciding about, so counting it as claimed would make a forced
+    refresh refuse to re-adopt the image the user chose and render over it.
+    """
     claimed: set[str] = set()
     for asset in data.get("assets", {}).values():
+        if "thumbnail" in asset.get("roles", []):
+            continue
         href = asset.get("href", "")
         if href:
             claimed.add(PurePath(href.removeprefix("./")).as_posix())
     return claimed
 
 
+def _is_generated(path: Path) -> bool:
+    """True for the ``{stem}.thumb.{ext}`` name ``thumbnail_path_for`` writes."""
+    return path.stem.lower().endswith(".thumb")
+
+
 def _is_adoptable(path: Path) -> bool:
     """True for the filenames the CLI, a human, or the MapLibre skill produce."""
     if path.suffix.lower() not in _THUMBNAIL_SUFFIXES:
         return False
-    stem = path.stem.lower()
-    # `data.thumb.jpg` — the convention `thumbnail_path_for` writes.
-    if stem.endswith(".thumb"):
+    if _is_generated(path):
         return True
-    return stem in _ADOPTABLE_STEMS
+    return path.stem.lower() in _ADOPTABLE_STEMS
 
 
-def _find_adoptable_image(collection_path: Path, data: dict[str, Any]) -> Path | None:
+def _find_adoptable_image(
+    collection_path: Path, data: dict[str, Any], *, skip_generated: bool = False
+) -> Path | None:
+    """The conventionally named image to adopt, if the collection holds one.
+
+    Args:
+        collection_path: Path to the collection directory.
+        data: Parsed collection.json.
+        skip_generated: Ignore our own ``*.thumb.*`` output. A forced refresh
+            passes True so it re-renders instead of re-adopting the stale render
+            it wrote last time. A human's ``thumbnail.png`` still wins, because
+            a force must not overwrite a picture somebody chose.
+    """
     claimed = _claimed_hrefs(data)
     candidates = sorted(
         p
         for p in collection_path.iterdir()
-        if p.is_file() and _is_adoptable(p) and p.name not in claimed
+        if p.is_file()
+        and _is_adoptable(p)
+        and not (skip_generated and _is_generated(p))
+        and PurePath(p.relative_to(collection_path)).as_posix() not in claimed
     )
     return candidates[0] if candidates else None
 
@@ -250,27 +284,50 @@ def _is_geospatial(collection_path: Path, data: dict[str, Any]) -> bool:
     return False
 
 
-def _resolve_for_collection(
-    collection_path: Path, catalog_root: Path, data: dict[str, Any]
-) -> tuple[Path, bool] | None:
-    """Return (thumbnail path, was_rendered), or None when there is nothing to do."""
-    adopted = _find_adoptable_image(collection_path, data)
+def _find_source(
+    collection_path: Path, data: dict[str, Any], *, force: bool = False
+) -> tuple[Path, str] | None:
+    """Pick the thumbnail source without drawing anything.
+
+    Split out of ``_resolve_for_collection`` so ``check --fix --dry-run`` can
+    answer "would this collection get a thumbnail?" using the same gates the
+    real run uses. Before the split, dry-run skipped straight to a "would
+    generate" line and promised work the real run then declined to do.
+
+    Returns:
+        (path, kind) where kind is ``adopt``, ``item``, or ``render``, or None
+        when the collection offers no source at all.
+    """
+    adopted = _find_adoptable_image(collection_path, data, skip_generated=force)
     if adopted is not None:
-        return adopted, False
+        return adopted, "adopt"
 
     item_thumb = _find_item_thumbnail(collection_path, data)
     if item_thumb is not None:
-        return item_thumb, False
+        return item_thumb, "item"
 
     geoparquet = _find_geoparquet(collection_path, data)
     if geoparquet is None:
         return None
+    return geoparquet, "render"
+
+
+def _resolve_for_collection(
+    collection_path: Path, catalog_root: Path, data: dict[str, Any], *, force: bool = False
+) -> tuple[Path, bool] | None:
+    """Return (thumbnail path, was_rendered), or None when there is nothing to do."""
+    source = _find_source(collection_path, data, force=force)
+    if source is None:
+        return None
+    path, kind = source
+    if kind != "render":
+        return path, False
 
     from portolan_cli.viz.pmtiles import _discover_style_for_thumbnail
 
     rendered = generate_vector_thumbnail(
         pmtiles_path=None,
-        geoparquet_path=geoparquet,
+        geoparquet_path=path,
         config=get_thumbnail_config(catalog_root),
         style_path=_discover_style_for_thumbnail(collection_path),
     )
@@ -279,10 +336,36 @@ def _resolve_for_collection(
     return rendered, True
 
 
+def _thumbnails_wanted(catalog_root: Path, generate: bool | None) -> bool:
+    """Resolve ``--thumbnails/--no-thumbnails`` against the catalog setting."""
+    if generate is not None:
+        return generate
+    return get_thumbnail_config(catalog_root).enabled
+
+
+def would_generate_thumbnail(
+    collection_path: Path, catalog_root: Path, *, generate: bool | None = None
+) -> bool:
+    """True when :func:`ensure_collection_thumbnail` would register something.
+
+    Runs every gate except the render itself, so a dry run and a real run agree.
+    """
+    if not _thumbnails_wanted(catalog_root, generate):
+        return False
+    data = _load_collection(collection_path)
+    if data is None or _has_thumbnail_asset(data):
+        return False
+    if not _is_geospatial(collection_path, data):
+        return False
+    return _find_source(collection_path, data) is not None
+
+
 def ensure_collection_thumbnail(
     collection_path: Path,
     catalog_root: Path,
     *,
+    generate: bool | None = None,
+    force: bool = False,
     verbose: bool = False,
 ) -> Path | None:
     """Give one collection a thumbnail asset, if it needs and can have one.
@@ -292,21 +375,29 @@ def ensure_collection_thumbnail(
     Args:
         collection_path: Path to the collection directory.
         catalog_root: Path to the catalog root.
+        generate: ``--thumbnails/--no-thumbnails``. None defers to the
+            ``thumbnails.enabled`` catalog setting. Checked here, not only in
+            the plural wrapper, so ``check --fix`` cannot generate a thumbnail
+            for a catalog that set ``enabled: false``.
+        force: Re-resolve and re-render even when a thumbnail asset is already
+            registered. Refreshes ``file:size`` and ``file:checksum`` too.
         verbose: Emit a line per collection touched.
 
     Returns:
         The registered thumbnail path, or None when nothing was registered.
     """
+    if not _thumbnails_wanted(catalog_root, generate):
+        return None
     data = _load_collection(collection_path)
     if data is None:
         return None
-    if _has_thumbnail_asset(data):
+    if _has_thumbnail_asset(data) and not force:
         return None
     if not _is_geospatial(collection_path, data):
         return None
 
     try:
-        resolved = _resolve_for_collection(collection_path, catalog_root, data)
+        resolved = _resolve_for_collection(collection_path, catalog_root, data, force=force)
     except Exception as exc:
         warn(f"Thumbnail generation failed for {collection_path.name}: {exc}")
         return None
@@ -314,21 +405,23 @@ def ensure_collection_thumbnail(
         return None
 
     thumbnail, was_rendered = resolved
-    register_collection_thumbnail(collection_path, thumbnail)
+    if not register_collection_thumbnail(collection_path, thumbnail):
+        return None
 
-    if was_rendered:
-        # Only track what we wrote. An adopted file is either already tracked or
-        # is the user's to manage.
-        try:
-            track_generated_assets(
-                collection_path,
-                [thumbnail],
-                catalog_root,
-                message=f"Generated thumbnail: {thumbnail.name}",
-                only_if_missing=True,
-            )
-        except Exception as exc:
-            warn(f"Failed to track {thumbnail.name} in versions.json: {exc}")
+    # Track every thumbnail we register, not only the ones we drew. An adopted
+    # image is a STAC asset the moment we point at it, and versions.json is the
+    # source of truth that push, drift, and integrity all read (ADR-0005). A
+    # forced refresh rewrites the record, so `only_if_missing` goes off.
+    try:
+        track_generated_assets(
+            collection_path,
+            [thumbnail],
+            catalog_root,
+            message=f"{'Generated' if was_rendered else 'Registered'} thumbnail: {thumbnail.name}",
+            only_if_missing=not force,
+        )
+    except Exception as exc:
+        warn(f"Failed to track {thumbnail.name} in versions.json: {exc}")
 
     if verbose:
         verb = "Rendered" if was_rendered else "Registered existing"
@@ -341,6 +434,7 @@ def ensure_collection_thumbnails(
     affected_collections: set[str],
     *,
     generate: bool | None = None,
+    force: bool = False,
     verbose: bool = False,
 ) -> None:
     """Ensure every affected collection carries a thumbnail asset.
@@ -353,20 +447,23 @@ def ensure_collection_thumbnails(
         affected_collections: Collection IDs touched by the command.
         generate: ``--thumbnails/--no-thumbnails``. None defers to the
             ``thumbnails.enabled`` catalog setting.
+        force: ``--force-thumbnails``. Redraw even when one is registered.
         verbose: Emit a line per collection touched.
     """
     if not affected_collections:
         return
-    if generate is False:
-        return
-    if generate is None and not get_thumbnail_config(catalog_root).enabled:
+    # Resolve the flag against config once, then hand the answer down, so the
+    # config read does not repeat per collection.
+    if not _thumbnails_wanted(catalog_root, generate):
         return
 
     for collection_id in sorted(affected_collections):
         collection_path = catalog_root / collection_id
         if not (collection_path / "collection.json").exists():
             continue
-        ensure_collection_thumbnail(collection_path, catalog_root, verbose=verbose)
+        ensure_collection_thumbnail(
+            collection_path, catalog_root, generate=True, force=force, verbose=verbose
+        )
 
 
 __all__ = [
@@ -374,4 +471,5 @@ __all__ = [
     "ensure_collection_thumbnail",
     "ensure_collection_thumbnails",
     "register_collection_thumbnail",
+    "would_generate_thumbnail",
 ]

--- a/portolan_cli/validation/fixers.py
+++ b/portolan_cli/validation/fixers.py
@@ -590,7 +590,10 @@ def _fix_thumbnail(root: Path, dry_run: bool) -> list[FixResult]:
     so a catalog generated before Issue #683 can heal itself with
     ``portolan check --fix`` instead of being re-added.
     """
-    from portolan_cli.collection_thumbnail import ensure_collection_thumbnail
+    from portolan_cli.collection_thumbnail import (
+        ensure_collection_thumbnail,
+        would_generate_thumbnail,
+    )
 
     results: list[FixResult] = []
     for node in _graph(root).iter("collection"):
@@ -602,7 +605,12 @@ def _fix_thumbnail(root: Path, dry_run: bool) -> list[FixResult]:
             continue
         collection_dir = node.abs_path.parent
         if dry_run:
-            results.append(_skipped(node.abs_path, "Would generate a collection thumbnail"))
+            # Ask the orchestrator, rather than assuming every collection can
+            # have one. A tabular collection and a collection with no drawable
+            # source both decline, and a dry run that claimed otherwise promised
+            # work the real run would not do.
+            if would_generate_thumbnail(collection_dir, root):
+                results.append(_skipped(node.abs_path, "Would generate a collection thumbnail"))
             continue
         thumbnail = ensure_collection_thumbnail(collection_dir, root)
         if thumbnail is not None:

--- a/portolan_cli/validation/fixers.py
+++ b/portolan_cli/validation/fixers.py
@@ -549,6 +549,72 @@ def _fix_styles(root: Path, dry_run: bool) -> list[FixResult]:
 
 
 # --------------------------------------------------------------------------
+# thumbnail — PTL-VIZ-001
+# --------------------------------------------------------------------------
+
+#: rashid's _THUMBNAIL_TYPES. A thumbnail asset typed anything else fails
+#: PTL-VIZ-001 just as surely as a missing one.
+_THUMBNAIL_MEDIA_TYPES = {"image/png", "image/jpeg", "image/webp"}
+_THUMBNAIL_TYPE_BY_SUFFIX = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+}
+
+
+def _retype_thumbnails(node: Node, dry_run: bool) -> FixResult | None:
+    """Re-derive a mistyped thumbnail's media type from the file it points at."""
+    changed = False
+    for asset in _assets_of(node).values():
+        if "thumbnail" not in roles_of(asset):
+            continue
+        if asset.get("type") in _THUMBNAIL_MEDIA_TYPES:
+            continue
+        href = asset.get("href")
+        if not isinstance(href, str):
+            continue
+        correct = _THUMBNAIL_TYPE_BY_SUFFIX.get(Path(href).suffix.lower())
+        if correct is None:
+            # Points at something that is not an image; retyping would lie.
+            continue
+        asset["type"] = correct
+        changed = True
+    if not changed:
+        return None
+    _write_node(node, dry_run=dry_run)
+    return _updated(node, "Retyped the thumbnail asset from the file it points at")
+
+
+def _fix_thumbnail(root: Path, dry_run: bool) -> list[FixResult]:
+    """Give every geospatial collection a correctly typed thumbnail asset.
+
+    Two repairs behind one rule id. A mistyped thumbnail is retyped in place.
+    A missing one is adopted or rendered by the same orchestrator ``add`` uses,
+    so a catalog generated before Issue #683 can heal itself with
+    ``portolan check --fix`` instead of being re-added.
+    """
+    from portolan_cli.collection_thumbnail import ensure_collection_thumbnail
+
+    results: list[FixResult] = []
+    for node in _graph(root).iter("collection"):
+        retyped = _retype_thumbnails(node, dry_run)
+        if retyped is not None:
+            results.append(retyped)
+            continue
+        if any("thumbnail" in roles_of(asset) for asset in _assets_of(node).values()):
+            continue
+        collection_dir = node.abs_path.parent
+        if dry_run:
+            results.append(_skipped(node.abs_path, "Would generate a collection thumbnail"))
+            continue
+        thumbnail = ensure_collection_thumbnail(collection_dir, root)
+        if thumbnail is not None:
+            results.append(_updated(node, f"Generated the collection thumbnail {thumbnail.name}"))
+    return results
+
+
+# --------------------------------------------------------------------------
 # item_mirror — PTL-MIR-001/002
 # --------------------------------------------------------------------------
 
@@ -834,6 +900,7 @@ FIXERS: dict[str, Fixer] = {
     "partition": _fix_partition,
     "item_mirror": _fix_item_mirror,
     "styles": _fix_styles,
+    "thumbnail": _fix_thumbnail,
     "pmtiles": _fix_pmtiles,
     "checksum": _fix_checksums,
     "convert": _fix_convert,

--- a/portolan_cli/validation/remediation.py
+++ b/portolan_cli/validation/remediation.py
@@ -168,9 +168,9 @@ RULE_REMEDIATION: dict[str, Remediation] = {
         "then populate its version fields."
     ),
     # ---- visualization ----
-    "PTL-VIZ-001": _instruct(
-        "Render a thumbnail (png or jpeg) for the collection and register it as an asset; "
-        "`portolan add` does this when the [thumbnails] extra is installed."
+    "PTL-VIZ-001": _auto(
+        "thumbnail",
+        "Register a thumbnail (png, jpeg or webp) asset for the collection.",
     ),
     "PTL-VIZ-002": _instruct(
         "Author style assets for the visual derivative; a style encodes cartographic intent "

--- a/portolan_cli/versions.py
+++ b/portolan_cli/versions.py
@@ -34,6 +34,7 @@ Structure:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from dataclasses import dataclass, field
@@ -508,3 +509,109 @@ def _compute_changes(versions_file: VersionsFile, new_assets: dict[str, Asset]) 
             changes.append(name)
 
     return changes
+
+
+def _compute_sha256(path: Path) -> str:
+    """Stream a file in 64KB chunks and return its SHA-256 hex digest.
+
+    Chunked to avoid loading large PMTiles/thumbnail files fully into memory.
+    """
+    hasher = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):  # 64KB chunks
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def track_generated_assets(
+    collection_path: Path,
+    asset_paths: list[Path],
+    catalog_root: Path,
+    *,
+    message: str,
+    only_if_missing: bool = False,
+) -> None:
+    """Track generated side-step assets (PMTiles, thumbnail) in versions.json.
+
+    Computes SHA-256, size, mtime and path records in a *single* new version
+    snapshot. A PMTiles and its thumbnail come from the same side-step on the
+    same source asset, so they belong in one version, not two (Issue #519).
+    ``add_version`` carries forward the previous version's assets, so the result
+    is a complete snapshot with the assets added or updated.
+
+    Lives here rather than beside either caller because both the PMTiles
+    side-step (``viz.pmtiles``) and the collection-thumbnail orchestrator
+    (``collection_thumbnail``) must record derived assets the same way. An
+    untracked derived asset breaks ``push`` (Issues #519, #735).
+
+    Args:
+        collection_path: Path to the collection directory.
+        asset_paths: Paths of the generated files to track.
+        catalog_root: Path to the catalog root (hrefs are catalog-root-relative).
+        message: Human-readable description of the change.
+        only_if_missing: If True, only track assets whose filename is not already
+            present in the latest version snapshot, and create no version at all
+            if every asset is already tracked. Used by the skip path to backfill
+            artifacts generated before tracking existed, without bumping a
+            version on every unchanged ``add`` (Issue #519).
+
+    Raises:
+        FileNotFoundError: If any asset path doesn't exist.
+    """
+    for asset_path in asset_paths:
+        if not asset_path.exists():
+            raise FileNotFoundError(f"File not found at {asset_path}")
+
+    versions_path = collection_path / "versions.json"
+
+    # If no versions.json, create a minimal one
+    if not versions_path.exists():
+        versions_file = VersionsFile(
+            spec_version="1.0.0",
+            current_version=None,
+            versions=[],
+        )
+    else:
+        versions_file = read_versions(versions_path)
+
+    # Backfill mode: skip assets already tracked, and create no version if none
+    # are missing (otherwise the message would force a no-op version bump).
+    paths_to_track = asset_paths
+    if only_if_missing and versions_file.versions:
+        tracked = versions_file.versions[-1].assets
+        paths_to_track = [p for p in asset_paths if p.name not in tracked]
+    if not paths_to_track:
+        return
+
+    assets: dict[str, Asset] = {}
+    for asset_path in paths_to_track:
+        stat = asset_path.stat()
+        # Href is relative to catalog root
+        try:
+            rel_path = asset_path.relative_to(catalog_root)
+        except ValueError:
+            # Fallback if not relative
+            rel_path = asset_path.relative_to(collection_path.parent)
+        assets[asset_path.name] = Asset(
+            sha256=_compute_sha256(asset_path),
+            size_bytes=stat.st_size,
+            href=rel_path.as_posix(),
+            mtime=stat.st_mtime,
+        )
+
+    # Determine next version
+    if versions_file.current_version:
+        major, minor, patch = parse_version(versions_file.current_version)
+        new_version = f"{major}.{minor}.{patch + 1}"
+    else:
+        new_version = "1.0.0"
+
+    updated = add_version(
+        versions_file,
+        version=new_version,
+        assets=assets,
+        breaking=False,
+        message=message,
+    )
+
+    write_versions(versions_path, updated)

--- a/portolan_cli/versions.py
+++ b/portolan_cli/versions.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -558,6 +558,7 @@ def track_generated_assets(
     *,
     message: str,
     only_if_missing: bool = False,
+    amend_latest: bool = False,
 ) -> None:
     """Track generated side-step assets (PMTiles, thumbnail) in versions.json.
 
@@ -582,6 +583,12 @@ def track_generated_assets(
             if every asset is already tracked. Used by the skip path to backfill
             artifacts generated before tracking existed, without bumping a
             version on every unchanged ``add`` (Issue #519).
+        amend_latest: If True, merge into the latest version rather than create a
+            new one. Pass this only when the caller wrote that version during the
+            same command, which is the case for the side-steps ``add`` runs after
+            its own snapshot. One ``add`` then stays one version. A repair pass
+            like ``check --fix`` leaves it False, since amending a snapshot that
+            may already be published would rewrite history.
 
     Raises:
         FileNotFoundError: If any asset path doesn't exist.
@@ -627,6 +634,20 @@ def track_generated_assets(
             href=_asset_href(asset_path, catalog_root, collection_path),
             mtime=stat.st_mtime,
         )
+
+    if amend_latest and versions_file.versions:
+        # Fold into the snapshot the caller just wrote, rather than bumping.
+        # One `add` is one version. A thumbnail is derived from assets in that
+        # same snapshot, so a second version would record no new user intent and
+        # would double every collection's history (Issue #519).
+        latest = versions_file.versions[-1]
+        versions_file.versions[-1] = replace(
+            latest,
+            assets={**latest.assets, **assets},
+            changes=list(dict.fromkeys([*latest.changes, *assets])),
+        )
+        write_versions(versions_path, versions_file)
+        return
 
     # Determine next version
     if versions_file.current_version:

--- a/portolan_cli/versions.py
+++ b/portolan_cli/versions.py
@@ -523,6 +523,34 @@ def _compute_sha256(path: Path) -> str:
     return hasher.hexdigest()
 
 
+def _asset_href(asset_path: Path, catalog_root: Path, collection_path: Path) -> str:
+    """The catalog-root-relative href recorded for a generated asset."""
+    try:
+        rel_path = asset_path.relative_to(catalog_root)
+    except ValueError:
+        # Fallback when the asset is not under the catalog root.
+        rel_path = asset_path.relative_to(collection_path.parent)
+    return rel_path.as_posix()
+
+
+def _is_tracked(
+    asset_path: Path,
+    tracked: dict[str, Asset],
+    catalog_root: Path,
+    collection_path: Path,
+) -> bool:
+    """True when the snapshot already records this exact file.
+
+    Compares the href, not the basename. Two item directories can each hold a
+    ``data.thumb.jpg``, and a basename match would treat the second as already
+    tracked and drop it from the snapshot.
+    """
+    existing = tracked.get(asset_path.name)
+    if existing is None:
+        return False
+    return existing.href == _asset_href(asset_path, catalog_root, collection_path)
+
+
 def track_generated_assets(
     collection_path: Path,
     asset_paths: list[Path],
@@ -576,26 +604,27 @@ def track_generated_assets(
 
     # Backfill mode: skip assets already tracked, and create no version if none
     # are missing (otherwise the message would force a no-op version bump).
+    #
+    # An asset is "already tracked" only when the recorded href points at the
+    # same file. Matching the basename alone made `item-a/data.thumb.jpg` and
+    # `item-b/data.thumb.jpg` indistinguishable, so the second one was silently
+    # dropped from the snapshot.
     paths_to_track = asset_paths
     if only_if_missing and versions_file.versions:
         tracked = versions_file.versions[-1].assets
-        paths_to_track = [p for p in asset_paths if p.name not in tracked]
+        paths_to_track = [
+            p for p in asset_paths if not _is_tracked(p, tracked, catalog_root, collection_path)
+        ]
     if not paths_to_track:
         return
 
     assets: dict[str, Asset] = {}
     for asset_path in paths_to_track:
         stat = asset_path.stat()
-        # Href is relative to catalog root
-        try:
-            rel_path = asset_path.relative_to(catalog_root)
-        except ValueError:
-            # Fallback if not relative
-            rel_path = asset_path.relative_to(collection_path.parent)
         assets[asset_path.name] = Asset(
             sha256=_compute_sha256(asset_path),
             size_bytes=stat.st_size,
-            href=rel_path.as_posix(),
+            href=_asset_href(asset_path, catalog_root, collection_path),
             mtime=stat.st_mtime,
         )
 

--- a/portolan_cli/viz/pmtiles.py
+++ b/portolan_cli/viz/pmtiles.py
@@ -22,7 +22,6 @@ Usage:
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import shutil
@@ -33,6 +32,7 @@ from typing import Any
 from portolan_cli.errors import PortolanError
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import error, info, success, warn
+from portolan_cli.versions import track_generated_assets
 
 # The PMTiles constants and pure asset/link classifiers now live in the
 # framework-free leaf pmtiles_links.py so validation/ can reach them without
@@ -523,153 +523,6 @@ def add_pmtiles_link_to_collection(
         write_json_atomic(collection_json_path, data)
 
 
-def add_thumbnail_asset_to_collection(
-    collection_path: Path,
-    pmtiles_key: str,
-    thumbnail_path: Path,
-) -> None:
-    """Add thumbnail asset to collection.json.
-
-    Args:
-        collection_path: Path to collection directory.
-        pmtiles_key: Asset key of the PMTiles file (thumbnail key will be pmtiles_key + "-thumbnail").
-        thumbnail_path: Path to thumbnail file.
-    """
-    collection_json_path = collection_path / "collection.json"
-    if not collection_json_path.exists():
-        return
-
-    data = json.loads(collection_json_path.read_text(encoding="utf-8"))
-    assets = data.get("assets", {})
-
-    thumb_key = f"{pmtiles_key}-thumbnail"
-    thumb_href = f"./{thumbnail_path.name}"
-
-    # Get title from PMTiles asset if available
-    pmtiles_asset = assets.get(pmtiles_key, {})
-    pmtiles_title = pmtiles_asset.get("title", pmtiles_key)
-
-    assets[thumb_key] = {
-        "href": thumb_href,
-        "type": "image/jpeg",
-        "title": f"{pmtiles_title} (thumbnail)",
-        "roles": ["thumbnail"],
-    }
-    data["assets"] = assets
-
-    write_json_atomic(collection_json_path, data)
-
-
-def _compute_sha256(path: Path) -> str:
-    """Stream a file in 64KB chunks and return its SHA-256 hex digest.
-
-    Chunked to avoid loading large PMTiles/thumbnail files fully into memory.
-    """
-    hasher = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(65536), b""):  # 64KB chunks
-            hasher.update(chunk)
-    return hasher.hexdigest()
-
-
-def _track_generated_assets_in_versions(
-    collection_path: Path,
-    asset_paths: list[Path],
-    catalog_root: Path,
-    *,
-    message: str,
-    only_if_missing: bool = False,
-) -> None:
-    """Track generated side-step assets (PMTiles, thumbnail) in versions.json.
-
-    Computes SHA-256, size, and mtime for each path and records them in a *single*
-    new version snapshot. The PMTiles and its thumbnail come from the same
-    side-step for the same source asset, so they belong in one version, not two
-    (Issue #519). ``add_version`` carries forward the previous version's assets,
-    so the result is a complete snapshot with these assets added/updated.
-
-    Args:
-        collection_path: Path to collection directory.
-        asset_paths: Paths to the generated files to track.
-        catalog_root: Path to catalog root (hrefs are catalog-root-relative).
-        message: Human-readable description of the change.
-        only_if_missing: When True, only track assets whose filename is not
-            already present in the latest version snapshot, and create no version
-            at all if every asset is already tracked. Used by the skip path to
-            backfill artifacts generated before this tracking existed without
-            bumping a version on every unchanged ``add`` (Issue #519).
-
-    Raises:
-        FileNotFoundError: If any asset path doesn't exist.
-    """
-    from portolan_cli.versions import (
-        Asset,
-        VersionsFile,
-        add_version,
-        parse_version,
-        read_versions,
-        write_versions,
-    )
-
-    for asset_path in asset_paths:
-        if not asset_path.exists():
-            raise FileNotFoundError(f"File not found at {asset_path}")
-
-    versions_path = collection_path / "versions.json"
-
-    # If no versions.json, create a minimal one
-    if not versions_path.exists():
-        versions_file = VersionsFile(
-            spec_version="1.0.0",
-            current_version=None,
-            versions=[],
-        )
-    else:
-        versions_file = read_versions(versions_path)
-
-    # Backfill mode: skip assets already tracked, and create no version if none
-    # are missing (otherwise the message would force a no-op version bump).
-    paths_to_track = asset_paths
-    if only_if_missing and versions_file.versions:
-        tracked = versions_file.versions[-1].assets
-        paths_to_track = [p for p in asset_paths if p.name not in tracked]
-    if not paths_to_track:
-        return
-
-    assets: dict[str, Asset] = {}
-    for asset_path in paths_to_track:
-        stat = asset_path.stat()
-        # Href is relative to catalog root
-        try:
-            rel_path = asset_path.relative_to(catalog_root)
-        except ValueError:
-            # Fallback if not relative
-            rel_path = asset_path.relative_to(collection_path.parent)
-        assets[asset_path.name] = Asset(
-            sha256=_compute_sha256(asset_path),
-            size_bytes=stat.st_size,
-            href=rel_path.as_posix(),
-            mtime=stat.st_mtime,
-        )
-
-    # Determine next version
-    if versions_file.current_version:
-        major, minor, patch = parse_version(versions_file.current_version)
-        new_version = f"{major}.{minor}.{patch + 1}"
-    else:
-        new_version = "1.0.0"
-
-    updated = add_version(
-        versions_file,
-        version=new_version,
-        assets=assets,
-        breaking=False,
-        message=message,
-    )
-
-    write_versions(versions_path, updated)
-
-
 def _backfill_skipped_assets(
     collection_path: Path, asset_key: str, pmtiles_path: Path, catalog_root: Path
 ) -> None:
@@ -677,18 +530,20 @@ def _backfill_skipped_assets(
 
     Runs on the skip path to heal catalogs whose artifacts were generated before
     versions.json tracking existed (Issue #519), without bumping a version when
-    everything is already tracked. When a thumbnail exists on disk it is also
-    re-registered as a STAC asset (mirroring the PMTiles), so the backfilled
-    versions.json entry can never be orphaned from collection.json.
+    everything is already tracked.
+
+    Registering the thumbnail as a STAC asset is not done here.
+    ``collection_thumbnail.ensure_collection_thumbnails`` adopts any
+    ``.thumb.jpg`` on disk and is the single writer of the thumbnail asset
+    (Issue #683), so a backfilled versions.json entry still cannot be orphaned
+    from collection.json.
     """
     backfill = [pmtiles_path]
     existing_thumb = thumbnail_path_for(pmtiles_path)
     if existing_thumb.exists():
-        # Ensure the thumbnail is a STAC asset too, even when skipping generation.
-        add_thumbnail_asset_to_collection(collection_path, f"{asset_key}-tiles", existing_thumb)
         backfill.append(existing_thumb)
     try:
-        _track_generated_assets_in_versions(
+        track_generated_assets(
             collection_path,
             backfill,
             catalog_root,
@@ -703,13 +558,18 @@ def _generate_thumbnail_asset(
     collection_path: Path,
     parquet_path: Path,
     pmtiles_path: Path,
-    asset_key: str,
     catalog_root: Path,
 ) -> Path | None:
-    """Generate the vector thumbnail and register it as a STAC asset.
+    """Render the vector thumbnail from the tiles, the higher-fidelity source.
 
-    Returns the thumbnail path on success, or None if disabled or failed. Failure
+    Writes the file and returns its path, or None if disabled or failed. Failure
     is non-fatal: it must not affect PMTiles success (Issue #13).
+
+    Registering the STAC asset is deliberately not done here.
+    ``collection_thumbnail.ensure_collection_thumbnails`` runs after this and
+    adopts the ``.thumb.jpg`` this writes, so one writer owns the thumbnail
+    asset shape (Issue #683). Rendering from PMTiles still wins, because this
+    runs first and adoption never overwrites.
     """
     try:
         thumb_config = get_thumbnail_config(catalog_root)
@@ -717,15 +577,12 @@ def _generate_thumbnail_asset(
             return None
         # Discover style for thumbnail (Issue #495)
         style_path = _discover_style_for_thumbnail(collection_path)
-        thumb_path = generate_vector_thumbnail(
+        return generate_vector_thumbnail(
             pmtiles_path=pmtiles_path,
             geoparquet_path=parquet_path,  # fallback
             config=thumb_config,
             style_path=style_path,
         )
-        if thumb_path:
-            add_thumbnail_asset_to_collection(collection_path, f"{asset_key}-tiles", thumb_path)
-        return thumb_path
     except Exception as e:
         warn(f"Thumbnail generation failed for {pmtiles_path.name}: {e}")
         return None
@@ -750,9 +607,7 @@ def _track_side_step_assets(
     else:
         message = f"Generated PMTiles: {pmtiles_path.name}"
     try:
-        _track_generated_assets_in_versions(
-            collection_path, generated_assets, catalog_root, message=message
-        )
+        track_generated_assets(collection_path, generated_assets, catalog_root, message=message)
     except Exception as e:
         warn(f"Failed to track generated assets in versions.json for {pmtiles_path.name}: {e}")
 
@@ -902,7 +757,7 @@ def generate_pmtiles_for_collection(
         # snapshot (one side-step == one version, not two, Issue #519).
         if generation_succeeded:
             thumb_path = _generate_thumbnail_asset(
-                collection_path, parquet_path, pmtiles_path, asset_key, catalog_root
+                collection_path, parquet_path, pmtiles_path, catalog_root
             )
             _track_side_step_assets(collection_path, pmtiles_path, thumb_path, catalog_root)
 

--- a/portolan_cli/viz/thumbnail.py
+++ b/portolan_cli/viz/thumbnail.py
@@ -50,7 +50,7 @@ def _ensure_contextily() -> Any:
         if _ctx_loaded:
             return _ctx_module
         try:
-            import contextily as ctx  # type: ignore
+            import contextily as ctx
 
             _ctx_module = ctx
         except ImportError:
@@ -142,6 +142,10 @@ class ThumbnailConfig:
             Set to 'none' to disable basemap.
         basemap_opacity: Basemap opacity 0.0-1.0 (default 1.0).
         basemap_zoom_adjust: Zoom level adjustment for basemap (default 0).
+        max_features: Feature ceiling for a single render (default 100,000).
+            Beyond it the reader samples, so render cost stays bounded in file
+            size. Thumbnails became part of the default add pipeline in Issue
+            #683, which is what makes an unbounded read a problem.
     """
 
     enabled: bool = True
@@ -150,6 +154,7 @@ class ThumbnailConfig:
     basemap_provider: str = "CartoDB.Positron"
     basemap_opacity: float = 1.0
     basemap_zoom_adjust: int = 0
+    max_features: int = 100_000
 
 
 def get_thumbnail_config(catalog_path: Path) -> ThumbnailConfig:
@@ -182,6 +187,9 @@ def get_thumbnail_config(catalog_path: Path) -> ThumbnailConfig:
         ),
         basemap_zoom_adjust=_parse_int(
             basemap.get("zoom_adjust"), "thumbnails.basemap.zoom_adjust", 0
+        ),
+        max_features=_parse_positive_int(
+            thumbnails.get("max_features"), "thumbnails.max_features", 100_000
         ),
     )
 
@@ -889,7 +897,7 @@ def _read_geoparquet_bounds_from_data(gpq_path: Path) -> tuple[float, float, flo
     Validates bounds for inf/nan values (issue #516). CRS may not be WGS84.
     """
     try:
-        import geopandas as gpd  # type: ignore[import-untyped]
+        import geopandas as gpd
     except ImportError:
         return None
 
@@ -910,21 +918,81 @@ def _read_geoparquet_bounds_from_data(gpq_path: Path) -> tuple[float, float, flo
         return None
 
 
+def _sample_geoparquet(gpq_path: Path, max_features: int) -> Any:
+    """Read a spread-out sample of a GeoParquet too large to render whole.
+
+    Selects row groups with a **stride across the file** rather than the leading
+    N. geoparquet-io writes spatially sorted output, so the first row groups
+    cover one corner of the extent and a leading sample would draw a fragment of
+    the data. Returns None when sampling is not possible, so the caller can fall
+    back to the full read.
+
+    The frame is unaffected: ``_read_geoparquet_bounds`` takes the full extent
+    from file metadata in O(1), so a sampled render still spans the whole bbox.
+    Only feature density drops.
+    """
+    try:
+        import geopandas as gpd
+        import numpy as np
+        import pyarrow.parquet as pq
+        from pyproj import CRS
+    except ImportError:
+        return None
+
+    parquet_file = pq.ParquetFile(str(gpq_path))
+    metadata = parquet_file.metadata
+    num_rows, num_groups = metadata.num_rows, metadata.num_row_groups
+
+    if num_groups > 1:
+        keep = max(2, round(num_groups * max_features / num_rows))
+        # linspace, not a fixed stride: it includes both endpoints, so the sample
+        # reaches the far edge of the extent. A stride from 0 skips the tail
+        # groups and draws only the leading corner of spatially sorted data.
+        groups = sorted({int(i) for i in np.linspace(0, num_groups - 1, min(keep, num_groups))})
+        table = parquet_file.read_row_groups(groups)
+    else:
+        # One row group: the decode already happened, but capping what matplotlib
+        # draws is still the dominant saving. Spread the picks across the file.
+        table = parquet_file.read().take(
+            np.linspace(0, num_rows - 1, max_features).astype(np.int64)
+        )
+
+    # A GeoParquet table is a WKB column plus `geo` file metadata, not GeoArrow
+    # extension types, so GeoDataFrame.from_arrow cannot read it. Rebuild the
+    # frame from the WKB and the CRS the metadata declares.
+    geo_meta = json.loads((table.schema.metadata or {})[b"geo"].decode("utf-8"))
+    primary = geo_meta["primary_column"]
+    projjson = geo_meta.get("columns", {}).get(primary, {}).get("crs")
+    # A null crs means OGC:CRS84 per the GeoParquet spec.
+    crs = CRS.from_json_dict(projjson) if projjson else "OGC:CRS84"
+
+    frame = table.to_pandas()
+    return gpd.GeoDataFrame(
+        frame.drop(columns=[primary]),
+        geometry=gpd.GeoSeries.from_wkb(frame[primary]),
+        crs=crs,
+    )
+
+
 def _read_geoparquet_for_thumbnail(
     gpq_path: Path,
+    max_features: int | None = None,
 ) -> tuple[Any, tuple[float, float, float, float] | None, Any]:
     """Read GeoParquet for thumbnail rendering.
 
-    Gets bbox from metadata (O(1)) for accurate extent, then reads the full file.
-    We render ALL features without sampling — contextily handles CRS reprojection
-    of basemap tiles, which is far more efficient than reprojecting geometry data.
+    Gets bbox from metadata (O(1)) for an accurate extent, then reads features.
+    Below ``max_features`` every feature is read and drawn — contextily handles
+    CRS reprojection of basemap tiles, which is far cheaper than reprojecting
+    geometry data. Above it the read is sampled, so a default ``add`` cannot
+    spend unbounded time on one collection (Issue #683).
 
     Args:
         gpq_path: Path to GeoParquet file.
+        max_features: Feature ceiling. None reads every feature.
 
     Returns:
         Tuple of (gdf, full_bbox, source_crs) where:
-        - gdf: GeoDataFrame with all features (or None if failed)
+        - gdf: GeoDataFrame of features to draw (or None if failed)
         - full_bbox: (minx, miny, maxx, maxy) from metadata or computed
         - source_crs: Original CRS of the data
     """
@@ -938,8 +1006,18 @@ def _read_geoparquet_for_thumbnail(
         # Get bbox from metadata first (O(1), no geometry parsing)
         full_bbox = _read_geoparquet_bounds(gpq_path)
 
-        # Read full file — no sampling, render all features
-        gdf = gpd.read_parquet(gpq_path)
+        gdf = None
+        if max_features is not None:
+            try:
+                import pyarrow.parquet as pq
+
+                if pq.ParquetFile(str(gpq_path)).metadata.num_rows > max_features:
+                    gdf = _sample_geoparquet(gpq_path, max_features)
+            except Exception as exc:
+                # Sampling is an optimization; a full read is always correct.
+                logger.debug("Falling back to a full read of %s: %s", gpq_path, exc)
+        if gdf is None:
+            gdf = gpd.read_parquet(gpq_path)
         if gdf.empty:
             return None, None, None
 
@@ -993,8 +1071,10 @@ def _render_geoparquet(
         return False
 
     try:
-        # Read full file + bbox from metadata
-        gdf, full_bounds, source_crs = _read_geoparquet_for_thumbnail(gpq_path)
+        # Read features + bbox from metadata, capped by config.max_features
+        gdf, full_bounds, source_crs = _read_geoparquet_for_thumbnail(
+            gpq_path, max_features=config.max_features
+        )
         if gdf is None or full_bounds is None:
             return False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,10 @@ dependencies = [
     "antimeridian>=0.3.11", # RFC 7946 compliant antimeridian handling for STAC bbox
     "click>=8.4,<8.5", # PYSEC-2026-2132 fix; 8.4 makes ParamType generic (temporal.FlexibleDateTime subscripts it)
     "defusedxml>=0.7.1", # Safe XML parsing (XXE protection) for CSW/ISO 19139 metadata
+    "geopandas>=0.14.0", # Reads GeoParquet for the thumbnail floor, which every collection needs (Issue #683)
     "geoparquet-io>=1.3.0", # WFS auto-tile + 100K page_size defaults (Issue #529); git main pinned via [tool.uv.sources]
     "httpx>=0.27.0", # HTTP client for ArcGIS REST API discovery
+    "matplotlib>=3.8.0", # Renders the deterministic thumbnail floor. Core, not optional: PTL-VIZ-001 is an ERROR, so a default install must be able to produce a conformant catalog (#518 Track 1, #683)
     "obstore>=0.8.2", # Cloud object storage (S3, GCS, Azure) via Rust bindings
     "python-dotenv>=1.0.0", # Load .env files for credentials (Issue #356)
     "numpy>=1.24.0", # Array ops (transitive via rasterio, but we import directly for thumbnails)
@@ -96,11 +98,13 @@ dev = [
 pmtiles = [
     "gpio-pmtiles>=0.1.0", # PMTiles generation from GeoParquet (requires tippecanoe)
 ]
+# Rendering itself is core (matplotlib, geopandas). What stays optional here is
+# the extra fidelity: basemap tiles under a vector thumbnail, and the MVT decode
+# that only the PMTiles render path uses. Both are lazily imported and guarded,
+# so a default install renders without them.
 thumbnails = [
     "contextily>=1.5.0", # Basemap tiles for vector thumbnails
-    "geopandas>=0.14.0", # GeoParquet reading for thumbnail generation
     "mapbox-vector-tile>=2.0.0", # MVT decoding for PMTiles thumbnail generation
-    "matplotlib>=3.8.0", # Rendering geometries to JPEG
 ]
 docs = [
     "mkdocs>=1.6.1",
@@ -211,7 +215,7 @@ strict = true # Enables all strict flags at once
 untyped_calls_exclude = ["pyarrow"]
 
 [[tool.mypy.overrides]]
-module = ["pyarrow.*", "rasterio.*", "gitingest.*", "matplotlib.*", "pyiceberg.*", "shapely.*", "pygeohash.*", "mutmut.*"]
+module = ["pyarrow.*", "rasterio.*", "gitingest.*", "matplotlib.*", "pyiceberg.*", "shapely.*", "pygeohash.*", "mutmut.*", "geopandas.*", "contextily.*"]
 ignore_missing_imports = true
 
 # ---------- security ----------

--- a/tests/benchmark/test_thumbnail_sampling_benchmark.py
+++ b/tests/benchmark/test_thumbnail_sampling_benchmark.py
@@ -1,0 +1,72 @@
+"""Benchmarks for the thumbnail feature cap (Issue #683).
+
+Thumbnails joined the default ``add`` pipeline, so an unbounded read became
+every user's problem rather than an opt-in cost. ``thumbnails.max_features``
+caps a render by sampling row groups spread across the file. These benchmarks
+track what the cap buys and confirm the sample still spans the whole extent,
+which is the property that makes a cheaper read acceptable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+#: Rows in the synthetic layer. Large enough that the cap bites at 100_000,
+#: small enough to build in a second.
+ROW_COUNT = 400_000
+MAX_FEATURES = 100_000
+
+
+@pytest.fixture(scope="module")
+def large_geoparquet(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A spatially sorted point layer spanning 0-100 degrees of longitude."""
+    import geopandas as gpd
+    import numpy as np
+    from shapely.geometry import Point
+
+    xs = np.linspace(0.0, 100.0, ROW_COUNT)
+    frame = gpd.GeoDataFrame(
+        {"idx": np.arange(ROW_COUNT)},
+        geometry=[Point(x, x / 100.0) for x in xs],
+        crs="EPSG:4326",
+    )
+    path = tmp_path_factory.mktemp("thumbnail-bench") / "points.parquet"
+    frame.to_parquet(path, row_group_size=10_000)
+    return path
+
+
+class TestThumbnailSamplingBenchmarks:
+    """The cap's cost and its correctness, measured rather than asserted in prose."""
+
+    @pytest.mark.benchmark(group="thumbnail-read")
+    @pytest.mark.slow
+    def test_full_read_performance(
+        self,
+        benchmark,  # type: ignore[no-untyped-def]
+        large_geoparquet: Path,
+    ) -> None:
+        """Baseline: every feature read, which is what happened before the cap."""
+        result = benchmark(_read_geoparquet_for_thumbnail, large_geoparquet, None)
+        gdf, _, _ = result
+        assert len(gdf) == ROW_COUNT
+
+    @pytest.mark.benchmark(group="thumbnail-read")
+    @pytest.mark.slow
+    def test_sampled_read_performance(
+        self,
+        benchmark,  # type: ignore[no-untyped-def]
+        large_geoparquet: Path,
+    ) -> None:
+        """The capped read, and proof the sample still reaches the far edge."""
+        result = benchmark(_read_geoparquet_for_thumbnail, large_geoparquet, MAX_FEATURES)
+        gdf, full_bbox, _ = result
+
+        assert len(gdf) < ROW_COUNT, "The cap must reduce the rows drawn"
+        # A leading sample would stop near longitude 25. Spread picks reach 100.
+        assert gdf.total_bounds[2] > 90.0, "The sample must reach the eastern edge"
+        assert full_bbox is not None
+        assert full_bbox[2] > 99.0, "The frame comes from metadata, not the sample"

--- a/tests/integration/test_generated_catalog_conformance.py
+++ b/tests/integration/test_generated_catalog_conformance.py
@@ -30,10 +30,6 @@ FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
 # exist in the CLI. Each is a tracked Phase-3 gap, not an accepted violation.
 KNOWN_GAPS = frozenset(
     {
-        # PTL-VIZ-001: every geospatial collection needs a thumbnail asset.
-        # Thumbnail rendering lives behind the optional [thumbnails] extra and
-        # is not part of the default add pipeline.
-        "PTL-VIZ-001",
         # PTL-DAT-007: every row group needs spatial statistics. geoparquet-io
         # writes a single row group for a file this small and emits neither a
         # bbox covering column nor native GeospatialStatistics for it, so the

--- a/tests/integration/test_pmtiles_integration.py
+++ b/tests/integration/test_pmtiles_integration.py
@@ -367,12 +367,18 @@ class TestPMTilesGeneration:
         assert "roads.pmtiles" in latest, "Untracked PMTiles must be backfilled on skip"
         if thumb_rendered:
             assert "roads.thumb.jpg" in latest, "Untracked thumbnail must be backfilled on skip"
-            # And it must be re-registered as a STAC asset, not left orphaned.
+            # And it must end up a STAC asset, not left orphaned. Registering moved
+            # to collection_thumbnail in #683, which `add` runs right after the
+            # PMTiles side-step; it adopts exactly the file the backfill tracked.
+            from portolan_cli.collection_thumbnail import ensure_collection_thumbnails
+
+            ensure_collection_thumbnails(catalog_root, {collection_with_geoparquet.name})
             coll_after = json.loads(coll_path.read_text())
             thumb_stac = [
                 k for k, v in coll_after["assets"].items() if "thumbnail" in v.get("roles", [])
             ]
             assert thumb_stac, "Backfilled thumbnail must be re-registered as a STAC asset"
+            assert coll_after["assets"]["thumbnail"]["href"] == "./roads.thumb.jpg"
 
     def test_backfill_is_idempotent_when_already_tracked(
         self, collection_with_geoparquet: Path

--- a/tests/integration/test_rashid_roundtrip.py
+++ b/tests/integration/test_rashid_roundtrip.py
@@ -32,12 +32,14 @@ pytestmark = pytest.mark.integration
 
 FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
 
-# Errors a generated catalog still carries: thumbnail rendering lives behind an
-# optional extra, and geoparquet-io writes a single row group with no
-# per-row-group spatial statistics for a file this small. Shared with
-# tests/integration/test_generated_catalog_conformance.py, which is the gate that
-# keeps the list honest.
-GENERATION_GAPS = frozenset({"PTL-VIZ-001", "PTL-DAT-007"})
+# The one error a generated catalog still carries: geoparquet-io writes a single
+# row group with no per-row-group spatial statistics for a file this small.
+# Shared with tests/integration/test_generated_catalog_conformance.py, which is
+# the gate that keeps the list honest.
+#
+# PTL-VIZ-001 left this list in #683, when `add` started emitting a
+# collection-level thumbnail asset on a default install.
+GENERATION_GAPS = frozenset({"PTL-DAT-007"})
 
 # What the corruptions below must produce, and nothing else.
 EXPECTED_FROM_DAMAGE = frozenset(
@@ -48,6 +50,7 @@ EXPECTED_FROM_DAMAGE = frozenset(
         "PTL-DAT-001",  # mutated file:checksum
         "PTL-CNF-001",  # removed schema URI
         "PTL-LNK-005",  # added rel:'self' link
+        "PTL-VIZ-001",  # thumbnail typed image/gif
     }
 )
 
@@ -140,6 +143,13 @@ def _corrupt(root: Path) -> None:
     for asset in data["assets"].values():
         if isinstance(asset.get("file:checksum"), str):
             asset["file:checksum"] = "1220" + "0" * 64
+
+    # 6. thumbnail: a media type outside png/jpeg/webp. Generation now satisfies
+    #    the missing-thumbnail branch of PTL-VIZ-001 (#683), so damage the branch
+    #    it cannot satisfy away, and the rule stays exercised end to end.
+    for asset in data["assets"].values():
+        if "thumbnail" in asset.get("roles", []):
+            asset["type"] = "image/gif"
 
     _write(collection_json, data)
     (root / "roads" / "AGENTS.md").unlink()
@@ -239,8 +249,9 @@ class TestRashidRoundtrip:
         assert "Fixed automatically (" in result.output
         assert "Action required (" in result.output
         # Every surviving finding carries its requirement sentence, and the AUTO
-        # survivor says the automatic fix did not settle it.
-        assert "Render a thumbnail" in result.output
+        # survivor says the automatic fix did not settle it. PTL-DAT-007 is the
+        # survivor since #683 made PTL-VIZ-001 satisfiable by generation.
+        assert "Rewrite the GeoParquet so every row group carries statistics." in result.output
         assert "the automatic fix did not resolve this" in result.output
 
     def test_post_fix_output_lists_each_survivor_once(self, catalog: Path) -> None:
@@ -251,7 +262,7 @@ class TestRashidRoundtrip:
             cli, ["check", str(catalog), "--metadata", "--fix"], catch_exceptions=False
         )
 
-        assert result.output.count("PTL-VIZ-001") == 1
+        assert result.output.count("PTL-DAT-007") == 1
         # The pre-fix rendering's headings are gone: the split replaces them.
         assert "Errors (" not in result.output
         assert "fixable by `portolan check --fix`" not in result.output

--- a/tests/unit/test_collection_thumbnail.py
+++ b/tests/unit/test_collection_thumbnail.py
@@ -590,3 +590,48 @@ class TestEveryRegisteredThumbnailIsTracked:
 
         second = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
         assert first["current_version"] == second["current_version"]
+
+
+@pytest.mark.unit
+class TestOneAddIsOneVersion:
+    """A side-step's derived asset folds into the snapshot ``add`` just wrote.
+
+    Thumbnails joined the default pipeline, so a second version per add would
+    double every collection's history. PMTiles never showed this because it is
+    gated on ``--pmtiles`` (Issue #519).
+    """
+
+    def _seed_version(self, collection_dir: Path, catalog_root: Path) -> None:
+        """Stand in for the snapshot ``add`` writes before the side-steps run."""
+        from portolan_cli.versions import track_generated_assets
+
+        track_generated_assets(
+            collection_dir,
+            [collection_dir / "roads.parquet"],
+            catalog_root,
+            message="Added roads.parquet",
+        )
+
+    def test_a_versioned_collection_gains_no_second_version(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        self._seed_version(collection_dir, tmp_path)
+
+        ensure_collection_thumbnails(tmp_path, {"roads"}, versioned_collections={"roads"})
+
+        versions = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
+        assert len(versions["versions"]) == 1
+        assert versions["current_version"] == "1.0.0"
+        latest = versions["versions"][-1]
+        assert sorted(latest["assets"]) == ["roads.parquet", "roads.thumb.jpg"]
+        assert "roads.thumb.jpg" in latest["changes"]
+
+    def test_a_skipped_collection_gets_its_own_version(self, tmp_path: Path) -> None:
+        """Backfill must not edit a snapshot that may already be published."""
+        collection_dir = _vector_collection(tmp_path)
+        self._seed_version(collection_dir, tmp_path)
+
+        ensure_collection_thumbnails(tmp_path, {"roads"}, versioned_collections=set())
+
+        versions = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
+        assert [v["version"] for v in versions["versions"]] == ["1.0.0", "1.0.1"]
+        assert sorted(versions["versions"][0]["assets"]) == ["roads.parquet"]

--- a/tests/unit/test_collection_thumbnail.py
+++ b/tests/unit/test_collection_thumbnail.py
@@ -356,14 +356,21 @@ class TestVectorRendering:
         assert "roads.thumb.jpg" in versions.versions[-1].assets
 
     @pytest.mark.unit
-    def test_adoption_creates_no_version(self, tmp_path: Path) -> None:
-        """Adopting a file we did not write must not bump a version."""
+    def test_adoption_records_one_version(self, tmp_path: Path) -> None:
+        """Adopting a file still records it: versions.json is the source of truth.
+
+        This asserted the opposite until the adopted image was found to reach the
+        remote through push's directory walk while staying invisible to every
+        check that reads ``current_version.assets``.
+        """
         collection_dir = _vector_collection(tmp_path)
         (collection_dir / "preview.png").write_bytes(PNG_BYTES)
 
         ensure_collection_thumbnails(tmp_path, {"roads"})
 
-        assert not (collection_dir / "versions.json").exists()
+        versions = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
+        assert len(versions["versions"]) == 1
+        assert sorted(versions["versions"][-1]["assets"]) == ["preview.png"]
 
     @pytest.mark.unit
     def test_render_failure_warns_and_does_not_raise(self, tmp_path: Path) -> None:
@@ -421,3 +428,165 @@ class TestNonGeospatialCollections:
     def test_missing_collection_is_skipped(self, tmp_path: Path) -> None:
         """A collection id with no collection.json on disk must not raise."""
         ensure_collection_thumbnails(tmp_path, {"ghost"})
+
+
+@pytest.mark.unit
+class TestSymlinkedCatalogRoot:
+    """A symlink anywhere in the path must not silently drop the registration.
+
+    ``_item_paths`` resolves its candidates. Comparing one resolved path against
+    an unresolved collection directory raised ValueError, so the raster branch
+    wrote nothing while still reporting a thumbnail. macOS hits this on every
+    temp directory, where ``/var`` is a symlink to ``/private/var``.
+    """
+
+    def test_item_sidecar_registers_through_a_symlink(self, tmp_path: Path) -> None:
+        real = tmp_path / "real"
+        collection_dir = real / "imagery"
+        item_dir = collection_dir / "dem-2020"
+        item_dir.mkdir(parents=True)
+        (item_dir / "dem.thumb.jpg").write_bytes(JPEG_BYTES)
+        (item_dir / "item.json").write_text(
+            json.dumps(
+                {
+                    "type": "Feature",
+                    "id": "dem-2020",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "assets": {
+                        "thumbnail": {"href": "./dem.thumb.jpg", "roles": ["thumbnail"]},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        _write_collection(
+            collection_dir,
+            {"cog": {"href": "./dem-2020/dem.tif", "roles": ["data"]}},
+        )
+        (item_dir / "dem.tif").write_bytes(b"II*\x00 fake-tif")
+        data = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
+        data["links"] = [{"rel": "item", "href": "./dem-2020/item.json"}]
+        (collection_dir / "collection.json").write_text(json.dumps(data), encoding="utf-8")
+
+        link = tmp_path / "catalog"
+        link.symlink_to(real, target_is_directory=True)
+
+        ensure_collection_thumbnails(link, {"imagery"})
+
+        thumbnails = _thumbnail_assets(collection_dir)
+        assert thumbnails, "A symlinked catalog root must still register the sidecar"
+        assert thumbnails["thumbnail"]["href"] == "./dem-2020/dem.thumb.jpg"
+
+    def test_an_href_escaping_the_collection_is_still_rejected(self, tmp_path: Path) -> None:
+        """Resolving both sides must not weaken the containment check."""
+        outside = tmp_path / "outside.png"
+        outside.write_bytes(PNG_BYTES)
+        collection_dir = tmp_path / "roads"
+        _write_collection(collection_dir)
+
+        assert register_collection_thumbnail(collection_dir, outside) is False
+        assert _thumbnail_assets(collection_dir) == {}
+
+
+@pytest.mark.unit
+class TestConfigOptOutOnEveryEntryPoint:
+    """``thumbnails.enabled: false`` binds the fixer path too.
+
+    ``check --fix`` calls the singular entry point. Only the plural wrapper read
+    the setting, so a catalog that opted out got thumbnails anyway.
+    """
+
+    def test_disabled_config_blocks_the_singular_entry_point(self, tmp_path: Path) -> None:
+        """The adoption branch is the reachable hole.
+
+        ``generate_vector_thumbnail`` already refuses when the config is off, so
+        the render branch was covered by accident. Adoption never reaches the
+        renderer, so a disabled catalog still got a thumbnail asset from it.
+        """
+        from portolan_cli.collection_thumbnail import ensure_collection_thumbnail
+
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text(
+            "thumbnails:\n  enabled: false\n", encoding="utf-8"
+        )
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "thumbnail.png").write_bytes(PNG_BYTES)
+
+        assert ensure_collection_thumbnail(collection_dir, tmp_path) is None
+        assert _thumbnail_assets(collection_dir) == {}
+
+    def test_an_explicit_generate_overrides_a_disabled_config(self, tmp_path: Path) -> None:
+        from portolan_cli.collection_thumbnail import ensure_collection_thumbnail
+
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text(
+            "thumbnails:\n  enabled: false\n", encoding="utf-8"
+        )
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "thumbnail.png").write_bytes(PNG_BYTES)
+
+        assert ensure_collection_thumbnail(collection_dir, tmp_path, generate=True) is not None
+        assert _thumbnail_assets(collection_dir)
+
+
+@pytest.mark.unit
+class TestForceRefresh:
+    """Without a force, the first render is the catalog's thumbnail forever."""
+
+    def test_force_redraws_a_generated_thumbnail(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+        rendered = collection_dir / "roads.thumb.jpg"
+        assert rendered.exists()
+        rendered.write_bytes(b"stale")
+
+        ensure_collection_thumbnails(tmp_path, {"roads"}, force=True)
+
+        assert rendered.read_bytes() != b"stale", "force must redraw, not re-adopt"
+        asset = _thumbnail_assets(collection_dir)["thumbnail"]
+        assert asset["file:size"] == rendered.stat().st_size
+
+    def test_without_force_a_registered_thumbnail_is_left_alone(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+        rendered = collection_dir / "roads.thumb.jpg"
+        rendered.write_bytes(b"stale")
+
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        assert rendered.read_bytes() == b"stale"
+
+    def test_force_keeps_a_thumbnail_the_user_supplied(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "thumbnail.png").write_bytes(PNG_BYTES)
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        ensure_collection_thumbnails(tmp_path, {"roads"}, force=True)
+
+        assert (collection_dir / "thumbnail.png").read_bytes() == PNG_BYTES
+        assert _thumbnail_assets(collection_dir)["thumbnail"]["href"] == "./thumbnail.png"
+
+
+@pytest.mark.unit
+class TestEveryRegisteredThumbnailIsTracked:
+    """versions.json is the source of truth, so an adopted image belongs in it."""
+
+    def test_an_adopted_image_lands_in_versions_json(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "thumbnail.png").write_bytes(PNG_BYTES)
+
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        versions = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
+        assert "thumbnail.png" in versions["versions"][-1]["assets"]
+
+    def test_a_second_add_creates_no_further_version(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "thumbnail.png").write_bytes(PNG_BYTES)
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+        first = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
+
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        second = json.loads((collection_dir / "versions.json").read_text(encoding="utf-8"))
+        assert first["current_version"] == second["current_version"]

--- a/tests/unit/test_collection_thumbnail.py
+++ b/tests/unit/test_collection_thumbnail.py
@@ -1,0 +1,423 @@
+"""Unit tests for the collection-level thumbnail orchestrator (Issue #683).
+
+``portolan init`` followed by ``portolan add`` used to produce a catalog that
+failed its own ``portolan check``: rashid's ``PTL-VIZ-001`` requires every
+geospatial collection to carry a ``thumbnail``-role asset, and the default add
+pipeline registered none. These tests pin the ladder that closes the gap —
+opt-out, already-registered, adopt, reference, render — and the guarantee that a
+render failure never fails the add.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from portolan_cli.collection_thumbnail import (
+    ensure_collection_thumbnails,
+    register_collection_thumbnail,
+)
+
+JPEG_BYTES = b"\xff\xd8\xff fake-jpeg-bytes"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n fake-png-bytes"
+
+#: A real GeoParquet. Geospatial status is derived by reading the ``geo`` schema
+#: metadata, so a collection built from placeholder bytes reads as tabular and is
+#: skipped — the same way ``PTL-VIZ-001`` skips it.
+GEOPARQUET_FIXTURE = Path(__file__).parent.parent / "fixtures" / "simple.parquet"
+
+
+def _write_collection(collection_dir: Path, assets: dict[str, Any] | None = None) -> Path:
+    """Write a minimal collection.json and return its path."""
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    data: dict[str, Any] = {
+        "type": "Collection",
+        "id": collection_dir.name,
+        "assets": assets if assets is not None else {},
+        "links": [],
+    }
+    path = collection_dir / "collection.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _vector_collection(catalog_root: Path, name: str = "roads") -> Path:
+    """A single-file vector collection: one collection-level GeoParquet asset."""
+    collection_dir = catalog_root / name
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(GEOPARQUET_FIXTURE, collection_dir / f"{name}.parquet")
+    _write_collection(
+        collection_dir,
+        {
+            name: {
+                "href": f"./{name}.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+            }
+        },
+    )
+    return collection_dir
+
+
+def _read_assets(collection_dir: Path) -> dict[str, Any]:
+    data = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
+    assets: dict[str, Any] = data.get("assets", {})
+    return assets
+
+
+def _thumbnail_assets(collection_dir: Path) -> dict[str, Any]:
+    return {
+        key: asset
+        for key, asset in _read_assets(collection_dir).items()
+        if "thumbnail" in asset.get("roles", [])
+    }
+
+
+class TestRegisterCollectionThumbnail:
+    """The single writer for a collection-level thumbnail asset."""
+
+    @pytest.mark.unit
+    def test_writes_canonical_key_roles_and_media_type(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "roads"
+        _write_collection(collection_dir)
+        thumb = collection_dir / "roads.thumb.jpg"
+        thumb.write_bytes(JPEG_BYTES)
+
+        register_collection_thumbnail(collection_dir, thumb)
+
+        assets = _read_assets(collection_dir)
+        assert "thumbnail" in assets, "The canonical asset key is 'thumbnail'"
+        assert assets["thumbnail"]["href"] == "./roads.thumb.jpg"
+        assert assets["thumbnail"]["type"] == "image/jpeg"
+        assert assets["thumbnail"]["roles"] == ["thumbnail"]
+
+    @pytest.mark.unit
+    def test_carries_file_size_and_multihash_checksum(self, tmp_path: Path) -> None:
+        """PTL-AST-003 wants file:size and file:checksum; the checksum is a multihash."""
+        collection_dir = tmp_path / "roads"
+        _write_collection(collection_dir)
+        thumb = collection_dir / "roads.thumb.jpg"
+        thumb.write_bytes(JPEG_BYTES)
+
+        register_collection_thumbnail(collection_dir, thumb)
+
+        asset = _read_assets(collection_dir)["thumbnail"]
+        assert asset["file:size"] == len(JPEG_BYTES)
+        # sha2-256 multihash: 0x12 (fn code), 0x20 (32-byte length), then the digest.
+        assert asset["file:checksum"].startswith("1220")
+        assert len(asset["file:checksum"]) == 68
+
+    @pytest.mark.unit
+    def test_png_gets_png_media_type(self, tmp_path: Path) -> None:
+        """Media type comes from the extension registry, not a hardcoded jpeg."""
+        collection_dir = tmp_path / "roads"
+        _write_collection(collection_dir)
+        thumb = collection_dir / "preview.png"
+        thumb.write_bytes(PNG_BYTES)
+
+        register_collection_thumbnail(collection_dir, thumb)
+
+        assert _read_assets(collection_dir)["thumbnail"]["type"] == "image/png"
+
+    @pytest.mark.unit
+    def test_href_for_an_item_thumbnail_stays_collection_relative(self, tmp_path: Path) -> None:
+        """A raster collection points at an item's sidecar, one directory down."""
+        collection_dir = tmp_path / "imagery"
+        _write_collection(collection_dir)
+        item_dir = collection_dir / "scene1"
+        item_dir.mkdir()
+        thumb = item_dir / "scene1.thumb.jpg"
+        thumb.write_bytes(JPEG_BYTES)
+
+        register_collection_thumbnail(collection_dir, thumb)
+
+        assert _read_assets(collection_dir)["thumbnail"]["href"] == "./scene1/scene1.thumb.jpg"
+
+    @pytest.mark.unit
+    def test_missing_collection_json_is_a_no_op(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "roads"
+        collection_dir.mkdir()
+        thumb = collection_dir / "roads.thumb.jpg"
+        thumb.write_bytes(JPEG_BYTES)
+
+        register_collection_thumbnail(collection_dir, thumb)
+
+        assert not (collection_dir / "collection.json").exists()
+
+
+class TestOptOut:
+    """Two ways to switch generation off, and neither may write anything."""
+
+    @pytest.mark.unit
+    def test_config_disabled_writes_nothing(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text(
+            "thumbnails:\n  enabled: false\n", encoding="utf-8"
+        )
+
+        with patch("portolan_cli.collection_thumbnail.generate_vector_thumbnail") as render:
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        render.assert_not_called()
+        assert _thumbnail_assets(collection_dir) == {}
+
+    @pytest.mark.unit
+    def test_generate_false_overrides_an_enabled_config(self, tmp_path: Path) -> None:
+        """``--no-thumbnails`` wins over the catalog default for a single run."""
+        collection_dir = _vector_collection(tmp_path)
+
+        with patch("portolan_cli.collection_thumbnail.generate_vector_thumbnail") as render:
+            ensure_collection_thumbnails(tmp_path, {"roads"}, generate=False)
+
+        render.assert_not_called()
+        assert _thumbnail_assets(collection_dir) == {}
+
+
+class TestAdoption:
+    """An image already on disk is adopted rather than overwritten."""
+
+    @pytest.mark.unit
+    def test_existing_thumbnail_asset_is_left_alone(self, tmp_path: Path) -> None:
+        """A registered thumbnail — hand-made or from the PMTiles render — wins."""
+        collection_dir = tmp_path / "roads"
+        _write_collection(
+            collection_dir,
+            {
+                "thumbnail": {
+                    "href": "./curated.png",
+                    "type": "image/png",
+                    "roles": ["thumbnail"],
+                    "title": "Hand-picked",
+                }
+            },
+        )
+
+        with patch("portolan_cli.collection_thumbnail.generate_vector_thumbnail") as render:
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        render.assert_not_called()
+        assert _read_assets(collection_dir)["thumbnail"]["title"] == "Hand-picked"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("filename", ["roads.thumb.jpg", "thumbnail.png", "preview.jpeg"])
+    def test_adopts_a_conventional_image(self, tmp_path: Path, filename: str) -> None:
+        """The names the CLI and the MapLibre skill actually write."""
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / filename).write_bytes(JPEG_BYTES)
+
+        with patch("portolan_cli.collection_thumbnail.generate_vector_thumbnail") as render:
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        render.assert_not_called()
+        assert _read_assets(collection_dir)["thumbnail"]["href"] == f"./{filename}"
+
+    @pytest.mark.unit
+    def test_does_not_adopt_an_unconventional_image(self, tmp_path: Path) -> None:
+        """A legend or logo PNG must never be promoted to the collection thumbnail."""
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "legend.png").write_bytes(PNG_BYTES)
+
+        rendered = collection_dir / "roads.thumb.jpg"
+
+        def _render(**_kwargs: Any) -> Path:
+            rendered.write_bytes(JPEG_BYTES)
+            return rendered
+
+        with patch(
+            "portolan_cli.collection_thumbnail.generate_vector_thumbnail", side_effect=_render
+        ):
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        assert _read_assets(collection_dir)["thumbnail"]["href"] == "./roads.thumb.jpg"
+
+    @pytest.mark.unit
+    def test_does_not_adopt_an_image_another_asset_claims(self, tmp_path: Path) -> None:
+        """A conventional name already registered under another role is off limits."""
+        collection_dir = tmp_path / "roads"
+        collection_dir.mkdir(parents=True)
+        shutil.copy(GEOPARQUET_FIXTURE, collection_dir / "roads.parquet")
+        (collection_dir / "preview.png").write_bytes(PNG_BYTES)
+        _write_collection(
+            collection_dir,
+            {
+                "roads": {
+                    "href": "./roads.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "roles": ["data"],
+                },
+                "legend": {
+                    "href": "./preview.png",
+                    "type": "image/png",
+                    "roles": ["legend"],
+                },
+            },
+        )
+
+        rendered = collection_dir / "roads.thumb.jpg"
+
+        def _render(**_kwargs: Any) -> Path:
+            rendered.write_bytes(JPEG_BYTES)
+            return rendered
+
+        with patch(
+            "portolan_cli.collection_thumbnail.generate_vector_thumbnail", side_effect=_render
+        ):
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        assets = _read_assets(collection_dir)
+        assert assets["legend"]["roles"] == ["legend"], "The claimed image keeps its own role"
+        assert assets["thumbnail"]["href"] == "./roads.thumb.jpg"
+
+
+class TestRasterCollections:
+    """Rasters reference the item sidecar that add already generates (#657)."""
+
+    @pytest.mark.unit
+    def test_references_an_item_thumbnail_without_rendering(self, tmp_path: Path) -> None:
+        collection_dir = tmp_path / "imagery"
+        item_dir = collection_dir / "scene1"
+        item_dir.mkdir(parents=True)
+        (item_dir / "scene1.tif").write_bytes(b"II*\x00 fake-tiff")
+        (item_dir / "scene1.thumb.jpg").write_bytes(JPEG_BYTES)
+        (item_dir / "scene1.json").write_text(
+            json.dumps(
+                {
+                    "type": "Feature",
+                    "id": "scene1",
+                    "geometry": {"type": "Point", "coordinates": [0, 0]},
+                    "assets": {
+                        "data": {"href": "./scene1.tif", "type": "image/tiff"},
+                        "thumbnail": {
+                            "href": "./scene1.thumb.jpg",
+                            "type": "image/jpeg",
+                            "roles": ["thumbnail"],
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        _write_collection(collection_dir)
+        data = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
+        data["links"] = [{"rel": "item", "href": "./scene1/scene1.json"}]
+        (collection_dir / "collection.json").write_text(json.dumps(data), encoding="utf-8")
+
+        with patch("portolan_cli.collection_thumbnail.generate_vector_thumbnail") as render:
+            ensure_collection_thumbnails(tmp_path, {"imagery"})
+
+        render.assert_not_called()
+        assert _read_assets(collection_dir)["thumbnail"]["href"] == "./scene1/scene1.thumb.jpg"
+
+
+class TestVectorRendering:
+    """The render path, and the promise that it can never fail an add."""
+
+    @pytest.mark.unit
+    def test_renders_and_registers(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+        rendered = collection_dir / "roads.thumb.jpg"
+
+        def _render(**_kwargs: Any) -> Path:
+            rendered.write_bytes(JPEG_BYTES)
+            return rendered
+
+        with patch(
+            "portolan_cli.collection_thumbnail.generate_vector_thumbnail", side_effect=_render
+        ) as render:
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        render.assert_called_once()
+        assert _read_assets(collection_dir)["thumbnail"]["href"] == "./roads.thumb.jpg"
+
+    @pytest.mark.unit
+    def test_tracks_the_rendered_file_in_versions_json(self, tmp_path: Path) -> None:
+        """An untracked derived asset breaks push (#519, #735)."""
+        from portolan_cli.versions import read_versions
+
+        collection_dir = _vector_collection(tmp_path)
+        rendered = collection_dir / "roads.thumb.jpg"
+
+        def _render(**_kwargs: Any) -> Path:
+            rendered.write_bytes(JPEG_BYTES)
+            return rendered
+
+        with patch(
+            "portolan_cli.collection_thumbnail.generate_vector_thumbnail", side_effect=_render
+        ):
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        versions = read_versions(collection_dir / "versions.json")
+        assert "roads.thumb.jpg" in versions.versions[-1].assets
+
+    @pytest.mark.unit
+    def test_adoption_creates_no_version(self, tmp_path: Path) -> None:
+        """Adopting a file we did not write must not bump a version."""
+        collection_dir = _vector_collection(tmp_path)
+        (collection_dir / "preview.png").write_bytes(PNG_BYTES)
+
+        ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        assert not (collection_dir / "versions.json").exists()
+
+    @pytest.mark.unit
+    def test_render_failure_warns_and_does_not_raise(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+
+        with patch(
+            "portolan_cli.collection_thumbnail.generate_vector_thumbnail",
+            side_effect=RuntimeError("matplotlib exploded"),
+        ):
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        assert _thumbnail_assets(collection_dir) == {}
+
+    @pytest.mark.unit
+    def test_render_returning_none_registers_nothing(self, tmp_path: Path) -> None:
+        collection_dir = _vector_collection(tmp_path)
+
+        with patch(
+            "portolan_cli.collection_thumbnail.generate_vector_thumbnail", return_value=None
+        ):
+            ensure_collection_thumbnails(tmp_path, {"roads"})
+
+        assert _thumbnail_assets(collection_dir) == {}
+
+
+class TestNonGeospatialCollections:
+    """PTL-VIZ-001 skips tabular collections, so generation must skip them too."""
+
+    @pytest.mark.unit
+    def test_tabular_collection_gets_no_thumbnail(self, tmp_path: Path) -> None:
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        collection_dir = tmp_path / "demographics"
+        collection_dir.mkdir(parents=True)
+        pq.write_table(pa.table({"population": [1, 2, 3]}), collection_dir / "census.parquet")
+        _write_collection(
+            collection_dir,
+            {
+                "census": {
+                    "href": "./census.parquet",
+                    "type": "application/vnd.apache.parquet",
+                    "roles": ["data"],
+                }
+            },
+        )
+
+        with patch("portolan_cli.collection_thumbnail.generate_vector_thumbnail") as render:
+            ensure_collection_thumbnails(tmp_path, {"demographics"})
+
+        render.assert_not_called()
+        assert _thumbnail_assets(collection_dir) == {}
+
+    @pytest.mark.unit
+    def test_missing_collection_is_skipped(self, tmp_path: Path) -> None:
+        """A collection id with no collection.json on disk must not raise."""
+        ensure_collection_thumbnails(tmp_path, {"ghost"})

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -362,7 +362,10 @@ class TestAddPMTilesLinkToCollection:
 
 
 class TestTrackGeneratedAssetsInVersions:
-    """Tests for _track_generated_assets_in_versions (Issue #519).
+    """Tests for versions.track_generated_assets (Issue #519).
+
+    Moved out of viz.pmtiles in #683: the collection-thumbnail orchestrator
+    records derived assets the same way, and viz may not reach the sync layer.
 
     Generated side-step artifacts (PMTiles, thumbnail) must be tracked in
     versions.json with a checksum, size, and mtime so sync can verify integrity
@@ -396,8 +399,7 @@ class TestTrackGeneratedAssetsInVersions:
     @pytest.mark.unit
     def test_asset_tracked_with_checksum_size_mtime(self, tmp_path: Path) -> None:
         """A generated thumbnail is added to versions.json as a full asset."""
-        from portolan_cli.versions import read_versions
-        from portolan_cli.viz.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import read_versions, track_generated_assets
 
         collection_dir = tmp_path / "demographics"
         collection_dir.mkdir()
@@ -406,7 +408,7 @@ class TestTrackGeneratedAssetsInVersions:
         thumb = collection_dir / "data.thumb.png"
         thumb.write_bytes(b"\x89PNG fake-thumbnail-bytes")
 
-        _track_generated_assets_in_versions(
+        track_generated_assets(
             collection_dir, [thumb], tmp_path, message="Generated thumbnail: data.thumb.png"
         )
 
@@ -430,8 +432,7 @@ class TestTrackGeneratedAssetsInVersions:
     @pytest.mark.unit
     def test_pmtiles_and_thumbnail_share_one_version(self, tmp_path: Path) -> None:
         """PMTiles + thumbnail tracked together land in a SINGLE version (Issue #519)."""
-        from portolan_cli.versions import read_versions
-        from portolan_cli.viz.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import read_versions, track_generated_assets
 
         collection_dir = tmp_path / "demographics"
         collection_dir.mkdir()
@@ -442,7 +443,7 @@ class TestTrackGeneratedAssetsInVersions:
         thumb = collection_dir / "data.thumb.jpg"
         thumb.write_bytes(b"\xff\xd8\xff jpeg")
 
-        _track_generated_assets_in_versions(
+        track_generated_assets(
             collection_dir, [pmtiles, thumb], tmp_path, message="Generated PMTiles and thumbnail"
         )
 
@@ -457,8 +458,7 @@ class TestTrackGeneratedAssetsInVersions:
     @pytest.mark.unit
     def test_only_if_missing_skips_already_tracked(self, tmp_path: Path) -> None:
         """only_if_missing creates no version when every asset is already tracked."""
-        from portolan_cli.versions import read_versions
-        from portolan_cli.viz.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import read_versions, track_generated_assets
 
         collection_dir = tmp_path / "demographics"
         collection_dir.mkdir()
@@ -467,7 +467,7 @@ class TestTrackGeneratedAssetsInVersions:
         parquet = collection_dir / "data.parquet"  # already tracked in fixture
         parquet.write_bytes(b"PAR1")
 
-        _track_generated_assets_in_versions(
+        track_generated_assets(
             collection_dir, [parquet], tmp_path, message="Backfill", only_if_missing=True
         )
 
@@ -479,8 +479,7 @@ class TestTrackGeneratedAssetsInVersions:
     @pytest.mark.unit
     def test_creates_versions_file_when_missing(self, tmp_path: Path) -> None:
         """First-ever version is created at 1.0.0 if versions.json is absent."""
-        from portolan_cli.versions import read_versions
-        from portolan_cli.viz.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import read_versions, track_generated_assets
 
         collection_dir = tmp_path / "demographics"
         collection_dir.mkdir()
@@ -488,7 +487,7 @@ class TestTrackGeneratedAssetsInVersions:
         thumb = collection_dir / "data.thumb.png"
         thumb.write_bytes(b"\x89PNG fake-thumbnail-bytes")
 
-        _track_generated_assets_in_versions(
+        track_generated_assets(
             collection_dir, [thumb], tmp_path, message="Generated thumbnail: data.thumb.png"
         )
 
@@ -499,14 +498,14 @@ class TestTrackGeneratedAssetsInVersions:
     @pytest.mark.unit
     def test_raises_when_asset_missing(self, tmp_path: Path) -> None:
         """A missing asset file is a hard error (no phantom asset)."""
-        from portolan_cli.viz.pmtiles import _track_generated_assets_in_versions
+        from portolan_cli.versions import track_generated_assets
 
         collection_dir = tmp_path / "demographics"
         collection_dir.mkdir()
         self._write_versions(collection_dir)
 
         with pytest.raises(FileNotFoundError):
-            _track_generated_assets_in_versions(
+            track_generated_assets(
                 collection_dir, [collection_dir / "data.thumb.png"], tmp_path, message="x"
             )
 
@@ -954,8 +953,10 @@ class TestGeneratePMTilesForCollection:
         (collection_dir / "collection.json").write_text(json.dumps(collection_json))
 
         # Source parquet OLDER than pmtiles -> _should_generate returns False.
+        # A real GeoParquet, because the thumbnail orchestrator derives geospatial
+        # status by reading the `geo` schema metadata (#683).
         parquet = collection_dir / "data.parquet"
-        parquet.write_bytes(b"PAR1")
+        shutil.copy(Path(__file__).parent.parent / "fixtures" / "simple.parquet", parquet)
         pmtiles = collection_dir / "data.pmtiles"
         pmtiles.write_bytes(b"PMTILES")
         # Thumbnail uses the .thumb.jpg convention (thumbnail_path_for).
@@ -995,13 +996,19 @@ class TestGeneratePMTilesForCollection:
         assert "data.pmtiles" in latest, "Untracked PMTiles should be backfilled on skip"
         assert "data.thumb.jpg" in latest, "Untracked thumbnail should be backfilled on skip"
 
-        # The thumbnail must also be (re-)registered as a STAC asset on skip, so a
-        # backfilled versions.json entry is never orphaned from collection.json.
+        # Registering the STAC asset moved to collection_thumbnail in #683, which
+        # adopts this .thumb.jpg. Prove the pair still meets: the orchestrator
+        # picks up exactly what the backfill tracked, so the versions.json entry
+        # cannot be orphaned from collection.json.
+        from portolan_cli.collection_thumbnail import ensure_collection_thumbnails
+
+        ensure_collection_thumbnails(tmp_path, {"demographics"})
         coll_json = json.loads((collection_dir / "collection.json").read_text())
         thumb_assets = [
             k for k, v in coll_json["assets"].items() if "thumbnail" in v.get("roles", [])
         ]
         assert thumb_assets, "Backfilled thumbnail must be registered as a STAC asset"
+        assert coll_json["assets"]["thumbnail"]["href"] == "./data.thumb.jpg"
 
         # Idempotent: a second run with everything tracked creates NO new version.
         with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):

--- a/tests/unit/test_thumbnail.py
+++ b/tests/unit/test_thumbnail.py
@@ -1260,3 +1260,102 @@ class TestThumbnailRendersVisibleGeometry:
 
         assert result is not None and result.exists()
         assert result.stat().st_size > 0
+
+
+class TestGeoparquetSampling:
+    """A bounded render, since thumbnails are now generated on every add (#683)."""
+
+    @staticmethod
+    def _write_geoparquet(path: Path, rows: int, row_group_size: int) -> None:
+        """A real GeoParquet whose points march west to east across the extent.
+
+        Spatially ordered on purpose: geoparquet-io writes spatially sorted
+        output, so a leading-N sample would draw only the western corner. The
+        ordering is what makes the stride assertion meaningful.
+        """
+        import geopandas as gpd
+        import shapely
+
+        gdf = gpd.GeoDataFrame(
+            {"idx": list(range(rows))},
+            geometry=[shapely.Point(x / rows * 10.0, 0.5) for x in range(rows)],
+            crs="EPSG:4326",
+        )
+        gdf.to_parquet(path, row_group_size=row_group_size)
+
+    @pytest.mark.unit
+    def test_below_the_cap_reads_every_feature(self, tmp_path: Path) -> None:
+        """The guarantee from #423 still holds for ordinary files."""
+        from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+        gpq = tmp_path / "small.parquet"
+        self._write_geoparquet(gpq, rows=500, row_group_size=100)
+
+        gdf, _bbox, _crs = _read_geoparquet_for_thumbnail(gpq, max_features=10_000)
+
+        assert len(gdf) == 500
+
+    @pytest.mark.unit
+    def test_above_the_cap_samples(self, tmp_path: Path) -> None:
+        from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+        gpq = tmp_path / "big.parquet"
+        self._write_geoparquet(gpq, rows=1000, row_group_size=100)
+
+        gdf, _bbox, _crs = _read_geoparquet_for_thumbnail(gpq, max_features=200)
+
+        assert 0 < len(gdf) < 1000, "A file over the cap must not be read whole"
+
+    @pytest.mark.unit
+    def test_the_sample_spans_the_full_extent(self, tmp_path: Path) -> None:
+        """A leading-N sample would cover the western sliver only."""
+        from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+        gpq = tmp_path / "big.parquet"
+        self._write_geoparquet(gpq, rows=1000, row_group_size=100)
+
+        gdf, bbox, _crs = _read_geoparquet_for_thumbnail(gpq, max_features=200)
+
+        # Points run x = 0 .. 9.99. A leading 200 would stop near x = 2.
+        assert gdf.total_bounds[2] > 8.0, "Sample must reach the eastern edge"
+        # And the frame still comes from file metadata, not from the sample.
+        assert bbox is not None
+        assert bbox[2] > 9.9
+
+    @pytest.mark.unit
+    def test_sampling_preserves_the_declared_crs(self, tmp_path: Path) -> None:
+        """The rebuilt frame must not silently lose its CRS."""
+        from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+        gpq = tmp_path / "big.parquet"
+        self._write_geoparquet(gpq, rows=1000, row_group_size=100)
+
+        gdf, _bbox, source_crs = _read_geoparquet_for_thumbnail(gpq, max_features=200)
+
+        assert gdf.crs is not None
+        assert gdf.crs.to_epsg() == 4326
+        assert source_crs is not None
+
+    @pytest.mark.unit
+    def test_single_row_group_still_caps_the_feature_count(self, tmp_path: Path) -> None:
+        """geoparquet-io writes one row group for many files; the cap must hold."""
+        from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+        gpq = tmp_path / "one_group.parquet"
+        self._write_geoparquet(gpq, rows=1000, row_group_size=100_000)
+
+        gdf, _bbox, _crs = _read_geoparquet_for_thumbnail(gpq, max_features=200)
+
+        assert len(gdf) == 200
+        assert gdf.total_bounds[2] > 8.0, "Even one group must be sampled across"
+
+    @pytest.mark.unit
+    def test_max_features_none_reads_everything(self, tmp_path: Path) -> None:
+        from portolan_cli.viz.thumbnail import _read_geoparquet_for_thumbnail
+
+        gpq = tmp_path / "big.parquet"
+        self._write_geoparquet(gpq, rows=1000, row_group_size=100)
+
+        gdf, _bbox, _crs = _read_geoparquet_for_thumbnail(gpq, max_features=None)
+
+        assert len(gdf) == 1000

--- a/tests/unit/validation/test_fixers.py
+++ b/tests/unit/validation/test_fixers.py
@@ -1404,3 +1404,81 @@ class TestNodeWriting:
         raw = (collection / "collection.json").read_text(encoding="utf-8")
         assert "Córdoba" in raw
         assert "\\u00f3" not in raw
+
+
+class TestThumbnailFixer:
+    """PTL-VIZ-001 has two repairs: retype a mistyped thumbnail, or make one."""
+
+    def _collection_with_thumbnail(self, tmp_path: Path, media_type: str) -> Path:
+        collection_dir = _tiny_catalog(tmp_path)
+        (collection_dir / "roads.thumb.jpg").write_bytes(b"\xff\xd8\xff fake-jpeg")
+        data = _read_json(collection_dir / "collection.json")
+        data["assets"] = {
+            "thumbnail": {
+                "href": "./roads.thumb.jpg",
+                "type": media_type,
+                "roles": ["thumbnail"],
+            }
+        }
+        _write_json(collection_dir / "collection.json", data)
+        return collection_dir
+
+    def test_retypes_from_the_file_it_points_at(self, tmp_path: Path) -> None:
+        collection_dir = self._collection_with_thumbnail(tmp_path, "image/gif")
+
+        results = FIXERS["thumbnail"](tmp_path, False)
+
+        assert [r.action for r in results] == [FixAction.UPDATED]
+        asset = _read_json(collection_dir / "collection.json")["assets"]["thumbnail"]
+        assert asset["type"] == "image/jpeg"
+
+    def test_a_correctly_typed_thumbnail_is_left_alone(self, tmp_path: Path) -> None:
+        collection_dir = self._collection_with_thumbnail(tmp_path, "image/jpeg")
+        before = _snapshot(tmp_path)
+
+        assert FIXERS["thumbnail"](tmp_path, False) == []
+        assert _snapshot(tmp_path) == before
+        assert collection_dir.exists()
+
+    def test_an_href_that_is_not_an_image_is_not_retyped(self, tmp_path: Path) -> None:
+        """Retyping a thumbnail that points at a CSV would state a falsehood."""
+        collection_dir = _tiny_catalog(tmp_path)
+        (collection_dir / "notes.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        data = _read_json(collection_dir / "collection.json")
+        data["assets"] = {
+            "thumbnail": {
+                "href": "./notes.csv",
+                "type": "text/csv",
+                "roles": ["thumbnail"],
+            }
+        }
+        _write_json(collection_dir / "collection.json", data)
+
+        assert FIXERS["thumbnail"](tmp_path, False) == []
+        asset = _read_json(collection_dir / "collection.json")["assets"]["thumbnail"]
+        assert asset["type"] == "text/csv"
+
+    def test_dry_run_reports_only_what_the_real_run_would_do(self, tmp_path: Path) -> None:
+        """A tabular collection offers no thumbnail source, so neither run acts.
+
+        The dry-run branch used to skip the orchestrator's gates and promise a
+        thumbnail for every collection that lacked one.
+        """
+        collection_dir = _tiny_catalog(tmp_path)
+        (collection_dir / "rates.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+        data = _read_json(collection_dir / "collection.json")
+        data["assets"] = {"rates": {"href": "./rates.csv", "roles": ["data"]}}
+        _write_json(collection_dir / "collection.json", data)
+
+        assert FIXERS["thumbnail"](tmp_path, True) == []
+        assert FIXERS["thumbnail"](tmp_path, False) == []
+
+    def test_dry_run_writes_nothing_for_a_collection_it_would_fix(self, tmp_path: Path) -> None:
+        collection_dir = self._collection_with_thumbnail(tmp_path, "image/gif")
+        before = _snapshot(tmp_path)
+
+        results = FIXERS["thumbnail"](tmp_path, True)
+
+        assert [r.action for r in results] == [FixAction.UPDATED]
+        assert _snapshot(tmp_path) == before
+        assert collection_dir.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -4579,9 +4579,11 @@ dependencies = [
     { name = "click" },
     { name = "cryptography" },
     { name = "defusedxml" },
+    { name = "geopandas" },
     { name = "geoparquet-io" },
     { name = "httpx" },
     { name = "lxml" },
+    { name = "matplotlib" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "obstore" },
@@ -4649,9 +4651,7 @@ pmtiles = [
 ]
 thumbnails = [
     { name = "contextily" },
-    { name = "geopandas" },
     { name = "mapbox-vector-tile" },
-    { name = "matplotlib" },
 ]
 
 [package.dev-dependencies]
@@ -4678,7 +4678,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.1" },
-    { name = "geopandas", marker = "extra == 'thumbnails'", specifier = ">=0.14.0" },
+    { name = "geopandas", specifier = ">=0.14.0" },
     { name = "geoparquet-io", git = "https://github.com/geoparquet/geoparquet-io.git?branch=main" },
     { name = "gitingest", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "gpio-pmtiles", marker = "extra == 'pmtiles'", specifier = ">=0.1.0" },
@@ -4687,7 +4687,7 @@ requires-dist = [
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mapbox-vector-tile", marker = "extra == 'thumbnails'", specifier = ">=2.0.0" },
-    { name = "matplotlib", marker = "extra == 'thumbnails'", specifier = ">=3.8.0" },
+    { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1" },
     { name = "mkdocs-click", marker = "extra == 'docs'", specifier = ">=0.8.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.1" },


### PR DESCRIPTION
## What this changes

Resolves #683. `portolan add` now gives every geospatial collection a thumbnail asset, so a freshly generated catalog passes its own `portolan check`.

A new `collection_thumbnail` orchestrator decides whether a collection needs a thumbnail and where one comes from, then delegates drawing to `viz.thumbnail`. It resolves in order: opt-out, an already-registered thumbnail, a non-geospatial collection, a conventionally named image on disk, a raster item's sidecar, then a render. It runs after the PMTiles side-step, so a higher-fidelity render from tiles is adopted rather than replaced.

Supporting changes: matplotlib and geopandas move to core dependencies; three thumbnail asset writers collapse into one keyed `thumbnail`; renders are capped at `thumbnails.max_features`; PTL-VIZ-001 becomes an auto-fix so older catalogs heal via `check --fix`; `--thumbnails/--no-thumbnails` and `--force-thumbnails` are added.

## Why

The issue names one cause. There were two. Vector rendering ran only inside `generate_pmtiles_for_collection`, gated on `--pmtiles`, so a default `add` rendered nothing **even with the `[thumbnails]` extra installed**. Separately, matplotlib and geopandas sat in that extra, so a default install could not render at all. Rasters were a third shape: #657 writes an item-level sidecar that no collection asset pointed at.

#518 Track 1 already settled that the matplotlib floor is "always available, runs on every collection". Gating it behind an extra contradicted that.

## Verification

A fresh catalog, built the way the issue describes, against a default install:

```
$ portolan init . --auto --title Demo --license CC-BY-4.0
$ cp simple.parquet roads/roads.parquet
$ portolan add roads/roads.parquet
✓ Added 1 file to 1 collection

$ portolan check
→ Errors (2):
✗ PTL-DAT-007 roads/collection.json: asset 'roads' provides no per-row-group spatial statistics
✗ PTL-PRV-001 roads/collection.json: collection declares no providers

$ jq '.assets.thumbnail' roads/collection.json
{
  "href": "./roads.thumb.jpg",
  "type": "image/jpeg",
  "roles": ["thumbnail"],
  "file:size": 4735,
  "file:checksum": "1220754cf1f93fe1f6968c93ad8b68d2c48a232bc245475c55909eb764ee06f2f88c"
}
```

PTL-VIZ-001 is gone; PTL-DAT-007 is the remaining tracked gap and PTL-PRV-001 is this fixture carrying no providers. The escape hatches, on the same catalog:

```
$ portolan add --force roads/roads.parquet          # preview.png present
"thumbnail": {"href": "./preview.png", "type": "image/png", ...}

$ portolan add --force --no-thumbnails roads/roads.parquet
thumbnail asset present: False

$ printf 'thumbnails:\n  enabled: false\n' >> .portolan/config.yaml
$ portolan add --force roads/roads.parquet
thumbnail asset present: False
```

An adversarial pass over the first revision found five defects. Reverting only the fixes turns the new tests red, which is what pins each one:

```
$ git checkout HEAD~1 -- portolan_cli/ && uv run pytest -k "Symlink or ConfigOptOut or ForceRefresh or EveryRegisteredThumbnail or adoption_records or dry_run_reports_only"
FAILED TestSymlinkedCatalogRoot::test_item_sidecar_registers_through_a_symlink
FAILED TestSymlinkedCatalogRoot::test_an_href_escaping_the_collection_is_still_rejected
FAILED TestConfigOptOutOnEveryEntryPoint::test_disabled_config_blocks_the_singular_entry_point
FAILED TestConfigOptOutOnEveryEntryPoint::test_an_explicit_generate_overrides_a_disabled_config
FAILED TestForceRefresh::test_force_redraws_a_generated_thumbnail
FAILED TestForceRefresh::test_force_keeps_a_thumbnail_the_user_supplied
FAILED TestEveryRegisteredThumbnailIsTracked::test_an_adopted_image_lands_in_versions_json
FAILED TestEveryRegisteredThumbnailIsTracked::test_a_second_add_creates_no_further_version
FAILED TestVectorRendering::test_adoption_records_one_version
FAILED TestThumbnailFixer::test_dry_run_reports_only_what_the_real_run_would_do
10 failed, 1 passed

$ git checkout HEAD -- portolan_cli/ && uv run pytest -k "..."
11 passed
```

In order: a symlink in the catalog path dropped the raster branch while still reporting success (macOS hits this on every temp directory); `thumbnails.enabled: false` bound only the plural wrapper, so `check --fix` generated anyway; a registered thumbnail was never redrawn and no flag forced it; `--fix --dry-run` promised thumbnails the real run declines; and an adopted image became a STAC asset with no versions.json record.

`check --fix` heals an older catalog, and the render cap now has a benchmark instead of a claim:

```
$ portolan check --fix
✓ Fixed automatically (1)
    Applied: thumbnail

$ uv run pytest tests/benchmark/test_thumbnail_sampling_benchmark.py
Name (time in ms)                      Min         Mean       Rounds
test_sampled_read_performance      72.0824      83.6409           12
test_full_read_performance        176.3044     190.2425            5
2 passed
```

Gates:

```
$ uv run pytest tests/unit/test_collection_thumbnail.py tests/unit/validation/test_fixers.py tests/unit/test_thumbnail.py tests/unit/test_pmtiles.py
228 passed, 1 skipped

$ uv run mypy portolan_cli
Success: no issues found in 156 source files

$ uv run lint-imports
Contracts: 6 kept, 0 broken.

$ uv run ruff check .
All checks passed!
```

## Notes for review

- matplotlib and geopandas become mandatory for every install, headless CI included. The alternative was downgrading PTL-VIZ-001 to a warning, which #518 Track 1 rules out.
- Resolving both sides before `relative_to` keeps the containment check that rejects an escaping href. A test pins it, since loosening the guard is the tempting wrong fix.
- `--force-thumbnails` skips our own `*.thumb.jpg` so it re-renders, and keeps a `thumbnail.png` somebody chose.
- `track_generated_assets` decides "already tracked" by href, not basename. Asset keys stay basenames, so published versions.json files still compare.
- `PTL-VIZ-001` leaves `KNOWN_GAPS` and `GENERATION_GAPS`. The roundtrip damages a thumbnail's media type instead, so the rule stays exercised.
- Sampling picks row groups with `linspace`, not a stride. A stride from 0 skips the tail groups and draws only the leading corner of spatially sorted data.
