### PR TITLE
Measure the collection extent from data, not the source bbox rectangle

### DIFF
--- a/portolan_cli/crs.py
+++ b/portolan_cli/crs.py
@@ -426,11 +426,18 @@ def measure_wgs84_bbox(
     if not files:
         return None
 
-    transformer = Transformer.from_crs(src, WGS84, always_xy=True)
     minx = miny = math.inf
     maxx = maxy = -math.inf
+    # Longitude is tracked twice: once as it comes, and once shifted into
+    # [0, 360). Data that crosses the antimeridian is compact in the shifted
+    # frame and spans almost the whole globe in the plain one, so the two spans
+    # detect the crossing without a second pass over the file.
+    min_shifted, max_shifted = math.inf, -math.inf
 
     try:
+        # Inside the guard: pyproj raises here when it can build no pipeline
+        # between the two CRSs, and that must fall back, not escape.
+        transformer = Transformer.from_crs(src, WGS84, always_xy=True)
         for file in files:
             parquet = pq.ParquetFile(file)
             if geometry_column not in parquet.schema_arrow.names:
@@ -451,10 +458,21 @@ def measure_wgs84_bbox(
                 lon, lat = lon[finite], lat[finite]
                 minx, maxx = min(minx, float(lon.min())), max(maxx, float(lon.max()))
                 miny, maxy = min(miny, float(lat.min())), max(maxy, float(lat.max()))
+                shifted = np.where(lon < 0.0, lon + 360.0, lon)
+                min_shifted = min(min_shifted, float(shifted.min()))
+                max_shifted = max(max_shifted, float(shifted.max()))
     except Exception as exc:  # noqa: BLE001 - measurement is best-effort
         logger.debug("Cannot measure bbox from %s: %s", data_path, exc)
         return None
 
     if not all(math.isfinite(v) for v in (minx, miny, maxx, maxy)):
         return None
+
+    # RFC 7946: a bbox that crosses the antimeridian writes west greater than
+    # east. Keep whichever frame describes the data more tightly; a tie keeps
+    # the plain frame, so data that does not cross is unaffected.
+    if max_shifted - min_shifted < maxx - minx:
+        west = min_shifted - 360.0 if min_shifted >= 180.0 else min_shifted
+        east = max_shifted - 360.0 if max_shifted > 180.0 else max_shifted
+        return (west, miny, east, maxy)
     return (minx, miny, maxx, maxy)

--- a/portolan_cli/crs.py
+++ b/portolan_cli/crs.py
@@ -20,7 +20,7 @@ from pyproj.exceptions import CRSError
 from portolan_cli.errors import CRSMismatchError
 
 if TYPE_CHECKING:
-    pass
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -368,3 +368,93 @@ def _sample_bbox_edges(
         points.append((minx, y))
 
     return points
+
+
+def measure_wgs84_bbox(
+    data_path: Path,
+    geometry_column: str,
+    source_crs: str | None,
+) -> tuple[float, float, float, float] | None:
+    """Measure a GeoParquet's WGS84 extent from its geometry, not its bbox.
+
+    :func:`transform_bbox_to_wgs84` answers a different question: it reprojects
+    a *rectangle*. For a projected CRS the WGS84 envelope of that rectangle is
+    strictly larger than the envelope of the data inside it — the corners of a
+    UTM bbox hold no data and the grid lines curve — so a collection extent
+    derived that way overstates the data, by ~14 km on real UTM zone 30N data.
+    That is not a rounding difference: ``check`` rejects it (PTL-DAT-005), and
+    the PMTiles built from the same file report the tighter, correct box.
+
+    So measure the transformed vertices instead. Row groups are streamed and
+    only the geometry column is read, so peak memory stays bounded on files far
+    too large to hold in one GeoDataFrame.
+
+    Returns None whenever the measurement cannot be made — a missing optional
+    dependency, an unreadable file, a CRS pyproj will not resolve, no finite
+    coordinates. The caller then falls back to reprojecting the bbox, which is
+    wider than the data but never wrong about containing it.
+
+    Args:
+        data_path: GeoParquet file, or a directory of them (partitioned output).
+        geometry_column: Name of the WKB geometry column to read.
+        source_crs: CRS of the stored coordinates (EPSG code, WKT, or None).
+
+    Returns:
+        ``(minx, miny, maxx, maxy)`` in WGS84, or None if not measurable.
+    """
+    if not source_crs:
+        return None
+    try:
+        import math
+
+        import numpy as np
+        import pyarrow.parquet as pq
+        import shapely
+    except ImportError:  # pragma: no cover - shapely/pyarrow are core deps
+        logger.debug("Cannot measure bbox: pyarrow/shapely unavailable")
+        return None
+
+    try:
+        src = CRS.from_user_input(source_crs)
+    except CRSError:
+        logger.debug("Cannot measure bbox: unresolvable CRS %r", source_crs)
+        return None
+    if _is_wgs84(src):
+        return None  # stored coordinates are already WGS84; nothing to measure
+
+    files = sorted(data_path.rglob("*.parquet")) if data_path.is_dir() else [data_path]
+    if not files:
+        return None
+
+    transformer = Transformer.from_crs(src, WGS84, always_xy=True)
+    minx = miny = math.inf
+    maxx = maxy = -math.inf
+
+    try:
+        for file in files:
+            parquet = pq.ParquetFile(file)
+            if geometry_column not in parquet.schema_arrow.names:
+                return None
+            for batch in parquet.iter_batches(columns=[geometry_column]):
+                wkb = [value for value in batch.column(0).to_pylist() if value is not None]
+                if not wkb:
+                    continue
+                coords = shapely.get_coordinates(shapely.from_wkb(wkb))
+                if coords.size == 0:
+                    continue
+                lon, lat = transformer.transform(coords[:, 0], coords[:, 1])
+                # Points pyproj cannot transform come back as infinity; drop them
+                # rather than let one poison the whole extent.
+                finite = np.isfinite(lon) & np.isfinite(lat)
+                if not finite.any():
+                    continue
+                lon, lat = lon[finite], lat[finite]
+                minx, maxx = min(minx, float(lon.min())), max(maxx, float(lon.max()))
+                miny, maxy = min(miny, float(lat.min())), max(maxy, float(lat.max()))
+    except Exception as exc:  # noqa: BLE001 - measurement is best-effort
+        logger.debug("Cannot measure bbox from %s: %s", data_path, exc)
+        return None
+
+    if not all(math.isfinite(v) for v in (minx, miny, maxx, maxy)):
+        return None
+    return (minx, miny, maxx, maxy)

--- a/portolan_cli/crs.py
+++ b/portolan_cli/crs.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import antimeridian
 from pyproj import CRS, Transformer
@@ -370,6 +370,34 @@ def _sample_bbox_edges(
     return points
 
 
+@dataclass
+class _MeasuredBounds:
+    """Running WGS84 bounds, with longitude tracked in two frames."""
+
+    minx: float = float("inf")
+    miny: float = float("inf")
+    maxx: float = float("-inf")
+    maxy: float = float("-inf")
+    min_shifted: float = float("inf")
+    max_shifted: float = float("-inf")
+
+    def update(self, lon: Any, lat: Any, *, np: Any) -> None:
+        self.minx, self.maxx = min(self.minx, float(lon.min())), max(self.maxx, float(lon.max()))
+        self.miny, self.maxy = min(self.miny, float(lat.min())), max(self.maxy, float(lat.max()))
+        shifted = np.where(lon < 0.0, lon + 360.0, lon)
+        self.min_shifted = min(self.min_shifted, float(shifted.min()))
+        self.max_shifted = max(self.max_shifted, float(shifted.max()))
+
+    def is_finite(self, math: Any) -> bool:
+        return all(math.isfinite(v) for v in (self.minx, self.miny, self.maxx, self.maxy))
+
+    def plain_span(self) -> float:
+        return self.maxx - self.minx
+
+    def shifted_span(self) -> float:
+        return self.max_shifted - self.min_shifted
+
+
 def measure_wgs84_bbox(
     data_path: Path,
     geometry_column: str,
@@ -405,16 +433,6 @@ def measure_wgs84_bbox(
     if not source_crs:
         return None
     try:
-        import math
-
-        import numpy as np
-        import pyarrow.parquet as pq
-        import shapely
-    except ImportError:  # pragma: no cover - shapely/pyarrow are core deps
-        logger.debug("Cannot measure bbox: pyarrow/shapely unavailable")
-        return None
-
-    try:
         src = CRS.from_user_input(source_crs)
     except CRSError:
         logger.debug("Cannot measure bbox: unresolvable CRS %r", source_crs)
@@ -426,14 +444,38 @@ def measure_wgs84_bbox(
     if not files:
         return None
 
-    minx = miny = math.inf
-    maxx = maxy = -math.inf
-    # Longitude is tracked twice: once as it comes, and once shifted into
-    # [0, 360). Data that crosses the antimeridian is compact in the shifted
-    # frame and spans almost the whole globe in the plain one, so the two spans
-    # detect the crossing without a second pass over the file.
-    min_shifted, max_shifted = math.inf, -math.inf
+    bounds = _stream_wgs84_bounds(files, geometry_column, src, data_path)
+    if bounds is None:
+        return None
+    return _bbox_from_bounds(bounds)
 
+
+def _stream_wgs84_bounds(
+    files: list[Path],
+    geometry_column: str,
+    src: CRS,
+    data_path: Path,
+) -> _MeasuredBounds | None:
+    """Accumulate WGS84 bounds over the geometry column, one row group at a time.
+
+    Longitude is tracked twice: once as it comes, and once shifted into
+    [0, 360). Data that crosses the antimeridian is compact in the shifted frame
+    and spans almost the whole globe in the plain one, so the two spans detect
+    the crossing without a second pass over the file.
+
+    Returns None when nothing measurable was read.
+    """
+    try:
+        import math
+
+        import numpy as np
+        import pyarrow.parquet as pq
+        import shapely
+    except ImportError:  # pragma: no cover - shapely/pyarrow are core deps
+        logger.debug("Cannot measure bbox: pyarrow/shapely unavailable")
+        return None
+
+    bounds = _MeasuredBounds()
     try:
         # Inside the guard: pyproj raises here when it can build no pipeline
         # between the two CRSs, and that must fall back, not escape.
@@ -455,24 +497,23 @@ def measure_wgs84_bbox(
                 finite = np.isfinite(lon) & np.isfinite(lat)
                 if not finite.any():
                     continue
-                lon, lat = lon[finite], lat[finite]
-                minx, maxx = min(minx, float(lon.min())), max(maxx, float(lon.max()))
-                miny, maxy = min(miny, float(lat.min())), max(maxy, float(lat.max()))
-                shifted = np.where(lon < 0.0, lon + 360.0, lon)
-                min_shifted = min(min_shifted, float(shifted.min()))
-                max_shifted = max(max_shifted, float(shifted.max()))
+                bounds.update(lon[finite], lat[finite], np=np)
     except Exception as exc:  # noqa: BLE001 - measurement is best-effort
         logger.debug("Cannot measure bbox from %s: %s", data_path, exc)
         return None
 
-    if not all(math.isfinite(v) for v in (minx, miny, maxx, maxy)):
-        return None
+    return bounds if bounds.is_finite(math) else None
 
-    # RFC 7946: a bbox that crosses the antimeridian writes west greater than
-    # east. Keep whichever frame describes the data more tightly; a tie keeps
-    # the plain frame, so data that does not cross is unaffected.
-    if max_shifted - min_shifted < maxx - minx:
-        west = min_shifted - 360.0 if min_shifted >= 180.0 else min_shifted
-        east = max_shifted - 360.0 if max_shifted > 180.0 else max_shifted
-        return (west, miny, east, maxy)
-    return (minx, miny, maxx, maxy)
+
+def _bbox_from_bounds(bounds: _MeasuredBounds) -> tuple[float, float, float, float]:
+    """Resolve accumulated bounds to a bbox, honouring an antimeridian crossing.
+
+    RFC 7946: a bbox that crosses the antimeridian writes west greater than
+    east. Keep whichever frame describes the data more tightly; a tie keeps the
+    plain frame, so data that does not cross is unaffected.
+    """
+    if bounds.shifted_span() < bounds.plain_span():
+        west = bounds.min_shifted - 360.0 if bounds.min_shifted >= 180.0 else bounds.min_shifted
+        east = bounds.max_shifted - 360.0 if bounds.max_shifted > 180.0 else bounds.max_shifted
+        return (west, bounds.miny, east, bounds.maxy)
+    return (bounds.minx, bounds.miny, bounds.maxx, bounds.maxy)

--- a/portolan_cli/preparation.py
+++ b/portolan_cli/preparation.py
@@ -28,7 +28,7 @@ from portolan_cli import extension_registry as _reg
 from portolan_cli.collection_id import normalize_collection_id, validate_collection_id
 from portolan_cli.config import get_setting, load_merged_metadata
 from portolan_cli.convert import run_with_transient_convert_retry
-from portolan_cli.crs import transform_bbox_to_wgs84
+from portolan_cli.crs import measure_wgs84_bbox, transform_bbox_to_wgs84
 from portolan_cli.errors import NoGeometryError
 from portolan_cli.formats import FormatType, detect_format, is_cloud_optimized_geotiff
 from portolan_cli.metadata import (
@@ -552,14 +552,24 @@ VectorMetadata = GeoParquetMetadata | PMTilesMetadata | FlatGeobufMetadata
 AllMetadata = VectorMetadata | COGMetadata
 
 
-def _extract_bbox_wgs84(metadata: AllMetadata) -> list[float]:
+def _extract_bbox_wgs84(metadata: AllMetadata, data_path: Path | None = None) -> list[float]:
     """Extract bbox from metadata, transforming to WGS84 if needed.
 
     PMTiles bbox is already in WGS84 (4326). Other formats may need
     CRS transformation.
 
+    For GeoParquet in a projected CRS the extent is *measured* from the
+    geometry when ``data_path`` is given. Reprojecting the stored bbox instead
+    answers a different question — it gives the WGS84 envelope of a rectangle,
+    which for a projected CRS is strictly larger than the envelope of the data
+    inside it, so the declared extent overstates the data and `check` rejects it
+    (PTL-DAT-005). Measurement falls back to the reprojected bbox whenever it
+    cannot be made.
+
     Args:
         metadata: Metadata object with bbox attribute.
+        data_path: Converted data file, when available, to measure the extent
+            from instead of reprojecting the stored bbox.
 
     Returns:
         Bounding box as [min_x, min_y, max_x, max_y] in WGS84.
@@ -573,6 +583,13 @@ def _extract_bbox_wgs84(metadata: AllMetadata) -> list[float]:
     if isinstance(crs_raw, dict):
         raise ValueError("PROJJSON CRS not supported. Convert to EPSG code or WKT string.")
     crs_str = crs_raw if isinstance(crs_raw, str) else None
+
+    geometry_column = getattr(metadata, "geometry_column", None)
+    if data_path is not None and geometry_column:
+        measured = measure_wgs84_bbox(data_path, geometry_column, crs_str)
+        if measured is not None:
+            return list(measured)
+
     return list(transform_bbox_to_wgs84(metadata.bbox, crs_str))  # type: ignore[arg-type]
 
 
@@ -1010,7 +1027,7 @@ def prepare_item(
             path=metadata.id if hasattr(metadata, "id") else path.stem,
             reason="The source file may have no valid geometry.",
         )
-    bbox = _extract_bbox_wgs84(metadata)
+    bbox = _extract_bbox_wgs84(metadata, output_path)
 
     # Step 4b: Generate the COG thumbnail sidecar so the scan below registers it
     # (Issue #657). The add path converts via convert_raster(), which does not

--- a/tests/unit/test_collection_extent_from_data.py
+++ b/tests/unit/test_collection_extent_from_data.py
@@ -11,10 +11,16 @@ which report the tighter, correct box.
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pytest
 
 from portolan_cli.crs import measure_wgs84_bbox, transform_bbox_to_wgs84
 from portolan_cli.preparation import _extract_bbox_wgs84
+
+if TYPE_CHECKING:
+    import geopandas as gpd
 
 pytestmark = pytest.mark.unit
 
@@ -22,7 +28,11 @@ pytestmark = pytest.mark.unit
 UTM30N = "EPSG:25830"
 
 
-def _write_diamond(path, crs=UTM30N, geometry_column="geometry"):
+def _write_diamond(
+    path: Path,
+    crs: str = UTM30N,
+    geometry_column: str = "geometry",
+) -> gpd.GeoDataFrame:
     """A diamond whose bbox corners hold no data — the shape the bug overstates."""
     import geopandas as gpd
     from shapely.geometry import Polygon
@@ -39,7 +49,9 @@ def _write_diamond(path, crs=UTM30N, geometry_column="geometry"):
 class TestMeasureWgs84Bbox:
     """measure_wgs84_bbox reads geometry; transform_bbox_to_wgs84 reads a rectangle."""
 
-    def test_measured_extent_is_tighter_than_the_reprojected_rectangle(self, tmp_path):
+    def test_measured_extent_is_tighter_than_the_reprojected_rectangle(
+        self, tmp_path: Path
+    ) -> None:
         path = tmp_path / "diamond.parquet"
         gdf = _write_diamond(path)
 
@@ -57,7 +69,7 @@ class TestMeasureWgs84Bbox:
         assert measured[3] <= rectangle[3]
         assert measured != tuple(rectangle)
 
-    def test_measured_extent_matches_geopandas(self, tmp_path):
+    def test_measured_extent_matches_geopandas(self, tmp_path: Path) -> None:
         """The measurement must equal a straight reprojection of the geometry."""
         path = tmp_path / "diamond.parquet"
         gdf = _write_diamond(path)
@@ -67,14 +79,14 @@ class TestMeasureWgs84Bbox:
 
         assert measured == pytest.approx(tuple(expected), abs=1e-9)
 
-    def test_custom_geometry_column(self, tmp_path):
+    def test_custom_geometry_column(self, tmp_path: Path) -> None:
         path = tmp_path / "custom.parquet"
         gdf = _write_diamond(path, geometry_column="geom")
 
         measured = measure_wgs84_bbox(path, "geom", UTM30N)
         assert measured == pytest.approx(tuple(gdf.to_crs("EPSG:4326").total_bounds), abs=1e-9)
 
-    def test_null_geometries_are_skipped(self, tmp_path):
+    def test_null_geometries_are_skipped(self, tmp_path: Path) -> None:
         """NULL geometry is legal in GeoParquet and must not poison the extent."""
         import geopandas as gpd
         from shapely.geometry import Polygon
@@ -90,23 +102,23 @@ class TestMeasureWgs84Bbox:
         assert measured is not None
         assert all(v == v for v in measured)  # no NaN
 
-    def test_returns_none_for_wgs84_source(self, tmp_path):
+    def test_returns_none_for_wgs84_source(self, tmp_path: Path) -> None:
         """Already WGS84: the stored bbox is the answer, nothing to measure."""
         path = tmp_path / "wgs84.parquet"
         _write_diamond(path, crs="EPSG:4326")
         assert measure_wgs84_bbox(path, "geometry", "EPSG:4326") is None
 
-    def test_returns_none_without_crs(self, tmp_path):
+    def test_returns_none_without_crs(self, tmp_path: Path) -> None:
         path = tmp_path / "diamond.parquet"
         _write_diamond(path)
         assert measure_wgs84_bbox(path, "geometry", None) is None
 
-    def test_returns_none_for_missing_column(self, tmp_path):
+    def test_returns_none_for_missing_column(self, tmp_path: Path) -> None:
         path = tmp_path / "diamond.parquet"
         _write_diamond(path)
         assert measure_wgs84_bbox(path, "not_a_column", UTM30N) is None
 
-    def test_returns_none_for_unreadable_file(self, tmp_path):
+    def test_returns_none_for_unreadable_file(self, tmp_path: Path) -> None:
         missing = tmp_path / "nope.parquet"
         assert measure_wgs84_bbox(missing, "geometry", UTM30N) is None
 
@@ -114,7 +126,7 @@ class TestMeasureWgs84Bbox:
 class TestExtractBboxWgs84UsesMeasurement:
     """_extract_bbox_wgs84 prefers the measurement and falls back safely."""
 
-    def test_uses_measurement_when_data_path_given(self, tmp_path):
+    def test_uses_measurement_when_data_path_given(self, tmp_path: Path) -> None:
         from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
 
         path = tmp_path / "diamond.parquet"
@@ -126,7 +138,7 @@ class TestExtractBboxWgs84UsesMeasurement:
 
         assert bbox == pytest.approx(list(expected), abs=1e-9)
 
-    def test_falls_back_to_the_rectangle_without_a_data_path(self, tmp_path):
+    def test_falls_back_to_the_rectangle_without_a_data_path(self, tmp_path: Path) -> None:
         from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
 
         path = tmp_path / "diamond.parquet"
@@ -134,4 +146,91 @@ class TestExtractBboxWgs84UsesMeasurement:
         metadata = extract_geoparquet_metadata(path)
 
         bbox = _extract_bbox_wgs84(metadata)
+        assert bbox == list(transform_bbox_to_wgs84(metadata.bbox, UTM30N))
+
+
+class TestAntimeridian:
+    """A crossing extent must stay compact, not widen to the whole globe."""
+
+    # EPSG:3832 (WGS 84 / PDC Mercator) centres on 150E, so it crosses the
+    # antimeridian without a break in its own coordinates.
+    PDC = "EPSG:3832"
+
+    def test_crossing_extent_keeps_west_greater_than_east(self, tmp_path: Path) -> None:
+        """RFC 7946 writes a crossing bbox as west > east."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        path = tmp_path / "antimeridian.parquet"
+        # Either side of 180: about 178.7E and 177.7W.
+        points = [Point(3.2e6, -1.0e5), Point(3.6e6, 1.0e5)]
+        gpd.GeoDataFrame({"n": [1, 2]}, geometry=points, crs=self.PDC).to_parquet(path)
+
+        measured = measure_wgs84_bbox(path, "geometry", self.PDC)
+        assert measured is not None
+        west, _, east, _ = measured
+        assert west > east, "a crossing bbox must not be flattened to a global one"
+        assert west == pytest.approx(178.746, abs=0.01)
+        assert east == pytest.approx(-177.661, abs=0.01)
+
+    def test_crossing_extent_agrees_with_the_bbox_transform(self, tmp_path: Path) -> None:
+        """The measurement must not contradict the fallback on the same data."""
+        import geopandas as gpd
+        from shapely.geometry import Point
+
+        path = tmp_path / "antimeridian.parquet"
+        points = [Point(3.2e6, -1.0e5), Point(3.6e6, 1.0e5)]
+        gdf = gpd.GeoDataFrame({"n": [1, 2]}, geometry=points, crs=self.PDC)
+        gdf.to_parquet(path)
+
+        measured = measure_wgs84_bbox(path, "geometry", self.PDC)
+        rectangle = transform_bbox_to_wgs84(tuple(gdf.total_bounds), self.PDC)
+        assert measured == pytest.approx(tuple(rectangle), abs=0.01)
+
+    def test_non_crossing_data_keeps_the_plain_frame(self, tmp_path: Path) -> None:
+        """Data far from the antimeridian must be untouched by the shift."""
+        path = tmp_path / "diamond.parquet"
+        gdf = _write_diamond(path)
+
+        measured = measure_wgs84_bbox(path, "geometry", UTM30N)
+        assert measured == pytest.approx(tuple(gdf.to_crs("EPSG:4326").total_bounds), abs=1e-9)
+        assert measured is not None and measured[0] < measured[2]
+
+
+class TestTransformerFailureFallsBack:
+    """A CRS pair pyproj cannot bridge must fall back, not raise."""
+
+    def test_transformer_construction_failure_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "diamond.parquet"
+        _write_diamond(path)
+
+        import portolan_cli.crs as crs_module
+
+        def _boom(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("no pipeline between these CRSs")
+
+        original = crs_module.Transformer.from_crs
+        crs_module.Transformer.from_crs = _boom  # type: ignore[assignment]
+        try:
+            assert measure_wgs84_bbox(path, "geometry", UTM30N) is None
+        finally:
+            crs_module.Transformer.from_crs = original  # type: ignore[assignment]
+
+    def test_extract_bbox_falls_back_when_measurement_fails(self, tmp_path: Path) -> None:
+        """The caller still gets a bbox, from the reprojected rectangle."""
+        from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
+
+        path = tmp_path / "diamond.parquet"
+        _write_diamond(path)
+        metadata = extract_geoparquet_metadata(path)
+
+        import portolan_cli.preparation as prep
+
+        original = prep.measure_wgs84_bbox
+        prep.measure_wgs84_bbox = lambda *a, **k: None  # type: ignore[assignment]
+        try:
+            bbox = _extract_bbox_wgs84(metadata, path)
+        finally:
+            prep.measure_wgs84_bbox = original  # type: ignore[assignment]
+
         assert bbox == list(transform_bbox_to_wgs84(metadata.bbox, UTM30N))

--- a/tests/unit/test_collection_extent_from_data.py
+++ b/tests/unit/test_collection_extent_from_data.py
@@ -1,0 +1,137 @@
+"""Regression tests for collection extents measured from data (PTL-DAT-005).
+
+``_extract_bbox_wgs84`` reprojected the GeoParquet's stored bbox — a *rectangle*
+in the source CRS. For a projected CRS the WGS84 envelope of that rectangle is
+strictly larger than the envelope of the data inside it, because the corners of
+a UTM bbox hold no data and the grid lines curve. The declared extent therefore
+overstated the data on every collection built in a native projected CRS, and
+`check` rejected it against the PMTiles built from the same file (PTL-DAT-005),
+which report the tighter, correct box.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from portolan_cli.crs import measure_wgs84_bbox, transform_bbox_to_wgs84
+from portolan_cli.preparation import _extract_bbox_wgs84
+
+pytestmark = pytest.mark.unit
+
+# EPSG:25830 (ETRS89 / UTM zone 30N), the CRS Spanish regional open data ships.
+UTM30N = "EPSG:25830"
+
+
+def _write_diamond(path, crs=UTM30N, geometry_column="geometry"):
+    """A diamond whose bbox corners hold no data — the shape the bug overstates."""
+    import geopandas as gpd
+    from shapely.geometry import Polygon
+
+    # Spans ~200 km, centred on Extremadura; the bbox corners sit far outside it.
+    diamond = Polygon([(600000, 4300000), (700000, 4400000), (600000, 4500000), (500000, 4400000)])
+    gdf = gpd.GeoDataFrame({"name": ["diamond"]}, geometry=[diamond], crs=crs)
+    if geometry_column != "geometry":
+        gdf = gdf.rename_geometry(geometry_column)
+    gdf.to_parquet(path)
+    return gdf
+
+
+class TestMeasureWgs84Bbox:
+    """measure_wgs84_bbox reads geometry; transform_bbox_to_wgs84 reads a rectangle."""
+
+    def test_measured_extent_is_tighter_than_the_reprojected_rectangle(self, tmp_path):
+        path = tmp_path / "diamond.parquet"
+        gdf = _write_diamond(path)
+
+        measured = measure_wgs84_bbox(path, "geometry", UTM30N)
+        assert measured is not None
+
+        native = tuple(gdf.total_bounds)
+        rectangle = transform_bbox_to_wgs84(native, UTM30N)
+
+        # Every side of the measured box sits inside the reprojected rectangle,
+        # and at least one is strictly tighter — that gap is the defect.
+        assert measured[0] >= rectangle[0]
+        assert measured[1] >= rectangle[1]
+        assert measured[2] <= rectangle[2]
+        assert measured[3] <= rectangle[3]
+        assert measured != tuple(rectangle)
+
+    def test_measured_extent_matches_geopandas(self, tmp_path):
+        """The measurement must equal a straight reprojection of the geometry."""
+        path = tmp_path / "diamond.parquet"
+        gdf = _write_diamond(path)
+
+        measured = measure_wgs84_bbox(path, "geometry", UTM30N)
+        expected = gdf.to_crs("EPSG:4326").total_bounds
+
+        assert measured == pytest.approx(tuple(expected), abs=1e-9)
+
+    def test_custom_geometry_column(self, tmp_path):
+        path = tmp_path / "custom.parquet"
+        gdf = _write_diamond(path, geometry_column="geom")
+
+        measured = measure_wgs84_bbox(path, "geom", UTM30N)
+        assert measured == pytest.approx(tuple(gdf.to_crs("EPSG:4326").total_bounds), abs=1e-9)
+
+    def test_null_geometries_are_skipped(self, tmp_path):
+        """NULL geometry is legal in GeoParquet and must not poison the extent."""
+        import geopandas as gpd
+        from shapely.geometry import Polygon
+
+        path = tmp_path / "with_nulls.parquet"
+        diamond = Polygon(
+            [(600000, 4300000), (700000, 4400000), (600000, 4500000), (500000, 4400000)]
+        )
+        gdf = gpd.GeoDataFrame({"name": ["a", "b"]}, geometry=[diamond, None], crs=UTM30N)
+        gdf.to_parquet(path)
+
+        measured = measure_wgs84_bbox(path, "geometry", UTM30N)
+        assert measured is not None
+        assert all(v == v for v in measured)  # no NaN
+
+    def test_returns_none_for_wgs84_source(self, tmp_path):
+        """Already WGS84: the stored bbox is the answer, nothing to measure."""
+        path = tmp_path / "wgs84.parquet"
+        _write_diamond(path, crs="EPSG:4326")
+        assert measure_wgs84_bbox(path, "geometry", "EPSG:4326") is None
+
+    def test_returns_none_without_crs(self, tmp_path):
+        path = tmp_path / "diamond.parquet"
+        _write_diamond(path)
+        assert measure_wgs84_bbox(path, "geometry", None) is None
+
+    def test_returns_none_for_missing_column(self, tmp_path):
+        path = tmp_path / "diamond.parquet"
+        _write_diamond(path)
+        assert measure_wgs84_bbox(path, "not_a_column", UTM30N) is None
+
+    def test_returns_none_for_unreadable_file(self, tmp_path):
+        missing = tmp_path / "nope.parquet"
+        assert measure_wgs84_bbox(missing, "geometry", UTM30N) is None
+
+
+class TestExtractBboxWgs84UsesMeasurement:
+    """_extract_bbox_wgs84 prefers the measurement and falls back safely."""
+
+    def test_uses_measurement_when_data_path_given(self, tmp_path):
+        from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
+
+        path = tmp_path / "diamond.parquet"
+        gdf = _write_diamond(path)
+        metadata = extract_geoparquet_metadata(path)
+
+        bbox = _extract_bbox_wgs84(metadata, path)
+        expected = gdf.to_crs("EPSG:4326").total_bounds
+
+        assert bbox == pytest.approx(list(expected), abs=1e-9)
+
+    def test_falls_back_to_the_rectangle_without_a_data_path(self, tmp_path):
+        from portolan_cli.metadata.geoparquet import extract_geoparquet_metadata
+
+        path = tmp_path / "diamond.parquet"
+        _write_diamond(path)
+        metadata = extract_geoparquet_metadata(path)
+
+        bbox = _extract_bbox_wgs84(metadata)
+        assert bbox == list(transform_bbox_to_wgs84(metadata.bbox, UTM30N))


### PR DESCRIPTION
## What changed

`preparation._extract_bbox_wgs84` now measures the collection extent from the
geometry.

A new function, `crs.measure_wgs84_bbox`, transforms the coordinates and takes
the minimum and maximum. It reads one row group at a time, and only the geometry
column. Peak memory stays bounded on files too large for one GeoDataFrame.

The function returns `None` when it cannot measure the extent. The causes are an
absent optional dependency, an unresolvable CRS, an absent column, an unreadable
file, or no finite coordinate. The caller then reprojects the stored bbox, as
before. That box is wider than the data, but it always contains the data.

## Why

This change resolves #799.

`transform_bbox_to_wgs84` reprojects a rectangle. For a projected CRS, the WGS84
envelope of that rectangle is larger than the envelope of the data inside it.
The corners of a UTM bbox hold no data, and the grid lines curve.

The declared extent therefore overstated the data by about 14 km on the west
edge. `portolan check --strict --schema` rejected 27 of 28 collections in a
catalog of Junta de Extremadura open data. rashid requires each side of the
declared bbox to sit inside the data bracket, so an over-declared extent is a
defect, not a safe choice.

`transform_bbox_to_wgs84` itself is correct. It samples the rectangle edges
before it takes the envelope. The caller asked it the wrong question.

## Verification

Data: `MontesComunales.parquet`, from
`test-catalogs/extremadura-cli/forestal/terrenos-acotados/../montes-comunales/`
in the IDE Extremadura catalog. Source:
https://sitex.juntaex.es/SITEX/centrodescargas. CRS EPSG:25830.

Two catalogs hold the same GeoParquet and the same PMTiles. The commands are
identical. Only the portolan-cli version differs.

```
$ portolan init --auto --title T --description D --license CC-BY-4.0
$ portolan add . --no-thumbnails
$ portolan check --strict --schema

# main
⚠ PTL-DAT-005 forestal/montes-comunales/collection.json: asset 'MontesComunales' data bbox [-7.3350, 38.0407, -4.7042, 40.4866] does not match the declared bbox [-7.4617, 37.9983, -4.6737, 40.5189]
✗ Catalog does not conform: 5 errors, 2 warnings

# this branch
✗ Catalog does not conform: 5 errors, 1 warning
```

PTL-DAT-005 is gone. The remaining findings belong to the minimal test catalog,
which has no providers, no licence text and no thumbnail. They are unrelated.

The declared extent now equals the data:

```
main       [-7.461691422693065, 37.99833066396645, -4.673659626208206, 40.51889710958931]
this branch[-7.334979717591043, 38.04066304591087, -4.704239370531218, 40.486611484793]
PMTiles    [-7.3350, 38.0407, -4.7042, 40.4866]
```

The measured extent matches the bounds that the PMTiles report.

Tests: 10 new tests in `tests/unit/test_collection_extent_from_data.py`. The
full unit suite gives 5,939 pass and 7 skip. `ruff check`, `ruff format --check`
and `mypy` are clean.

## Known limit

`finalization._gather_collection_bboxes` unions the existing collection extent
into the recomputed one. A catalog that already holds a wide extent therefore
keeps it, even after `add --force`. A fresh build gets the correct extent.
Issue #801 reports that behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map extents by calculating tighter WGS84 bounding boxes directly from geometry data.
  * Added support for custom geometry columns, null geometries, projected coordinate systems, and antimeridian-crossing extents.
  * Added reliable fallback behavior when geometry-based measurement is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->