### PR TITLE
fix(metadata): re-extract a raster's bands on a metadata refresh (#737)

### DIFF
--- a/portolan_cli/metadata/update.py
+++ b/portolan_cli/metadata/update.py
@@ -13,14 +13,18 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+import rasterio
 
 from portolan_cli.collection import (
     read_collection_json,
     write_collection_json,
 )
+from portolan_cli.formats import RASTER_EXTENSIONS, FormatType
 from portolan_cli.item import (
     _extract_geometry_from_file,
     _get_media_type,
@@ -28,6 +32,7 @@ from portolan_cli.item import (
     write_item_json,
 )
 from portolan_cli.json_io import write_json_atomic
+from portolan_cli.metadata.cog import extract_cog_metadata
 from portolan_cli.models.collection import (
     CollectionModel,
     ExtentModel,
@@ -44,17 +49,31 @@ from portolan_cli.versions import (
 
 logger = logging.getLogger(__name__)
 
+#: The band name ``extract_cog_metadata`` generates. A band called anything else
+#: was named by a human, so the band refresh below keeps that name rather than
+#: writing the placeholder back over it.
+_GENERATED_BAND_NAME = re.compile(r"^band_\d+$")
+
 
 def update_item_metadata(item_path: Path, file_path: Path) -> ItemModel:
     """Re-extract metadata from file and update existing STAC item.
 
     Refreshes only the fields this metadata pass owns, the item's bbox,
-    geometry, datetime, and the data asset's href, and preserves everything
-    else on disk. That deliberately includes the item's ``stac_extensions``,
-    the data asset's ``bands`` / ``statistics``, every non-``data`` asset such
-    as the ``thumbnail`` that ``portolan add`` registers for COGs (#657), and
-    the data asset's media type, which the refresh backfills only when it is
-    missing.
+    geometry, datetime, the data asset's href, and, for a raster, the data
+    asset's ``bands`` array. Everything else on disk is preserved. That
+    deliberately includes the item's ``stac_extensions``, every non-``data``
+    asset such as the ``thumbnail`` that ``portolan add`` registers for COGs
+    (#657), a non-raster asset's ``bands`` (#659), and the data asset's media
+    type, which the refresh backfills only when it is missing.
+
+    A raster's ``bands`` array is the exception, because it describes the shape
+    of the file and formats.md makes the file authoritative for band statistics.
+    Re-shape a 4-band COG into a 1-band COG and a preserved array documents
+    bands that no longer exist (#737), on a command whose job is freshness. So
+    the refresh re-reads the array from the bytes with the extractors
+    ``portolan add`` uses. A failed or empty extraction keeps what is on disk,
+    because a refresh that cannot read the file must not destroy the record
+    (#659).
 
     The update edits the raw item JSON in place rather than round-tripping
     through :class:`ItemModel`. The model only carries href/type/roles/title for
@@ -90,8 +109,8 @@ def update_item_metadata(item_path: Path, file_path: Path) -> ItemModel:
     properties = item_data.setdefault("properties", {})
     properties["datetime"] = datetime.now(timezone.utc).isoformat()
 
-    # Refresh the data asset's href/type in place, leaving its bands/statistics
-    # (and any human-authored title) and all other assets untouched.
+    # Refresh the data asset's href/type in place, leaving any human-authored
+    # title and all other assets untouched.
     assets: dict[str, Any] = item_data.setdefault("assets", {})
     data_key = _find_data_asset_key(assets)
     data_asset = assets.setdefault(data_key, {})
@@ -104,12 +123,144 @@ def update_item_metadata(item_path: Path, file_path: Path) -> ItemModel:
     if not data_asset.get("type"):
         data_asset["type"] = _get_media_type(file_path)
     data_asset.setdefault("roles", ["data"])
+    _refresh_raster_bands(data_asset, file_path)
 
     # Write the full record back to disk. Atomic, so a kill mid-write cannot
     # leave a truncated item.json where a valid one used to be (issue #687).
     write_json_atomic(item_path, item_data)
 
     return ItemModel.from_dict(item_data)
+
+
+def _refresh_raster_bands(data_asset: dict[str, Any], file_path: Path) -> None:
+    """Re-extract a raster data asset's ``bands`` array in place (#737).
+
+    A non-raster asset is untouched, so a GeoParquet asset's array still survives
+    the refresh verbatim (#659). So does a raster's array when the extraction
+    fails or reads no bands, because a refresh that cannot see the file has
+    nothing better to write than what is already recorded.
+
+    When the band count is unchanged the fresh values are merged over the
+    existing band, keeping the descriptive fields extraction cannot derive. When
+    the count changes the file has been re-shaped, so a label written for one of
+    four bands cannot be assumed to describe the one band that is left, and the
+    fresh array replaces the old one outright.
+    """
+    if file_path.suffix.lower() not in RASTER_EXTENSIONS:
+        return
+
+    fresh = _extract_raster_bands(file_path)
+    if not fresh:
+        logger.warning(
+            "Could not re-extract bands from '%s'; keeping the recorded array",
+            file_path.name,
+        )
+        return
+
+    existing = data_asset.get("bands")
+    if isinstance(existing, list) and len(existing) == len(fresh):
+        fresh = [
+            _merge_band(new, old) if isinstance(old, dict) else new
+            for new, old in zip(fresh, existing, strict=True)
+        ]
+
+    data_asset["bands"] = fresh
+
+
+def _extract_raster_bands(file_path: Path) -> list[dict[str, Any]]:
+    """The ``bands`` array ``portolan add`` would write for this raster.
+
+    Orchestrates the extractors the add path uses, ``extract_cog_metadata`` for
+    the per-band shape and ``preparation``'s statistics helpers for the
+    ``statistics`` sub-object, so a refreshed array and a freshly added one are
+    built by the same code and carry the same STAC field names. Returns an empty
+    list when the raster cannot be read, which the caller treats as "keep what is
+    on disk".
+
+    Reads with ``GDAL_PAM_ENABLED=NO`` so a ``.aux.xml`` sidecar cannot answer
+    for the file. formats.md is explicit that statistics MUST be embedded in the
+    file and that a PAM sidecar does not satisfy that, and GDAL never invalidates
+    a sidecar when the raster underneath is replaced. `add` leaves one next to
+    every raster it computes statistics for, so a refresh that trusted it would
+    copy the old raster's numbers onto the new bands. It is also how rashid reads
+    a COG for PTL-DAT-009.
+    """
+    # Imported inside the function on purpose: `preparation` imports the
+    # `metadata` package this module belongs to, so a module-level import would
+    # close an import cycle.
+    from portolan_cli.preparation import (
+        _add_statistics_to_properties,
+        _extract_statistics_best_effort,
+    )
+
+    with rasterio.Env(GDAL_PAM_ENABLED="NO"):
+        try:
+            stac_properties = extract_cog_metadata(file_path).to_stac_properties()
+        except Exception:
+            logger.warning("Raster metadata extraction failed for '%s'", file_path, exc_info=True)
+            return []
+
+        # Statistics are a configured enrichment, so they need the catalog whose
+        # settings gate them. A raster outside any catalog gets the band shape only.
+        catalog_root, collection_dir = _statistics_scope(file_path)
+        if catalog_root is not None:
+            band_stats, parquet_stats = _extract_statistics_best_effort(
+                file_path, FormatType.RASTER, catalog_root, collection_path=collection_dir
+            )
+            # `_extract_statistics_best_effort` already applied the
+            # `statistics.enabled` gate, returning nothing when the setting is
+            # off, so the flag here is always True.
+            _add_statistics_to_properties(
+                stac_properties, FormatType.RASTER, band_stats, parquet_stats, stats_enabled=True
+            )
+
+    bands = stac_properties.get("bands")
+    if not isinstance(bands, list):
+        return []
+    return [band for band in bands if isinstance(band, dict)]
+
+
+def _statistics_scope(file_path: Path) -> tuple[Path | None, Path | None]:
+    """The (catalog root, collection dir) a statistics setting resolves against.
+
+    The refresh is handed one file, so the scope `add` receives as arguments has
+    to be recovered from the path. The catalog root comes from the usual sentinel
+    walk, the collection from the nearest ancestor holding a ``collection.json``.
+    Either may be None, and `get_setting` then falls back a level.
+    """
+    from portolan_cli.catalog import find_catalog_root
+
+    catalog_root = find_catalog_root(file_path.parent)
+    if catalog_root is None:
+        return None, None
+
+    for parent in file_path.parents:
+        if (parent / "collection.json").exists():
+            return catalog_root, parent
+        if parent == catalog_root:
+            break
+    return catalog_root, None
+
+
+def _merge_band(fresh: dict[str, Any], existing: dict[str, Any]) -> dict[str, Any]:
+    """Fresh band values over the recorded ones, keeping what pixels cannot say.
+
+    The split follows what is derivable. ``data_type``, ``nodata`` and
+    ``statistics`` come from the file, which formats.md makes the authority for
+    them. A ``name`` or ``description`` a human wrote is descriptive, not
+    derivable, so it survives. A name is kept unless it is the generated
+    ``band_N`` placeholder, and any other recorded key the extractor does not
+    produce carries over. That also means a value extraction failed to read,
+    including a ``nodata`` that came from ``metadata.yaml`` defaults the refresh
+    never sees, is preserved rather than dropped.
+    """
+    merged = {**existing, **fresh}
+
+    name = existing.get("name")
+    if isinstance(name, str) and name and not _GENERATED_BAND_NAME.match(name):
+        merged["name"] = name
+
+    return merged
 
 
 def _find_data_asset_key(assets: dict[str, Any]) -> str:

--- a/tests/unit/test_metadata_update.py
+++ b/tests/unit/test_metadata_update.py
@@ -13,15 +13,19 @@ import json
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import pytest
+import rasterio
 
+from portolan_cli.catalog import init_catalog
 from portolan_cli.collection import (
     create_collection,
     read_collection_json,
     write_collection_json,
 )
 from portolan_cli.item import create_item, read_item_json, write_item_json
+from portolan_cli.metadata.cog import COGMetadata
 from portolan_cli.metadata.update import (
     create_missing_item,
     update_collection_extent,
@@ -39,6 +43,55 @@ from portolan_cli.versions import (
 # Path to test fixtures
 FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
 REALDATA_FIXTURES = FIXTURES_DIR / "realdata"
+
+# The band-refresh rasters (#737). A 4-band int16 COG, and the 1-band uint8 COG
+# that replaces it on disk.
+FOUR_BAND_RASTER = REALDATA_FIXTURES / "rapidai4eo-sample.tif"
+ONE_BAND_RASTER = FIXTURES_DIR / "raster" / "valid" / "singleband.tif"
+
+# The statistics formats.md requires on every COG band ("Raster statistics"),
+# under the STAC field names the raster extension defines.
+REQUIRED_BAND_STATISTICS = frozenset({"minimum", "maximum", "mean", "stddev"})
+
+# The 4-band raster's band 1 statistics, as `add` records them. They are the
+# stale values a refresh must not carry onto a re-shaped file, and 302 is not
+# even representable in the 1-band raster's uint8 bands.
+STALE_BAND_1_STATISTICS = {
+    "minimum": 302.0,
+    "maximum": 1015.0,
+    "mean": 460.38215000000383,
+    "stddev": 51.76964613919496,
+}
+
+
+def _raster_item(root: Path, source: Path) -> tuple[Path, Path]:
+    """Copy `source` into a collection under `root` and write its item.json.
+
+    Returns (item_path, data_path). Initializes a real catalog, because the
+    statistics enrichment only runs where its setting resolves.
+    """
+    if not source.exists():
+        pytest.skip(f"Raster fixture not available: {source.name}")
+    init_catalog(root, license_id="CC-BY-4.0")
+    collection_dir = root / "imagery"
+    collection_dir.mkdir(exist_ok=True)
+    data_file = collection_dir / "scene1.tif"
+    shutil.copy(source, data_file)
+    item = create_item(item_id="scene1", data_path=data_file, collection_id="imagery")
+    return write_item_json(item, collection_dir), data_file
+
+
+def _record_bands(item_path: Path, bands: list[dict[str, Any]]) -> None:
+    """Write `bands` onto the item's data asset, as a previous `add` would have."""
+    item_json = json.loads(item_path.read_text())
+    item_json["assets"]["data"]["bands"] = bands
+    item_path.write_text(json.dumps(item_json, indent=2))
+
+
+def _read_bands(item_path: Path) -> list[dict[str, Any]]:
+    """The data asset's bands array as it stands on disk."""
+    bands: list[dict[str, Any]] = json.loads(item_path.read_text())["assets"]["data"]["bands"]
+    return bands
 
 
 class TestUpdateItemMetadata:
@@ -312,6 +365,236 @@ class TestUpdateItemMetadata:
 
         result = json.loads(item_path.read_text())
         assert result["assets"]["data"]["type"] == cog_media_type
+
+    @pytest.mark.unit
+    @pytest.mark.realdata
+    def test_update_item_metadata_reextracts_reshaped_raster_bands(self, tmp_path: Path) -> None:
+        """A re-shaped raster gets a re-extracted bands array (#737).
+
+        Preserving the array verbatim (#659) leaves 4 int16 bands describing a
+        1-band uint8 file. formats.md makes the file the authority for band
+        statistics, so the raster refresh re-reads the bytes on disk.
+        """
+        item_path, data_file = _raster_item(tmp_path, FOUR_BAND_RASTER)
+        _record_bands(
+            item_path,
+            [
+                {
+                    "name": f"band_{index}",
+                    "data_type": "int16",
+                    "statistics": dict(STALE_BAND_1_STATISTICS),
+                }
+                for index in range(1, 5)
+            ],
+        )
+
+        # Re-shape the raster in place: 4-band int16 becomes 1-band uint8.
+        shutil.copy(ONE_BAND_RASTER, data_file)
+
+        update_item_metadata(item_path, data_file)
+
+        bands = _read_bands(item_path)
+        assert [band["name"] for band in bands] == ["band_1"]
+        assert bands[0]["data_type"] == "uint8"
+        statistics = bands[0]["statistics"]
+        # The full set formats.md requires, describing the uint8 file. Every
+        # value sits inside the type's range, not the int16 raster's 302..1015.
+        assert REQUIRED_BAND_STATISTICS <= statistics.keys()
+        assert 0 <= statistics["minimum"] <= statistics["maximum"] <= 255
+        assert 0 <= statistics["mean"] <= 255
+
+    @pytest.mark.unit
+    def test_update_item_metadata_keeps_hand_authored_band_fields(self, tmp_path: Path) -> None:
+        """A same-shape refresh keeps the band name and description a human wrote (#737).
+
+        A name and a description are descriptive, not derivable from pixels, so
+        the refresh keeps them. The data type is derivable, so it comes from the
+        file.
+        """
+        item_path, data_file = _raster_item(tmp_path, ONE_BAND_RASTER)
+        _record_bands(
+            item_path,
+            [
+                {
+                    "name": "red",
+                    "description": "Surface reflectance, hand authored",
+                    "data_type": "int16",
+                }
+            ],
+        )
+
+        update_item_metadata(item_path, data_file)
+
+        bands = _read_bands(item_path)
+        assert len(bands) == 1
+        assert bands[0]["name"] == "red"
+        assert bands[0]["description"] == "Surface reflectance, hand authored"
+        assert bands[0]["data_type"] == "uint8"
+        assert REQUIRED_BAND_STATISTICS <= bands[0]["statistics"].keys()
+
+    @pytest.mark.unit
+    @pytest.mark.realdata
+    def test_update_item_metadata_drops_band_labels_when_count_changes(
+        self, tmp_path: Path
+    ) -> None:
+        """A hand-authored label never lands on a band it no longer describes (#737)."""
+        item_path, data_file = _raster_item(tmp_path, FOUR_BAND_RASTER)
+        _record_bands(
+            item_path,
+            [
+                {"name": name, "description": f"{name} band", "data_type": "int16"}
+                for name in ("red", "green", "blue", "nir")
+            ],
+        )
+
+        shutil.copy(ONE_BAND_RASTER, data_file)
+
+        update_item_metadata(item_path, data_file)
+
+        bands = _read_bands(item_path)
+        assert [band["name"] for band in bands] == ["band_1"]
+        assert "description" not in bands[0]
+
+    @pytest.mark.unit
+    def test_update_item_metadata_ignores_statistics_sidecar(self, tmp_path: Path) -> None:
+        """A PAM sidecar cannot answer for the file's statistics (#737).
+
+        formats.md is explicit that an external ``.aux.xml`` sidecar does not
+        satisfy the embedded-statistics requirement. GDAL writes one when it
+        computes statistics and never invalidates it when the raster underneath
+        is replaced, so the refresh must read past it.
+        """
+        item_path, data_file = _raster_item(tmp_path, ONE_BAND_RASTER)
+        _record_bands(
+            item_path,
+            [{"name": "band_1", "data_type": "int16", "statistics": STALE_BAND_1_STATISTICS}],
+        )
+
+        # The sidecar `add` left when it read the int16 raster this uint8 file
+        # replaced.
+        (data_file.parent / f"{data_file.name}.aux.xml").write_text(
+            '<PAMDataset><PAMRasterBand band="1"><Metadata>'
+            '<MDI key="STATISTICS_MINIMUM">302</MDI>'
+            '<MDI key="STATISTICS_MAXIMUM">1015</MDI>'
+            '<MDI key="STATISTICS_MEAN">460.38215</MDI>'
+            '<MDI key="STATISTICS_STDDEV">51.769646139195</MDI>'
+            '<MDI key="STATISTICS_VALID_PERCENT">100</MDI>'
+            "</Metadata></PAMRasterBand></PAMDataset>"
+        )
+
+        update_item_metadata(item_path, data_file)
+
+        statistics = _read_bands(item_path)[0]["statistics"]
+        assert REQUIRED_BAND_STATISTICS <= statistics.keys()
+        assert statistics["minimum"] != STALE_BAND_1_STATISTICS["minimum"]
+        assert statistics["maximum"] <= 255
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("failure", ["raises", "empty"])
+    def test_update_item_metadata_preserves_bands_when_reextraction_fails(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        failure: str,
+    ) -> None:
+        """A failed re-extraction keeps the existing array rather than deleting it (#737).
+
+        The lesson of #659. A refresh that cannot read the file must not
+        destroy the record it cannot replace.
+        """
+        item_path, data_file = _raster_item(tmp_path, ONE_BAND_RASTER)
+        bands = [{"name": "band_1", "data_type": "int16", "statistics": STALE_BAND_1_STATISTICS}]
+        _record_bands(item_path, bands)
+
+        def broken(self: COGMetadata) -> dict[str, Any]:
+            if failure == "raises":
+                raise OSError("band extraction failed")
+            return {}
+
+        monkeypatch.setattr(COGMetadata, "to_stac_properties", broken)
+
+        update_item_metadata(item_path, data_file)
+
+        assert _read_bands(item_path) == bands
+
+    @pytest.mark.unit
+    def test_update_item_metadata_computes_statistics_from_pixels(self, tmp_path: Path) -> None:
+        """The refreshed statistics come from the pixels, not from the file's tags (#737).
+
+        This is what keeps the band refresh independent of #748, where a COG
+        Portolan writes carries its statistics in a PAM sidecar instead of
+        embedded in the file. The refresh reads with ``GDAL_PAM_ENABLED=NO`` and
+        the raster below embeds no statistics at all, so a refresh that only
+        read recorded values would write none. ``statistics.raster_mode``
+        defaults to ``approx``, which computes them, so a full set arrives.
+        """
+        item_path, data_file = _raster_item(tmp_path, ONE_BAND_RASTER)
+        _record_bands(item_path, [{"name": "band_1", "data_type": "int16"}])
+
+        # The precondition that makes this a real assertion: nothing to read.
+        with rasterio.Env(GDAL_PAM_ENABLED="NO"), rasterio.open(data_file) as src:
+            assert "STATISTICS_MINIMUM" not in src.tags(bidx=1)
+        assert not (data_file.parent / f"{data_file.name}.aux.xml").exists()
+
+        update_item_metadata(item_path, data_file)
+
+        band = _read_bands(item_path)[0]
+        assert band["data_type"] == "uint8"
+        assert REQUIRED_BAND_STATISTICS <= band["statistics"].keys()
+        assert 0 <= band["statistics"]["minimum"] <= band["statistics"]["maximum"] <= 255
+
+    @pytest.mark.unit
+    def test_update_item_metadata_keeps_statistics_extraction_cannot_recompute(
+        self, tmp_path: Path
+    ) -> None:
+        """A same-shape refresh never trades recorded statistics for none (#737).
+
+        ``statistics.raster_mode`` defaults to ``approx``, which computes the
+        values. A catalog can set ``cached`` instead, and then the extractor
+        reads embedded tags only. The raster below has none and the refresh
+        disables PAM, so extraction returns no ``statistics`` key at all. The
+        merge must therefore keep the recorded object rather than drop it.
+        """
+        item_path, data_file = _raster_item(tmp_path, ONE_BAND_RASTER)
+        (tmp_path / ".portolan" / "config.yaml").write_text(
+            "statistics:\n  enabled: true\n  raster_mode: cached\n"
+        )
+        _record_bands(
+            item_path,
+            [{"name": "band_1", "data_type": "int16", "statistics": dict(STALE_BAND_1_STATISTICS)}],
+        )
+
+        update_item_metadata(item_path, data_file)
+
+        band = _read_bands(item_path)[0]
+        # Derivable from the file, so the refresh owns it.
+        assert band["data_type"] == "uint8"
+        # Not derivable in this mode, so the recorded object survives intact.
+        assert band["statistics"] == STALE_BAND_1_STATISTICS
+
+    @pytest.mark.unit
+    def test_update_item_metadata_preserves_bands_for_unreadable_raster(
+        self, tmp_path: Path
+    ) -> None:
+        """A raster extension the COG reader cannot open preserves, it does not raise (#737).
+
+        The guard keys on ``RASTER_EXTENSIONS``, which is every extension that
+        routes as raster, so it is wider than the COGs ``extract_cog_metadata``
+        reads. A ``.jp2`` GDAL has no driver for, or any raster whose bytes are
+        unreadable, must therefore fall through to the preserve path rather than
+        failing the refresh.
+        """
+        item_path, data_file = _raster_item(tmp_path, ONE_BAND_RASTER)
+        unreadable = data_file.with_suffix(".jp2")
+        data_file.rename(unreadable)
+        unreadable.write_bytes(b"not a JPEG 2000 codestream")
+
+        bands = [{"name": "band_1", "data_type": "uint16"}]
+        _record_bands(item_path, bands)
+
+        update_item_metadata(item_path, unreadable)
+
+        assert _read_bands(item_path) == bands
 
 
 class TestCreateMissingItem:


### PR DESCRIPTION
## What this changes

A metadata refresh now re-extracts a raster's `bands` array from the file. It
reuses the extractors `add` uses. It reads with `GDAL_PAM_ENABLED=NO`, so a stale
`.aux.xml` sidecar cannot answer for the file. A non-raster asset keeps its array
verbatim. A failed or empty extraction also keeps the recorded array.

## Why

Resolves #737. `check --fix --metadata` preserved the array verbatim. Re-shape a
4-band COG into a 1-band COG, and the item then documents bands that no longer
exist. That is wrong for a command whose job is freshness.

#660 changed this function to preserve rather than delete. Re-extraction is the
third position. The spec supports it. `formats.md` makes the file authoritative
for band statistics, and it rejects a PAM sidecar as proof.

The band count drives the merge. On an equal count the fresh values win, and a
hand-written `name` survives. On a changed count the fresh array replaces the old
one. A label for one of four bands cannot describe the single band left.

## Verification

The repro adds `tests/fixtures/realdata/rapidai4eo-sample.tif`, 4 bands and
int16. It then overwrites that file with `tests/fixtures/raster/valid/singleband.tif`,
1 band and uint8. The stale sidecar from the first add stays on disk.

```console
--- bands recorded by add (4-band int16 source) ---
    band_1 int16 {'minimum': 302.0, 'maximum': 1015.0, 'mean': 460.38, 'stddev': 51.77}
    band_2 int16 {'minimum': 379.0, 'maximum': 1440.0, 'mean': 655.82, 'stddev': 96.18}
    band_3 int16 {'minimum': 364.0, 'maximum': 1989.0, 'mean': 761.20, 'stddev': 160.51}
    band_4 int16 {'minimum': 814.0, 'maximum': 3299.0, 'mean': 1642.90, 'stddev': 306.44}
--- raster on disk replaced: bands 1, dtype uint8 ---
--- stale PAM sidecar from the first add is still there ---
scene1.tif.aux.xml

$ portolan check --fix --metadata
✓ Fixed automatically (2)

--- bands after the fix ---
    band count: 1
    band_1 uint8 {'minimum': 0.0, 'maximum': 255.0, 'mean': 127.5, 'stddev': 127.5}
```

The values come from pixels, through `rasterio`'s `DatasetReader.stats`. A runtime
spy confirms the code ignores the sidecar.

```console
--- calls made during the refresh ---
    ('DatasetReader.tags', {'bidx': 1, 'has_STATISTICS_MINIMUM': False})
    ('DatasetReader.stats', {'approx': True})
```

`PTL-DAT-009` does NOT clear. Issue #748 is the reason. rashid reads the
statistics in the raster bytes, not the item's `bands` array.

```console
$ portolan check --strict --metadata
✗ PTL-DAT-009 imagery/scene1/scene1.json: asset 'data' band(s) [1] lack embedded min/max/mean/stddev statistics
✗ Catalog does not conform: 6 errors, 2 warnings
```

The same message appears after a plain `add` with no refresh. It also appears when
the stale 4-band array goes back by hand. So this change neither helps nor harms
that rule. #748 owns it.

Revert `update.py` and six new tests go red on a band-value assertion, never on
setup.

```console
$ uv run pytest tests/unit/test_metadata_update.py -q --no-cov
E   AssertionError: assert ['band_1', 'band_2', 'band_3', 'band_4'] == ['band_1']
E   AssertionError: assert 'int16' == 'uint8'
6 failed, 4 passed, 26 deselected
```

The four #659 tests from #660 still pass. They lock preserve-not-delete for the
non-raster case.

```console
$ uv run pytest -m unit -q --no-cov
5646 passed, 9 skipped, 1331 deselected

$ uv run pytest -m integration -q --no-cov
1122 passed, 5 skipped, 5859 deselected

$ uv run mypy portolan_cli && uv run lint-imports
Success: no issues found in 158 source files
Contracts: 6 kept, 0 broken.

$ uv run ruff check . && uv run vulture portolan_cli tests && uv run xenon --max-absolute=C portolan_cli
All checks passed!
```

One limit is worth a note. A count change replaces the array. So a re-shaped
raster loses a `nodata` value from `metadata.yaml` defaults. `add` re-applies it
on the next run. The refresh does not call
`_apply_nodata_defaults_to_bands`, because that helper raises on a per-band list
whose length no longer matches. A raise would turn a refresh into a `check --fix`
failure.

The suite runs above used `6500a4f`. A rebase moved that commit to `59453c7` and
changed no content. `git show` returns the same patch for both. CI repeats every
suite on the head.
