### PR TITLE
ci: scope the iceberg coverage upload to the iceberg backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: portolan-sdi/portolan-cli
+          flags: main
 
   iceberg-test:
     name: Iceberg Unit & Integration Tests (Python ${{ matrix.python-version }} / ${{ matrix.os }})
@@ -244,7 +245,7 @@ jobs:
           command: uv sync --extra iceberg --extra dev
 
       - name: Run unit and integration tests
-        run: uv run pytest tests/iceberg/ -v --tb=short -m "not e2e and not e2e_slow and not network and not slow" --cov=portolan_cli/backends/iceberg --cov-report=term-missing --cov-report=xml
+        run: uv run pytest tests/iceberg/ -v --tb=short -m "not e2e and not e2e_slow and not network and not slow" --cov-reset --cov=portolan_cli/backends/iceberg --cov-report=term-missing --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/uv.lock
+++ b/uv.lock
@@ -4632,7 +4632,6 @@ iceberg = [
     { name = "pyiceberg", extra = ["sql-sqlite"] },
     { name = "shapely" },
 ]
-pmtiles = []
 thumbnails = [
     { name = "contextily" },
     { name = "mapbox-vector-tile" },
@@ -4683,7 +4682,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.0" },
     { name = "pmtiles", specifier = ">=3.0.0" },
-    { name = "pyarrow", specifier = ">=12.0.0,<25.0.0" },
+    { name = "pyarrow", specifier = ">=12.0.0,<26.0.0" },
     { name = "pygeohash", marker = "extra == 'iceberg'", specifier = ">=1.2.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyiceberg", extras = ["sql-sqlite"], marker = "extra == 'iceberg'", specifier = ">=0.8.0" },


### PR DESCRIPTION
## What changed

The Iceberg CI job now reports coverage for the Iceberg backend alone. It added `--cov-reset` before its own `--cov` value.

The main test job now uploads with `flags: main`. The flags table in the pull request comment shows both jobs.

The commit also refreshes `uv.lock`. See "Lock refresh" below.

## Why

The `iceberg` Codecov flag reported 23.75%. The Iceberg backend covers 92%. This resolves #823.

`pyproject.toml` line 143 sets `addopts` with `--cov=portolan_cli`. pytest-cov accumulates every `--cov` value. The Iceberg job added `--cov=portolan_cli/backends/iceberg` on top of that, so the report measured all 23,793 statements of the package while the job ran only `tests/iceberg/`.

A reader sees the flags table and concludes the project has 24% coverage. The repository total is 84.32% and was always correct.

`--cov-config` does not fix this. The extra source arrives on the command line, not from a configuration file. `--cov-reset` clears the sources accumulated so far.

### Lock refresh

`uv lock --check` fails on `main`. Every `uv run` therefore rewrites `uv.lock`, the pre-commit hooks report modified files, and the commit fails. The refresh is required to commit at all.

## Verification

Run the Iceberg job command from `.github/workflows/ci.yml` with the fix:

```
$ uv run pytest tests/iceberg/ -v --tb=short \
    -m "not e2e and not e2e_slow and not network and not slow" \
    --cov-reset --cov=portolan_cli/backends/iceberg \
    --cov-report=term-missing --cov-report=xml

Name                                              Stmts   Miss Branch BrPart  Cover
portolan_cli/backends/iceberg/__init__.py             7      1      2      1    78%
portolan_cli/backends/iceberg/backend.py            271     14     82     14    92%
portolan_cli/backends/iceberg/config.py              24      1      6      2    90%
portolan_cli/backends/iceberg/export.py              21      0      6      0   100%
portolan_cli/backends/iceberg/spatial.py             49      0     18      2    97%
portolan_cli/backends/iceberg/stac_generator.py      69      2     20      4    93%
portolan_cli/backends/iceberg/versioning.py          75      6     30      6    89%
-----------------------------------------------------------------------------------
TOTAL                                               516     24    164     29    92%
====================== 146 passed, 9 deselected in 24.65s ======================
```

The report covers 516 statements at 92%. Before the fix the same command covered 23,793 statements at 22%.

The Codecov API reports the state this change corrects:

```
$ curl -s "https://api.codecov.io/api/v2/github/portolan-sdi/repos/portolan-cli/flags/"
{"count":1,"next":null,"previous":null,
 "results":[{"flag_name":"iceberg","coverage":23.75489}]}

$ curl -s "https://api.codecov.io/api/v2/github/portolan-sdi/repos/portolan-cli/"
"totals": {"files": 155, "lines": 23746, "hits": 20025,
           "coverage": 84.32, "sessions": 2}
```

The data source is the Codecov API for `portolan-sdi/portolan-cli` at commit `2339e07`.

`uv lock --check` passes after the refresh:

```
$ uv lock --check
Resolved 263 packages in 168ms
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage reporting accuracy for the Iceberg backend.
  * Coverage uploads are now labeled consistently for the main test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->