### PR TITLE
fix(formats): list GeoPackage layers from gpkg_contents, features only

### DIFF
--- a/portolan_cli/formats.py
+++ b/portolan_cli/formats.py
@@ -538,6 +538,16 @@ def list_layers(path: Path) -> list[str] | None:
         if not (path.is_dir() and extension == ".gdb"):
             return None
 
+    # A GeoPackage declares its own layers: gpkg_contents is spec-mandated and
+    # names each table's data_type. Reading it directly returns only feature
+    # layers, so non-spatial tables (QGIS ``layer_styles``, attribute-only
+    # tables) never become collection assets (#784) — and it keeps working on
+    # files where the delegated listing comes back empty.
+    if extension == ".gpkg":
+        feature_layers = _gpkg_feature_layers(path)
+        if feature_layers is not None:
+            return feature_layers if feature_layers else None
+
     # Delegate to geoparquet-io for both GeoPackage and FileGDB
     try:
         layers = gpio.list_layers(str(path.resolve()))
@@ -557,6 +567,30 @@ def list_layers(path: Path) -> list[str] | None:
     except Exception as e:
         logger.error("Failed to list layers in %s: %s", path, e)
         return None
+
+
+def _gpkg_feature_layers(path: Path) -> list[str] | None:
+    """Feature layers of a GeoPackage, straight from ``gpkg_contents``.
+
+    Returns None when the file cannot be read as a GeoPackage (caller falls
+    back to the delegated listing); an empty list means the file genuinely
+    has no feature layers.
+    """
+    import sqlite3
+
+    try:
+        con = sqlite3.connect(f"file:{path.resolve()}?mode=ro", uri=True)
+        try:
+            rows = con.execute(
+                "SELECT table_name FROM gpkg_contents WHERE data_type = 'features'"
+                " ORDER BY table_name"
+            ).fetchall()
+        finally:
+            con.close()
+    except sqlite3.Error as e:
+        logger.debug("Could not read gpkg_contents from %s: %s", path, e)
+        return None
+    return [row[0] for row in rows]
 
 
 def is_multilayer(path: Path) -> bool:

--- a/tests/unit/test_multilayer.py
+++ b/tests/unit/test_multilayer.py
@@ -188,3 +188,52 @@ class TestMultiLayerConversion:
 
         layer_names = {r.layer for r in results}
         assert layer_names == {"points", "lines", "polygons"}
+
+
+class TestGpkgNonSpatialLayers:
+    """gpkg_contents-based listing excludes non-spatial tables (issue #784)."""
+
+    def _gpkg_with_layer_styles(self, tmp_path: Path) -> Path:
+        """Copy the multilayer fixture and register a QGIS layer_styles table."""
+        import shutil
+        import sqlite3
+
+        gpkg = tmp_path / "styled.gpkg"
+        shutil.copy2(FIXTURES_DIR / "multilayer.gpkg", gpkg)
+        con = sqlite3.connect(gpkg)
+        con.execute("CREATE TABLE layer_styles (id INTEGER PRIMARY KEY, styleQML TEXT)")
+        con.execute(
+            "INSERT INTO gpkg_contents (table_name, data_type, identifier)"
+            " VALUES ('layer_styles', 'attributes', 'layer_styles')"
+        )
+        con.commit()
+        con.close()
+        return gpkg
+
+    @pytest.mark.unit
+    def test_layer_styles_excluded(self, tmp_path: Path) -> None:
+        from portolan_cli.formats import list_layers
+
+        gpkg = self._gpkg_with_layer_styles(tmp_path)
+        layers = list_layers(gpkg)
+
+        assert layers is not None
+        assert "layer_styles" not in layers
+        assert sorted(layers) == sorted(list_layers(FIXTURES_DIR / "multilayer.gpkg"))
+
+    @pytest.mark.unit
+    def test_matches_fixture_listing(self) -> None:
+        """gpkg_contents listing agrees with the delegated listing on clean files."""
+        from portolan_cli.formats import _gpkg_feature_layers, list_layers
+
+        direct = _gpkg_feature_layers(FIXTURES_DIR / "multilayer.gpkg")
+        assert direct is not None
+        assert sorted(direct) == sorted(list_layers(FIXTURES_DIR / "multilayer.gpkg"))
+
+    @pytest.mark.unit
+    def test_non_gpkg_returns_none(self, tmp_path: Path) -> None:
+        from portolan_cli.formats import _gpkg_feature_layers
+
+        not_gpkg = tmp_path / "plain.gpkg"
+        not_gpkg.write_text("not a sqlite file")
+        assert _gpkg_feature_layers(not_gpkg) is None


### PR DESCRIPTION
## What changed

GeoPackage layer listing reads `gpkg_contents WHERE data_type = 'features'` directly (stdlib sqlite3), so non-spatial tables — QGIS `layer_styles`, attribute-only tables — are never converted into collection assets. The delegated geoparquet-io listing stays as fallback for files whose `gpkg_contents` can't be read.

## Why

Fixes #784. Bonus found while fixing: on the real file below, `gpio.list_layers` returned `None` outright, so multilayer detection silently failed; the spec-mandated table is the reliable source.

## Verification

Against the GeoPackage from the issue: Junta de Extremadura CORINE 2000, downloaded from the SITEX download center (https://sitex.juntaex.es/SITEX/centrodescargas/viewsubcategoria/24, product "Usos del suelo - CORINE Land Cover", 2000) — one feature layer plus a QGIS `layer_styles` table:

```
>>> list_layers(Path('clc2000.gpkg'))   # before: None (delegated listing failed)
['CLC2000_Extremadura_v2']
>>> is_multilayer(Path('clc2000.gpkg'))
False
```

Unit tests add a fixture with a registered `layer_styles` table and assert it is excluded.

## Implementation notes

New `_gpkg_feature_layers()` in `formats.py`, read-only sqlite connection; empty list means genuinely no feature layers, None means unreadable → fallback.

## Related issues

#784; largely removes the need for a `--layer` flag (#756 discussion).

## Breaking Changes

## Checklist

See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).

- [x] Tests written **first** and exercise real behavior (TDD)
- [ ] Integration coverage where the change crosses layers
- [x] `prek run --all-files` is green locally; all required CI checks pass
- [ ] Changed lines are covered (`codecov/patch`)
- [ ] At least one adversarial review (actively tried to break it)
- [ ] CodeRabbit comments addressed
- [ ] Docs updated and, for non-obvious decisions, an ADR added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GeoPackage layer listings now include only spatial feature layers.
  * Non-spatial tables are excluded from results.
  * Empty GeoPackages correctly return no layers.
  * Added fallback handling for files that cannot be read directly.

* **Tests**
  * Added coverage for GeoPackage layer filtering and invalid file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
