### PR TITLE
fix(pmtiles): make --force-pmtiles generate tiles and drop gpio-pmtiles

### DIFF
--- a/.claude/rules/conversion-and-visualization.md
+++ b/.claude/rules/conversion-and-visualization.md
@@ -121,8 +121,12 @@ render paths.
 - PMTiles is required for vector datasets > 100 MB and recommended > 10 MB. Generate alongside the GeoParquet.
 - `pmtiles.src_crs` from `.portolan/config.yaml` must be threaded
   `get_pmtiles_settings()` (in `pmtiles.py`) -> `generate_pmtiles_for_collection()`
-  -> `gpio-pmtiles`, which reprojects to WGS84 before tippecanoe. Dropping it
-  breaks PMTiles for any projected source.
+  -> `geoparquet_io.api.ops.create_pmtiles`, which reprojects to WGS84 before
+  tippecanoe. Dropping it breaks PMTiles for any projected source. The
+  deprecated `gpio-pmtiles` package is gone (#754); do not import it again.
+- `--force-pmtiles` implies `--pmtiles`. `generate_or_suggest_pmtiles` ORs the
+  two into `requested`, which gates generation and decides whether a failure
+  exits non-zero (#760).
 - A generated `.pmtiles` MUST be a **collection-level** asset AND have a
   `rel: "pmtiles"` link (web-map-links extension). Item-level-only is
   non-conformant (rashid PTL-VIZ-003, an error). PMTiles discovery

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -558,7 +558,8 @@ pmtiles.attribution: "© OpenStreetMap contributors"
     - **macOS**: `brew install tippecanoe`
     - **Ubuntu**: `apt install tippecanoe`
 
-    Also requires the optional `pmtiles` extra: `pip install portolan-cli[pmtiles]`
+    No Python extra is needed. The tiling code ships in `geoparquet-io`, which a
+    default install already carries.
 
 ### Commands
 
@@ -566,8 +567,8 @@ pmtiles.attribution: "© OpenStreetMap contributors"
 # Generate PMTiles during add
 portolan add boundaries/ --pmtiles
 
-# Force regeneration even if up-to-date
-portolan add boundaries/ --pmtiles --force-pmtiles
+# Force regeneration even if up-to-date (--force-pmtiles implies --pmtiles)
+portolan add boundaries/ --force-pmtiles
 
 # Check for missing PMTiles (produces warning, not error)
 portolan check
@@ -575,7 +576,7 @@ portolan check
 
 ### How It Works
 
-- Uses [gpio-pmtiles](https://github.com/geoparquet-io/gpio-pmtiles) wrapper around tippecanoe
+- Uses [geoparquet-io](https://github.com/geoparquet/geoparquet-io) `create_pmtiles`, a wrapper around tippecanoe
 - PMTiles stored alongside source GeoParquet (e.g., `data.parquet` → `data.pmtiles`)
 - Registered as collection-level asset with role `["overview"]`
 - Tracked in `versions.json` for push

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3087,7 +3087,7 @@ def _check_partition_prompt(
     "--force-pmtiles",
     "force_pmtiles",
     is_flag=True,
-    help="Regenerate PMTiles even if they exist and are up-to-date.",
+    help="Regenerate PMTiles even if they exist and are up-to-date. Implies --pmtiles.",
 )
 @click.option(
     "--thumbnails/--no-thumbnails",

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -102,7 +102,7 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "pmtiles.where": None,  # None = no SQL filter
     "pmtiles.include_cols": None,  # None = include all columns
     "pmtiles.precision": 6,  # Coordinate decimal precision
-    "pmtiles.attribution": None,  # None = gpio-pmtiles default
+    "pmtiles.attribution": None,  # None = geoparquet-io default
     "pmtiles.src_crs": None,  # None = use metadata CRS
     # Push exclusion patterns for metadata sync (Issue #426)
     # These files/directories are never synced to remote storage.

--- a/portolan_cli/metadata/pmtiles.py
+++ b/portolan_cli/metadata/pmtiles.py
@@ -105,7 +105,7 @@ def extract_pmtiles_metadata(path: Path) -> PMTilesMetadata:
         from pmtiles.tile import MagicNumberNotFound
     except ImportError as e:
         raise ImportError(
-            "pmtiles package not installed. Install with: pip install portolan-cli[pmtiles]"
+            "pmtiles package not installed. Install with: pip install pmtiles"
         ) from e
 
     if not path.exists():

--- a/portolan_cli/metadata/pmtiles.py
+++ b/portolan_cli/metadata/pmtiles.py
@@ -104,9 +104,7 @@ def extract_pmtiles_metadata(path: Path) -> PMTilesMetadata:
         from pmtiles.reader import MmapSource, Reader
         from pmtiles.tile import MagicNumberNotFound
     except ImportError as e:
-        raise ImportError(
-            "pmtiles package not installed. Install with: pip install pmtiles"
-        ) from e
+        raise ImportError("pmtiles package not installed. Install with: pip install pmtiles") from e
 
     if not path.exists():
         raise FileNotFoundError(f"PMTiles file not found: {path}")

--- a/portolan_cli/validation/remediation.py
+++ b/portolan_cli/validation/remediation.py
@@ -219,7 +219,7 @@ RULE_REMEDIATION: dict[str, Remediation] = {
     ),
     "PTL-VIZ-004": _instruct(
         "Generate a PMTiles derivative for this large vector collection so browsers can render it "
-        "; run `portolan viz` with the [pmtiles] extra."
+        "; run `portolan add --pmtiles` with tippecanoe on PATH."
     ),
     # fixer `styles` is new in Phase 3; it corrects the style asset media type
     "PTL-VIZ-005": _auto(

--- a/portolan_cli/viz/pmtiles.py
+++ b/portolan_cli/viz/pmtiles.py
@@ -6,7 +6,7 @@ to the source GeoParquet, registered as collection-level assets with role
 ["visual"], and tracked in versions.json for push.
 
 Requires:
-- gpio-pmtiles package (optional dependency: `pip install portolan-cli[pmtiles]`)
+- geoparquet-io (a core dependency) for `create_pmtiles`
 - tippecanoe binary installed and in PATH
 
 Usage:
@@ -65,7 +65,7 @@ class PMTilesError(PortolanError):
 
 
 class PMTilesNotAvailableError(PMTilesError):
-    """Raised when gpio-pmtiles package is not installed.
+    """Raised when geoparquet-io does not provide PMTiles generation.
 
     Error code: PRTLN-PMT001
     """
@@ -74,7 +74,8 @@ class PMTilesNotAvailableError(PMTilesError):
 
     def __init__(self) -> None:
         super().__init__(
-            "gpio-pmtiles package not installed. Install with: pip install portolan-cli[pmtiles]"
+            "geoparquet-io does not provide PMTiles generation. "
+            "Install with: pip install 'geoparquet-io>=1.3.0'"
         )
 
 
@@ -146,12 +147,15 @@ def check_pmtiles_available() -> None:
     """Check that PMTiles generation dependencies are available.
 
     Raises:
-        PMTilesNotAvailableError: If gpio-pmtiles is not installed.
+        PMTilesNotAvailableError: If geoparquet-io has no PMTiles support.
         TippecanoeNotFoundError: If tippecanoe is not in PATH.
     """
-    # Check for gpio-pmtiles
+    # Check for the geoparquet-io PMTiles API. geoparquet-io is a core
+    # dependency, so this only fails on a version below 1.3.0 (Issue #754).
     try:
-        import gpio_pmtiles  # type: ignore[import-untyped] # noqa: F401
+        from geoparquet_io.api.ops import (  # type: ignore[import-untyped] # noqa: F401
+            create_pmtiles,
+        )
     except ImportError as e:
         raise PMTilesNotAvailableError() from e
 
@@ -282,16 +286,16 @@ def generate_pmtiles(
         src_crs: Override source CRS if metadata is incorrect.
 
     Raises:
-        PMTilesNotAvailableError: If gpio-pmtiles not installed.
+        PMTilesNotAvailableError: If geoparquet-io has no PMTiles support.
         TippecanoeNotFoundError: If tippecanoe not in PATH.
         PMTilesGenerationError: If generation fails.
     """
     check_pmtiles_available()
 
-    from gpio_pmtiles import create_pmtiles_from_geoparquet
+    from geoparquet_io.api.ops import create_pmtiles
 
     try:
-        create_pmtiles_from_geoparquet(
+        create_pmtiles(
             input_path=str(parquet_path),
             output_path=str(pmtiles_path),
             min_zoom=min_zoom,
@@ -672,7 +676,7 @@ def generate_pmtiles_for_collection(
         PMTilesResult with generated, skipped, and failed counts.
 
     Raises:
-        PMTilesNotAvailableError: If gpio-pmtiles not installed.
+        PMTilesNotAvailableError: If geoparquet-io has no PMTiles support.
         TippecanoeNotFoundError: If tippecanoe not in PATH.
     """
     # Check dependencies upfront
@@ -845,7 +849,8 @@ def generate_or_suggest_pmtiles(
     """Generate PMTiles for affected collections when requested or configured.
 
     For each affected collection, resolves PMTiles settings and generates when
-    ``--pmtiles`` was passed or ``pmtiles.enabled`` is configured. Generation runs
+    ``--pmtiles`` or ``--force-pmtiles`` was passed, or ``pmtiles.enabled`` is
+    configured. Generation runs
     regardless of output mode so the JSON envelope reflects the final state; an explicitly-requested generation that fails exits non-zero.
 
     Args:
@@ -859,13 +864,19 @@ def generate_or_suggest_pmtiles(
     if not affected_collections:
         return
 
+    # --force-pmtiles asks for a rebuild, so it also turns generation on. The
+    # default is pmtiles.enabled false, so the flag alone used to exit 0 and
+    # leave the old tiles in place (Issue #760). `requested` also drives the
+    # reports below: an explicit request that fails must exit non-zero.
+    requested = generate_pmtiles or force
+
     for coll_id in affected_collections:
         coll_path = catalog_root / coll_id
         if not (coll_path / "collection.json").exists():
             continue
 
         settings = get_pmtiles_settings(catalog_root, coll_id, coll_path)
-        if not (generate_pmtiles or settings.enabled):
+        if not (requested or settings.enabled):
             continue
 
         try:
@@ -883,13 +894,13 @@ def generate_or_suggest_pmtiles(
                 attribution=settings.attribution,
                 src_crs=settings.src_crs,
             )
-            _report_pmtiles_result(result, verbose, generate_pmtiles, use_json=use_json)
+            _report_pmtiles_result(result, verbose, requested, use_json=use_json)
         except PMTilesNotAvailableError as e:
             _report_pmtiles_unavailable(
-                e, generate_pmtiles, settings.enabled, verbose, coll_id, use_json=use_json
+                e, requested, settings.enabled, verbose, coll_id, use_json=use_json
             )
         except TippecanoeNotFoundError as e:
-            _report_tippecanoe_missing(e, generate_pmtiles, coll_id, use_json=use_json)
+            _report_tippecanoe_missing(e, requested, coll_id, use_json=use_json)
 
 
 def _report_pmtiles_result(
@@ -929,9 +940,9 @@ def _report_pmtiles_unavailable(
         return
     # Warn if pmtiles.enabled in config (user expectation), or info if just verbose
     if config_enabled:
-        warn(f"PMTiles enabled for '{coll_id}' but gpio-pmtiles not installed")
+        warn(f"PMTiles enabled for '{coll_id}' but geoparquet-io has no PMTiles support")
     elif verbose:
-        info(f"Skipping PMTiles for '{coll_id}': gpio-pmtiles not installed")
+        info(f"Skipping PMTiles for '{coll_id}': geoparquet-io has no PMTiles support")
 
 
 def _report_tippecanoe_missing(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,9 +95,10 @@ dev = [
     "vulture>=2.14",
     "xenon>=0.9.3",
 ]
-pmtiles = [
-    "gpio-pmtiles>=0.1.0", # PMTiles generation from GeoParquet (requires tippecanoe)
-]
+# PMTiles generation now comes from core geoparquet-io (>=1.3.0), which owns
+# create_pmtiles. The extra stays declared, and empty, so an existing
+# `pip install portolan-cli[pmtiles]` still resolves (Issue #754).
+pmtiles = []
 # Rendering itself is core (matplotlib, geopandas). What stays optional here is
 # the extra fidelity: basemap tiles under a vector thumbnail, and the MVT decode
 # that only the PMTiles render path uses. Both are lazily imported and guarded,

--- a/tests/integration/test_pmtiles_integration.py
+++ b/tests/integration/test_pmtiles_integration.py
@@ -542,7 +542,7 @@ class TestPMTilesMultipleAssets:
 
 
 class TestPMTilesAdvancedParameters:
-    """Test PMTiles generation with advanced gpio-pmtiles parameters."""
+    """Test PMTiles generation with advanced geoparquet-io parameters."""
 
     def test_precision_parameter_accepted(self, collection_with_geoparquet: Path) -> None:
         """Custom precision parameter is accepted by tippecanoe."""
@@ -609,3 +609,60 @@ class TestPMTilesAdvancedParameters:
         assert len(result.generated) == 1
         assert result.success is True
         assert (collection_with_geoparquet / "roads.pmtiles").exists()
+
+
+class TestForcePMTilesFlagEndToEnd:
+    """`portolan add --force-pmtiles` generates tiles on its own (Issue #760)."""
+
+    def test_force_flag_alone_generates_pmtiles(self, tmp_path: Path, fixtures_dir: Path) -> None:
+        """--force-pmtiles without --pmtiles tiles a catalog that never opted in.
+
+        `pmtiles.enabled` defaults to false. Before the fix the gate read
+        `--pmtiles` alone, so this command exited 0 and wrote no tiles.
+        """
+        from click.testing import CliRunner
+
+        from portolan_cli import cli
+
+        root = tmp_path / "catalog"
+        collection_dir = root / "roads"
+        collection_dir.mkdir(parents=True)
+        shutil.copy(
+            fixtures_dir / "realdata" / "road-detections.parquet", collection_dir / "roads.parquet"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "init",
+                str(root),
+                "--auto",
+                "--title",
+                "Force Flag Catalog",
+                "--description",
+                "Roads published to prove --force-pmtiles tiles on its own.",
+                "--license",
+                "CC-BY-4.0",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+        # The catalog never opts in, so only the flag can turn generation on.
+        config_text = (root / ".portolan" / "config.yaml").read_text(encoding="utf-8")
+        assert "pmtiles" not in config_text, config_text
+
+        result = runner.invoke(
+            cli,
+            [
+                "add",
+                "--portolan-dir",
+                str(root),
+                "--force-pmtiles",
+                str(collection_dir / "roads.parquet"),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert (collection_dir / "roads.pmtiles").is_file(), result.output

--- a/tests/unit/test_pmtiles.py
+++ b/tests/unit/test_pmtiles.py
@@ -24,7 +24,7 @@ class TestPMTilesErrors:
         from portolan_cli.viz.pmtiles import PMTilesNotAvailableError
 
         error = PMTilesNotAvailableError()
-        assert "gpio-pmtiles" in str(error)
+        assert "geoparquet-io" in str(error)
         assert "pip install" in str(error)
 
     @pytest.mark.unit
@@ -95,19 +95,19 @@ class TestCheckPMTilesAvailable:
     """Tests for dependency checking."""
 
     @pytest.mark.unit
-    def test_raises_when_gpio_pmtiles_not_installed(self) -> None:
-        """Raises PMTilesNotAvailableError when gpio-pmtiles missing."""
+    def test_raises_when_geoparquet_io_pmtiles_not_installed(self) -> None:
+        """Raises PMTilesNotAvailableError when geoparquet-io PMTiles support is missing."""
         from portolan_cli.viz.pmtiles import (
             PMTilesNotAvailableError,
             check_pmtiles_available,
         )
 
         # Setting sys.modules[name] = None makes `import name` raise ImportError,
-        # scoped to gpio_pmtiles only. Do NOT patch builtins.__import__ globally
-        # here: mutmut's trampoline runs `import os` at call time, so a global
-        # __import__ side_effect raises from the trampoline before the function
-        # body's try/except runs, failing the baseline stats phase (#612).
-        with patch.dict("sys.modules", {"gpio_pmtiles": None}):
+        # scoped to geoparquet_io.api.ops only. Do NOT patch builtins.__import__
+        # globally here: mutmut's trampoline runs `import os` at call time, so a
+        # global __import__ side_effect raises from the trampoline before the
+        # function body's try/except runs, failing the baseline stats phase (#612).
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": None}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with pytest.raises(PMTilesNotAvailableError):
                     check_pmtiles_available()
@@ -120,9 +120,9 @@ class TestCheckPMTilesAvailable:
             check_pmtiles_available,
         )
 
-        # Mock gpio_pmtiles as available but tippecanoe missing
+        # Mock geoparquet-io PMTiles support as available but tippecanoe missing
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value=None):
                 with pytest.raises(TippecanoeNotFoundError):
                     check_pmtiles_available()
@@ -606,8 +606,8 @@ class TestGeneratePMTiles:
     """Tests for generate_pmtiles function parameter passthrough."""
 
     @pytest.mark.unit
-    def test_passes_all_parameters_to_gpio_pmtiles(self, tmp_path: Path) -> None:
-        """All parameters are passed through to create_pmtiles_from_geoparquet."""
+    def test_passes_all_parameters_to_geoparquet_io(self, tmp_path: Path) -> None:
+        """All parameters are passed through to geoparquet-io create_pmtiles."""
         from portolan_cli.viz.pmtiles import generate_pmtiles
 
         parquet = tmp_path / "data.parquet"
@@ -616,9 +616,9 @@ class TestGeneratePMTiles:
 
         mock_create = MagicMock()
         mock_module = MagicMock()
-        mock_module.create_pmtiles_from_geoparquet = mock_create
+        mock_module.create_pmtiles = mock_create
 
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 generate_pmtiles(
                     parquet,
@@ -659,14 +659,39 @@ class TestGeneratePMTiles:
 
         mock_create = MagicMock()
         mock_module = MagicMock()
-        mock_module.create_pmtiles_from_geoparquet = mock_create
+        mock_module.create_pmtiles = mock_create
 
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 generate_pmtiles(parquet, pmtiles)
 
         call_kwargs = mock_create.call_args[1]
         assert call_kwargs["precision"] == 6
+
+    @pytest.mark.unit
+    def test_does_not_import_deprecated_gpio_pmtiles(self, tmp_path: Path) -> None:
+        """Generation works when gpio-pmtiles is absent (Issue #754).
+
+        `sys.modules[name] = None` makes `import name` raise ImportError. The
+        deprecated package is therefore unreachable for the duration of the test.
+        """
+        from portolan_cli.viz.pmtiles import generate_pmtiles
+
+        parquet = tmp_path / "data.parquet"
+        pmtiles = tmp_path / "data.pmtiles"
+        parquet.write_bytes(b"PAR1")
+
+        mock_create = MagicMock()
+        mock_module = MagicMock()
+        mock_module.create_pmtiles = mock_create
+
+        with patch.dict(
+            "sys.modules", {"gpio_pmtiles": None, "geoparquet_io.api.ops": mock_module}
+        ):
+            with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
+                generate_pmtiles(parquet, pmtiles)
+
+        mock_create.assert_called_once()
 
 
 class TestGeneratePMTilesForCollection:
@@ -685,7 +710,7 @@ class TestGeneratePMTilesForCollection:
 
         # Mock dependencies as available
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 result = generate_pmtiles_for_collection(collection_dir, tmp_path)
 
@@ -732,7 +757,7 @@ class TestGeneratePMTilesForCollection:
         mock_generate = MagicMock()
         mock_module = MagicMock()
 
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate):
                     generate_pmtiles_for_collection(
@@ -766,7 +791,7 @@ class TestGeneratePMTilesForCollection:
     def test_cleans_up_partial_file_on_failure(self, tmp_path: Path) -> None:
         """Partial PMTiles file is deleted when generation fails (Issue #385).
 
-        When gpio-pmtiles/tippecanoe fails mid-generation, it may leave a
+        When geoparquet-io or tippecanoe fails mid-generation, it may leave a
         partial output file. This test verifies that such files are cleaned
         up to prevent phantom assets in versions.json on subsequent add runs.
         """
@@ -795,12 +820,12 @@ class TestGeneratePMTilesForCollection:
 
         # Mock generate_pmtiles to create partial file then raise
         def mock_generate_raises(*args: object, **kwargs: object) -> None:
-            # Simulate: gpio-pmtiles creates file, then fails mid-processing
+            # Simulate: geoparquet-io creates file, then fails mid-processing
             pmtiles_path.write_bytes(b"partial content")
             raise PMTilesGenerationError("data.parquet", ValueError("Non-geospatial"))
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate_raises):
                     result = generate_pmtiles_for_collection(collection_dir, tmp_path)
@@ -843,7 +868,7 @@ class TestGeneratePMTilesForCollection:
             raise RuntimeError("Unexpected tippecanoe crash")
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate_unexpected):
                     result = generate_pmtiles_for_collection(collection_dir, tmp_path)
@@ -882,7 +907,7 @@ class TestGeneratePMTilesForCollection:
             raise KeyboardInterrupt()
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate_interrupted):
                     with pytest.raises(KeyboardInterrupt):
@@ -948,7 +973,7 @@ class TestGeneratePMTilesForCollection:
             return thumb_path
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate):
                     with patch(
@@ -1005,7 +1030,7 @@ class TestGeneratePMTilesForCollection:
             pmtiles_path.write_bytes(b"PMTILES")
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate):
                     generate_pmtiles_for_collection(collection_dir, tmp_path)
@@ -1075,7 +1100,7 @@ class TestGeneratePMTilesForCollection:
         (collection_dir / "versions.json").write_text(json.dumps(versions_json))
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 result = generate_pmtiles_for_collection(collection_dir, tmp_path)
 
@@ -1103,7 +1128,7 @@ class TestGeneratePMTilesForCollection:
         assert coll_json["assets"]["thumbnail"]["href"] == "./data.thumb.jpg"
 
         # Idempotent: a second run with everything tracked creates NO new version.
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 generate_pmtiles_for_collection(collection_dir, tmp_path)
         versions_after = read_versions(collection_dir / "versions.json")
@@ -1164,7 +1189,7 @@ class TestGeneratePMTilesForCollection:
             pmtiles_path.write_bytes(b"PMTILES")
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate):
                     with _patch(
@@ -1198,7 +1223,7 @@ class TestGeneratePMTilesForCollection:
             raise RuntimeError("render exploded")
 
         mock_module = MagicMock()
-        with patch.dict("sys.modules", {"gpio_pmtiles": mock_module}):
+        with patch.dict("sys.modules", {"geoparquet_io.api.ops": mock_module}):
             with patch("portolan_cli.viz.pmtiles.shutil.which", return_value="/usr/bin/tippecanoe"):
                 with patch("portolan_cli.viz.pmtiles.generate_pmtiles", mock_generate):
                     with patch("portolan_cli.viz.pmtiles.generate_vector_thumbnail", boom):
@@ -1376,3 +1401,71 @@ class TestGenerateOrSuggestPMTiles:
                 verbose=False,
             )
         mock_gen.assert_not_called()
+
+    @pytest.mark.unit
+    def test_force_alone_generates_when_config_disabled(self, tmp_path: Path) -> None:
+        """--force-pmtiles alone turns generation on (Issue #760).
+
+        Before the fix the gate read `--pmtiles` only. A catalog with
+        `pmtiles.enabled: false` therefore skipped the collection, and
+        `generate_pmtiles_for_collection` never ran.
+        """
+        from portolan_cli.viz.pmtiles import PMTilesResult, generate_or_suggest_pmtiles
+
+        coll_path = _make_collection(tmp_path, "roads", "pmtiles:\n  enabled: false\n")
+        with patch(
+            "portolan_cli.viz.pmtiles.generate_pmtiles_for_collection",
+            return_value=PMTilesResult(),
+        ) as mock_gen:
+            generate_or_suggest_pmtiles(
+                tmp_path,
+                {"roads"},
+                generate_pmtiles=False,
+                force=True,
+                verbose=False,
+            )
+        mock_gen.assert_called_once()
+        assert mock_gen.call_args.args[0] == coll_path
+        assert mock_gen.call_args.kwargs["force"] is True
+
+    @pytest.mark.unit
+    def test_force_alone_unavailable_exits(self, tmp_path: Path) -> None:
+        """--force-pmtiles alone is an explicit request, so a missing tool exits 1."""
+        from portolan_cli.viz.pmtiles import (
+            PMTilesNotAvailableError,
+            generate_or_suggest_pmtiles,
+        )
+
+        _make_collection(tmp_path, "roads", "pmtiles:\n  enabled: false\n")
+        with patch(
+            "portolan_cli.viz.pmtiles.generate_pmtiles_for_collection",
+            side_effect=PMTilesNotAvailableError(),
+        ):
+            with pytest.raises(SystemExit):
+                generate_or_suggest_pmtiles(
+                    tmp_path,
+                    {"roads"},
+                    generate_pmtiles=False,
+                    force=True,
+                    verbose=False,
+                )
+
+    @pytest.mark.unit
+    def test_force_alone_failure_exits(self, tmp_path: Path) -> None:
+        """A failure under --force-pmtiles alone exits 1 instead of a warning."""
+        from portolan_cli.viz.pmtiles import PMTilesResult, generate_or_suggest_pmtiles
+
+        _make_collection(tmp_path, "roads", "pmtiles:\n  enabled: false\n")
+        failed = PMTilesResult(failed=[(Path("roads.parquet"), "tippecanoe failed")])
+        with patch(
+            "portolan_cli.viz.pmtiles.generate_pmtiles_for_collection",
+            return_value=failed,
+        ):
+            with pytest.raises(SystemExit):
+                generate_or_suggest_pmtiles(
+                    tmp_path,
+                    {"roads"},
+                    generate_pmtiles=False,
+                    force=True,
+                    verbose=False,
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -1884,20 +1884,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gpio-pmtiles"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "geoparquet-io" },
-    { name = "pyarrow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/7d/35f870fa181a96bf4395bd54196b5118483e11daf25737754cf736213dfa/gpio_pmtiles-0.2.0.tar.gz", hash = "sha256:ce51abb350eb484325c1e30dc60cd82f20d8190f0ff3b641d5ff800af1d1c46c", size = 195995, upload-time = "2026-04-29T12:21:45.445Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e9/1d8173559da8f35957bb6e5d208ef2584674f1c467558a2234d052a31630/gpio_pmtiles-0.2.0-py3-none-any.whl", hash = "sha256:5a1d7e3d9e7faed24c11128e0fd2470ac9e7e478428a5480ec8a6dc66c22257d", size = 13388, upload-time = "2026-04-29T12:21:44.096Z" },
-]
-
-[[package]]
 name = "graphql-core"
 version = "3.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -4646,9 +4632,7 @@ iceberg = [
     { name = "pyiceberg", extra = ["sql-sqlite"] },
     { name = "shapely" },
 ]
-pmtiles = [
-    { name = "gpio-pmtiles" },
-]
+pmtiles = []
 thumbnails = [
     { name = "contextily" },
     { name = "mapbox-vector-tile" },
@@ -4682,7 +4666,6 @@ requires-dist = [
     { name = "geopandas", specifier = ">=0.14.0" },
     { name = "geoparquet-io", git = "https://github.com/geoparquet/geoparquet-io.git?branch=main" },
     { name = "gitingest", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "gpio-pmtiles", marker = "extra == 'pmtiles'", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.151.5" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },


### PR DESCRIPTION
## What changed

`portolan add --force-pmtiles` now generates new PMTiles even when `pmtiles.enabled` is `false`. The flag implies `--pmtiles`, including its failure behavior: if generation fails, the command exits 1 instead of silently keeping old tiles.

PMTiles generation now uses `geoparquet_io.api.ops.create_pmtiles`. The deprecated `gpio-pmtiles` dependency is removed. The `pmtiles` extra remains as an empty compatibility extra, so existing `pip install portolan-cli[pmtiles]` commands still work.

## Why

Resolves #760 and #754.

`--force-pmtiles` is used when existing tiles need to be rebuilt, but the old code only generated tiles when `--pmtiles` was also set. A forced rebuild could therefore exit successfully without rebuilding anything.

The CLI also depended on the deprecated `gpio-pmtiles` package even though `geoparquet-io`, already a core dependency, now provides the maintained implementation.

## Verification

Using `tests/fixtures/realdata/road-detections.parquet`, which contains 1,000 features, `--force-pmtiles` on `main` exits 0 without creating PMTiles:

```text id="7p0m1f"
$ portolan add roads/roads.parquet --force-pmtiles
✓ Added 1 file to 1 collection
$ ls roads/
AGENTS.md  README.md  collection.json  roads.parquet  roads.thumb.jpg  versions.json
```

The same command on this branch creates the file:

```text id="o0c86v"
$ portolan add roads/roads.parquet --force-pmtiles
✓ Generated PMTiles: roads.pmtiles
✓ Added 1 file to 1 collection
$ ls roads/
AGENTS.md  README.md  collection.json  roads.parquet  roads.pmtiles  roads.thumb.jpg  styles  versions.json
```

The environment has no `gpio-pmtiles` installation. On `main`, `--pmtiles` therefore fails with `PRTLN-PMT001`; this branch successfully generates the same tiles through `geoparquet-io`.

The PMTiles test suites pass with deprecation warnings treated as errors:

```text id="i44v69"
$ uv run pytest tests/unit/test_pmtiles.py tests/integration/test_pmtiles_integration.py \
    -q --no-cov -W error::DeprecationWarning
65 passed, 1 skipped in 14.41s
```

Seven targeted assertions fail against `main`, covering forced generation, failure handling, removal of the deprecated import, and the `geoparquet-io` integration.

## Implementation notes

`generate_or_suggest_pmtiles` now treats `generate_pmtiles or force` as an explicit generation request. That controls both whether generation runs and whether a failure returns a non-zero exit status.

`check_pmtiles_available` now imports `geoparquet_io.api.ops.create_pmtiles`, and `PMTilesNotAvailableError` points users to `geoparquet-io`.

The existing unlink-before-generation behavior remains because the `force` argument to `create_pmtiles` was added after geoparquet-io 1.3.0.

The `uv.lock` dependency entry was edited directly because the local uv version would otherwise rewrite the entire 9,000-line lockfile. `uv lock --check` passes.

Install and remediation hints were also updated: `PTL-VIZ-004` now points to `portolan add --pmtiles`, while the PMTiles reader points to `pip install pmtiles`.

## Breaking Changes

None. Existing `[pmtiles]` installs continue to resolve, while PMTiles generation itself is now provided by the default `geoparquet-io` dependency.

## Checklist

* [x] Tests written **first** and exercise real behavior (TDD)
* [x] Integration coverage where the change crosses layers
* [ ] `prek run --all-files` is green locally; all required CI checks pass
* [ ] Changed lines are covered (`codecov/patch`)
* [ ] At least one adversarial review
* [ ] CodeRabbit comments addressed
* [x] Docs updated and, for non-obvious decisions, an ADR added
