### PR TITLE
fix(check): point PTL-VIZ-004 remediation at 'portolan add --pmtiles'

### DIFF
--- a/portolan_cli/validation/remediation.py
+++ b/portolan_cli/validation/remediation.py
@@ -218,8 +218,9 @@ RULE_REMEDIATION: dict[str, Remediation] = {
         "Register the PMTiles asset with a rel='pmtiles' link (web-map-links v1.3.0).",
     ),
     "PTL-VIZ-004": _instruct(
-        "Generate a PMTiles derivative for this large vector collection so browsers can render it "
-        "; run `portolan viz` with the [pmtiles] extra."
+        "Generate a PMTiles derivative for this large vector collection so browsers can render "
+        "it; run `portolan add <collection> --pmtiles` (requires the [pmtiles] extra and "
+        "tippecanoe)."
     ),
     # fixer `styles` is new in Phase 3; it corrects the style asset media type
     "PTL-VIZ-005": _auto(


### PR DESCRIPTION
## What

Replaces the PTL-VIZ-004 remediation text that told users to run `portolan viz` — a command that does not exist — with the actual command, `portolan add <collection> --pmtiles` (noting the `[pmtiles]` extra and tippecanoe prerequisites).

## Why

Anyone following the current remediation hits a dead end (`Error: No such command 'viz'`). Found while building the IDE Extremadura catalog with 1.0.0b0.

Fixes #787

## Verification

`grep -rn "portolan viz"` over portolan_cli/, tests/ and docs/ returns nothing; `tests/unit/validation/test_remediation_table.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated remediation guidance for `PTL-VIZ-004` to instruct users to run `portolan add <collection> --pmtiles` instead of `portolan viz`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->