### PR TITLE
fix(stac): document a tabular collection's table (#749)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -21,7 +21,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 import pystac
@@ -91,6 +91,7 @@ from portolan_cli.formats import (
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.licensing import LICENSE_REL, license_gap, resolve_license
+from portolan_cli.metadata.tabular import extract_tabular_metadata
 from portolan_cli.preparation import (
     _MEDIA_TYPE_MAP as _MEDIA_TYPE_MAP,  # noqa: PLC0414
 )
@@ -158,6 +159,8 @@ from portolan_cli.stac import (
     apply_provenance,
     create_collection,
     declare_file_extension,
+    document_tabular_table,
+    set_temporal_extent,
     update_catalog_provenance,
 )
 from portolan_cli.stac_parquet import PARQUET_FILENAME
@@ -1722,5 +1725,37 @@ def _update_collection_with_asset(
         **file_fields(asset_path),
     }
 
+    _document_tabular_asset(collection_data, asset_key, asset_path)
+
     # Write updated collection
     write_json_atomic(collection_json_path, collection_data)
+
+
+def _document_tabular_asset(
+    collection_data: dict[str, Any],
+    asset_key: str,
+    asset_path: Path,
+) -> None:
+    """Answer the Tabular Data SHOULDs for a plain-Parquet asset (issue #749).
+
+    The spec asks a tabular collection to document its columns with the table
+    extension, and to populate ``extent.temporal`` when the data carries a time
+    dimension. Both are read from the Parquet footer here, because this function
+    is the only writer a collection-level non-geo asset passes through — the
+    tabular path never reaches ``finalize_items``, where geo collections get
+    their table metadata.
+
+    Non-Parquet and GeoParquet assets are left alone:
+    :func:`extract_tabular_metadata` returns None for both.
+
+    Args:
+        collection_data: Parsed ``collection.json``, mutated in place.
+        asset_key: Key the asset was just written under.
+        asset_path: Path to the asset file on disk.
+    """
+    metadata = extract_tabular_metadata(asset_path)
+    if metadata is None:
+        return
+    document_tabular_table(collection_data, asset_key, metadata)
+    if metadata.temporal_interval is not None:
+        set_temporal_extent(collection_data, metadata.temporal_interval)

--- a/portolan_cli/metadata/__init__.py
+++ b/portolan_cli/metadata/__init__.py
@@ -5,6 +5,7 @@ This module provides:
 Extraction functions:
 - extract_geoparquet_metadata(): Extract from GeoParquet
 - extract_cog_metadata(): Extract from COG
+- extract_tabular_metadata(): Extract from plain (geometry-less) Parquet
 
 Detection functions:
 - get_stored_metadata(): Read existing STAC item + versions.json
@@ -81,6 +82,10 @@ from portolan_cli.metadata.statistics import (
     extract_band_statistics,
     extract_parquet_statistics,
 )
+from portolan_cli.metadata.tabular import (
+    TabularMetadata,
+    extract_tabular_metadata,
+)
 from portolan_cli.metadata.update import (
     create_missing_item,
     update_collection_extent,
@@ -101,10 +106,12 @@ __all__ = [
     "FlatGeobufMetadata",
     "GeoParquetMetadata",
     "PMTilesMetadata",
+    "TabularMetadata",
     "extract_cog_metadata",
     "extract_flatgeobuf_metadata",
     "extract_geoparquet_metadata",
     "extract_pmtiles_metadata",
+    "extract_tabular_metadata",
     # Statistics
     "BandStatistics",
     "ColumnStatistics",

--- a/portolan_cli/metadata/tabular.py
+++ b/portolan_cli/metadata/tabular.py
@@ -1,0 +1,119 @@
+"""Plain-Parquet (tabular) metadata extraction.
+
+A tabular asset is a Parquet file with no ``geo`` metadata key. The spec's
+Tabular Data section asks such a collection to document its columns with the
+STAC table extension and to populate ``extent.temporal`` when the data carries
+a time dimension (rashid PTL-DAT-015, issue #749).
+
+Both answers come from the Parquet footer, so nothing here reads row data:
+the Arrow schema gives column names and types, and per-row-group column
+statistics give the temporal bounds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time, timezone
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+
+@dataclass(frozen=True)
+class TabularMetadata:
+    """Metadata extracted from a plain (geometry-less) Parquet file.
+
+    Attributes:
+        schema: Column names mapped to their Arrow type names.
+        row_count: Number of rows.
+        temporal_interval: Earliest and latest value across every temporal
+            column, or None when the file carries no temporal column or the
+            writer emitted no statistics for one.
+    """
+
+    schema: dict[str, str]
+    row_count: int
+    temporal_interval: tuple[datetime, datetime] | None
+
+
+def extract_tabular_metadata(path: Path) -> TabularMetadata | None:
+    """Extract table metadata from a plain Parquet file.
+
+    Args:
+        path: Path to the candidate asset.
+
+    Returns:
+        TabularMetadata, or None when ``path`` is not a readable Parquet file
+        or is GeoParquet. GeoParquet is excluded deliberately: the geospatial
+        storage rules own it, and its schema already reaches the collection
+        through ``add_table_extension``.
+    """
+    if path.suffix.lower() != ".parquet":
+        return None
+    try:
+        parquet = pq.ParquetFile(path)
+    except Exception:  # noqa: BLE001 - unreadable Parquet: the format checks own it
+        return None
+    if (parquet.schema_arrow.metadata or {}).get(b"geo") is not None:
+        return None
+
+    return TabularMetadata(
+        schema={field.name: str(field.type) for field in parquet.schema_arrow},
+        row_count=parquet.metadata.num_rows,
+        temporal_interval=_temporal_interval(parquet),
+    )
+
+
+def _temporal_interval(parquet: pq.ParquetFile) -> tuple[datetime, datetime] | None:
+    """Earliest and latest value across every temporal column of the file.
+
+    Reads per-row-group column statistics rather than the data. A column whose
+    writer emitted no statistics contributes nothing, so a file where no
+    temporal column carries statistics yields None and leaves the collection's
+    extent alone rather than guessing at it.
+    """
+    temporal_columns = {
+        field.name for field in parquet.schema_arrow if pa.types.is_temporal(field.type)
+    }
+    if not temporal_columns:
+        return None
+
+    bounds: list[datetime] = []
+    metadata = parquet.metadata
+    for group in range(metadata.num_row_groups):
+        row_group = metadata.row_group(group)
+        for index in range(row_group.num_columns):
+            column = row_group.column(index)
+            if column.path_in_schema not in temporal_columns:
+                continue
+            statistics = column.statistics
+            if statistics is None or not statistics.has_min_max:
+                continue
+            bounds.extend(
+                normalized
+                for raw in (statistics.min, statistics.max)
+                if (normalized := _as_utc(raw)) is not None
+            )
+
+    if not bounds:
+        return None
+    return min(bounds), max(bounds)
+
+
+def _as_utc(value: object) -> datetime | None:
+    """Normalize a Parquet temporal statistic to a timezone-aware UTC datetime.
+
+    Parquet exposes date columns as ``date`` and timestamp columns as
+    ``datetime``, which may be naive. STAC requires RFC 3339, so a date becomes
+    midnight and a naive datetime is read as UTC. Time-of-day and duration
+    statistics carry no calendar date, so they cannot bound an extent and are
+    dropped.
+    """
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, date):
+        return datetime.combine(value, time.min, tzinfo=timezone.utc)
+    return None

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Sequence
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pystac
 from pystac.summaries import Summarizer, SummaryStrategy
@@ -26,6 +26,9 @@ from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.providers import derive_provenance, resolve_providers
 from portolan_cli.utils import href_root
+
+if TYPE_CHECKING:
+    from portolan_cli.metadata.tabular import TabularMetadata
 
 # Any versioned Portolan profile URI, not just the current one: matching the
 # whole family is what lets a stale claim be rewritten rather than duplicated.
@@ -1093,6 +1096,87 @@ def add_table_extension(
         if collection.stac_extensions is None:
             collection.stac_extensions = []
         collection.stac_extensions.append(ext_url)
+
+
+def document_tabular_table(
+    collection_data: dict[str, Any],
+    asset_key: str,
+    metadata: TabularMetadata,
+) -> None:
+    """Document a plain-Parquet asset's columns with the table extension (issue #749).
+
+    The tabular writer builds ``collection.json`` as raw JSON outside
+    ``finalize_items``, so it cannot reach :func:`add_table_extension`, which
+    takes a pystac Collection. This is the dict-level counterpart, and it is the
+    only writer of ``table:*`` on that path.
+
+    Where the columns land depends on what else the collection holds. When this
+    is its only Parquet data asset, the collection *is* the table — the
+    single-file collection pattern the spec's Tabular Data section describes —
+    so the fields go on the collection, where ``readme`` and ``metadata.yaml``
+    already read them. When another Parquet data asset is present, that one owns
+    the collection-level schema, so these columns go on the asset instead of
+    overwriting it. The table extension permits both placements and rashid
+    (PTL-DAT-015) accepts either.
+
+    Descriptions a human wrote on existing columns survive, matching
+    :data:`MergeStrategy.SMART`; only names and types are refreshed.
+
+    Args:
+        collection_data: Parsed ``collection.json``, mutated in place.
+        asset_key: Key of the Parquet asset under ``assets``.
+        metadata: Schema and row count read from that asset.
+    """
+    assets = collection_data.get("assets", {})
+    others_hold_the_collection = any(
+        key != asset_key
+        and "data" in (asset.get("roles") or [])
+        and str(asset.get("href", "")).lower().endswith(".parquet")
+        for key, asset in assets.items()
+    )
+    target: dict[str, Any] = assets[asset_key] if others_hold_the_collection else collection_data
+
+    existing = target.get("table:columns")
+    target["table:columns"] = _merge_table_columns(
+        existing if isinstance(existing, list) else [],
+        metadata.schema,
+        MergeStrategy.SMART,
+    )
+    target["table:row_count"] = metadata.row_count
+
+    declared = collection_data.setdefault("stac_extensions", [])
+    if EXTENSION_URLS["table"] not in declared:
+        declared.append(EXTENSION_URLS["table"])
+
+
+def set_temporal_extent(
+    collection_data: dict[str, Any],
+    interval: tuple[datetime, datetime],
+) -> None:
+    """Populate a collection's temporal extent from a derived interval (issue #749).
+
+    Only fills an extent that is still open at both ends, the sentinel
+    ``[[null, null]]`` a tabular collection is created with. A bound already
+    present came from a human or from the collection's items, and machine-read
+    column statistics do not outrank either.
+
+    Args:
+        collection_data: Parsed ``collection.json``, mutated in place.
+        interval: Start and end datetimes, each serialized to RFC 3339.
+    """
+    extent = collection_data.setdefault("extent", {})
+    temporal = extent.setdefault("temporal", {})
+    bounds = temporal.get("interval")
+    if isinstance(bounds, list) and any(
+        isinstance(pair, list) and any(bound is not None for bound in pair) for pair in bounds
+    ):
+        return
+    temporal["interval"] = [[_rfc3339(interval[0]), _rfc3339(interval[1])]]
+
+
+def _rfc3339(moment: datetime) -> str:
+    """Serialize a UTC datetime the way STAC spells it, with a trailing ``Z``."""
+    return moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 def get_existing_table_metadata(collection: pystac.Collection) -> object | None:

--- a/tests/integration/test_generated_catalog_conformance.py
+++ b/tests/integration/test_generated_catalog_conformance.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import shutil
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -90,17 +91,6 @@ EXPECTED_ADVISORIES: dict[str, int] = {
     # PTL-DAT-010, twice, one per raster item: the valid-percent half of the
     # PTL-DAT-009 sidecar problem above. Same root cause, same issue #748.
     "PTL-DAT-010": 2,
-    # PTL-DAT-015 (issue #749): the tabular collection documents no
-    # `table:columns`. `_apply_table_extension` in finalization.py gates on
-    # FormatType.VECTOR, so the tabular writer never reaches it.
-    "PTL-DAT-015": 1,
-    # PTL-VIZ-001, on that same tabular collection, and downstream of the line
-    # above rather than separate from it. `table:columns` is how rashid decides
-    # whether a collection is geospatial. Without it the question is undecidable,
-    # so rashid softens the thumbnail MUST to a warning instead of skipping the
-    # check. Documenting the columns answers it and retires both entries, which
-    # is why #749 covers this line too.
-    "PTL-VIZ-001": 1,
     # PTL-PRO-002, once per collection: every collection is a mirror, because
     # metadata.yaml names a producer distinct from the host. Advisory — a
     # rel:'canonical' link is only meaningful when the upstream publishes STAC.
@@ -158,11 +148,23 @@ def _build_catalog(root: Path) -> None:
     shutil.copy(FIXTURE, nested_dir / "quality.parquet")
 
     # A geometry-less Parquet exercises the tabular path, which writes its
-    # collection.json outside finalize_items.
+    # collection.json outside finalize_items. The timestamp column is load-bearing
+    # (issue #749): PTL-DAT-015 asks a tabular collection for `table:columns` and,
+    # only when the data has a time dimension, for `extent.temporal`. Without a
+    # temporal column the gate would cover half the rule and call it done.
     tabular_dir = root / "demographics"
     tabular_dir.mkdir(parents=True)
     pq.write_table(
-        pa.table({"tract_id": ["001", "002"], "population": [5000, 7500]}),
+        pa.table(
+            {
+                "tract_id": ["001", "002"],
+                "population": [5000, 7500],
+                "surveyed_at": pa.array(
+                    [datetime(2020, 4, 1), datetime(2020, 9, 30)],
+                    pa.timestamp("us"),
+                ),
+            }
+        ),
         tabular_dir / "census.parquet",
     )
 
@@ -688,6 +690,70 @@ class TestThumbnailsSurviveARealPass:
         collection = _load(generated_catalog / "demographics" / "collection.json")
 
         assert "thumbnail" not in collection["assets"]
+
+
+class TestTheTabularCollectionDocumentsItsTable:
+    """#749: a tabular collection answers both Tabular Data SHOULDs.
+
+    The advisory counts above prove PTL-DAT-015 stopped firing. These read the
+    emitted bytes instead, because a rule can go quiet for the wrong reason —
+    an unreadable Parquet makes rashid skip the check entirely. Asserting the
+    column names and the derived interval pins the values, not just the silence.
+    """
+
+    def test_columns_land_on_the_collection(self, generated_catalog: Path) -> None:
+        """The collection is the table, so its schema belongs at collection level.
+
+        ``readme`` and ``metadata`` read ``table:columns`` from here, not from
+        the asset, so a schema parked on the asset would be invisible to both.
+        """
+        collection = _load(generated_catalog / "demographics" / "collection.json")
+
+        assert [column["name"] for column in collection["table:columns"]] == [
+            "tract_id",
+            "population",
+            "surveyed_at",
+        ]
+        assert [column["type"] for column in collection["table:columns"]] == [
+            "string",
+            "int64",
+            "timestamp[us]",
+        ]
+        assert collection["table:row_count"] == 2
+        assert "table:primary_geometry" not in collection
+
+    def test_the_table_extension_is_declared(self, generated_catalog: Path) -> None:
+        collection = _load(generated_catalog / "demographics" / "collection.json")
+
+        assert (
+            "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+            in collection["stac_extensions"]
+        )
+
+    def test_the_temporal_extent_comes_from_the_timestamp_column(
+        self, generated_catalog: Path
+    ) -> None:
+        """Read from Parquet column statistics, not from the clock.
+
+        The bounds are the fixture's own values, so a fallback to "now" or to
+        the sentinel ``[[null, null]]`` fails here rather than passing quietly.
+        """
+        collection = _load(generated_catalog / "demographics" / "collection.json")
+
+        assert collection["extent"]["temporal"]["interval"] == [
+            ["2020-04-01T00:00:00Z", "2020-09-30T00:00:00Z"]
+        ]
+
+    def test_the_geo_collections_keep_their_own_schema(self, generated_catalog: Path) -> None:
+        """The tabular writer must not reach a collection it does not own.
+
+        Both writers stamp ``table:columns`` at collection level, so a geo
+        collection is where a mistargeted tabular stamp would surface.
+        """
+        collection = _load(generated_catalog / "roads" / "collection.json")
+
+        assert "geometry" in {column["name"] for column in collection["table:columns"]}
+        assert "tract_id" not in {column["name"] for column in collection["table:columns"]}
 
 
 class TestNoUndefinedPortolanFieldsAreEmitted:

--- a/tests/unit/test_tabular_metadata.py
+++ b/tests/unit/test_tabular_metadata.py
@@ -1,0 +1,350 @@
+"""Unit tests for plain-Parquet table metadata (issue #749).
+
+Covers the three pieces the tabular path needs to answer PTL-DAT-015:
+reading columns and temporal bounds from a Parquet footer, writing
+``table:columns`` to the right place in ``collection.json``, and filling a
+temporal extent without overwriting one that is already set.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from portolan_cli.metadata.tabular import extract_tabular_metadata
+from portolan_cli.stac import document_tabular_table, set_temporal_extent
+
+TABLE_EXTENSION = "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+
+
+def _write(path: Path, table: pa.Table) -> Path:
+    pq.write_table(table, path)
+    return path
+
+
+class TestExtractTabularMetadata:
+    """What the extractor reads, and what it refuses to read."""
+
+    @pytest.mark.unit
+    def test_reads_column_names_types_and_row_count(self, tmp_path: Path) -> None:
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table({"tract_id": ["001", "002"], "population": [5000, 7500]}),
+        )
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.schema == {"tract_id": "string", "population": "int64"}
+        assert metadata.row_count == 2
+
+    @pytest.mark.unit
+    def test_returns_none_for_geoparquet(self, tmp_path: Path) -> None:
+        """GeoParquet is not tabular: the geospatial storage rules own it.
+
+        A GeoParquet stamped here would overwrite the schema
+        ``add_table_extension`` derives from the same file during finalization.
+        """
+        table = pa.table({"id": ["a"]}).replace_schema_metadata(
+            {b"geo": b'{"version": "1.1.0", "primary_column": "geometry", "columns": {}}'}
+        )
+        source = _write(tmp_path / "roads.parquet", table)
+
+        assert extract_tabular_metadata(source) is None
+
+    @pytest.mark.unit
+    def test_returns_none_for_a_non_parquet_suffix(self, tmp_path: Path) -> None:
+        source = tmp_path / "census.csv"
+        source.write_text("tract_id,population\n001,5000\n", encoding="utf-8")
+
+        assert extract_tabular_metadata(source) is None
+
+    @pytest.mark.unit
+    def test_returns_none_for_an_unreadable_parquet(self, tmp_path: Path) -> None:
+        """A corrupt file yields nothing rather than raising: `add` stays atomic."""
+        source = tmp_path / "broken.parquet"
+        source.write_bytes(b"not parquet at all")
+
+        assert extract_tabular_metadata(source) is None
+
+
+class TestTemporalInterval:
+    """The interval comes from column statistics, so no row data is read."""
+
+    @pytest.mark.unit
+    def test_is_none_without_a_temporal_column(self, tmp_path: Path) -> None:
+        source = _write(tmp_path / "census.parquet", pa.table({"population": [5000]}))
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.temporal_interval is None
+
+    @pytest.mark.unit
+    def test_spans_the_min_and_max_of_a_timestamp_column(self, tmp_path: Path) -> None:
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table(
+                {
+                    "surveyed_at": pa.array(
+                        [datetime(2020, 9, 30), datetime(2020, 4, 1), datetime(2020, 6, 15)],
+                        pa.timestamp("us"),
+                    )
+                }
+            ),
+        )
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.temporal_interval == (
+            datetime(2020, 4, 1, tzinfo=timezone.utc),
+            datetime(2020, 9, 30, tzinfo=timezone.utc),
+        )
+
+    @pytest.mark.unit
+    def test_reads_a_date_column_as_midnight_utc(self, tmp_path: Path) -> None:
+        """STAC needs RFC 3339, which a bare calendar date cannot express."""
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table({"day": pa.array([date(2019, 1, 1), date(2022, 2, 2)], pa.date32())}),
+        )
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.temporal_interval == (
+            datetime(2019, 1, 1, tzinfo=timezone.utc),
+            datetime(2022, 2, 2, tzinfo=timezone.utc),
+        )
+
+    @pytest.mark.unit
+    def test_spans_every_temporal_column(self, tmp_path: Path) -> None:
+        """Two time columns bound one extent between them, widest wins."""
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table(
+                {
+                    "opened": pa.array([datetime(2020, 4, 1)], pa.timestamp("us")),
+                    "closed": pa.array([datetime(2023, 8, 9)], pa.timestamp("us")),
+                }
+            ),
+        )
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.temporal_interval == (
+            datetime(2020, 4, 1, tzinfo=timezone.utc),
+            datetime(2023, 8, 9, tzinfo=timezone.utc),
+        )
+
+    @pytest.mark.unit
+    def test_converts_a_zoned_timestamp_to_utc(self, tmp_path: Path) -> None:
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table(
+                {
+                    "surveyed_at": pa.array(
+                        [datetime(2020, 4, 1, 12, 0)],
+                        pa.timestamp("us", tz="America/New_York"),
+                    )
+                }
+            ),
+        )
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.temporal_interval is not None
+        start, end = metadata.temporal_interval
+        assert start.tzinfo is not None
+        assert start.utcoffset() == end.utcoffset()
+
+    @pytest.mark.unit
+    def test_ignores_a_time_of_day_column(self, tmp_path: Path) -> None:
+        """A clock time carries no calendar date, so it cannot bound an extent."""
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table({"opens": pa.array([43200000000], pa.time64("us"))}),
+        )
+
+        metadata = extract_tabular_metadata(source)
+
+        assert metadata is not None
+        assert metadata.temporal_interval is None
+
+
+def _collection(assets: dict[str, Any]) -> dict[str, Any]:
+    return {"assets": assets, "stac_extensions": []}
+
+
+class TestDocumentTabularTable:
+    """Where the columns land, and what survives a re-add."""
+
+    @pytest.mark.unit
+    def test_writes_to_the_collection_when_the_parquet_stands_alone(self, tmp_path: Path) -> None:
+        source = _write(tmp_path / "census.parquet", pa.table({"tract_id": ["001"]}))
+        metadata = extract_tabular_metadata(source)
+        assert metadata is not None
+        collection = _collection({"census": {"href": "./census.parquet", "roles": ["data"]}})
+
+        document_tabular_table(collection, "census", metadata)
+
+        assert collection["table:columns"] == [{"name": "tract_id", "type": "string"}]
+        assert collection["table:row_count"] == 1
+        assert "table:columns" not in collection["assets"]["census"]
+        assert collection["stac_extensions"] == [TABLE_EXTENSION]
+
+    @pytest.mark.unit
+    def test_writes_to_the_asset_when_another_parquet_owns_the_collection(
+        self, tmp_path: Path
+    ) -> None:
+        """A geo collection's own schema must survive a companion tabular file."""
+        source = _write(tmp_path / "lanes.parquet", pa.table({"road_id": ["a"]}))
+        metadata = extract_tabular_metadata(source)
+        assert metadata is not None
+        collection = _collection(
+            {
+                "roads": {"href": "./roads.parquet", "roles": ["data"]},
+                "lanes": {"href": "./lanes.parquet", "roles": ["data"]},
+            }
+        )
+        collection["table:columns"] = [{"name": "geometry", "type": "binary"}]
+
+        document_tabular_table(collection, "lanes", metadata)
+
+        assert collection["table:columns"] == [{"name": "geometry", "type": "binary"}]
+        assert collection["assets"]["lanes"]["table:columns"] == [
+            {"name": "road_id", "type": "string"}
+        ]
+
+    @pytest.mark.unit
+    def test_a_companion_csv_does_not_displace_the_collection(self, tmp_path: Path) -> None:
+        """Only another Parquet claims the collection level.
+
+        Converting a CSV tracks both files as data assets. Counting the CSV
+        would push the schema onto the asset on re-add and strand a stale copy
+        at collection level.
+        """
+        source = _write(tmp_path / "census.parquet", pa.table({"tract_id": ["001"]}))
+        metadata = extract_tabular_metadata(source)
+        assert metadata is not None
+        collection = _collection(
+            {
+                "census": {"href": "./census.parquet", "roles": ["data"]},
+                "census.csv": {"href": "./census.csv", "roles": ["data"]},
+            }
+        )
+
+        document_tabular_table(collection, "census", metadata)
+
+        assert collection["table:columns"] == [{"name": "tract_id", "type": "string"}]
+        assert "table:columns" not in collection["assets"]["census"]
+
+    @pytest.mark.unit
+    def test_a_thumbnail_does_not_displace_the_collection(self, tmp_path: Path) -> None:
+        source = _write(tmp_path / "census.parquet", pa.table({"tract_id": ["001"]}))
+        metadata = extract_tabular_metadata(source)
+        assert metadata is not None
+        collection = _collection(
+            {
+                "census": {"href": "./census.parquet", "roles": ["data"]},
+                "thumbnail": {"href": "./census.thumb.png", "roles": ["thumbnail"]},
+            }
+        )
+
+        document_tabular_table(collection, "census", metadata)
+
+        assert collection["table:columns"] == [{"name": "tract_id", "type": "string"}]
+
+    @pytest.mark.unit
+    def test_preserves_a_human_authored_column_description(self, tmp_path: Path) -> None:
+        """`add` merges, it never regenerates."""
+        source = _write(
+            tmp_path / "census.parquet",
+            pa.table({"tract_id": ["001"], "population": [5000]}),
+        )
+        metadata = extract_tabular_metadata(source)
+        assert metadata is not None
+        collection = _collection({"census": {"href": "./census.parquet", "roles": ["data"]}})
+        collection["table:columns"] = [
+            {"name": "tract_id", "type": "string", "description": "Census tract identifier"}
+        ]
+
+        document_tabular_table(collection, "census", metadata)
+
+        assert collection["table:columns"] == [
+            {"name": "tract_id", "type": "string", "description": "Census tract identifier"},
+            {"name": "population", "type": "int64"},
+        ]
+
+    @pytest.mark.unit
+    def test_declares_the_table_extension_once(self, tmp_path: Path) -> None:
+        source = _write(tmp_path / "census.parquet", pa.table({"tract_id": ["001"]}))
+        metadata = extract_tabular_metadata(source)
+        assert metadata is not None
+        collection = _collection({"census": {"href": "./census.parquet", "roles": ["data"]}})
+
+        document_tabular_table(collection, "census", metadata)
+        document_tabular_table(collection, "census", metadata)
+
+        assert collection["stac_extensions"].count(TABLE_EXTENSION) == 1
+
+
+class TestSetTemporalExtent:
+    """A derived interval fills a gap; it never overrules a stated bound."""
+
+    @pytest.mark.unit
+    def test_fills_the_open_sentinel(self) -> None:
+        collection: dict[str, Any] = {"extent": {"temporal": {"interval": [[None, None]]}}}
+
+        set_temporal_extent(
+            collection,
+            (
+                datetime(2020, 4, 1, tzinfo=timezone.utc),
+                datetime(2020, 9, 30, tzinfo=timezone.utc),
+            ),
+        )
+
+        assert collection["extent"]["temporal"]["interval"] == [
+            ["2020-04-01T00:00:00Z", "2020-09-30T00:00:00Z"]
+        ]
+
+    @pytest.mark.unit
+    def test_leaves_an_existing_bound_alone(self) -> None:
+        """A stated start came from a human or from items, and outranks statistics."""
+        collection: dict[str, Any] = {
+            "extent": {"temporal": {"interval": [["1999-01-01T00:00:00Z", None]]}}
+        }
+
+        set_temporal_extent(
+            collection,
+            (
+                datetime(2020, 4, 1, tzinfo=timezone.utc),
+                datetime(2020, 9, 30, tzinfo=timezone.utc),
+            ),
+        )
+
+        assert collection["extent"]["temporal"]["interval"] == [["1999-01-01T00:00:00Z", None]]
+
+    @pytest.mark.unit
+    def test_builds_the_extent_when_the_collection_has_none(self) -> None:
+        collection: dict[str, Any] = {}
+
+        set_temporal_extent(
+            collection,
+            (
+                datetime(2020, 4, 1, tzinfo=timezone.utc),
+                datetime(2020, 9, 30, tzinfo=timezone.utc),
+            ),
+        )
+
+        assert collection["extent"]["temporal"]["interval"] == [
+            ["2020-04-01T00:00:00Z", "2020-09-30T00:00:00Z"]
+        ]


### PR DESCRIPTION
## What this changes

`portolan add` now documents a tabular collection's table. A geometry-less
Parquet gets `table:columns` and `table:row_count`, the table extension is
declared, and a temporal column fills `extent.temporal`. Columns land on the
collection when the Parquet stands alone, and on the asset when another Parquet
data asset already owns the collection-level schema.

The conformance gate drops the two advisories #749 pinned, and its fixture gains
a timestamp column so the extent half of the rule is covered rather than assumed.

## Why

Resolves #749. A consumer could not learn a tabular collection's schema without
opening the file. The tabular writer builds `collection.json` outside
`finalize_items`, and `_apply_table_extension_from_disk` gates on
`FormatType.VECTOR`, so neither route reached `add_table_extension`.

PTL-VIZ-001 went with it: `table:columns` is how rashid decides whether a
collection is geospatial, and without an answer it softens the thumbnail MUST to
a warning instead of skipping the check.

## Verification

The issue's own reproduction, now clean, plus the emitted bytes:

```console
$ uv run portolan check /tmp/tabbug | grep -E "PTL-DAT-015|PTL-VIZ-001"
$ jq -c '."table:columns", ."table:row_count", .extent.temporal' \
    /tmp/tabbug/demographics/collection.json
[{"name":"tract_id","type":"string"},{"name":"population","type":"int64"},{"name":"surveyed_at","type":"timestamp[us]"}]
2
{"interval":[["2020-04-01T00:00:00Z","2020-09-30T00:00:00Z"]]}
```

Reverting the stamp turns the gate red, so the assertions bite:

```console
$ uv run pytest tests/integration/test_generated_catalog_conformance.py -q
FAILED ...::TestGeneratedCatalogConformance::test_no_unexpected_advisories
FAILED ...::TestTheTabularCollectionDocumentsItsTable::test_columns_land_on_the_collection
FAILED ...::TestTheTabularCollectionDocumentsItsTable::test_the_table_extension_is_declared
FAILED ...::TestTheTabularCollectionDocumentsItsTable::test_the_temporal_extent_comes_from_the_timestamp_column
4 failed, 33 passed in 5.19s
```

With the fix in place, and a geo collection checked for a mistargeted stamp:

```console
$ uv run pytest tests/integration/test_generated_catalog_conformance.py \
    tests/unit/test_tabular_metadata.py -q
56 passed in 5.18s
```

Data read: `tests/fixtures/realdata/road-detections.parquet` for the companion
case, and the census table the gate generates.
