### PR TITLE
fix(item): derive media type from the extension registry (#736)

### DIFF
--- a/portolan_cli/item.py
+++ b/portolan_cli/item.py
@@ -11,9 +11,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from portolan_cli import extension_registry as _reg
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
 from portolan_cli.models.item import AssetModel, ItemModel
+
+# Sourced from the registry so this cannot drift from what `add` writes. A COG
+# missing "profile=cloud-optimized" is invisible to rashid's COG detection gate.
+_MEDIA_TYPE_MAP: dict[str, str] = _reg.field_map("media_type")
+
+# The registry keys only ".parquet", but this module's own geometry path treats
+# ".geoparquet" as a parquet variant (see _extract_geometry_from_file). Alias it
+# to the registry's value so the two stay consistent without a second literal.
+_MEDIA_TYPE_MAP.setdefault(".geoparquet", _MEDIA_TYPE_MAP[".parquet"])
 
 
 def create_item(
@@ -154,18 +164,7 @@ def _get_media_type(path: Path) -> str:
     Returns:
         Media type string.
     """
-    suffix = path.suffix.lower()
-
-    media_types = {
-        ".parquet": "application/vnd.apache.parquet",
-        ".geoparquet": "application/vnd.apache.parquet",
-        ".tif": "image/tiff; application=geotiff",
-        ".tiff": "image/tiff; application=geotiff",
-        ".json": "application/json",
-        ".geojson": "application/geo+json",
-    }
-
-    return media_types.get(suffix, "application/octet-stream")
+    return _MEDIA_TYPE_MAP.get(path.suffix.lower(), "application/octet-stream")
 
 
 def write_item_json(item: ItemModel, path: Path) -> Path:

--- a/tests/unit/test_item_media_type.py
+++ b/tests/unit/test_item_media_type.py
@@ -1,0 +1,54 @@
+"""Regression tests for item media-type derivation (issue #736).
+
+`item._get_media_type` carried its own hardcoded extension map, so a COG came
+out as `image/tiff; application=geotiff` without `profile=cloud-optimized`.
+rashid uses `is_cog_media_type` as a detection gate, so the missing profile made
+`PTL-MIR-001` silently never fire instead of flagging the collection. `add` was
+unaffected because it uses the registry-backed map in `preparation`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portolan_cli import extension_registry as _reg
+from portolan_cli.item import _get_media_type, create_item
+
+pytestmark = pytest.mark.unit
+
+COG_MEDIA_TYPE = "image/tiff; application=geotiff; profile=cloud-optimized"
+
+
+@pytest.mark.parametrize("filename", ["scene.tif", "scene.tiff"])
+def test_geotiff_media_type_carries_cog_profile(filename: str) -> None:
+    # Pre-fix, the hardcoded map dropped "; profile=cloud-optimized".
+    assert _get_media_type(Path(filename)) == COG_MEDIA_TYPE
+
+
+def test_media_types_match_the_registry() -> None:
+    """Every known extension agrees with the registry, so the two cannot drift."""
+    for ext, expected in _reg.field_map("media_type").items():
+        assert _get_media_type(Path(f"sample{ext}")) == expected, ext
+
+
+def test_unknown_extension_still_falls_back() -> None:
+    assert _get_media_type(Path("sample.unknown")) == "application/octet-stream"
+
+
+def test_geoparquet_alias_tracks_parquet() -> None:
+    """The registry keys only .parquet, but this module accepts either suffix."""
+    assert _get_media_type(Path("data.geoparquet")) == _get_media_type(Path("data.parquet"))
+
+
+@pytest.mark.parametrize("suffix", [".tif", ".tiff"])
+def test_create_item_emits_cog_media_type(tmp_path: Path, suffix: str) -> None:
+    """The issue's reproduction: create_item's data asset must name the profile."""
+    source = Path(__file__).parent.parent / "fixtures" / "raster" / "valid" / "singleband.tif"
+    data_path = tmp_path / f"scene1{suffix}"
+    data_path.write_bytes(source.read_bytes())
+
+    item = create_item("scene1", data_path, "imagery")
+
+    assert item.to_dict()["assets"]["data"]["type"] == COG_MEDIA_TYPE


### PR DESCRIPTION
## What this changes

`item._get_media_type` now reads the shared `extension_registry` map instead of
its own hardcoded dict, so a COG's data asset carries `profile=cloud-optimized`.
`.geoparquet` is aliased to the registry's `.parquet` value, because the registry
does not key it while this module's geometry path accepts either suffix.

## Why

Resolves #736. The hardcoded map dropped the profile, and rashid uses
`is_cog_media_type` as a detection gate, so `PTL-MIR-001` never fired and scene
counting undercounted. Catalogs were silently under-validated rather than
flagged. `add` was already correct via `preparation`, so the two paths disagreed.

## Verification

The issue's reproduction, run against `tests/fixtures/realdata/rapidai4eo-sample.tif`.

```console
$ uv run python -c "
from pathlib import Path
from portolan_cli.item import create_item
it = create_item('scene1', Path('tests/fixtures/realdata/rapidai4eo-sample.tif'), 'demo')
print(it.to_dict()['assets']['data']['type'])"
image/tiff; application=geotiff; profile=cloud-optimized
```

`item.py` and `preparation.py` now agree, which was the disagreement reported.

```console
$ uv run python -c "
from portolan_cli.item import _get_media_type as a
from portolan_cli.preparation import _get_media_type as b
from pathlib import Path
p=Path('x.tif'); print(a(p)); print(b(p)); print('match', a(p)==b(p))"
image/tiff; application=geotiff; profile=cloud-optimized
image/tiff; application=geotiff; profile=cloud-optimized
match True
```

Suites and gates.

```console
$ uv run pytest -m unit -q --no-cov
5626 passed, 9 skipped, 1318 deselected

$ uv run pytest -m integration -q --no-cov
1109 passed, 5 skipped, 5839 deselected

$ uv run mypy portolan_cli && uv run lint-imports
Success: no issues found in 158 source files
Contracts: 6 kept, 0 broken.
```
