### PR TITLE
fix(sync): skip a missing optional derivative on push (#735)

### DIFF
--- a/.claude/rules/sync.md
+++ b/.claude/rules/sync.md
@@ -89,6 +89,26 @@ uploaded.
 one. Diff by sha256 against the remote `versions.json` and upload only new or
 changed assets. (See `_get_assets_to_upload` in `push.py`.)
 
+## A missing optional derivative warns, a missing data asset raises
+
+The spec gives every asset at least one role. See portolan-spec
+specs/portolan/core.md, section Assets. Four roles mark an optional derivative,
+namely `visual`, `thumbnail`, `style` and `collection-mirror`. Single-File
+Collections says a collection "may optionally carry a `.pmtiles`, a
+`thumbnail.png`, and a `styles/` directory". Push skips one that left the disk,
+and it warns. Two roles keep the `FileNotFoundError`, namely `data` and `source`.
+Nothing can rebuild those (#735). Conformance gaps belong to `portolan check`,
+not to push.
+
+The predicate `derived_assets.is_optional_derivative` decides. It reads the role
+from the collection.json or item.json that registers the href. The lookup runs
+only for an absent asset, so the common path pays nothing. Filenames are a
+fallback for an href no STAC object claims. Never classify by a filename alone.
+The extension registry gives `.pmtiles` the role `data`, so push would drop a
+publisher's own PMTiles as a derivative. Never classify by a versions.json field
+either. A data asset and a derived asset carry the same fields there, and
+published catalogs predate any new flag.
+
 ## Discovery recurses, nested catalogs exist
 
 Collection discovery must `rglob("versions.json")` (skipping `.portolan/`) so a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions are recorded where they apply (see `.claude/rules/documentation.md`)
 - **NO** new dependencies without discussion
 
-<!-- freshness: last-verified: 2026-08-13 -->
+<!-- freshness: last-verified: 2026-08-18 -->
 ## Design Principles
 
 | Principle | Meaning |

--- a/portolan_cli/collection_thumbnail.py
+++ b/portolan_cli/collection_thumbnail.py
@@ -31,20 +31,25 @@ from pathlib import Path, PurePath
 from typing import Any
 
 from portolan_cli import extension_registry as _reg
+from portolan_cli.constants import ROLE_THUMBNAIL
 from portolan_cli.formats import is_geoparquet
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import detail, warn
 from portolan_cli.stac_parquet import sync_file_extension
 from portolan_cli.sync.checksums import compute_checksum, multihash_sha256
 from portolan_cli.versions import track_generated_assets
-from portolan_cli.viz.thumbnail import generate_vector_thumbnail, get_thumbnail_config
+from portolan_cli.viz.thumbnail import (
+    generate_vector_thumbnail,
+    get_thumbnail_config,
+    is_generated_thumbnail,
+)
 
 logger = logging.getLogger(__name__)
 
 #: The canonical asset key. STAC consumers find a thumbnail by role, but a
 #: well-known key keeps collection.json readable and matches the item-level
 #: convention in ``preparation._ROLE_KEYS``.
-THUMBNAIL_ASSET_KEY = "thumbnail"
+THUMBNAIL_ASSET_KEY = ROLE_THUMBNAIL
 
 #: Extensions that may serve as a thumbnail, per rashid's ``_THUMBNAIL_TYPES``.
 #: Sourced from the extension registry so media types stay single-sourced.
@@ -119,7 +124,7 @@ def register_collection_thumbnail(
     asset: dict[str, Any] = {
         "href": f"./{href}",
         "type": _media_type_for(thumbnail_path),
-        "roles": ["thumbnail"],
+        "roles": [ROLE_THUMBNAIL],
     }
     if title:
         asset["title"] = title
@@ -144,7 +149,9 @@ def register_collection_thumbnail(
 
 
 def _has_thumbnail_asset(data: dict[str, Any]) -> bool:
-    return any("thumbnail" in asset.get("roles", []) for asset in data.get("assets", {}).values())
+    return any(
+        ROLE_THUMBNAIL in asset.get("roles", []) for asset in data.get("assets", {}).values()
+    )
 
 
 def _claimed_hrefs(data: dict[str, Any]) -> set[str]:
@@ -156,7 +163,7 @@ def _claimed_hrefs(data: dict[str, Any]) -> set[str]:
     """
     claimed: set[str] = set()
     for asset in data.get("assets", {}).values():
-        if "thumbnail" in asset.get("roles", []):
+        if ROLE_THUMBNAIL in asset.get("roles", []):
             continue
         href = asset.get("href", "")
         if href:
@@ -166,7 +173,7 @@ def _claimed_hrefs(data: dict[str, Any]) -> set[str]:
 
 def _is_generated(path: Path) -> bool:
     """True for the ``{stem}.thumb.{ext}`` name ``thumbnail_path_for`` writes."""
-    return path.stem.lower().endswith(".thumb")
+    return is_generated_thumbnail(path.name)
 
 
 def _is_adoptable(path: Path) -> bool:
@@ -226,7 +233,7 @@ def _find_item_thumbnail(collection_path: Path, data: dict[str, Any]) -> Path | 
         except (OSError, json.JSONDecodeError):
             continue
         for asset in item.get("assets", {}).values():
-            if "thumbnail" not in asset.get("roles", []):
+            if ROLE_THUMBNAIL not in asset.get("roles", []):
                 continue
             href = str(asset.get("href", "")).removeprefix("./")
             candidate = item_json.parent / href

--- a/portolan_cli/constants.py
+++ b/portolan_cli/constants.py
@@ -110,6 +110,32 @@ SIDECAR_PATTERNS: dict[str, list[str]] = {
     primary: list(patterns) for primary, patterns in _reg.SIDECAR_OF.items()
 }
 
+# STAC asset roles, as the spec names them. See portolan-spec
+# specs/portolan/core.md, section Assets. Every asset carries a `type` and at
+# least one role. Role `data` marks the primary GeoParquet, COG or Parquet. Role
+# `visual` marks the PMTiles derivative a client draws. Role `thumbnail` marks
+# the preview image. Role `style` marks a MapLibre style file, which the spec
+# itself defines. Role `default` marks the one style a client draws first. Role
+# `collection-mirror` marks the STAC-GeoParquet copy of a collection's items.
+# Role `source` marks an upstream original. One home keeps every writer and every
+# reader on the same vocabulary.
+ROLE_VISUAL: str = "visual"
+ROLE_THUMBNAIL: str = "thumbnail"
+ROLE_STYLE: str = "style"
+ROLE_DEFAULT: str = "default"
+ROLE_COLLECTION_MIRROR: str = "collection-mirror"
+
+# Roles the spec calls optional. Single-File Collections in core.md says a
+# collection "may optionally carry a `.pmtiles`, a `thumbnail.png`, and a
+# `styles/` directory". The item mirror in formats.md is a SHOULD and a derived
+# copy. The item JSON stays the normative representation. Portolan rebuilds each
+# artifact from data the catalog still holds. An absent one is a warning, not a
+# failed push (Issue #735). Roles `data`, `source` and `metadata` are absent on
+# purpose, because nothing can reconstruct them.
+OPTIONAL_DERIVATIVE_ROLES: frozenset[str] = frozenset(
+    {ROLE_VISUAL, ROLE_THUMBNAIL, ROLE_STYLE, ROLE_COLLECTION_MIRROR}
+)
+
 # Change detection constants
 # 2 second tolerance for NFS/CIFS compatibility where mtime resolution is coarse
 MTIME_TOLERANCE_SECONDS: float = 2.0

--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -44,6 +44,7 @@ from portolan_cli.viz.thumbnail import (
     ThumbnailConfig,
     generate_vector_thumbnail,
     get_thumbnail_config,
+    thumbnail_path_for,
 )
 
 logger = logging.getLogger(__name__)
@@ -220,10 +221,12 @@ def generate_cog_thumbnail(
         logger.debug("rasterio/numpy not available, skipping thumbnail generation")
         return None
 
-    # Use ".thumb.jpg" rather than ".jpg" so we don't clobber a user-supplied
-    # sibling thumbnail (e.g. hand-curated data.jpg next to data.tif). The
-    # extension is still .jpg, so _scan_item_assets assigns role "thumbnail".
-    thumb_path = cog_path.with_name(f"{cog_path.stem}.thumb.jpg")
+    # `thumbnail_path_for` names it ".thumb.jpg" rather than ".jpg", so we leave
+    # a user-supplied sibling alone (e.g. hand-curated data.jpg next to
+    # data.tif). The extension stays .jpg, so _scan_item_assets assigns role
+    # "thumbnail". The vector render calls the same helper. One convention then
+    # names every thumbnail we write, and push recognizes it (Issue #735).
+    thumb_path = thumbnail_path_for(cog_path)
 
     try:
         with rasterio.open(cog_path) as src:

--- a/portolan_cli/derived_assets.py
+++ b/portolan_cli/derived_assets.py
@@ -1,0 +1,176 @@
+"""Tell an optional derivative from data nothing can rebuild (Issue #735).
+
+``versions.json`` records every file a collection publishes. ``push`` treated
+each entry as a hard requirement. One absent file then failed the whole catalog.
+That rule fits the user's data. It does not fit a derivative Portolan generates.
+One ``portolan add`` on a single COG records two of them. A deleted thumbnail
+then broke push on a sound catalog.
+
+The spec supplies the vocabulary. Section Assets in specs/portolan/core.md gives
+every asset a ``type`` and at least one role. It also names each artifact here.
+Role ``data`` marks the primary GeoParquet, COG or Parquet. Role ``visual`` marks
+the PMTiles derivative a client draws. Role ``thumbnail`` marks the preview
+image. Role ``style`` marks a MapLibre style file. Role ``collection-mirror``
+marks the items.parquet copy. Section Single-File Collections then says a
+collection "may optionally carry a ``.pmtiles``, a ``thumbnail.png``, and a
+``styles/`` directory". The item mirror in formats.md is a SHOULD and "a derived
+Parquet copy". The item JSON stays the normative representation. So an absent
+optional derivative is no reason to abort a push. Conformance gaps belong to
+``portolan check``.
+
+The role decides. Function :func:`resolve_asset_roles` reads the collection.json
+or item.json that registers the href. It returns the roles that object records.
+The lookup runs only for an asset that is already absent, so the common path pays
+nothing.
+
+Filenames are a fallback for an href no STAC object claims. That happens when the
+manifest outlives the metadata. A name cannot replace a role. A publisher may ship
+PMTiles as the primary asset. The extension registry gives ``.pmtiles`` the role
+``data``, so a name alone would skip a file nothing can rebuild. Each pattern
+comes from the module that writes the file.
+
+* ``items.parquet``, from ``stac_parquet.PARQUET_FILENAME``
+* ``*.pmtiles``, from ``viz.pmtiles_links.PMTILES_SUFFIX``
+* ``*.thumb.*``, from ``viz.thumbnail.is_generated_thumbnail``
+
+An asset with role ``source`` stays a hard failure. The spec says a publisher
+"does not need to retain, rehost, or redistribute" the upstream original. Such an
+asset carries an absolute upstream href. versions.json tracks catalog-relative
+paths, so that asset never reaches this code. What does reach it is a local
+original the publisher kept and then lost. Portolan cannot rebuild that file, so
+push says so.
+
+Classification never reads a versions.json field. A data asset and a derived
+asset carry the same fields there. An item-level asset from ``finalization``
+carries no ``source_path``, no ``feature_count`` and no ``schema_fingerprint``.
+That is the same shape ``track_generated_assets`` writes. Published beta catalogs
+also predate any new flag. Such a flag would keep the hard failure on the
+catalogs that hit this bug.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from portolan_cli.constants import OPTIONAL_DERIVATIVE_ROLES, ROLE_DEFAULT
+from portolan_cli.stac_parquet import PARQUET_FILENAME
+from portolan_cli.viz.pmtiles_links import PMTILES_SUFFIX
+from portolan_cli.viz.thumbnail import is_generated_thumbnail
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["is_derived_asset", "is_optional_derivative", "resolve_asset_roles"]
+
+_COLLECTION_JSON = "collection.json"
+
+
+def _candidate_stac_files(catalog_root: Path, asset_path: Path) -> list[Path]:
+    """STAC objects that could register ``asset_path``, nearest first.
+
+    An item JSON takes the name of its item directory. The search therefore reads
+    every JSON beside the asset. It then walks up to each ``collection.json``,
+    because a collection thumbnail may point into an item directory.
+    """
+    candidates: list[Path] = []
+    directory = asset_path.parent
+    if directory.is_dir():
+        candidates.extend(sorted(p for p in directory.glob("*.json") if p.is_file()))
+    while True:
+        collection_json = directory / _COLLECTION_JSON
+        if collection_json.is_file() and collection_json not in candidates:
+            candidates.append(collection_json)
+        if directory == catalog_root or catalog_root not in directory.parents:
+            break
+        directory = directory.parent
+    return candidates
+
+
+def _roles_from_stac_file(stac_file: Path, asset_path: Path) -> set[str] | None:
+    """Roles ``stac_file`` gives ``asset_path``, or None when it claims no such href."""
+    try:
+        data: dict[str, Any] = json.loads(stac_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.debug("Cannot read %s: %s", stac_file, exc)
+        return None
+    assets = data.get("assets")
+    if not isinstance(assets, dict):
+        return None
+    for asset in assets.values():
+        if not isinstance(asset, dict):
+            continue
+        href = str(asset.get("href", ""))
+        if not href or "://" in href or href.startswith("/"):
+            continue
+        # Resolve both sides. The asset is absent, so resolve() cannot verify it,
+        # but it still normalizes "..". Resolving one side only would break every
+        # catalog reached through a symlink, macOS /var among them.
+        candidate = (stac_file.parent / href.removeprefix("./")).resolve()
+        if candidate != asset_path.resolve():
+            continue
+        roles = asset.get("roles")
+        return {str(role) for role in roles} if isinstance(roles, list) else set()
+    return None
+
+
+def resolve_asset_roles(catalog_root: Path, href: str) -> set[str]:
+    """The roles the owning STAC object records for ``href``.
+
+    Args:
+        catalog_root: Path to the catalog root.
+        href: Catalog-root-relative asset href from versions.json.
+
+    Returns:
+        The roles, or an empty set when no readable STAC object claims the href.
+    """
+    asset_path = catalog_root / href
+    for stac_file in _candidate_stac_files(catalog_root, asset_path):
+        roles = _roles_from_stac_file(stac_file, asset_path)
+        if roles is not None:
+            return roles
+    return set()
+
+
+def is_optional_derivative(catalog_root: Path, href: str) -> bool:
+    """True when the catalog can lose ``href`` and stay sound.
+
+    The role decides. An asset is optional when the spec calls every role it
+    carries an optional derivative. Role ``default`` does not count, because it
+    only qualifies a style. An asset with no role on record falls back to
+    :func:`is_derived_asset`.
+
+    Args:
+        catalog_root: Path to the catalog root.
+        href: Catalog-root-relative asset href from versions.json.
+
+    Returns:
+        True for an artifact push may skip, False for data it must not skip.
+    """
+    decisive = resolve_asset_roles(catalog_root, href) - {ROLE_DEFAULT}
+    if decisive:
+        return decisive <= OPTIONAL_DERIVATIVE_ROLES
+    return is_derived_asset(href)
+
+
+def is_derived_asset(href: str) -> bool:
+    """True when ``href`` carries the name of an artifact Portolan generates.
+
+    The fallback for an href no STAC object claims. Prefer
+    :func:`is_optional_derivative`, which asks the role first.
+
+    Args:
+        href: Catalog-root-relative asset href from versions.json, POSIX-style,
+            for example ``imagery/scene1/scene1.thumb.jpg``.
+
+    Returns:
+        True for the item mirror, a PMTiles archive, or a thumbnail we drew.
+        False for anything else. The caller then treats it as the user's data.
+    """
+    name = PurePosixPath(href).name.lower()
+    if name == PARQUET_FILENAME:
+        return True
+    if name.endswith(PMTILES_SUFFIX):
+        return True
+    return is_generated_thumbnail(name)

--- a/portolan_cli/stac_parquet.py
+++ b/portolan_cli/stac_parquet.py
@@ -33,6 +33,7 @@ from typing import Any
 
 from rashid.catalog import is_absolute_href
 
+from portolan_cli.constants import ROLE_COLLECTION_MIRROR
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import info, warn
 from portolan_cli.sync.checksums import file_fields
@@ -429,8 +430,8 @@ def register_mirror_asset(collection_path: Path) -> None:
     if matching:
         for asset in matching:
             roles = asset.setdefault("roles", [])
-            if "collection-mirror" not in roles:
-                roles.append("collection-mirror")
+            if ROLE_COLLECTION_MIRROR not in roles:
+                roles.append(ROLE_COLLECTION_MIRROR)
                 modified = True
             if "stac-items" in roles:
                 roles.remove("stac-items")
@@ -445,7 +446,7 @@ def register_mirror_asset(collection_path: Path) -> None:
             "href": f"./{PARQUET_FILENAME}",
             "type": PARQUET_MEDIA_TYPE,
             "title": "STAC items as GeoParquet",
-            "roles": ["collection-mirror"],
+            "roles": [ROLE_COLLECTION_MIRROR],
         }
         stamp_file_fields(asset, collection_path)
         assets[asset_key] = asset

--- a/portolan_cli/sync/push.py
+++ b/portolan_cli/sync/push.py
@@ -36,6 +36,7 @@ from portolan_cli.async_utils import (
 )
 from portolan_cli.catalog import intermediate_catalog_ids
 from portolan_cli.constants import LEGACY_GLOB_FIELD
+from portolan_cli.derived_assets import is_optional_derivative
 from portolan_cli.logo import LOGO_ASSETS_DIRNAME
 from portolan_cli.output import detail, error, info, output_section, success, warn
 from portolan_cli.sync.upload import ObjectStore, setup_store
@@ -492,6 +493,11 @@ def _get_assets_to_upload(
     new or changed (different sha256) are included. This prevents re-uploading
     unchanged assets when adding a single file to a large catalog (Issue #329).
 
+    A recorded asset that is absent from disk raises. One exception applies. An
+    optional derivative only warns, and this function skips it (Issue #735). The
+    asset role in the STAC metadata decides which is which. See
+    ``derived_assets.is_optional_derivative``.
+
     Args:
         catalog_root: Path to catalog root.
         versions_data: Local versions.json data.
@@ -503,7 +509,8 @@ def _get_assets_to_upload(
         List of absolute paths to asset files that need to be uploaded.
 
     Raises:
-        FileNotFoundError: If a referenced asset file doesn't exist.
+        FileNotFoundError: If a referenced ``data`` or ``source`` asset file
+            doesn't exist.
     """
     # Build set of (href, sha256) pairs from all remote versions
     remote_assets = _build_remote_asset_set(remote_versions_data)
@@ -537,6 +544,17 @@ def _get_assets_to_upload(
             # Resolve path relative to catalog root
             asset_path = catalog_root / href
             if not asset_path.exists():
+                # The spec calls four roles optional derivatives, namely
+                # `visual`, `thumbnail`, `style` and `collection-mirror`. See
+                # portolan-spec specs/portolan/core.md, sections Assets and
+                # Single-File Collections. Portolan rebuilds each one from data
+                # the catalog still holds. An absent one must not fail a sound
+                # push (Issue #735). Conformance gaps belong to `portolan check`.
+                # Roles `data` and `source` stay a hard error, because nothing
+                # can reconstruct them.
+                if is_optional_derivative(catalog_root, href):
+                    warn(f"Optional asset not found, skipped: {href} (version {version_str})")
+                    continue
                 raise FileNotFoundError(
                     f"Asset referenced in version {version_str} not found: {href}"
                 )

--- a/portolan_cli/viz/pmtiles.py
+++ b/portolan_cli/viz/pmtiles.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from portolan_cli.constants import ROLE_VISUAL
 from portolan_cli.errors import PortolanError
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import error, info, success, warn
@@ -40,7 +41,11 @@ from portolan_cli.versions import track_generated_assets
 # importing this module (which pulls in output/thumbnail/style). Re-imported
 # here — both constants are used below — so pmtiles.py's public API is unchanged
 # for existing callers/tests (see pmtiles_links.py, issue #563).
-from portolan_cli.viz.pmtiles_links import PMTILES_MEDIA_TYPE, WEB_MAP_LINKS_EXTENSION
+from portolan_cli.viz.pmtiles_links import (
+    PMTILES_MEDIA_TYPE,
+    PMTILES_SUFFIX,
+    WEB_MAP_LINKS_EXTENSION,
+)
 from portolan_cli.viz.thumbnail import (
     generate_vector_thumbnail,
     get_thumbnail_config,
@@ -420,7 +425,7 @@ def add_pmtiles_asset_to_collection(
         "href": pmtiles_href,
         "type": PMTILES_MEDIA_TYPE,
         "title": f"{source_title} (vector tiles)",
-        "roles": ["visual"],
+        "roles": [ROLE_VISUAL],
     }
 
     # Add any extra properties
@@ -679,7 +684,7 @@ def generate_pmtiles_for_collection(
     geoparquet_assets = _find_geoparquet_assets(collection_path)
 
     for asset_key, parquet_path in geoparquet_assets:
-        pmtiles_path = parquet_path.with_suffix(".pmtiles")
+        pmtiles_path = parquet_path.with_suffix(PMTILES_SUFFIX)
 
         # Compute href relative to collection (preserves subdirectory structure)
         # Use as_posix() for STAC-compliant forward slashes on all platforms

--- a/portolan_cli/viz/pmtiles_links.py
+++ b/portolan_cli/viz/pmtiles_links.py
@@ -19,6 +19,12 @@ from typing import Any
 # MIME type for PMTiles (matches add.py).
 PMTILES_MEDIA_TYPE = "application/vnd.pmtiles"
 
+# Filename suffix of a generated tile archive, and the single source of that
+# name. ``pmtiles.py`` writes ``parquet_path.with_suffix(PMTILES_SUFFIX)``.
+# ``derived_assets.py`` reads the same constant, so push and the writer agree on
+# which files Portolan generated (Issue #735).
+PMTILES_SUFFIX = ".pmtiles"
+
 # web-map-links STAC extension declared for the rel="pmtiles" collection link
 # (Issue #569). v1.3.0 defines the pmtiles rel, the application/vnd.pmtiles media
 # type, and the pmtiles:layers field for default-visible vector layers.
@@ -38,7 +44,7 @@ def pmtiles_asset_hrefs(assets: dict[str, Any]) -> list[str]:
         if isinstance(asset, dict)
         and (
             asset.get("type") == PMTILES_MEDIA_TYPE
-            or str(asset.get("href", "")).endswith(".pmtiles")
+            or str(asset.get("href", "")).endswith(PMTILES_SUFFIX)
         )
         and asset.get("href")
     ]

--- a/portolan_cli/viz/style.py
+++ b/portolan_cli/viz/style.py
@@ -30,7 +30,12 @@ from pathlib import Path
 from typing import Any
 
 from portolan_cli.config import load_config
-from portolan_cli.constants import LEGACY_LEGEND_MANIFEST_FIELD, LEGACY_STYLE_MANIFEST_FIELD
+from portolan_cli.constants import (
+    LEGACY_LEGEND_MANIFEST_FIELD,
+    LEGACY_STYLE_MANIFEST_FIELD,
+    ROLE_DEFAULT,
+    ROLE_STYLE,
+)
 from portolan_cli.json_io import write_json_atomic
 from portolan_cli.output import info
 from portolan_cli.stac_parquet import stamp_file_fields, sync_file_extension
@@ -394,11 +399,12 @@ def enrich_cog_assets(
 
 #: Role every style asset carries. A client discovers a collection's styles by
 #: filtering assets on it, which is why the spec defines no manifest property.
-STYLE_ROLE = "style"
+#: The name comes from ``constants``, the one home for the role vocabulary.
+STYLE_ROLE = ROLE_STYLE
 
 #: Second role marking the style a client should draw first (core.md,
 #: Visualization Styles).
-DEFAULT_ROLE = "default"
+DEFAULT_ROLE = ROLE_DEFAULT
 
 #: Asset key :func:`write_default_style` writes. Nothing in STAC reads meaning
 #: into a key, so this only breaks the tie when no style is marked yet.

--- a/portolan_cli/viz/thumbnail.py
+++ b/portolan_cli/viz/thumbnail.py
@@ -20,7 +20,7 @@ import logging
 import math
 import threading
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from portolan_cli.config import load_config
@@ -194,6 +194,14 @@ def get_thumbnail_config(catalog_path: Path) -> ThumbnailConfig:
     )
 
 
+#: Infix that marks an image Portolan drew, as in ``scene1.thumb.jpg``. It keeps
+#: a render off a hand-curated sibling such as ``scene1.jpg``. That also makes it
+#: the one reliable mark of our own output. ``convert.py``,
+#: ``collection_thumbnail.py`` and ``derived_assets.py`` all read the name from
+#: here, so no module repeats it.
+THUMBNAIL_STEM_SUFFIX = ".thumb"
+
+
 def thumbnail_path_for(data_path: Path) -> Path:
     """Return the thumbnail path for a data file (single source of the convention).
 
@@ -207,7 +215,18 @@ def thumbnail_path_for(data_path: Path) -> Path:
     Returns:
         Path to the sibling thumbnail file.
     """
-    return data_path.with_name(f"{data_path.stem}.thumb.jpg")
+    return data_path.with_name(f"{data_path.stem}{THUMBNAIL_STEM_SUFFIX}.jpg")
+
+
+def is_generated_thumbnail(filename: str) -> bool:
+    """True when ``filename`` carries the ``{stem}.thumb.{ext}`` name we write.
+
+    The test reads the basename alone. It answers for a versions.json href and
+    for a path on disk. An adopted ``thumbnail.png`` returns False, because that
+    image belongs to the user. Only a file Portolan drew is safe to redraw
+    (Issue #735).
+    """
+    return PurePosixPath(filename.lower()).stem.endswith(THUMBNAIL_STEM_SUFFIX)
 
 
 # =============================================================================

--- a/tests/integration/test_push_missing_derived_asset.py
+++ b/tests/integration/test_push_missing_derived_asset.py
@@ -1,0 +1,128 @@
+"""The Issue #735 reproduction, end to end on real data.
+
+An ``init`` plus an ``add`` on one COG records three assets in version 1.0.0.
+They are the raster the user supplied, the ``.thumb.jpg`` Portolan drew from it,
+and the ``items.parquet`` mirror. A user who deletes either derived artifact
+once made push raise ``FileNotFoundError``. The rest of the catalog was fine.
+
+The roles here are the ones a real ``add`` emits, not a fixture's guess. That is
+what the classifier reads, per specs/portolan/core.md, section Assets.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.derived_assets import resolve_asset_roles
+from portolan_cli.sync.push import _get_assets_to_upload
+
+pytestmark = [pytest.mark.integration, pytest.mark.realdata]
+
+
+@pytest.fixture(scope="module")
+def raster_catalog(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A catalog with one added COG. Built once for this module."""
+    catalog_root = tmp_path_factory.mktemp("issue-735")
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["init", str(catalog_root), "--auto", "--license", "CC-BY-4.0", "--title", "Repro 735"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+
+    fixture = Path(__file__).parent.parent / "fixtures" / "realdata" / "rapidai4eo-sample.tif"
+    scene_dir = catalog_root / "imagery" / "scene1"
+    scene_dir.mkdir(parents=True)
+    shutil.copy(fixture, scene_dir / "scene1.tif")
+
+    result = runner.invoke(
+        cli,
+        [
+            "add",
+            "--portolan-dir",
+            str(catalog_root),
+            str(catalog_root / "imagery"),
+            "--datetime",
+            "2024-01-01",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, f"Add failed: {result.output}"
+    return catalog_root
+
+
+@pytest.fixture
+def catalog(raster_catalog: Path, tmp_path: Path) -> Path:
+    """A writable copy of the built catalog, one per test."""
+    destination = tmp_path / "catalog"
+    shutil.copytree(raster_catalog, destination)
+    return destination
+
+
+def _push_assets(catalog_root: Path) -> list[Path]:
+    """Drive the raise site the way ``push`` does, without a remote."""
+    versions_data = json.loads((catalog_root / "imagery" / "versions.json").read_text())
+    return _get_assets_to_upload(catalog_root, versions_data, ["1.0.0"], None)
+
+
+def test_add_records_both_derived_artifacts(catalog: Path) -> None:
+    """The premise of the bug: version 1.0.0 records artifacts add generated."""
+    versions_data = json.loads((catalog / "imagery" / "versions.json").read_text())
+    hrefs = {asset["href"] for asset in versions_data["versions"][0]["assets"].values()}
+
+    assert "imagery/scene1/scene1.tif" in hrefs
+    assert "imagery/scene1/scene1.thumb.jpg" in hrefs
+    assert "imagery/items.parquet" in hrefs
+
+
+def test_add_emits_the_roles_the_classifier_reads(catalog: Path) -> None:
+    """The emitted STAC gives each tracked file its spec role."""
+    assert resolve_asset_roles(catalog, "imagery/scene1/scene1.tif") == {"data"}
+    assert resolve_asset_roles(catalog, "imagery/scene1/scene1.thumb.jpg") == {"thumbnail"}
+    assert resolve_asset_roles(catalog, "imagery/items.parquet") == {"collection-mirror"}
+
+
+def test_missing_cog_thumbnail_is_skipped(
+    catalog: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The exact repro: delete the COG thumbnail, then push the collection."""
+    (catalog / "imagery" / "scene1" / "scene1.thumb.jpg").unlink()
+
+    hrefs = [path.relative_to(catalog).as_posix() for path in _push_assets(catalog)]
+
+    # Sorted because the order is not a contract. push.py iterates the assets
+    # dict in versions.json, so the order follows what add recorded, which
+    # follows filesystem enumeration and differs per platform.
+    assert sorted(hrefs) == ["imagery/items.parquet", "imagery/scene1/scene1.tif"]
+    assert "imagery/scene1/scene1.thumb.jpg" in capsys.readouterr().err
+
+
+def test_missing_items_parquet_is_skipped(
+    catalog: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The second path in the issue, where the item mirror is gone."""
+    (catalog / "imagery" / "items.parquet").unlink()
+
+    hrefs = [path.relative_to(catalog).as_posix() for path in _push_assets(catalog)]
+
+    assert sorted(hrefs) == [
+        "imagery/scene1/scene1.thumb.jpg",
+        "imagery/scene1/scene1.tif",
+    ]
+    assert "imagery/items.parquet" in capsys.readouterr().err
+
+
+def test_missing_source_raster_still_raises(catalog: Path) -> None:
+    """The user's COG is not derived, so its absence stays a hard failure."""
+    (catalog / "imagery" / "scene1" / "scene1.tif").unlink()
+
+    with pytest.raises(FileNotFoundError, match=r"imagery/scene1/scene1\.tif"):
+        _push_assets(catalog)

--- a/tests/unit/test_derived_assets.py
+++ b/tests/unit/test_derived_assets.py
@@ -1,0 +1,224 @@
+"""Unit tests for optional-derivative classification (Issue #735).
+
+The spec supplies the vocabulary. Section Assets in specs/portolan/core.md gives
+every asset at least one role. Role `data` marks the primary file. Role `visual`
+marks the PMTiles derivative a client draws. Role `thumbnail` marks the preview,
+role `style` a MapLibre style, role `collection-mirror` the items.parquet copy.
+Section Single-File Collections then says a collection "may optionally carry a
+`.pmtiles`, a `thumbnail.png`, and a `styles/` directory". So an absent optional
+derivative is no reason to fail a push. A `data` or `source` asset stays a hard
+error.
+
+The role comes first. The filename patterns run only when no STAC object claims
+the href. Each pattern comes from the module that writes the file.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import pytest
+
+from portolan_cli.derived_assets import (
+    is_derived_asset,
+    is_optional_derivative,
+    resolve_asset_roles,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _asset(href: str, roles: list[str]) -> dict[str, Any]:
+    return {"href": href, "type": "application/octet-stream", "roles": roles}
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> Path:
+    """A catalog whose STAC objects register one asset per spec role."""
+    collection = tmp_path / "imagery"
+    _write_json(
+        collection / "collection.json",
+        {
+            "type": "Collection",
+            "id": "imagery",
+            "assets": {
+                # A publisher's own PMTiles, published as the primary data.
+                "data": _asset("./data.pmtiles", ["data"]),
+                "geoparquet-items": _asset("./items.parquet", ["collection-mirror"]),
+                "visual": _asset("./render.pmtiles", ["visual"]),
+                "thumbnail": _asset("./thumbnail.png", ["thumbnail"]),
+                "style-labeled": _asset("./styles/style.json", ["style", "default"]),
+                "upstream": _asset("./original.gpkg", ["source"]),
+                # An image that is the data itself, not a preview.
+                "photo": _asset("./photo.png", ["data"]),
+                "remote": _asset("https://example.com/elsewhere.tif", ["visual"]),
+            },
+        },
+    )
+    _write_json(
+        collection / "scene1" / "scene1.json",
+        {
+            "type": "Feature",
+            "id": "scene1",
+            "assets": {
+                "data": _asset("./scene1.tif", ["data"]),
+                "thumbnail": _asset("./scene1.thumb.jpg", ["thumbnail"]),
+            },
+        },
+    )
+    return tmp_path
+
+
+class TestResolveAssetRoles:
+    """The href resolves to the roles its owning STAC object records."""
+
+    def test_collection_level_asset(self, catalog: Path) -> None:
+        assert resolve_asset_roles(catalog, "imagery/items.parquet") == {"collection-mirror"}
+
+    def test_item_level_asset(self, catalog: Path) -> None:
+        assert resolve_asset_roles(catalog, "imagery/scene1/scene1.tif") == {"data"}
+
+    def test_collection_asset_inside_an_item_directory(self, catalog: Path) -> None:
+        """A collection thumbnail may point into an item directory."""
+        assert resolve_asset_roles(catalog, "imagery/scene1/scene1.thumb.jpg") == {"thumbnail"}
+
+    def test_style_carries_both_roles(self, catalog: Path) -> None:
+        assert resolve_asset_roles(catalog, "imagery/styles/style.json") == {"style", "default"}
+
+    def test_unclaimed_href_resolves_to_nothing(self, catalog: Path) -> None:
+        assert resolve_asset_roles(catalog, "imagery/orphan.parquet") == set()
+
+    def test_absolute_href_never_matches_a_local_path(self, catalog: Path) -> None:
+        assert resolve_asset_roles(catalog, "imagery/elsewhere.tif") == set()
+
+    def test_unreadable_stac_object_resolves_to_nothing(self, tmp_path: Path) -> None:
+        (tmp_path / "imagery").mkdir()
+        (tmp_path / "imagery" / "collection.json").write_text("{not json", encoding="utf-8")
+        assert resolve_asset_roles(tmp_path, "imagery/items.parquet") == set()
+
+
+class TestOptionalByRole:
+    """The role decides, per specs/portolan/core.md."""
+
+    @pytest.mark.parametrize(
+        "href",
+        [
+            "imagery/items.parquet",
+            "imagery/render.pmtiles",
+            "imagery/thumbnail.png",
+            "imagery/styles/style.json",
+            "imagery/scene1/scene1.thumb.jpg",
+        ],
+    )
+    def test_optional_derivative_is_skippable(self, catalog: Path, href: str) -> None:
+        assert is_optional_derivative(catalog, href) is True
+
+    @pytest.mark.parametrize(
+        "href",
+        [
+            # `data` beats the filename. A publisher may publish PMTiles as the
+            # primary asset, and the extension registry gives .pmtiles role data.
+            "imagery/data.pmtiles",
+            "imagery/photo.png",
+            "imagery/scene1/scene1.tif",
+            # The publisher need not rehost an upstream original, but a local
+            # copy that vanished is still unrecoverable data.
+            "imagery/original.gpkg",
+        ],
+    )
+    def test_required_asset_is_not_skippable(self, catalog: Path, href: str) -> None:
+        assert is_optional_derivative(catalog, href) is False
+
+
+class TestFilenameFallback:
+    """With no role on record, the generated filenames decide."""
+
+    @pytest.mark.parametrize(
+        "href",
+        ["imagery/orphan.thumb.jpg", "imagery/items.parquet", "imagery/orphan.pmtiles"],
+    )
+    def test_generated_name_is_skippable(self, tmp_path: Path, href: str) -> None:
+        assert is_optional_derivative(tmp_path, href) is True
+
+    @pytest.mark.parametrize(
+        "href",
+        ["imagery/thumbnail.png", "imagery/scene1/scene1.tif", "imagery/data.parquet"],
+    )
+    def test_unknown_name_is_not_skippable(self, tmp_path: Path, href: str) -> None:
+        assert is_optional_derivative(tmp_path, href) is False
+
+
+class TestDerivedArtifacts:
+    """The fallback calls every generated filename derived."""
+
+    @pytest.mark.parametrize(
+        "href",
+        [
+            "items.parquet",
+            "imagery/items.parquet",
+            "imagery/nested/items.parquet",
+            "imagery/data.pmtiles",
+            "imagery/nested/data.pmtiles",
+            "imagery/scene1/scene1.thumb.jpg",
+            "imagery/data.thumb.jpg",
+            "imagery/SCENE1/SCENE1.THUMB.JPG",
+            "imagery/data.thumb.png",
+        ],
+    )
+    def test_generated_artifact_is_derived(self, href: str) -> None:
+        assert is_derived_asset(href) is True
+
+    def test_items_parquet_name_comes_from_the_generator(self) -> None:
+        """The mirror name is read from stac_parquet, not copied."""
+        from portolan_cli.stac_parquet import PARQUET_FILENAME
+
+        assert is_derived_asset(f"imagery/{PARQUET_FILENAME}") is True
+
+    def test_pmtiles_suffix_comes_from_the_generator(self) -> None:
+        """The PMTiles suffix is read from the viz layer, not copied."""
+        from portolan_cli.viz.pmtiles_links import PMTILES_SUFFIX
+
+        generated = PurePosixPath("imagery/data.parquet").with_suffix(PMTILES_SUFFIX)
+        assert is_derived_asset(str(generated)) is True
+
+    def test_thumbnail_name_comes_from_the_generator(self) -> None:
+        """The ``{stem}.thumb.jpg`` convention is read from the viz layer."""
+        from portolan_cli.viz.thumbnail import thumbnail_path_for
+
+        generated = thumbnail_path_for(Path("imagery/scene1/scene1.tif"))
+        assert is_derived_asset(generated.as_posix()) is True
+
+
+class TestSourceArtifacts:
+    """The fallback never calls an unknown filename derived."""
+
+    @pytest.mark.parametrize(
+        "href",
+        [
+            "imagery/scene1/scene1.tif",
+            "imagery/data.parquet",
+            "imagery/data.geojson",
+            # A collection thumbnail Portolan adopted rather than drew. With no
+            # role on record the conservative answer is a hard error (#735).
+            "imagery/thumbnail.png",
+            "imagery/thumbnail.jpg",
+            "imagery/preview.png",
+            # A photo collection: plain images that are the data itself.
+            "photos/2024/portrait.jpg",
+            "photos/2024/thumb.jpg",
+            # Near misses on the generated names.
+            "imagery/my-items.parquet",
+            "imagery/items.parquet.bak",
+            "imagery/pmtiles",
+            "imagery/thumb.parquet",
+        ],
+    )
+    def test_source_artifact_is_not_derived(self, href: str) -> None:
+        assert is_derived_asset(href) is False

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -887,6 +887,159 @@ class TestMissingAssetDetection:
             )
 
 
+class TestMissingDerivedAsset:
+    """Push warns and skips an optional derivative that left the disk (#735).
+
+    The spec calls a ``visual``, ``thumbnail``, ``style`` or
+    ``collection-mirror`` asset optional. Portolan rebuilds each one from other
+    files in the catalog. A user who deletes one still holds a sound catalog. An
+    asset with role ``data`` or ``source`` still raises. The role decides, and
+    the filenames only answer for an href no STAC object claims.
+    """
+
+    @staticmethod
+    def _versions_data(assets: dict[str, str]) -> dict[str, Any]:
+        """One version whose assets are ``{asset_name: href}``."""
+        return {
+            "versions": [
+                {
+                    "version": "1.0.0",
+                    "assets": {
+                        name: {"sha256": f"sha-{name}", "size_bytes": 10, "href": href}
+                        for name, href in assets.items()
+                    },
+                }
+            ]
+        }
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "missing_href",
+        [
+            "test/scene1/scene1.thumb.jpg",
+            "test/items.parquet",
+            "test/data.pmtiles",
+        ],
+    )
+    def test_missing_derived_asset_is_skipped(
+        self, local_catalog: Path, capsys: pytest.CaptureFixture[str], missing_href: str
+    ) -> None:
+        """Push skips a recorded derived artifact that is no longer on disk."""
+        from portolan_cli.sync.push import _get_assets_to_upload
+
+        source = local_catalog / "test" / "scene1" / "scene1.tif"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(b"raster bytes")
+
+        assets = _get_assets_to_upload(
+            catalog_root=local_catalog,
+            versions_data=self._versions_data(
+                {
+                    "scene1/scene1.tif": "test/scene1/scene1.tif",
+                    "derived": missing_href,
+                }
+            ),
+            versions_to_push=["1.0.0"],
+        )
+
+        assert assets == [source.resolve()]
+        assert missing_href in capsys.readouterr().err
+
+    @pytest.mark.unit
+    def test_missing_source_asset_still_raises(self, local_catalog: Path) -> None:
+        """The user's own data is still a hard failure."""
+        from portolan_cli.sync.push import _get_assets_to_upload
+
+        with pytest.raises(FileNotFoundError, match=r"test/scene1/scene1\.tif"):
+            _get_assets_to_upload(
+                catalog_root=local_catalog,
+                versions_data=self._versions_data({"scene1/scene1.tif": "test/scene1/scene1.tif"}),
+                versions_to_push=["1.0.0"],
+            )
+
+    @staticmethod
+    def _register_collection_asset(
+        catalog_root: Path, key: str, href: str, roles: list[str]
+    ) -> None:
+        """Give the collection.json one asset, so the href resolves to a role."""
+        collection_json = catalog_root / "test" / "collection.json"
+        data = json.loads(collection_json.read_text())
+        data.setdefault("assets", {})[key] = {
+            "href": href,
+            "type": "application/octet-stream",
+            "roles": roles,
+        }
+        collection_json.write_text(json.dumps(data, indent=2))
+
+    @pytest.mark.unit
+    def test_data_role_beats_a_generated_filename(self, local_catalog: Path) -> None:
+        """A publisher's own PMTiles carries role `data`, so push still raises.
+
+        The extension registry gives .pmtiles the role `data`, and the spec lets
+        a publisher ship PMTiles as the primary asset. A filename test alone
+        would skip that file and publish a manifest without it.
+        """
+        from portolan_cli.sync.push import _get_assets_to_upload
+
+        self._register_collection_asset(local_catalog, "data", "./data.pmtiles", ["data"])
+
+        with pytest.raises(FileNotFoundError, match=r"test/data\.pmtiles"):
+            _get_assets_to_upload(
+                catalog_root=local_catalog,
+                versions_data=self._versions_data({"data.pmtiles": "test/data.pmtiles"}),
+                versions_to_push=["1.0.0"],
+            )
+
+    @pytest.mark.unit
+    def test_thumbnail_role_wins_over_an_unknown_filename(
+        self, local_catalog: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Push skips a preview the spec calls optional, whatever its name."""
+        from portolan_cli.sync.push import _get_assets_to_upload
+
+        self._register_collection_asset(local_catalog, "thumbnail", "./preview.webp", ["thumbnail"])
+
+        assets = _get_assets_to_upload(
+            catalog_root=local_catalog,
+            versions_data=self._versions_data({"preview.webp": "test/preview.webp"}),
+            versions_to_push=["1.0.0"],
+        )
+
+        assert assets == []
+        assert "test/preview.webp" in capsys.readouterr().err
+
+    @pytest.mark.unit
+    def test_source_role_still_raises(self, local_catalog: Path) -> None:
+        """An upstream original kept locally is data nothing can rebuild."""
+        from portolan_cli.sync.push import _get_assets_to_upload
+
+        self._register_collection_asset(local_catalog, "upstream", "./original.gpkg", ["source"])
+
+        with pytest.raises(FileNotFoundError, match=r"test/original\.gpkg"):
+            _get_assets_to_upload(
+                catalog_root=local_catalog,
+                versions_data=self._versions_data({"original.gpkg": "test/original.gpkg"}),
+                versions_to_push=["1.0.0"],
+            )
+
+    @pytest.mark.unit
+    def test_missing_user_supplied_image_still_raises(self, local_catalog: Path) -> None:
+        """An adopted ``thumbnail.png`` is the user's image, not our render.
+
+        One writer records both an adopted image and a rendered one. Only the
+        ``{stem}.thumb.jpg`` name marks an artifact Portolan drew. A user's own
+        picture must keep the hard failure.
+        """
+        from portolan_cli.sync.push import _get_assets_to_upload
+
+        with pytest.raises(FileNotFoundError, match=r"test/thumbnail\.png"):
+            _get_assets_to_upload(
+                catalog_root=local_catalog,
+                versions_data=self._versions_data({"thumbnail.png": "test/thumbnail.png"}),
+                versions_to_push=["1.0.0"],
+            )
+
+
 # =============================================================================
 # Force Flag Tests
 # =============================================================================


### PR DESCRIPTION
## What this changes

`push` no longer fails on a recorded but missing optional derivative. For an
absent asset, `push` reads the roles from the STAC JSON that registers it. It then
warns and skips when every role is `visual`, `thumbnail`, `style`, or
`collection-mirror`. A missing `data` or `source` asset still raises.

## Why

Resolves #735. Every entry in `versions.json` was a hard requirement. So one
deleted derived artifact broke `push` on a catalog that is otherwise sound. The
COG thumbnail hits this at version 1.0.0 from `add` alone.

The spec supplies the distinction, so this invents nothing. Every asset carries at
least one role, and `core.md` names them. Single-File Collections says a
collection "may optionally carry a `.pmtiles`, a `thumbnail.png`, and a `styles/`
directory". The Item mirror section of `formats.md` makes `items.parquet` a SHOULD.
It also keeps the item JSON normative.

A filename rule fails here. The registry gives `.pmtiles` the `data` role. A
publisher can ship PMTiles as their primary asset.

## Verification

The issue's reproduction reads `tests/fixtures/realdata/rapidai4eo-sample.tif`
into a fresh catalog at `$CAT`. The old code raised `FileNotFoundError` at
`push.py:540` here.

```console
$ portolan init $CAT --auto --license CC-BY-4.0 --title "Repro 735"
$ portolan add $CAT/imagery --portolan-dir $CAT --datetime 2024-01-01
✓ Added 1 file to 1 collection
$ rm $CAT/imagery/scene1/scene1.thumb.jpg
$ python drive_push.py
⚠ Optional asset not found, skipped: imagery/scene1/scene1.thumb.jpg (version 1.0.0)
imagery/scene1/scene1.tif roles=['data']
imagery/scene1/scene1.thumb.jpg roles=['thumbnail']
imagery/items.parquet roles=['collection-mirror']
assets to upload: 2
```

A missing `data` asset still raises. The role decides, not the name, so a
`.pmtiles` registered as `data` also raises.

```console
$ rm $CAT/imagery/scene1/scene1.tif && python drive_push.py
FileNotFoundError: Asset referenced in version 1.0.0 not found: imagery/scene1/scene1.tif

$ rm $CAT/tiles/basemap.pmtiles && python drive_push.py
roles on record: ['data']
FileNotFoundError: Asset referenced in version 1.0.0 not found: tiles/basemap.pmtiles
```

Suites and gates.

```console
$ uv run pytest -m unit -q --no-cov
5703 passed, 9 skipped, 1336 deselected

$ uv run pytest -m integration -q --no-cov
1127 passed, 5 skipped, 5904 deselected

$ uv run mypy portolan_cli && uv run lint-imports
Success: no issues found in 159 source files
Contracts: 6 kept, 0 broken.

$ uv run vulture portolan_cli tests && uv run xenon --max-absolute=C portolan_cli && uv run deptry .
Success! No dependency issues found.
```


One limit remains. The manifest still lists a skipped asset, so a remote href can
404 until a later run rebuilds it. A follow-up must prune the entry.

The unit run above used `067806a`, the head of this branch. The integration run
used `5846144`. A rebase moved that commit to `067806a` and changed no content.
`git show` returns the same patch for both. CI repeats every suite on the head.
