### PR TITLE
fix: apply the root metadata.yaml title to catalog.json (#815)

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -564,9 +564,17 @@ def _ensure_tabular_collection(
     # Update catalog links to include this collection
     _update_catalog_links(catalog_root, collection_id)
 
-    # Issue #502: backfill the human-readable title onto the new child link.
-    from portolan_cli.catalog import ensure_link_titles, ensure_schema_uris
+    from portolan_cli.catalog import (
+        apply_catalog_human_titles,
+        ensure_link_titles,
+        ensure_schema_uris,
+    )
 
+    # Issue #815: the root catalog takes its own title and description from the
+    # root metadata.yaml.
+    apply_catalog_human_titles(catalog_root)
+
+    # Issue #502: backfill the human-readable title onto the new child link.
     ensure_link_titles(catalog_root)
 
     # / issue #654: the same conformance artifacts finalize_items writes

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -938,6 +938,60 @@ def ensure_link_titles(catalog_root: Path) -> bool:
     return changed_any
 
 
+def apply_catalog_human_titles(catalog_root: Path) -> bool:
+    """Apply the root metadata.yaml title/description to catalog.json (issue #815).
+
+    A collection takes its human-authored title and description from
+    ``metadata.yaml`` through :func:`portolan_cli.stac.apply_human_titles`. The
+    root catalog kept the value ``init`` wrote, so a title a human authored after
+    creation never reached ``catalog.json``. ``extract`` names the catalog after
+    its directory, which made that the published title.
+
+    Only the root ``catalog.json`` is touched. A subcatalog title comes from its
+    own path segment, and a title never inherits (see
+    :data:`portolan_cli.config.NON_INHERITED_METADATA_KEYS`).
+
+    Idempotent. A catalog that already carries the values is not rewritten.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+
+    Returns:
+        True if catalog.json was modified.
+    """
+    from portolan_cli.config import NON_INHERITED_METADATA_KEYS, load_merged_metadata
+
+    catalog_path = catalog_root / "catalog.json"
+    if not catalog_path.is_file():
+        return False
+
+    metadata = load_merged_metadata(catalog_root, catalog_root)
+    if not metadata:
+        return False
+
+    try:
+        catalog_data = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(catalog_data, dict):
+        return False
+
+    changed = False
+    for field in NON_INHERITED_METADATA_KEYS:
+        value = metadata.get(field)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        cleaned = value.strip()
+        if catalog_data.get(field) == cleaned:
+            continue
+        catalog_data[field] = cleaned
+        changed = True
+
+    if changed:
+        write_json_atomic(catalog_path, catalog_data)
+    return changed
+
+
 def ensure_schema_uris(catalog_root: Path) -> bool:
     """Declare the Portolan profile schema URI across a catalog tree (issue #654).
 

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -938,34 +938,29 @@ def ensure_link_titles(catalog_root: Path) -> bool:
     return changed_any
 
 
-def apply_catalog_human_titles(catalog_root: Path) -> bool:
-    """Apply the root metadata.yaml title/description to catalog.json (issue #815).
+#: metadata.yaml keys that a catalog copies onto its own catalog.json (#815).
+#: Kept apart from :data:`portolan_cli.config.NON_INHERITED_METADATA_KEYS`, which
+#: answers a different question. That constant names the keys a child never takes
+#: from a parent. This one names the keys a catalog publishes about itself.
+_CATALOG_HUMAN_FIELDS: tuple[str, ...] = ("title", "description")
 
-    A collection takes its human-authored title and description from
-    ``metadata.yaml`` through :func:`portolan_cli.stac.apply_human_titles`. The
-    root catalog kept the value ``init`` wrote, so a title a human authored after
-    creation never reached ``catalog.json``. ``extract`` names the catalog after
-    its directory, which made that the published title.
 
-    Only the root ``catalog.json`` is touched. A subcatalog title comes from its
-    own path segment, and a title never inherits (see
-    :data:`portolan_cli.config.NON_INHERITED_METADATA_KEYS`).
-
-    Idempotent. A catalog that already carries the values is not rewritten.
+def _apply_human_fields(
+    catalog_path: Path,
+    metadata: dict[str, Any],
+    *,
+    dry_run: bool = False,
+) -> bool:
+    """Copy the human-authored fields of ``metadata`` onto one catalog.json.
 
     Args:
-        catalog_root: Root directory of the catalog.
+        catalog_path: Path of the ``catalog.json`` to update.
+        metadata: Metadata that belongs to the catalog at ``catalog_path``.
+        dry_run: If True, report the change without writing the file.
 
     Returns:
-        True if catalog.json was modified.
+        True if the file was rewritten, or would be under ``dry_run``.
     """
-    from portolan_cli.config import NON_INHERITED_METADATA_KEYS, load_merged_metadata
-
-    catalog_path = catalog_root / "catalog.json"
-    if not catalog_path.is_file():
-        return False
-
-    metadata = load_merged_metadata(catalog_root, catalog_root)
     if not metadata:
         return False
 
@@ -977,7 +972,7 @@ def apply_catalog_human_titles(catalog_root: Path) -> bool:
         return False
 
     changed = False
-    for field in NON_INHERITED_METADATA_KEYS:
+    for field in _CATALOG_HUMAN_FIELDS:
         value = metadata.get(field)
         if not isinstance(value, str) or not value.strip():
             continue
@@ -987,8 +982,46 @@ def apply_catalog_human_titles(catalog_root: Path) -> bool:
         catalog_data[field] = cleaned
         changed = True
 
-    if changed:
+    if changed and not dry_run:
         write_json_atomic(catalog_path, catalog_data)
+    return changed
+
+
+def apply_catalog_human_titles(catalog_root: Path, *, dry_run: bool = False) -> list[Path]:
+    """Apply each metadata.yaml title/description to its catalog.json (issue #815).
+
+    A collection takes its human-authored title and description from
+    ``metadata.yaml`` through :func:`portolan_cli.stac.apply_human_titles`. A
+    catalog took the value ``init`` wrote, so a title a human authored after
+    creation never reached ``catalog.json``. ``extract`` names the catalog after
+    its directory, which made that the published title.
+
+    Every ``catalog.json`` in the visible tree is treated the same way. Each one
+    reads the ``metadata.yaml`` in its own directory. A title never inherits (see
+    :data:`portolan_cli.config.NON_INHERITED_METADATA_KEYS`), so a root title
+    cannot rename a subcatalog below it.
+
+    Idempotent. A catalog that already carries the values is not rewritten. The
+    sweep only writes a value it finds. It never clears a field, so a title
+    removed from ``metadata.yaml`` stays on ``catalog.json`` until a human or
+    ``check --fix`` replaces it.
+
+    Args:
+        catalog_root: Root directory of the catalog.
+        dry_run: If True, report what would change without writing.
+
+    Returns:
+        The catalog.json paths that were modified, in sweep order.
+    """
+    from portolan_cli.config import load_merged_metadata
+
+    changed: list[Path] = []
+    for catalog_path in visible_stac_files(catalog_root):
+        if catalog_path.name != "catalog.json":
+            continue
+        metadata = load_merged_metadata(catalog_path.parent, catalog_root)
+        if _apply_human_fields(catalog_path, metadata, dry_run=dry_run):
+            changed.append(catalog_path)
     return changed
 
 

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -44,7 +44,7 @@ from portolan_cli.licensing import (
     OTHER_LICENSE,
     license_gap,
 )
-from portolan_cli.metadata.fix import FixReport
+from portolan_cli.metadata.fix import FixAction, FixReport, FixResult
 from portolan_cli.output import detail, error, success, warn
 from portolan_cli.output import info as info_output
 from portolan_cli.query import ItemInfo
@@ -1818,6 +1818,7 @@ def _run_fix_and_repairs(
     Returns:
         The JSON ``fix`` section and whether a fix failed.
     """
+    from portolan_cli.catalog import apply_catalog_human_titles
     from portolan_cli.scan.check import resolve_catalog_root_for_check
     from portolan_cli.validation.fixers import apply_fixers
 
@@ -1825,16 +1826,35 @@ def _run_fix_and_repairs(
     applied: list[str] = []
     selected: list[str] = []
     skip_reasons: dict[str, list[str]] = {}
-    if run_metadata and findings:
+    title_results: list[FixResult] = []
+    if run_metadata:
         catalog_root = resolve_catalog_root_for_check(path) or path
-        skip = {"convert"} if run_geo_assets else set()
-        run = apply_fixers(catalog_root, findings, dry_run=dry_run, skip=skip)
-        fixer_report = run.report
-        # What the fixers *did*, not what the findings asked for: a fixer that
-        # ran and changed nothing is a skip with a reason, never an "Applied".
-        applied = run.applied
-        selected = run.selected
-        skip_reasons = run.skip_reasons
+        # Issue #815: a catalog publishes the title and description a human wrote
+        # in its own metadata.yaml. No rashid rule reports the drift, because
+        # rashid grades catalog.json alone and never reads metadata.yaml. The
+        # sweep therefore runs on its own, like the item-freshness pass below,
+        # and not through the finding-driven registry.
+        title_results = [
+            FixResult(
+                file_path=catalog_path,
+                action=FixAction.UPDATED,
+                success=True,
+                message="Applied the metadata.yaml title/description",
+            )
+            for catalog_path in apply_catalog_human_titles(catalog_root, dry_run=dry_run)
+        ]
+        if findings:
+            skip = {"convert"} if run_geo_assets else set()
+            run = apply_fixers(catalog_root, findings, dry_run=dry_run, skip=skip)
+            fixer_report = run.report
+            # What the fixers *did*, not what the findings asked for: a fixer
+            # that ran and changed nothing is a skip with a reason, never an
+            # "Applied".
+            applied = run.applied
+            selected = run.selected
+            skip_reasons = run.skip_reasons
+        if title_results:
+            fixer_report = FixReport(results=[*title_results, *fixer_report.results])
 
     legacy_data, legacy_failed = _run_legacy_fix_workflow(
         path=path,

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -192,6 +192,7 @@ def resolve_s3_endpoint_settings() -> S3EndpointSettings:
 
 # Config file name (inside .portolan/)
 CONFIG_FILENAME = "config.yaml"
+METADATA_FILENAME = "metadata.yaml"
 
 
 def get_config_path(catalog_path: Path) -> Path:
@@ -855,13 +856,23 @@ def load_merged_config(
     return merged
 
 
+#: metadata.yaml keys that name one object and therefore never inherit (#815).
+#: Every other key describes a whole subtree, such as the license, the contact,
+#: or the attribution. A child that declares none of those takes the parent
+#: value. A title does the opposite. It identifies the object it sits on, so an
+#: inherited title renamed every collection after its catalog.
+NON_INHERITED_METADATA_KEYS: tuple[str, ...] = ("title", "description")
+
+
 def load_merged_metadata(
     path: Path,
     catalog_root: Path,
 ) -> dict[str, Any]:
     """Load merged metadata.yaml from hierarchy.
 
-    Simply delegates to load_merged_yaml for metadata.yaml files.
+    Delegates to load_merged_yaml, then drops the keys in
+    :data:`NON_INHERITED_METADATA_KEYS` that came from an ancestor rather than
+    from ``path`` itself (#815).
 
     Args:
         path: Path to collection or subcatalog directory.
@@ -870,7 +881,16 @@ def load_merged_metadata(
     Returns:
         Merged metadata dictionary.
     """
-    return load_merged_yaml(path, "metadata.yaml", catalog_root)
+    merged = load_merged_yaml(path, METADATA_FILENAME, catalog_root)
+    if not merged:
+        return merged
+
+    own_path = path / ".portolan" / METADATA_FILENAME
+    own = (_load_validated_mapping(own_path) or {}) if own_path.is_file() else {}
+    for key in NON_INHERITED_METADATA_KEYS:
+        if key in merged and key not in own:
+            del merged[key]
+    return merged
 
 
 # =============================================================================

--- a/portolan_cli/external.py
+++ b/portolan_cli/external.py
@@ -266,9 +266,13 @@ def add_external(
     collection_dir.mkdir(parents=True, exist_ok=True)
     _save_collection_with_links(collection, collection_dir, catalog_root, resolved_id)
 
-    # Issue #502: backfill the human-readable title onto the new child link.
-    from portolan_cli.catalog import ensure_link_titles
+    from portolan_cli.catalog import apply_catalog_human_titles, ensure_link_titles
 
+    # Issue #815: a catalog takes its own title and description from its
+    # metadata.yaml, the same way the add sweeps apply them.
+    apply_catalog_human_titles(catalog_root)
+
+    # Issue #502: backfill the human-readable title onto the new child link.
     ensure_link_titles(catalog_root)
 
     collection_path = collection_dir / "collection.json"

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -1128,11 +1128,20 @@ def finalize_items(
     for collection_id, items in by_collection.items():
         results.extend(_finalize_collection(catalog_root, collection_id, items, merge_strategy))
 
+    from portolan_cli.catalog import (
+        apply_catalog_human_titles,
+        ensure_link_titles,
+        ensure_schema_uris,
+    )
+
+    # Issue #815: the root catalog takes its title and description from the root
+    # metadata.yaml, as every collection already does. It runs before the README
+    # sweep below, which reads catalog.json.
+    apply_catalog_human_titles(catalog_root)
+
     # Issue #502: backfill human-readable titles onto child/item links so STAC
     # Browser renders names without fetching every child. Done once per batch
     # (O(catalog), not per-collection) after all collections are written.
-    from portolan_cli.catalog import ensure_link_titles, ensure_schema_uris
-
     ensure_link_titles(catalog_root)
 
     # / issue #654: every catalog and collection declares the Portolan

--- a/portolan_cli/metadata/fix.py
+++ b/portolan_cli/metadata/fix.py
@@ -173,7 +173,8 @@ def repair_titles_and_links(catalog_root: Path, *, dry_run: bool = False) -> lis
     - every item referenced by an item link gets a title in its properties;
     - every ``child``/``item`` link gets its target's title backfilled.
 
-    Existing human-authored titles/descriptions are preserved.
+    Existing human-authored titles/descriptions are preserved. A title in a
+    catalog's own ``metadata.yaml`` overrides the derived one (issue #815).
 
     Args:
         catalog_root: Root directory of the catalog.
@@ -182,7 +183,7 @@ def repair_titles_and_links(catalog_root: Path, *, dry_run: bool = False) -> lis
     Returns:
         FixResults for each file that was (or would be) modified.
     """
-    from portolan_cli.catalog import ensure_link_titles
+    from portolan_cli.catalog import apply_catalog_human_titles, ensure_link_titles
     from portolan_cli.humanize import derive_title
 
     results: list[FixResult] = []
@@ -224,6 +225,20 @@ def repair_titles_and_links(catalog_root: Path, *, dry_run: bool = False) -> lis
         # Repair item titles referenced by this collection's item links so the
         # link-title backfill below has a title to copy.
         results.extend(_repair_item_titles(stac_file, data, dry_run=dry_run))
+
+    # Issue #815: a title a human wrote in metadata.yaml wins over the derived
+    # one above. The sweep runs after the loop for that reason. A user who
+    # edits metadata.yaml repairs the catalog with `check --fix` and does not
+    # re-run `add` over the data.
+    for catalog_path in apply_catalog_human_titles(catalog_root, dry_run=dry_run):
+        results.append(
+            FixResult(
+                file_path=catalog_path,
+                action=FixAction.UPDATED,
+                success=True,
+                message="Applied the metadata.yaml title/description",
+            )
+        )
 
     # Backfill child/item link titles from their (now-titled) targets.
     if not dry_run:

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -687,6 +687,8 @@ _TEMPLATE = """# .portolan/metadata.yaml
 # Portolan auto-derives a human-readable title from the collection id
 # (e.g. "publico_arbolado" -> "Publico Arbolado"). Set these to override it
 # with a better name/description; leave blank to keep the auto-derived value.
+# At the catalog root they name the catalog itself. They apply to this object
+# alone: a child never inherits a title or a description from its parent.
 # -----------------------------------------------------------------------------
 
 # title: ""                         # optional - overrides the auto-derived title

--- a/portolan_cli/metadata_yaml.py
+++ b/portolan_cli/metadata_yaml.py
@@ -687,8 +687,9 @@ _TEMPLATE = """# .portolan/metadata.yaml
 # Portolan auto-derives a human-readable title from the collection id
 # (e.g. "publico_arbolado" -> "Publico Arbolado"). Set these to override it
 # with a better name/description; leave blank to keep the auto-derived value.
-# At the catalog root they name the catalog itself. They apply to this object
-# alone: a child never inherits a title or a description from its parent.
+# At the catalog root they name the catalog itself. A subcatalog names itself
+# the same way. They apply to this object alone. A child never inherits a
+# title or a description from its parent.
 # -----------------------------------------------------------------------------
 
 # title: ""                         # optional - overrides the auto-derived title

--- a/tests/integration/test_mandatory_titles_add.py
+++ b/tests/integration/test_mandatory_titles_add.py
@@ -187,3 +187,70 @@ class TestRootMetadataTitleReachesCatalog:
 
         readme = (collection_dir / "README.md").read_text(encoding="utf-8")
         assert readme.startswith("# Publico Areas Programaticas Desarrollo Social")
+
+
+@pytest.mark.integration
+class TestCheckFixAppliesTheMetadataTitle:
+    """`portolan check --fix` applies a title edited after creation (#815).
+
+    No rashid rule reports the drift, because rashid grades `catalog.json` and
+    never reads `metadata.yaml`. A user who renames the catalog must not have to
+    re-run `add` over the data to publish the new name.
+    """
+
+    def test_check_fix_applies_the_edited_title(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        _add_slug_collection(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump(
+                {
+                    "license": "CC-BY-4.0",
+                    "title": "Philadelphia Housing and Land Use",
+                    "description": "Ten collections about property and zoning.",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        # The fixture catalog carries unrelated conformance gaps, such as a
+        # missing provider, so `check` exits non-zero. The title sweep still runs.
+        CliRunner().invoke(cli, ["check", "--fix", str(root)], catch_exceptions=False)
+
+        catalog = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
+        assert catalog["title"] == "Philadelphia Housing and Land Use"
+        assert catalog["description"] == "Ten collections about property and zoning."
+
+    def test_dry_run_leaves_the_catalog_untouched(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        _add_slug_collection(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump({"license": "CC-BY-4.0", "title": "Philadelphia Housing"}),
+            encoding="utf-8",
+        )
+
+        CliRunner().invoke(cli, ["check", "--fix", "--dry-run", str(root)], catch_exceptions=False)
+
+        catalog = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
+        assert catalog["title"] == "Demo Catalog"
+
+    def test_collection_readme_does_not_show_the_root_description(self, tmp_path: Path) -> None:
+        """A description names one object and never inherits (#815)."""
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump(
+                {
+                    "license": "CC-BY-4.0",
+                    "title": "Philadelphia Housing and Land Use",
+                    "description": "Ten collections about property and zoning.",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        collection_dir = _add_slug_collection(root)
+
+        readme = (collection_dir / "README.md").read_text(encoding="utf-8")
+        assert "Ten collections about property and zoning." not in readme

--- a/tests/integration/test_mandatory_titles_add.py
+++ b/tests/integration/test_mandatory_titles_add.py
@@ -108,3 +108,82 @@ class TestAddProducesHumanReadableTitles:
         catalog = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
         child = next(link for link in catalog["links"] if link.get("rel") == "child")
         assert child["title"] == "Áreas Programáticas de Desarrollo Social"
+
+
+@pytest.mark.integration
+class TestRootMetadataTitleReachesCatalog:
+    """`portolan add` applies the root metadata.yaml title (issue #815)."""
+
+    def test_root_title_and_description_reach_catalog_json(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump(
+                {
+                    "license": "CC-BY-4.0",
+                    "title": "Philadelphia Housing and Land Use",
+                    "description": "Ten collections about property and zoning.",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        _add_slug_collection(root)
+
+        catalog = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
+        assert catalog["title"] == "Philadelphia Housing and Land Use"
+        assert catalog["description"] == "Ten collections about property and zoning."
+
+    def test_root_title_does_not_replace_collection_title(self, tmp_path: Path) -> None:
+        """A collection with its own title keeps it (issue #815)."""
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump({"license": "CC-BY-4.0", "title": "Philadelphia Housing and Land Use"}),
+            encoding="utf-8",
+        )
+
+        collection_dir = _add_slug_collection(
+            root,
+            metadata_yaml={"license": "CC-BY-4.0", "title": "Property Parcels"},
+        )
+
+        coll = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
+        assert coll["title"] == "Property Parcels"
+
+    def test_readme_shows_the_root_title(self, tmp_path: Path) -> None:
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump({"license": "CC-BY-4.0", "title": "Philadelphia Housing and Land Use"}),
+            encoding="utf-8",
+        )
+
+        _add_slug_collection(root)
+
+        readme = (root / "README.md").read_text(encoding="utf-8")
+        assert readme.startswith("# Philadelphia Housing and Land Use")
+
+    def test_collection_without_a_title_keeps_the_humanized_one(self, tmp_path: Path) -> None:
+        """The root title must not rename every collection (issue #815)."""
+        root = tmp_path / "catalog"
+        _init_catalog(root)
+        (root / ".portolan" / "metadata.yaml").write_text(
+            yaml.dump(
+                {
+                    "license": "CC-BY-4.0",
+                    "title": "Philadelphia Housing and Land Use",
+                    "description": "Ten collections about property and zoning.",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        collection_dir = _add_slug_collection(root)
+
+        coll = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
+        assert coll["title"] == "Publico Areas Programaticas Desarrollo Social"
+        assert coll["description"] == "Publico Areas Programaticas Desarrollo Social"
+
+        readme = (collection_dir / "README.md").read_text(encoding="utf-8")
+        assert readme.startswith("# Publico Areas Programaticas Desarrollo Social")

--- a/tests/unit/test_catalog_root_titles.py
+++ b/tests/unit/test_catalog_root_titles.py
@@ -49,7 +49,7 @@ class TestApplyCatalogHumanTitles:
             },
         )
 
-        assert apply_catalog_human_titles(tmp_path) is True
+        assert apply_catalog_human_titles(tmp_path) == [tmp_path / "catalog.json"]
 
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         assert catalog["title"] == "Philadelphia Housing and Land Use"
@@ -59,7 +59,7 @@ class TestApplyCatalogHumanTitles:
         _catalog(tmp_path)
         _metadata(tmp_path, {"title": "Philadelphia Housing"})
 
-        assert apply_catalog_human_titles(tmp_path) is True
+        assert apply_catalog_human_titles(tmp_path) == [tmp_path / "catalog.json"]
 
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         assert catalog["title"] == "Philadelphia Housing"
@@ -69,7 +69,7 @@ class TestApplyCatalogHumanTitles:
         _catalog(tmp_path)
         _metadata(tmp_path, {"title": "   ", "description": ""})
 
-        assert apply_catalog_human_titles(tmp_path) is False
+        assert apply_catalog_human_titles(tmp_path) == []
 
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         assert catalog["title"] == "Phl Housing Demo"
@@ -78,7 +78,7 @@ class TestApplyCatalogHumanTitles:
     def test_no_metadata_yaml_leaves_catalog_untouched(self, tmp_path: Path) -> None:
         _catalog(tmp_path)
 
-        assert apply_catalog_human_titles(tmp_path) is False
+        assert apply_catalog_human_titles(tmp_path) == []
 
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         assert catalog["title"] == "Phl Housing Demo"
@@ -87,14 +87,14 @@ class TestApplyCatalogHumanTitles:
         _catalog(tmp_path)
         _metadata(tmp_path, {"title": "Philadelphia Housing"})
 
-        assert apply_catalog_human_titles(tmp_path) is True
-        assert apply_catalog_human_titles(tmp_path) is False
+        assert apply_catalog_human_titles(tmp_path) == [tmp_path / "catalog.json"]
+        assert apply_catalog_human_titles(tmp_path) == []
 
     def test_non_string_values_are_ignored(self, tmp_path: Path) -> None:
         _catalog(tmp_path)
         _metadata(tmp_path, {"title": 42, "description": ["a", "b"]})
 
-        assert apply_catalog_human_titles(tmp_path) is False
+        assert apply_catalog_human_titles(tmp_path) == []
 
         catalog = json.loads((tmp_path / "catalog.json").read_text())
         assert catalog["title"] == "Phl Housing Demo"
@@ -102,9 +102,9 @@ class TestApplyCatalogHumanTitles:
     def test_subcatalog_keeps_its_own_title(self, tmp_path: Path) -> None:
         """The root title must not overwrite a subcatalog title.
 
-        ``load_merged_metadata`` merges a parent file into a child, so a
-        subcatalog with no title of its own inherits the root one. The sweep
-        therefore touches the root ``catalog.json`` alone.
+        The sweep reads every ``catalog.json``. A subcatalog with no
+        ``metadata.yaml`` of its own keeps the title its path segment produced,
+        because ``title`` never inherits from a parent.
         """
         _catalog(tmp_path)
         _metadata(tmp_path, {"title": "Philadelphia Housing"})
@@ -129,17 +129,46 @@ class TestApplyCatalogHumanTitles:
         subcatalog = json.loads((sub / "catalog.json").read_text())
         assert subcatalog["title"] == "Zoning"
 
+    def test_subcatalog_takes_its_own_metadata_title(self, tmp_path: Path) -> None:
+        """A subcatalog reads the metadata.yaml in its own directory (#815)."""
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+        sub = tmp_path / "zoning"
+        _catalog(sub, id="zoning", title="Zoning", description="Catalog: zoning")
+        _metadata(sub, {"title": "Zoning and Land Use", "description": "Base districts."})
+
+        assert apply_catalog_human_titles(tmp_path) == [
+            tmp_path / "catalog.json",
+            sub / "catalog.json",
+        ]
+
+        subcatalog = json.loads((sub / "catalog.json").read_text())
+        assert subcatalog["title"] == "Zoning and Land Use"
+        assert subcatalog["description"] == "Base districts."
+        assert json.loads((tmp_path / "catalog.json").read_text())["title"] == (
+            "Philadelphia Housing"
+        )
+
+    def test_dry_run_reports_without_writing(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+
+        assert apply_catalog_human_titles(tmp_path, dry_run=True) == [tmp_path / "catalog.json"]
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "Phl Housing Demo"
+
     def test_missing_catalog_json_is_a_no_op(self, tmp_path: Path) -> None:
         _metadata(tmp_path, {"title": "Philadelphia Housing"})
 
-        assert apply_catalog_human_titles(tmp_path) is False
+        assert apply_catalog_human_titles(tmp_path) == []
 
     def test_unreadable_catalog_json_is_a_no_op(self, tmp_path: Path) -> None:
         tmp_path.mkdir(parents=True, exist_ok=True)
         (tmp_path / "catalog.json").write_text("{not json", encoding="utf-8")
         _metadata(tmp_path, {"title": "Philadelphia Housing"})
 
-        assert apply_catalog_human_titles(tmp_path) is False
+        assert apply_catalog_human_titles(tmp_path) == []
 
 
 @pytest.mark.unit

--- a/tests/unit/test_catalog_root_titles.py
+++ b/tests/unit/test_catalog_root_titles.py
@@ -1,0 +1,193 @@
+"""Unit tests for the root catalog title override (issue #815).
+
+The root ``.portolan/metadata.yaml`` may carry ``title`` and ``description``.
+``apply_catalog_human_titles`` copies them onto the root ``catalog.json``, the
+way ``apply_human_titles`` already does for a collection.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from portolan_cli.catalog import apply_catalog_human_titles
+
+
+def _catalog(root: Path, **overrides: object) -> None:
+    data: dict[str, object] = {
+        "type": "Catalog",
+        "stac_version": "1.1.0",
+        "id": "phl-housing-demo",
+        "title": "Phl Housing Demo",
+        "description": "A Portolan-managed STAC catalog",
+        "links": [],
+    }
+    data.update(overrides)
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "catalog.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def _metadata(root: Path, data: dict[str, object]) -> None:
+    portolan = root / ".portolan"
+    portolan.mkdir(parents=True, exist_ok=True)
+    (portolan / "metadata.yaml").write_text(yaml.dump(data), encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestApplyCatalogHumanTitles:
+    def test_title_and_description_reach_catalog_json(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+        _metadata(
+            tmp_path,
+            {
+                "license": "CC-BY-4.0",
+                "title": "Philadelphia Housing and Land Use",
+                "description": "Ten collections about property and zoning.",
+            },
+        )
+
+        assert apply_catalog_human_titles(tmp_path) is True
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "Philadelphia Housing and Land Use"
+        assert catalog["description"] == "Ten collections about property and zoning."
+
+    def test_title_alone_leaves_description(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+
+        assert apply_catalog_human_titles(tmp_path) is True
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "Philadelphia Housing"
+        assert catalog["description"] == "A Portolan-managed STAC catalog"
+
+    def test_blank_values_leave_catalog_untouched(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": "   ", "description": ""})
+
+        assert apply_catalog_human_titles(tmp_path) is False
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "Phl Housing Demo"
+        assert catalog["description"] == "A Portolan-managed STAC catalog"
+
+    def test_no_metadata_yaml_leaves_catalog_untouched(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+
+        assert apply_catalog_human_titles(tmp_path) is False
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "Phl Housing Demo"
+
+    def test_second_run_reports_no_change(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+
+        assert apply_catalog_human_titles(tmp_path) is True
+        assert apply_catalog_human_titles(tmp_path) is False
+
+    def test_non_string_values_are_ignored(self, tmp_path: Path) -> None:
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": 42, "description": ["a", "b"]})
+
+        assert apply_catalog_human_titles(tmp_path) is False
+
+        catalog = json.loads((tmp_path / "catalog.json").read_text())
+        assert catalog["title"] == "Phl Housing Demo"
+
+    def test_subcatalog_keeps_its_own_title(self, tmp_path: Path) -> None:
+        """The root title must not overwrite a subcatalog title.
+
+        ``load_merged_metadata`` merges a parent file into a child, so a
+        subcatalog with no title of its own inherits the root one. The sweep
+        therefore touches the root ``catalog.json`` alone.
+        """
+        _catalog(tmp_path)
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+        sub = tmp_path / "zoning"
+        sub.mkdir()
+        (sub / "catalog.json").write_text(
+            json.dumps(
+                {
+                    "type": "Catalog",
+                    "stac_version": "1.1.0",
+                    "id": "zoning",
+                    "title": "Zoning",
+                    "description": "Catalog: zoning",
+                    "links": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        apply_catalog_human_titles(tmp_path)
+
+        subcatalog = json.loads((sub / "catalog.json").read_text())
+        assert subcatalog["title"] == "Zoning"
+
+    def test_missing_catalog_json_is_a_no_op(self, tmp_path: Path) -> None:
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+
+        assert apply_catalog_human_titles(tmp_path) is False
+
+    def test_unreadable_catalog_json_is_a_no_op(self, tmp_path: Path) -> None:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "catalog.json").write_text("{not json", encoding="utf-8")
+        _metadata(tmp_path, {"title": "Philadelphia Housing"})
+
+        assert apply_catalog_human_titles(tmp_path) is False
+
+
+@pytest.mark.unit
+class TestTitleDoesNotInherit:
+    """title/description name one object and never inherit (issue #815)."""
+
+    def test_collection_does_not_take_the_root_title(self, tmp_path: Path) -> None:
+        from portolan_cli.config import load_merged_metadata
+
+        _metadata(tmp_path, {"license": "CC-BY-4.0", "title": "Philadelphia Housing"})
+        collection = tmp_path / "dor_parcel"
+        collection.mkdir()
+
+        merged = load_merged_metadata(collection, tmp_path)
+
+        assert "title" not in merged
+        # Everything else still inherits.
+        assert merged["license"] == "CC-BY-4.0"
+
+    def test_collection_keeps_its_own_title(self, tmp_path: Path) -> None:
+        from portolan_cli.config import load_merged_metadata
+
+        _metadata(tmp_path, {"license": "CC-BY-4.0", "title": "Philadelphia Housing"})
+        collection = tmp_path / "dor_parcel"
+        _metadata(collection, {"title": "Property Parcels"})
+
+        merged = load_merged_metadata(collection, tmp_path)
+
+        assert merged["title"] == "Property Parcels"
+        assert merged["license"] == "CC-BY-4.0"
+
+    def test_root_keeps_its_own_title(self, tmp_path: Path) -> None:
+        from portolan_cli.config import load_merged_metadata
+
+        _metadata(tmp_path, {"title": "Philadelphia Housing", "description": "Ten collections."})
+
+        merged = load_merged_metadata(tmp_path, tmp_path)
+
+        assert merged["title"] == "Philadelphia Housing"
+        assert merged["description"] == "Ten collections."
+
+    def test_description_does_not_inherit(self, tmp_path: Path) -> None:
+        from portolan_cli.config import load_merged_metadata
+
+        _metadata(tmp_path, {"description": "Ten collections."})
+        collection = tmp_path / "dor_parcel"
+        collection.mkdir()
+
+        merged = load_merged_metadata(collection, tmp_path)
+
+        assert "description" not in merged


### PR DESCRIPTION
## What changed

A catalog now publishes the `title` and `description` a human writes in its own
`.portolan/metadata.yaml`. Both `portolan add` and `portolan check --fix` apply
them. This resolves #815.

The fix has three parts.

1. `catalog.apply_catalog_human_titles` copies the `title` and `description`
   from each `metadata.yaml` onto the `catalog.json` beside it. It walks every
   catalog in the visible tree, so a subcatalog names itself the same way the
   root does. The function is idempotent and takes a `dry_run` flag. It returns
   the paths it changed.
2. `config.load_merged_metadata` no longer inherits `title` and `description`
   from a parent directory. `load_merged_yaml` merges a parent file into a
   child. A root title therefore renamed every collection under it. The new
   constant
   `config.NON_INHERITED_METADATA_KEYS` names the two keys that identify one
   object. Every other key still inherits, such as the license, the contact,
   and the attribution.
3. Four call sites run the sweep. `finalization.finalize_items` and
   `add._ensure_tabular_collection` end an `add`. `external.add_external` ends
   an external registration. `cli._run_fix_and_repairs` runs it for
   `portolan check --fix`.

The second part is the reason the first one is safe. Without it, a root title
propagates down and overwrites each collection title. The second part also drops
an inherited `description`. A collection that declares no description of its own
now takes the derived one instead of the root text.

Two details of the repair path matter.

- The sweep runs outside the finding-driven fixer registry, next to the
  item-freshness pass. No rashid rule reports the drift. The validator grades
  `catalog.json` alone.
- The repair in `metadata.fix.repair_titles_and_links` runs the sweep after it
  derives titles. A human title therefore wins over a derived one.

`portolan metadata init` writes a template. The template now states that a title
applies to the object it sits on and never inherits.

## Why

The catalog title is the first thing a reader sees. A catalog created by
`portolan extract` took the name of its directory. Nothing re-read the root
metadata afterwards.

The result was a silent drift.

- Validation reported success.
<!-- ste-ok: GERUND "Phl Housing Demo" is a quoted catalog title, not a verb -->
- Source Cooperative published "Phl Housing Demo" and "A Portolan-managed STAC
  catalog".
- The `--title` flag of `portolan init` was no help. The catalog already
  existed.

A user who renames a catalog after creation must not re-run `add` over the data.
The new name reaches `catalog.json` without that step. `portolan check --fix` is
the repair command, so it applies the name.

## Verification

Two commands publish the title. Each one has a reproduction below.

Start with `portolan add`. Reproduce the report in #815. Create the catalog, write the root title, then add
a file.

```bash
portolan init phl-housing-demo --license CC-BY-4.0 --auto
cd phl-housing-demo
cat >> .portolan/metadata.yaml <<'YAML'
title: Philadelphia Housing and Land Use
description: >
  Ten collections describing property, zoning, vacancy,
  and affordable housing in Philadelphia.
YAML
mkdir -p dor_parcel
cp tests/fixtures/simple.parquet dor_parcel/data.parquet
portolan add .
portolan readme
```

Before the fix, `catalog.json` kept the derived name:

```json
{
  "title": "Phl Housing Demo",
  "description": "A Portolan-managed STAC catalog"
}
```

After the fix, `jq -r '{title, description}' catalog.json` reports:

```json
{
  "title": "Philadelphia Housing and Land Use",
  "description": "Ten collections describing property, zoning, vacancy, and affordable housing in Philadelphia."
}
```

The collection keeps its own derived title. `jq -r '{title, description}'
dor_parcel/collection.json` reports:

```json
{
  "title": "Dor Parcel",
  "description": "Dor Parcel"
}
```

Before the second part of the fix, the same command reported
`"Philadelphia Housing and Land Use"` for the collection.

`head -3 README.md` reports the root title:

```
# Philadelphia Housing and Land Use

Ten collections describing property, zoning, vacancy, and affordable housing in Philadelphia.
```

Now the repair path. A review of this branch found that the first version applied the title on `add`
alone. Rename a catalog that holds no new data, then repair it.

```bash
portolan init mycat --auto --license CC-BY-4.0
cd mycat
printf 'title: "Dutch Heat Atlas"\ndescription: "Heat maps for the Netherlands."\n' \
  >> .portolan/metadata.yaml
portolan check --fix
```

Before this change, `check --fix` reported success and changed nothing:

```
✓ Catalog conforms (1 file(s) checked)
✓ Fixed automatically (0)
```

```json
{"title": "Mycat", "description": "A Portolan-managed STAC catalog"}
```

After this change, the same command reports the repair:

```
✓ Created/updated 1 metadata item
✓ Catalog conforms (1 file(s) checked)
```

```json
{"title": "Dutch Heat Atlas", "description": "Heat maps for the Netherlands."}
```

`portolan check --fix --dry-run` reports `create/update 1 metadata item` and
leaves `catalog.json` unchanged.

The data is `tests/fixtures/simple.parquet` in this repository.

The full fast suite passes:

```
$ uv run pytest tests/ --ignore=tests/iceberg/ \
    -m 'not network and not slow and not benchmark' -n 4 -q
6934 passed, 8 skipped, 66 warnings in 125.77s (0:02:05)
```

`uv run ruff check .`, `uv run mypy portolan_cli`, `uv run lint-imports`, and
`uv run xenon --max-absolute=C portolan_cli` report no problems.

## Tests

- `tests/unit/test_catalog_root_titles.py` covers
  `apply_catalog_human_titles`, the `dry_run` flag, a subcatalog that reads its
  own `metadata.yaml`, and the non-inheriting keys.
- `tests/integration/test_mandatory_titles_add.py` covers the `add` path and the
  `check --fix` path. It asserts that the root title reaches `catalog.json` and
  the README. It asserts that a collection without its own title keeps the
  humanized one. It asserts that a collection README does not show the root
  description.
