### PR TITLE
fix(convert): repair shapefile encoding sidecars before conversion

### DIFF
--- a/portolan_cli/convert.py
+++ b/portolan_cli/convert.py
@@ -611,6 +611,60 @@ def run_with_transient_convert_retry(
     raise AssertionError("vector conversion retry loop exited without returning")
 
 
+def repair_shapefile_encoding_sidecar(shp: Path) -> Path | None:
+    """Make a shapefile's ``.cpg`` sidecar match what its DBF records contain.
+
+    Legacy government shapefiles routinely ship Latin-1 attribute text with no
+    ``.cpg`` (GDAL then passes raw bytes through and the GeoParquet writer's
+    UTF-8 validation fails deep in the pipeline), and some ship a sidecar that
+    LIES — UTF-8 records declared as ``1252``, which converts "successfully"
+    into mojibake (issue #783; both defects observed in SITEX Extremadura
+    data).
+
+    The encoding test reads only the DBF *records region* (after the header
+    length at bytes 8-9): the header is binary and would false-flag valid
+    UTF-8 files. Rules, both safe by construction:
+
+    - records are NOT valid UTF-8 and no/UTF-8 sidecar -> write ``ISO-8859-1``
+      (the standard single-byte fallback; it always decodes);
+    - records ARE valid UTF-8 with non-ASCII content but the sidecar declares
+      something else -> correct it to ``UTF-8`` (non-ASCII UTF-8 is
+      essentially unambiguous).
+
+    Returns the sidecar path when one was written or corrected, else None.
+    """
+    import struct
+
+    from portolan_cli.output import info as _output_info
+
+    dbf, cpg = shp.with_suffix(".dbf"), shp.with_suffix(".cpg")
+    if not dbf.exists():
+        return None
+    raw = dbf.read_bytes()
+    if len(raw) <= 32:
+        return None
+    header_len = struct.unpack_from("<H", raw, 8)[0]
+    records = raw[header_len:]
+    try:
+        records.decode("utf-8")
+        records_are_utf8 = True
+    except UnicodeDecodeError:
+        records_are_utf8 = False
+    has_non_ascii = any(b > 0x7F for b in records)
+    declared = cpg.read_text(errors="replace").strip().upper() if cpg.exists() else None
+
+    if records_are_utf8 and has_non_ascii and declared not in (None, "UTF-8", "UTF8"):
+        cpg.write_text("UTF-8")
+        _output_info(f"Corrected {cpg.name}: declared {declared}, DBF records are UTF-8")
+        return cpg
+    if not records_are_utf8 and (declared is None or "UTF" in (declared or "")):
+        cpg.write_text("ISO-8859-1")
+        what = f"corrected from {declared}" if declared else "written"
+        _output_info(f"Encoding sidecar {cpg.name} {what}: DBF records are not valid UTF-8")
+        return cpg
+    return None
+
+
 def _convert_vector(
     source: Path,
     output_dir: Path,
@@ -639,6 +693,9 @@ def _convert_vector(
     if settings is None:
         settings = VectorSettings()
     resolved = settings
+
+    if source.suffix.lower() == ".shp":
+        repair_shapefile_encoding_sidecar(source)
 
     output_path = output_dir / f"{source.stem}.parquet"
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -2059,3 +2059,73 @@ class TestVectorConversionRetriesTransientInterrupt:
             _convert_vector(tmp_path / "in.geojson", tmp_path)
 
         assert calls["n"] == 1
+
+
+class TestRepairShapefileEncodingSidecar:
+    """Encoding sidecar repair before shapefile conversion (issue #783)."""
+
+    def _dbf(self, path: Path, records: bytes) -> None:
+        """Minimal DBF: 32-byte header whose bytes 8-9 point past itself."""
+        import struct
+
+        header = bytearray(32)
+        header[0] = 0x03
+        struct.pack_into("<H", header, 8, 32)
+        path.write_bytes(bytes(header) + records)
+
+    def _shp(self, tmp_path: Path, records: bytes, cpg: str | None = None) -> Path:
+        shp = tmp_path / "data.shp"
+        shp.write_bytes(b"\x00" * 100)
+        self._dbf(shp.with_suffix(".dbf"), records)
+        if cpg is not None:
+            shp.with_suffix(".cpg").write_text(cpg)
+        return shp
+
+    @pytest.mark.unit
+    def test_latin1_records_without_cpg_get_iso_sidecar(self, tmp_path: Path) -> None:
+        from portolan_cli.convert import repair_shapefile_encoding_sidecar
+
+        shp = self._shp(tmp_path, "Tentud\xeda embalse".encode("latin-1"))
+        result = repair_shapefile_encoding_sidecar(shp)
+
+        assert result is not None
+        assert shp.with_suffix(".cpg").read_text() == "ISO-8859-1"
+
+    @pytest.mark.unit
+    def test_lying_cpg_over_utf8_records_is_corrected(self, tmp_path: Path) -> None:
+        from portolan_cli.convert import repair_shapefile_encoding_sidecar
+
+        shp = self._shp(tmp_path, "Valle del Árrago".encode(), cpg="1252")
+        result = repair_shapefile_encoding_sidecar(shp)
+
+        assert result is not None
+        assert shp.with_suffix(".cpg").read_text() == "UTF-8"
+
+    @pytest.mark.unit
+    def test_correct_sidecars_left_alone(self, tmp_path: Path) -> None:
+        from portolan_cli.convert import repair_shapefile_encoding_sidecar
+
+        # UTF-8 records with UTF-8 sidecar
+        shp = self._shp(tmp_path, "Café".encode(), cpg="UTF-8")
+        assert repair_shapefile_encoding_sidecar(shp) is None
+        # Latin-1 records already declared ISO-8859-1
+        sub = tmp_path / "b"
+        sub.mkdir()
+        shp2 = self._shp(sub, "Espa\xf1a".encode("latin-1"), cpg="ISO-8859-1")
+        assert repair_shapefile_encoding_sidecar(shp2) is None
+
+    @pytest.mark.unit
+    def test_ascii_records_without_cpg_untouched(self, tmp_path: Path) -> None:
+        from portolan_cli.convert import repair_shapefile_encoding_sidecar
+
+        shp = self._shp(tmp_path, b"plain ascii only")
+        assert repair_shapefile_encoding_sidecar(shp) is None
+        assert not shp.with_suffix(".cpg").exists()
+
+    @pytest.mark.unit
+    def test_missing_dbf_is_noop(self, tmp_path: Path) -> None:
+        from portolan_cli.convert import repair_shapefile_encoding_sidecar
+
+        shp = tmp_path / "solo.shp"
+        shp.write_bytes(b"\x00" * 100)
+        assert repair_shapefile_encoding_sidecar(shp) is None


### PR DESCRIPTION
## What changed

Before converting a `.shp`, `repair_shapefile_encoding_sidecar()` validates the declared encoding against the DBF **records region** and fixes the `.cpg` when the bytes prove it wrong: Latin-1 records with no (or a UTF-8) sidecar get `ISO-8859-1`; UTF-8 records with a lying sidecar (e.g. `1252`) get corrected to `UTF-8`. Correct files are never touched; each repair prints an info line. Covers both `add` and `check --geo-assets --fix`, since both convert through `_convert_vector`.

## Why

Fixes #783. Both defects come from real data: most SITEX (Junta de Extremadura) shapefiles ship Latin-1 text with no `.cpg` and crash conversion with `Invalid unicode (byte sequence mismatch) detected in segment statistics update`; montes protectores ships UTF-8 records declared `1252`, which converted "successfully" into `Valle del Ãrrago`.

## Verification

Reproduced with the SITEX data (downloads from https://sitex.juntaex.es/SITEX/centrodescargas, staged in the Extremadura pipeline): after sidecar repair, all 28 collections convert with correct text —

```
protectores: [('Valle del Árrago',), ('Sierra de los Ángeles-La Debra',)]
embalses:    [('Embalse de Tentudía',), ('Embalse de Culebrín',)]
```

Unit tests build minimal DBFs byte-by-byte and pin all four cases (Latin-1 no-cpg, lying cpg, correct cpg untouched, ASCII untouched).

## Implementation notes

Records-region check matters: testing the whole file false-flags valid UTF-8 DBFs because the 32-byte header is binary. Both rules are conservative — ISO-8859-1 always decodes, and non-ASCII valid UTF-8 is essentially unambiguous.

## Related issues

#783; the same heuristic runs in geoparquet-io's ingestion context (gpio#642/#643 data).

## Breaking Changes

## Checklist

See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).

- [x] Tests written **first** and exercise real behavior (TDD)
- [ ] Integration coverage where the change crosses layers
- [x] `prek run --all-files` is green locally; all required CI checks pass
- [ ] Changed lines are covered (`codecov/patch`)
- [ ] At least one adversarial review (actively tried to break it)
- [ ] CodeRabbit comments addressed
- [ ] Docs updated and, for non-obvious decisions, an ADR added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shapefile conversion by automatically detecting and correcting missing or inaccurate character-encoding metadata.
  * Preserved valid encoding declarations and avoided changes for ASCII-only data.

* **Tests**
  * Added coverage for Latin-1, UTF-8, existing encoding declarations, ASCII-only records, and missing companion files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->