### PR TITLE
fix(viz): write loadable pmtiles:// style sources with the archive zoom range

### DIFF
--- a/portolan_cli/extract/common/converters/base.py
+++ b/portolan_cli/extract/common/converters/base.py
@@ -308,6 +308,8 @@ def make_mapbox_style(
     source_layer: str,
     layers: list[dict[str, Any]],
     pmtiles_url: str | None = None,
+    min_zoom: int | None = None,
+    max_zoom: int | None = None,
 ) -> dict[str, Any]:
     """Build a complete Mapbox GL style document.
 
@@ -315,14 +317,23 @@ def make_mapbox_style(
         name: Style name (appears in style["name"]).
         source_layer: Default source layer name.
         layers: List of layer dicts (from make_*_layer functions).
-        pmtiles_url: Optional PMTiles URL for the source.
+        pmtiles_url: Optional PMTiles URL for the source. A bare path is
+            written with the ``pmtiles://`` scheme so MapLibre can load it
+            (issue #756). When omitted, the source is completed later by
+            ``viz.style.complete_style_sources`` once the archive exists.
+        min_zoom: Optional archive minimum zoom (source ``minzoom``).
+        max_zoom: Optional archive maximum zoom (source ``maxzoom``).
 
     Returns:
         Complete Mapbox GL style dict with version, sources, and layers.
     """
     source: dict[str, Any] = {"type": "vector"}
     if pmtiles_url:
-        source["url"] = pmtiles_url
+        source["url"] = pmtiles_url if "://" in pmtiles_url else f"pmtiles://{pmtiles_url}"
+    if min_zoom is not None:
+        source["minzoom"] = min_zoom
+    if max_zoom is not None:
+        source["maxzoom"] = max_zoom
 
     return {
         "version": 8,

--- a/portolan_cli/viz/pmtiles.py
+++ b/portolan_cli/viz/pmtiles.py
@@ -356,16 +356,39 @@ def _write_default_style_for_geoparquet(
 
         config = get_vector_style_config(catalog_path) if catalog_path else VectorStyleConfig()
 
+        # Thread the archive's zoom range into the style source so MapLibre
+        # never requests tiles beyond what tippecanoe produced (issue #756).
+        min_zoom, max_zoom = _pmtiles_zoom_range(collection_path / pmtiles_relative_path)
+
         return write_default_style(
             collection_path=collection_path,
             geometry_type=geometry_type,
             source_layer=layer_name,
             pmtiles_relative_path=pmtiles_relative_path,
             config=config,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
         )
     except Exception as e:
         logger.debug("Failed to write default style for %s: %s", parquet_path, e)
         return None
+
+
+def _pmtiles_zoom_range(pmtiles_path: Path) -> tuple[int | None, int | None]:
+    """Read (min_zoom, max_zoom) from a PMTiles archive header, or (None, None).
+
+    Zoom range is advisory for styles: a style without it still loads, so any
+    failure to read the header degrades to omitting the range rather than
+    failing style generation.
+    """
+    try:
+        from portolan_cli.metadata.pmtiles import extract_pmtiles_metadata
+
+        meta = extract_pmtiles_metadata(pmtiles_path)
+    except Exception as e:  # pragma: no cover - defensive, header read is best-effort
+        logger.debug("Could not read PMTiles zoom range from %s: %s", pmtiles_path, e)
+        return None, None
+    return meta.min_zoom, meta.max_zoom
 
 
 def add_pmtiles_asset_to_collection(
@@ -787,7 +810,24 @@ def generate_pmtiles_for_collection(
             _track_side_step_assets(collection_path, pmtiles_path, thumb_path, catalog_root)
 
     # Discover and register style assets
-    from portolan_cli.viz.style import discover_styles, register_style_assets
+    from portolan_cli.viz.style import (
+        complete_style_sources,
+        discover_styles,
+        register_style_assets,
+    )
+
+    # Repair styles written before the archive existed (extract-produced SLD
+    # styles have a vector source with no URL) and normalize bare-path URLs to
+    # the loadable pmtiles:// form, filling the archive's zoom range (#756).
+    if result.generated:
+        newest = result.generated[-1]
+        min_zoom, max_zoom = _pmtiles_zoom_range(newest)
+        complete_style_sources(
+            collection_path,
+            pmtiles_relative_path=newest.name,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+        )
 
     styles = discover_styles(collection_path)
     register_style_assets(collection_path, styles)

--- a/portolan_cli/viz/style.py
+++ b/portolan_cli/viz/style.py
@@ -175,12 +175,26 @@ class RasterStyleConfig:
 # =============================================================================
 
 
+def pmtiles_source_url(pmtiles_path: str) -> str:
+    """Return a MapLibre-loadable source URL for a PMTiles path.
+
+    The MapLibre PMTiles plugin only intercepts URLs carrying the
+    ``pmtiles://`` scheme; a bare path is treated as TileJSON and fails to
+    load (issue #756). Paths that already carry a scheme are returned as-is.
+    """
+    if "://" in pmtiles_path:
+        return pmtiles_path
+    return f"pmtiles://{pmtiles_path}"
+
+
 def build_full_style(
     name: str,
     geometry_type: str,
     source_layer: str,
     pmtiles_relative_path: str,
     config: VectorStyleConfig,
+    min_zoom: int | None = None,
+    max_zoom: int | None = None,
 ) -> dict[str, Any]:
     """Build complete Mapbox GL v8 style with sources and layers.
 
@@ -193,7 +207,13 @@ def build_full_style(
         geometry_type: OGC geometry type (Point, LineString, Polygon, etc.).
         source_layer: Name of the source layer in PMTiles.
         pmtiles_relative_path: Relative path to PMTiles file (e.g., "../data.pmtiles").
+            Written as a ``pmtiles://`` URL so MapLibre can load it.
         config: Style configuration.
+        min_zoom: Minimum zoom of the PMTiles archive, written as the source's
+            ``minzoom`` (omitted when None).
+        max_zoom: Maximum zoom of the PMTiles archive, written as the source's
+            ``maxzoom`` so MapLibre does not request tiles beyond the archive's
+            range (omitted when None).
 
     Returns:
         Complete Mapbox GL style spec dict with version, name, sources, and layers.
@@ -235,15 +255,19 @@ def build_full_style(
         "paint": paint,
     }
 
+    source: dict[str, Any] = {
+        "type": "vector",
+        "url": pmtiles_source_url(pmtiles_relative_path),
+    }
+    if min_zoom is not None:
+        source["minzoom"] = min_zoom
+    if max_zoom is not None:
+        source["maxzoom"] = max_zoom
+
     return {
         "version": 8,
         "name": name,
-        "sources": {
-            "data": {
-                "type": "vector",
-                "url": pmtiles_relative_path,
-            }
-        },
+        "sources": {"data": source},
         "layers": [layer],
     }
 
@@ -279,12 +303,81 @@ def write_style_file(
     return style_path
 
 
+def complete_style_sources(
+    collection_path: Path,
+    pmtiles_relative_path: str,
+    min_zoom: int | None = None,
+    max_zoom: int | None = None,
+) -> list[Path]:
+    """Make every style under styles/ point at a loadable PMTiles source.
+
+    Styles can be written before their archive exists (extract converts SLD
+    styles at extraction time), leaving a vector source with no ``url``; older
+    generations also wrote bare relative paths, which MapLibre treats as
+    TileJSON and fails to load (issue #756). Run after PMTiles generation,
+    this pass repairs both cases and fills the archive's zoom range:
+
+    - a vector source with no ``url`` gets ``pmtiles://../<archive>``;
+    - a bare-path ``url`` is prefixed with the ``pmtiles://`` scheme;
+    - ``minzoom``/``maxzoom`` are set when absent and known.
+
+    Sources that already carry a scheme keep their URL (only the zoom range
+    may be filled in). Files are rewritten only when something changed.
+
+    Args:
+        collection_path: Path to the collection directory.
+        pmtiles_relative_path: Archive path relative to the collection
+            (e.g., "data.pmtiles"), used for sources with no URL.
+        min_zoom: Archive minimum zoom, or None to leave sources untouched.
+        max_zoom: Archive maximum zoom, or None to leave sources untouched.
+
+    Returns:
+        Paths of the style files that were modified.
+    """
+    styles_dir = collection_path / "styles"
+    if not styles_dir.is_dir():
+        return []
+
+    modified: list[Path] = []
+    for style_path in sorted(styles_dir.glob("*.json")):
+        try:
+            style = json.loads(style_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        sources = style.get("sources")
+        if not isinstance(sources, dict):
+            continue
+        changed = False
+        for source in sources.values():
+            if not isinstance(source, dict) or source.get("type") != "vector":
+                continue
+            url = source.get("url")
+            if not url:
+                source["url"] = pmtiles_source_url(f"../{pmtiles_relative_path}")
+                changed = True
+            elif "://" not in url:
+                source["url"] = pmtiles_source_url(url)
+                changed = True
+            if min_zoom is not None and "minzoom" not in source:
+                source["minzoom"] = min_zoom
+                changed = True
+            if max_zoom is not None and "maxzoom" not in source:
+                source["maxzoom"] = max_zoom
+                changed = True
+        if changed:
+            write_json_atomic(style_path, style)
+            modified.append(style_path)
+    return modified
+
+
 def write_default_style(
     collection_path: Path,
     geometry_type: str,
     source_layer: str,
     pmtiles_relative_path: str,
     config: VectorStyleConfig | None = None,
+    min_zoom: int | None = None,
+    max_zoom: int | None = None,
 ) -> Path | None:
     """Write default style to {collection_path}/styles/default.json.
 
@@ -298,6 +391,8 @@ def write_default_style(
         pmtiles_relative_path: PMTiles path relative to collection (e.g., "data.pmtiles"
             or "sub/data.pmtiles"). Will be prefixed with "../" for styles/ directory.
         config: Optional style configuration (uses defaults if None).
+        min_zoom: Optional minimum zoom of the PMTiles archive (source minzoom).
+        max_zoom: Optional maximum zoom of the PMTiles archive (source maxzoom).
 
     Returns:
         Path to written file, or None if default.json already exists.
@@ -318,6 +413,8 @@ def write_default_style(
         source_layer=source_layer,
         pmtiles_relative_path=f"../{pmtiles_relative_path}",
         config=config,
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
     )
 
     return write_style_file(styles_dir, "default", style_dict)

--- a/tests/integration/test_thumbnail_workflow.py
+++ b/tests/integration/test_thumbnail_workflow.py
@@ -120,7 +120,7 @@ class TestStyleInStacAssets:
 
         assert style["version"] == 8
         assert style["name"] == "Default"
-        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert style["sources"]["data"]["url"] == "pmtiles://../data.pmtiles"
         assert len(style["layers"]) == 1
         assert style["layers"][0]["type"] == "fill"
 

--- a/tests/unit/extract/common/converters/test_base.py
+++ b/tests/unit/extract/common/converters/test_base.py
@@ -338,7 +338,7 @@ class TestMapboxStyleBuilder:
             layers=[layer],
             pmtiles_url="../data.pmtiles",
         )
-        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert style["sources"]["data"]["url"] == "pmtiles://../data.pmtiles"
 
     def test_make_mapbox_style_multiple_layers(self) -> None:
         """Style with multiple layers (e.g., fill + outline)."""

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -577,7 +577,7 @@ class TestBuildFullStyle:
         assert "sources" in style
         assert "data" in style["sources"]
         assert style["sources"]["data"]["type"] == "vector"
-        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert style["sources"]["data"]["url"] == "pmtiles://../data.pmtiles"
 
         # Check layers
         assert "layers" in style
@@ -798,7 +798,7 @@ class TestWriteDefaultStyle:
         style = json.loads(result_path.read_text())
         assert style["version"] == 8
         assert style["name"] == "Default"
-        assert style["sources"]["data"]["url"] == "../data.pmtiles"
+        assert style["sources"]["data"]["url"] == "pmtiles://../data.pmtiles"
         assert style["layers"][0]["type"] == "fill"
         assert style["layers"][0]["source"] == "data"
         assert style["layers"][0]["source-layer"] == "parcels"
@@ -1492,3 +1492,132 @@ class TestRegisterLegendAssets:
         # A rewrite strips the removed manifest the old catalog carried.
         assert "portolan:legends" not in updated
         assert updated["assets"]["legends/source"]["roles"] == ["legend"]
+
+
+class TestPmtilesSourceUrl:
+    """pmtiles_source_url and zoom range on generated sources (issue #756)."""
+
+    @pytest.mark.unit
+    def test_prefixes_bare_paths(self) -> None:
+        from portolan_cli.viz.style import pmtiles_source_url
+
+        assert pmtiles_source_url("../data.pmtiles") == "pmtiles://../data.pmtiles"
+        assert pmtiles_source_url("pmtiles://../data.pmtiles") == "pmtiles://../data.pmtiles"
+        assert pmtiles_source_url("https://x/y.pmtiles") == "https://x/y.pmtiles"
+
+    @pytest.mark.unit
+    def test_build_full_style_writes_zoom_range(self) -> None:
+        from portolan_cli.viz.style import VectorStyleConfig, build_full_style
+
+        style = build_full_style(
+            name="Default",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=VectorStyleConfig(),
+            min_zoom=4,
+            max_zoom=12,
+        )
+        source = style["sources"]["data"]
+        assert source["url"] == "pmtiles://../data.pmtiles"
+        assert source["minzoom"] == 4
+        assert source["maxzoom"] == 12
+
+    @pytest.mark.unit
+    def test_build_full_style_omits_unknown_zoom_range(self) -> None:
+        from portolan_cli.viz.style import VectorStyleConfig, build_full_style
+
+        style = build_full_style(
+            name="Default",
+            geometry_type="Polygon",
+            source_layer="parcels",
+            pmtiles_relative_path="../data.pmtiles",
+            config=VectorStyleConfig(),
+        )
+        source = style["sources"]["data"]
+        assert "minzoom" not in source
+        assert "maxzoom" not in source
+
+
+class TestCompleteStyleSources:
+    """complete_style_sources repairs unloadable style sources (issue #756)."""
+
+    def _write(self, path: Path, style: dict) -> None:
+        import json
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(style))
+
+    @pytest.mark.unit
+    def test_fills_missing_url_and_zoom(self, tmp_path: Path) -> None:
+        import json
+
+        from portolan_cli.viz.style import complete_style_sources
+
+        style_path = tmp_path / "styles" / "default.json"
+        self._write(
+            style_path,
+            {"version": 8, "sources": {"data": {"type": "vector"}}, "layers": []},
+        )
+
+        modified = complete_style_sources(
+            tmp_path, pmtiles_relative_path="data.pmtiles", min_zoom=0, max_zoom=11
+        )
+
+        assert modified == [style_path]
+        source = json.loads(style_path.read_text())["sources"]["data"]
+        assert source["url"] == "pmtiles://../data.pmtiles"
+        assert source["minzoom"] == 0
+        assert source["maxzoom"] == 11
+
+    @pytest.mark.unit
+    def test_prefixes_bare_url_keeps_schemed_url(self, tmp_path: Path) -> None:
+        import json
+
+        from portolan_cli.viz.style import complete_style_sources
+
+        bare = tmp_path / "styles" / "bare.json"
+        schemed = tmp_path / "styles" / "schemed.json"
+        self._write(
+            bare,
+            {"version": 8, "sources": {"data": {"type": "vector", "url": "../a.pmtiles"}}},
+        )
+        self._write(
+            schemed,
+            {
+                "version": 8,
+                "sources": {"data": {"type": "vector", "url": "pmtiles://../b.pmtiles"}},
+            },
+        )
+
+        complete_style_sources(tmp_path, pmtiles_relative_path="a.pmtiles")
+
+        assert json.loads(bare.read_text())["sources"]["data"]["url"] == "pmtiles://../a.pmtiles"
+        assert json.loads(schemed.read_text())["sources"]["data"]["url"] == "pmtiles://../b.pmtiles"
+
+    @pytest.mark.unit
+    def test_untouched_file_not_rewritten(self, tmp_path: Path) -> None:
+        from portolan_cli.viz.style import complete_style_sources
+
+        style_path = tmp_path / "styles" / "ok.json"
+        self._write(
+            style_path,
+            {
+                "version": 8,
+                "sources": {
+                    "data": {
+                        "type": "vector",
+                        "url": "pmtiles://../a.pmtiles",
+                        "minzoom": 0,
+                        "maxzoom": 10,
+                    }
+                },
+            },
+        )
+        assert complete_style_sources(tmp_path, "a.pmtiles", min_zoom=1, max_zoom=9) == []
+
+    @pytest.mark.unit
+    def test_no_styles_dir(self, tmp_path: Path) -> None:
+        from portolan_cli.viz.style import complete_style_sources
+
+        assert complete_style_sources(tmp_path, "a.pmtiles") == []


### PR DESCRIPTION
## What changed

Generated MapLibre styles now load their data. Style sources are written as `pmtiles://<relative path>` and carry `minzoom`/`maxzoom` read from the archive header. A completion pass after PMTiles generation (`complete_style_sources`) repairs styles written before the archive existed — the extract/SLD case, which had a vector source with no URL — and normalizes bare-path URLs, leaving already-schemed URLs alone.

The `check` rule for unresolvable style sources is not here: that is PORTO-FMT-015 enforcement and belongs in rashid.

## Why

Fixes #756. A bare URL is treated as TileJSON by MapLibre and fails silently; all 28 styles in a real catalog rendered nothing.

## Verification

Re-ran on the catalog that surfaced the bug (Junta de Extremadura mirror, collection `forestal/montes-comunales`):

```
>>> complete_style_sources(col, 'MontesComunales.pmtiles', min_zoom=mn, max_zoom=mx)
modified: ['default.json']
"data": {"type": "vector", "url": "pmtiles://../MontesComunales.pmtiles", "minzoom": 0, "maxzoom": 13}
```

The published broken form for comparison: https://storage.googleapis.com/carto-portolan-ide-extremadura-cli/forestal/montes-comunales/styles/default.json

## Implementation notes

New `pmtiles_source_url()` and `complete_style_sources()` in `viz/style.py`; zoom range read via `metadata.pmtiles.extract_pmtiles_metadata` (best-effort, omitted on failure); `make_mapbox_style` gains optional zoom params and normalizes bare URLs inline. Unit tests cover the scheme, zoom range, and completion pass.

## Related issues

#756, #758 (thumbnail fidelity, separate), rashid follow-up for the check rule.

## Breaking Changes

## Checklist

See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).

- [x] Tests written **first** and exercise real behavior (TDD)
- [x] Integration coverage where the change crosses layers
- [x] `prek run --all-files` is green locally; all required CI checks pass
- [ ] Changed lines are covered (`codecov/patch`)
- [ ] At least one adversarial review (actively tried to break it)
- [ ] CodeRabbit comments addressed
- [ ] Docs updated and, for non-obvious decisions, an ADR added

🤖 Generated with [Claude Code](https://claude.com/claude-code)