### PR TITLE
fix(viz): render thumbnails from the GeoParquet, PMTiles as fallback

### DIFF
--- a/portolan_cli/viz/pmtiles.py
+++ b/portolan_cli/viz/pmtiles.py
@@ -608,16 +608,18 @@ def _generate_thumbnail_asset(
     pmtiles_path: Path,
     catalog_root: Path,
 ) -> Path | None:
-    """Render the vector thumbnail from the tiles, the higher-fidelity source.
+    """Render the vector thumbnail, preferring the exact GeoParquet geometry.
 
     Writes the file and returns its path, or None if disabled or failed. Failure
-    is non-fatal: it must not affect PMTiles success (Issue #13).
+    is non-fatal: it must not affect PMTiles success (Issue #13). PMTiles are
+    only the fallback source: at thumbnail zoom they carry tippecanoe's
+    simplification and tiny-polygon placeholder squares (issue #786).
 
     Registering the STAC asset is deliberately not done here.
     ``collection_thumbnail.ensure_collection_thumbnails`` runs after this and
     adopts the ``.thumb.jpg`` this writes, so one writer owns the thumbnail
-    asset shape (Issue #683). Rendering from PMTiles still wins, because this
-    runs first and adoption never overwrites.
+    asset shape (Issue #683). This render still wins, because it runs first
+    and adoption never overwrites.
     """
     try:
         thumb_config = get_thumbnail_config(catalog_root)
@@ -626,8 +628,8 @@ def _generate_thumbnail_asset(
         # Discover style for thumbnail (Issue #495)
         style_path = _discover_style_for_thumbnail(collection_path)
         return generate_vector_thumbnail(
-            pmtiles_path=pmtiles_path,
-            geoparquet_path=parquet_path,  # fallback
+            pmtiles_path=pmtiles_path,  # fallback
+            geoparquet_path=parquet_path,
             config=thumb_config,
             style_path=style_path,
         )

--- a/portolan_cli/viz/thumbnail.py
+++ b/portolan_cli/viz/thumbnail.py
@@ -5,7 +5,7 @@ Mirrors the COG thumbnail pattern in convert.py.
 
 Public API:
 - ThumbnailConfig: Configuration dataclass for thumbnail generation
-- generate_vector_thumbnail: Orchestrator (prefers PMTiles, falls back to GeoParquet)
+- generate_vector_thumbnail: Orchestrator (prefers GeoParquet, falls back to PMTiles)
 - generate_thumbnail_from_pmtiles: Generate from PMTiles
 - generate_thumbnail_from_geoparquet: Generate from GeoParquet
 - add_basemap: Add contextily basemap to matplotlib axes
@@ -1291,14 +1291,19 @@ def generate_vector_thumbnail(
     config: ThumbnailConfig,
     style_path: Path | None = None,
 ) -> Path | None:
-    """Generate thumbnail for vector data, preferring PMTiles.
+    """Generate thumbnail for vector data, preferring the GeoParquet source.
 
-    Orchestrator function that tries PMTiles first, then falls back to GeoParquet.
-    This is the main entry point for vector thumbnail generation.
+    Orchestrator function: renders from the GeoParquet when it is locally
+    available, falling back to decoding PMTiles. The parquet carries exact
+    geometry; PMTiles at thumbnail zoom carry tippecanoe's simplification and
+    its tiny-polygon placeholder squares, so datasets whose features are small
+    at collection scale (parcels, forests, POI clusters) rendered as floating
+    rectangles instead of their real shapes (issue #786). Tiles remain the
+    right source when no local parquet exists (e.g. remote data).
 
     Args:
-        pmtiles_path: Path to PMTiles file (optional).
-        geoparquet_path: Path to GeoParquet file (optional, used as fallback).
+        pmtiles_path: Path to PMTiles file (optional, used as fallback).
+        geoparquet_path: Path to GeoParquet file (optional, preferred).
         config: Thumbnail configuration.
         style_path: Optional path to Mapbox GL style for categorical coloring.
 
@@ -1313,15 +1318,15 @@ def generate_vector_thumbnail(
         logger.debug("No source files provided for thumbnail")
         return None
 
-    # Try PMTiles first
-    if pmtiles_path is not None:
-        result = generate_thumbnail_from_pmtiles(pmtiles_path, config, style_path)
+    # Prefer the exact geometry: render from the local GeoParquet
+    if geoparquet_path is not None and geoparquet_path.exists():
+        result = generate_thumbnail_from_geoparquet(geoparquet_path, config, style_path)
         if result is not None:
             return result
-        logger.debug("PMTiles thumbnail failed, falling back to GeoParquet")
+        logger.debug("GeoParquet thumbnail failed, falling back to PMTiles")
 
-    # Fall back to GeoParquet
-    if geoparquet_path is not None:
-        return generate_thumbnail_from_geoparquet(geoparquet_path, config, style_path)
+    # Fall back to PMTiles (simplified tile geometry)
+    if pmtiles_path is not None:
+        return generate_thumbnail_from_pmtiles(pmtiles_path, config, style_path)
 
     return None

--- a/tests/unit/test_thumbnail.py
+++ b/tests/unit/test_thumbnail.py
@@ -323,14 +323,68 @@ class TestGenerateVectorThumbnail:
     """Tests for generate_vector_thumbnail orchestrator function."""
 
     @pytest.mark.unit
-    def test_prefers_pmtiles_when_available(self, tmp_path: Path) -> None:
-        """Prefers PMTiles over GeoParquet when both available."""
+    def test_prefers_geoparquet_when_available(self, tmp_path: Path) -> None:
+        """Prefers the exact GeoParquet geometry over PMTiles (issue #786)."""
         from portolan_cli.viz.thumbnail import ThumbnailConfig, generate_vector_thumbnail
 
         pmtiles_path = tmp_path / "data.pmtiles"
         gpq_path = tmp_path / "data.parquet"
         pmtiles_path.touch()
         gpq_path.touch()
+
+        with (
+            patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_pmtiles") as mock_pmtiles,
+            patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_geoparquet") as mock_gpq,
+        ):
+            mock_gpq.return_value = tmp_path / "data.thumb.jpg"
+
+            config = ThumbnailConfig()
+            result = generate_vector_thumbnail(
+                pmtiles_path=pmtiles_path,
+                geoparquet_path=gpq_path,
+                config=config,
+            )
+
+            mock_gpq.assert_called_once()
+            mock_pmtiles.assert_not_called()
+            assert result == tmp_path / "data.thumb.jpg"
+
+    @pytest.mark.unit
+    def test_falls_back_to_pmtiles(self, tmp_path: Path) -> None:
+        """Falls back to PMTiles when the GeoParquet render fails."""
+        from portolan_cli.viz.thumbnail import ThumbnailConfig, generate_vector_thumbnail
+
+        pmtiles_path = tmp_path / "data.pmtiles"
+        gpq_path = tmp_path / "data.parquet"
+        pmtiles_path.touch()
+        gpq_path.touch()
+
+        with (
+            patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_pmtiles") as mock_pmtiles,
+            patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_geoparquet") as mock_gpq,
+        ):
+            mock_gpq.return_value = None  # GeoParquet render failed
+            mock_pmtiles.return_value = tmp_path / "data.thumb.jpg"
+
+            config = ThumbnailConfig()
+            result = generate_vector_thumbnail(
+                pmtiles_path=pmtiles_path,
+                geoparquet_path=gpq_path,
+                config=config,
+            )
+
+            mock_gpq.assert_called_once()
+            mock_pmtiles.assert_called_once()
+            assert result == tmp_path / "data.thumb.jpg"
+
+    @pytest.mark.unit
+    def test_missing_parquet_uses_pmtiles(self, tmp_path: Path) -> None:
+        """A geoparquet path that does not exist on disk goes straight to PMTiles."""
+        from portolan_cli.viz.thumbnail import ThumbnailConfig, generate_vector_thumbnail
+
+        pmtiles_path = tmp_path / "data.pmtiles"
+        pmtiles_path.touch()
+        gone = tmp_path / "gone.parquet"  # never created
 
         with (
             patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_pmtiles") as mock_pmtiles,
@@ -341,40 +395,12 @@ class TestGenerateVectorThumbnail:
             config = ThumbnailConfig()
             result = generate_vector_thumbnail(
                 pmtiles_path=pmtiles_path,
-                geoparquet_path=gpq_path,
+                geoparquet_path=gone,
                 config=config,
             )
 
-            mock_pmtiles.assert_called_once()
             mock_gpq.assert_not_called()
-            assert result == tmp_path / "data.thumb.jpg"
-
-    @pytest.mark.unit
-    def test_falls_back_to_geoparquet(self, tmp_path: Path) -> None:
-        """Falls back to GeoParquet when PMTiles fails."""
-        from portolan_cli.viz.thumbnail import ThumbnailConfig, generate_vector_thumbnail
-
-        pmtiles_path = tmp_path / "data.pmtiles"
-        gpq_path = tmp_path / "data.parquet"
-        pmtiles_path.touch()
-        gpq_path.touch()
-
-        with (
-            patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_pmtiles") as mock_pmtiles,
-            patch("portolan_cli.viz.thumbnail.generate_thumbnail_from_geoparquet") as mock_gpq,
-        ):
-            mock_pmtiles.return_value = None  # PMTiles failed
-            mock_gpq.return_value = tmp_path / "data.thumb.jpg"
-
-            config = ThumbnailConfig()
-            result = generate_vector_thumbnail(
-                pmtiles_path=pmtiles_path,
-                geoparquet_path=gpq_path,
-                config=config,
-            )
-
             mock_pmtiles.assert_called_once()
-            mock_gpq.assert_called_once()
             assert result == tmp_path / "data.thumb.jpg"
 
     @pytest.mark.unit


### PR DESCRIPTION
## What changed

`generate_vector_thumbnail` now prefers rendering from the collection's GeoParquet (exact geometry) and only decodes PMTiles when no local parquet exists or the parquet render fails. Previously the order was reversed on the belief that tiles were the higher-fidelity source.

## Why

Fixes #786. At thumbnail zoom, tippecanoe has already replaced sub-pixel polygons with its tiny-polygon placeholder squares and simplified everything else — a 170-polygon forest dataset rendered as six floating rectangles.

## Verification

Regenerated the thumbnail for the collection from the issue (Junta de Extremadura mirror, `forestal/montes-comunales`, data at https://storage.googleapis.com/carto-portolan-ide-extremadura-cli/forestal/montes-comunales/collection.json):

```
>>> generate_vector_thumbnail(pmtiles_path=..., geoparquet_path=..., config=ThumbnailConfig(), style_path=...)
rendered: MontesComunales.thumb.jpg   # real forest polygons over the basemap
```

Broken before-image for comparison: https://storage.googleapis.com/carto-portolan-ide-extremadura-cli/forestal/montes-comunales/MontesComunales.thumb.jpg (six blue rectangles). 161 thumbnail/pmtiles/workflow tests pass; orchestrator tests updated to the new preference plus a new missing-parquet→tiles case.

## Implementation notes

Order flip in `viz/thumbnail.py` only; `_generate_thumbnail_asset` docstrings updated. The parquet path also guards `exists()` so registered-but-absent files go straight to tiles.

## Related issues

#786; related but distinct: #758 (style fidelity of the renderer).

## Breaking Changes

## Checklist

See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).

- [x] Tests written **first** and exercise real behavior (TDD)
- [x] Integration coverage where the change crosses layers
- [x] `prek run --all-files` is green locally; all required CI checks pass
- [ ] Changed lines are covered (`codecov/patch`)
- [ ] At least one adversarial review (actively tried to break it)
- [ ] CodeRabbit comments addressed
- [ ] Docs updated and, for non-obvious decisions, an ADR added

🤖 Generated with [Claude Code](https://claude.com/claude-code)