### PR TITLE
extract into an existing catalog writes data and styles, then aborts before collection.json

### DIFF
--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -836,7 +836,7 @@ def _auto_init_catalog(
         True if catalog was initialized, False if no files to add.
     """
     from portolan_cli.add import add_files
-    from portolan_cli.catalog import init_catalog
+    from portolan_cli.catalog import CatalogState, detect_state, init_catalog
 
     # Get list of extracted COG files (nested in item directories)
     collection_dir = output_dir / collection_name
@@ -845,9 +845,14 @@ def _auto_init_catalog(
     if not cog_files:
         return False  # Nothing to add
 
-    # Initialize the catalog. license_id=None because the ImageServer path seeds
-    # metadata.yaml from the harvested service licenseInfo (issue #686).
-    init_catalog(output_dir, title=service_name, license_id=None)
+    # A directory that is already a Portolan catalog gets the new rasters added to
+    # it, not an abort after the tiles already downloaded (issue #767). init_catalog
+    # raises CatalogAlreadyExistsError on a MANAGED directory, so skip it. The
+    # catalog already carries a license, so the add license gate (issue #686) passes.
+    if detect_state(output_dir) is not CatalogState.MANAGED:
+        # Initialize the catalog. license_id=None because the ImageServer path seeds
+        # metadata.yaml from the harvested service licenseInfo (issue #686).
+        init_catalog(output_dir, title=service_name, license_id=None)
 
     # Add all COG files - this creates items per raster
     add_files(

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -649,10 +649,13 @@ def _auto_init_catalog(
     filtered_title = None if is_technical_name(title) else title
     filtered_description = None if is_technical_name(description) else description
 
-    def _post_init(out: Path, _files: list[Path]) -> None:
+    def _post_init(out: Path, _files: list[Path], fresh: bool) -> None:
         # Per Issue #369: overwrite init_catalog defaults with the rich
-        # (unfiltered) service metadata now that catalog.json exists.
-        update_stac_metadata(out / "catalog.json", title=title, description=description)
+        # (unfiltered) service metadata now that catalog.json exists. Skip this
+        # when the catalog already existed, so a second extraction from a different
+        # service does not replace the root title/description (issue #832).
+        if fresh:
+            update_stac_metadata(out / "catalog.json", title=title, description=description)
         # Seed metadata.yaml here, between init_catalog and add_files, so the
         # harvested license is in place before add checks for one (issue #686).
         _seed_metadata_from_extraction(out, report, resolved_license)

--- a/portolan_cli/extract/carto/orchestrator.py
+++ b/portolan_cli/extract/carto/orchestrator.py
@@ -531,7 +531,7 @@ def _auto_init_catalog(
     and seeds metadata.yaml at catalog and collection level.
     """
 
-    def _post_init(out: Path, parquet_files: list[Path]) -> None:
+    def _post_init(out: Path, parquet_files: list[Path], _fresh: bool) -> None:
         # Non-geo (tabular) outputs carry no `geo` metadata key; add_files only
         # accepts them as standalone collection-level assets when tabular support
         # is enabled. Enable it before add_files when any output is

--- a/portolan_cli/extract/common/orchestrator_base.py
+++ b/portolan_cli/extract/common/orchestrator_base.py
@@ -77,6 +77,11 @@ def init_extracted_catalog(
     metadata, or enabling tabular support for non-geo outputs), then add the
     assets.
 
+    When ``output_dir`` is already a Portolan catalog, the ``init_catalog`` step
+    is skipped and the assets are added as new collections (issue #767). This lets
+    a caller extract more layers into a catalog they already built, rather than
+    abort after the download wrote the data.
+
     Args:
         output_dir: The catalog output directory.
         report: The extraction report.
@@ -89,16 +94,24 @@ def init_extracted_catalog(
         The list of added parquet files, or ``None`` when there was nothing to
         add (the caller should then stop — no catalog was created).
     """
-    from portolan_cli.catalog import add_files, init_catalog
+    from portolan_cli.catalog import CatalogState, add_files, detect_state, init_catalog
 
     parquet_files = collect_successful_parquet_files(output_dir, report)
     if not parquet_files:
         return None
 
-    # license_id=None: extract owns metadata.yaml, seeding it from harvested service
-    # metadata in post_init below. Writing a template here first would make that
-    # seeder's O_EXCL create a no-op and drop everything harvested (issue #686).
-    init_catalog(output_dir, title=title, description=description, license_id=None)
+    # A directory that is already a Portolan catalog gets the new collections added
+    # to it, not an abort after the download already wrote the data (issue #767). A
+    # caller who runs extract into a directory they already extracted into wants the
+    # new layers added, not a refusal. init_catalog raises CatalogAlreadyExistsError
+    # on a MANAGED directory, so skip it. The catalog already carries a license, so
+    # the add license gate (issue #686) still passes.
+    if detect_state(output_dir) is not CatalogState.MANAGED:
+        # license_id=None: extract owns metadata.yaml, seeding it from harvested
+        # service metadata in post_init below. Writing a template here first would
+        # make that seeder's O_EXCL create a no-op and drop everything harvested
+        # (issue #686).
+        init_catalog(output_dir, title=title, description=description, license_id=None)
 
     if post_init is not None:
         post_init(output_dir, parquet_files)

--- a/portolan_cli/extract/common/orchestrator_base.py
+++ b/portolan_cli/extract/common/orchestrator_base.py
@@ -66,7 +66,7 @@ def init_extracted_catalog(
     *,
     title: str | None,
     description: str | None,
-    post_init: Callable[[Path, list[Path]], None] | None = None,
+    post_init: Callable[[Path, list[Path], bool], None] | None = None,
 ) -> list[Path] | None:
     """Initialize a catalog and add the extracted assets.
 
@@ -87,8 +87,12 @@ def init_extracted_catalog(
         report: The extraction report.
         title: Catalog title for ``init_catalog`` (already filtered by caller).
         description: Catalog description for ``init_catalog``.
-        post_init: Optional hook called as ``post_init(output_dir, parquet_files)``
-            between ``init_catalog`` and ``add_files``.
+        post_init: Optional hook called as
+            ``post_init(output_dir, parquet_files, fresh)`` between ``init_catalog``
+            and ``add_files``. ``fresh`` is True only when this call created the
+            catalog. A hook must not overwrite root catalog metadata when ``fresh``
+            is False, because the catalog already belongs to an earlier extraction
+            (issue #832).
 
     Returns:
         The list of added parquet files, or ``None`` when there was nothing to
@@ -106,7 +110,8 @@ def init_extracted_catalog(
     # new layers added, not a refusal. init_catalog raises CatalogAlreadyExistsError
     # on a MANAGED directory, so skip it. The catalog already carries a license, so
     # the add license gate (issue #686) still passes.
-    if detect_state(output_dir) is not CatalogState.MANAGED:
+    fresh = detect_state(output_dir) is not CatalogState.MANAGED
+    if fresh:
         # license_id=None: extract owns metadata.yaml, seeding it from harvested
         # service metadata in post_init below. Writing a template here first would
         # make that seeder's O_EXCL create a no-op and drop everything harvested
@@ -114,7 +119,7 @@ def init_extracted_catalog(
         init_catalog(output_dir, title=title, description=description, license_id=None)
 
     if post_init is not None:
-        post_init(output_dir, parquet_files)
+        post_init(output_dir, parquet_files, fresh)
 
     add_files(paths=parquet_files, catalog_root=output_dir)
     return parquet_files

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -813,12 +813,15 @@ def _auto_init_catalog(
     # Extract and filter service title/description (Issue #369, #376)
     filtered_title, filtered_description = _derive_catalog_titles(discovery_result)
 
-    def _post_init(out: Path, _files: list[Path]) -> None:
+    def _post_init(out: Path, _files: list[Path], fresh: bool) -> None:
         # Per Issue #369/#376: overwrite init_catalog defaults with the filtered
         # service metadata (filtered values avoid overwriting with boilerplate).
-        update_stac_metadata(
-            out / "catalog.json", title=filtered_title, description=filtered_description
-        )
+        # Skip this when the catalog already existed, so a second extraction from a
+        # different service does not replace the root title/description (issue #832).
+        if fresh:
+            update_stac_metadata(
+                out / "catalog.json", title=filtered_title, description=filtered_description
+            )
         # Seed metadata.yaml here, between init_catalog and add_files, so the
         # harvested license is in place before add checks for one (issue #686).
         _seed_metadata_from_extraction(out, report, resolved_license)

--- a/tests/integration/extract/test_extract_auto_init.py
+++ b/tests/integration/extract/test_extract_auto_init.py
@@ -190,6 +190,55 @@ class TestAutoInitCatalog:
         assert (output_dir / "layer_0" / "collection.json").exists()
         assert (output_dir / "layer_1" / "collection.json").exists()
 
+    def test_second_extraction_adds_collection_to_existing_catalog(self, tmp_path: Path) -> None:
+        """A second extraction into an existing catalog adds a collection (issue #767).
+
+        Before the fix, the second _auto_init_catalog call raised
+        CatalogAlreadyExistsError after the data was already on disk, so the
+        second layer's collection.json was never written.
+        """
+        import json
+
+        output_dir = tmp_path / "shared_catalog"
+        output_dir.mkdir()
+
+        def _extract_layer(name: str, layer_id: int) -> ExtractionReport:
+            layer_dir = output_dir / name
+            layer_dir.mkdir()
+            output_parquet = layer_dir / "data.parquet"
+            shutil.copy(FIXTURES_DIR / "simple.parquet", output_parquet)
+            report = make_report(
+                layers=[
+                    make_layer_result(
+                        layer_id=layer_id,
+                        name=name,
+                        output_path=f"{name}/data.parquet",
+                        size_bytes=output_parquet.stat().st_size,
+                    )
+                ],
+            )
+            _auto_init_catalog(output_dir, report, TEST_LICENSE)
+            return report
+
+        # First layer creates the catalog.
+        _extract_layer("layer_a", 0)
+        assert (output_dir / "catalog.json").exists()
+        assert (output_dir / "layer_a" / "collection.json").exists()
+
+        # Second layer must be added, not refused.
+        _extract_layer("layer_b", 1)
+        assert (output_dir / "layer_b" / "collection.json").exists(), (
+            "second layer's collection.json should be written into the existing catalog"
+        )
+
+        # The root catalog links to both collections.
+        catalog_json = json.loads((output_dir / "catalog.json").read_text())
+        child_hrefs = {
+            link.get("href") for link in catalog_json.get("links", []) if link.get("rel") == "child"
+        }
+        assert "./layer_a/collection.json" in child_hrefs
+        assert "./layer_b/collection.json" in child_hrefs
+
     def test_auto_init_skipped_when_no_successful_layers(self, tmp_path: Path) -> None:
         """No catalog created when all layers failed."""
         output_dir = tmp_path / "failed_extraction"

--- a/tests/integration/extract/test_extract_auto_init.py
+++ b/tests/integration/extract/test_extract_auto_init.py
@@ -239,6 +239,75 @@ class TestAutoInitCatalog:
         assert "./layer_a/collection.json" in child_hrefs
         assert "./layer_b/collection.json" in child_hrefs
 
+    def test_second_extraction_keeps_root_catalog_title_and_description(
+        self, tmp_path: Path
+    ) -> None:
+        """A second extraction from a different service keeps the root metadata (issue #832).
+
+        The #767 fix lets a second extraction add a collection to an existing
+        catalog. Before this fix, that second run also rewrote the root
+        catalog.json title and description with the new service's values. The
+        root metadata must survive the second extraction.
+        """
+        import json
+
+        output_dir = tmp_path / "shared_catalog"
+        output_dir.mkdir()
+
+        def _extract(name: str, layer_id: int, source_url: str, description: str) -> None:
+            layer_dir = output_dir / name
+            layer_dir.mkdir()
+            output_parquet = layer_dir / "data.parquet"
+            shutil.copy(FIXTURES_DIR / "simple.parquet", output_parquet)
+            report = make_report(
+                layers=[
+                    make_layer_result(
+                        layer_id=layer_id,
+                        name=name,
+                        output_path=f"{name}/data.parquet",
+                        size_bytes=output_parquet.stat().st_size,
+                    )
+                ],
+                source_url=source_url,
+            )
+            report.metadata_extracted = MetadataExtracted(
+                source_url=source_url,
+                description=description,
+                attribution=None,
+                keywords=None,
+                contact_name=None,
+                processing_notes=None,
+                known_issues=None,
+                license_info_raw=None,
+            )
+            _auto_init_catalog(output_dir, report, TEST_LICENSE)
+
+        # First extraction seeds the root title and description.
+        _extract(
+            "housing",
+            0,
+            "https://services.arcgis.com/abc/arcgis/rest/services/HousingData/FeatureServer",
+            "Housing information for the municipality.",
+        )
+        catalog_before = json.loads((output_dir / "catalog.json").read_text())
+        assert catalog_before.get("title") == "HousingData"
+        assert "housing information" in catalog_before.get("description", "").lower()
+
+        # Second extraction from a different service must not replace the root metadata.
+        _extract(
+            "roads",
+            1,
+            "https://services.arcgis.com/abc/arcgis/rest/services/RoadNetwork/FeatureServer",
+            "Road centerlines for the region.",
+        )
+        catalog_after = json.loads((output_dir / "catalog.json").read_text())
+        assert catalog_after.get("title") == "HousingData", (
+            "second extraction must not overwrite the root catalog title"
+        )
+        assert catalog_after.get("description") == catalog_before.get("description"), (
+            "second extraction must not overwrite the root catalog description"
+        )
+
     def test_auto_init_skipped_when_no_successful_layers(self, tmp_path: Path) -> None:
         """No catalog created when all layers failed."""
         output_dir = tmp_path / "failed_extraction"

--- a/tests/unit/extract/arcgis/imageserver/test_extractor.py
+++ b/tests/unit/extract/arcgis/imageserver/test_extractor.py
@@ -547,3 +547,66 @@ class TestJsonErrorParsing:
         # Error message should contain the ArcGIS error details
         assert "400" in str(exc_info.value)
         assert "exceeds the size limit" in str(exc_info.value)
+
+
+@pytest.mark.unit
+class TestAutoInitCatalogExistingCatalog:
+    """Tests for _auto_init_catalog on an existing catalog (issue #767, #832)."""
+
+    def _make_tile(self, output_dir: Path, collection_name: str = "tiles") -> None:
+        """Write a placeholder COG so _auto_init_catalog finds a file to add."""
+        item_dir = output_dir / collection_name / "tile_0_0"
+        item_dir.mkdir(parents=True)
+        (item_dir / "tile_0_0.tif").write_bytes(b"fake-cog")
+
+    def test_first_extraction_initializes_catalog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh directory calls init_catalog, then add_files."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _auto_init_catalog
+
+        self._make_tile(tmp_path)
+        events: list[str] = []
+
+        import portolan_cli.add as add_mod
+        import portolan_cli.catalog as catalog_mod
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: events.append("init"))
+        monkeypatch.setattr(add_mod, "add_files", lambda **k: events.append("add"))
+
+        result = _auto_init_catalog(tmp_path, service_name="svc")
+
+        assert result is True
+        assert events == ["init", "add"]
+
+    def test_second_extraction_skips_init_on_existing_catalog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second ImageServer extraction adds tiles without aborting (issue #767).
+
+        The COG tiles download before _auto_init_catalog runs. Before the fix,
+        init_catalog raised CatalogAlreadyExistsError on a MANAGED directory, so
+        the run aborted after the download and never wrote collection.json. The
+        guard must skip init_catalog and add the tiles instead.
+        """
+        from portolan_cli.extract.arcgis.imageserver.extractor import _auto_init_catalog
+
+        # Mark the directory as an existing Portolan catalog. detect_state reads
+        # config.yaml alone to return MANAGED.
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text("# Portolan configuration\n")
+
+        self._make_tile(tmp_path, collection_name="naip-2024")
+        events: list[str] = []
+
+        import portolan_cli.add as add_mod
+        import portolan_cli.catalog as catalog_mod
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: events.append("init"))
+        monkeypatch.setattr(add_mod, "add_files", lambda **k: events.append("add"))
+
+        result = _auto_init_catalog(tmp_path, service_name="svc", collection_name="naip-2024")
+
+        assert result is True
+        # init_catalog is skipped for an existing catalog; the tiles are added.
+        assert events == ["add"]

--- a/tests/unit/extract/common/test_orchestrator_base.py
+++ b/tests/unit/extract/common/test_orchestrator_base.py
@@ -97,7 +97,7 @@ class TestInitExtractedCatalog:
         report = _report([_layer(0, "a", status="failed")])
         called = {"post_init": False}
 
-        def _post_init(_out: Path, _files: list[Path]) -> None:
+        def _post_init(_out: Path, _files: list[Path], _fresh: bool) -> None:
             called["post_init"] = True
 
         result = init_extracted_catalog(
@@ -132,9 +132,12 @@ class TestInitExtractedCatalog:
         def _fake_add(*, paths: list[Path], catalog_root: Path) -> None:
             events.append("add")
 
-        def _post_init(_out: Path, files: list[Path]) -> None:
+        def _post_init(_out: Path, files: list[Path], fresh: bool) -> None:
             events.append("post_init")
             assert files == [tmp_path / "a/a.parquet"]
+            # The catalog was created by this call, so the hook may seed root
+            # metadata (issue #832).
+            assert fresh is True
 
         monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
         monkeypatch.setattr(catalog_mod, "add_files", _fake_add)
@@ -175,9 +178,12 @@ class TestInitExtractedCatalog:
         def _fake_add(*, paths: list[Path], catalog_root: Path) -> None:
             events.append("add")
 
-        def _post_init(_out: Path, files: list[Path]) -> None:
+        def _post_init(_out: Path, files: list[Path], fresh: bool) -> None:
             events.append("post_init")
             assert files == [tmp_path / "a/a.parquet"]
+            # The catalog already existed, so the hook must not overwrite root
+            # metadata (issue #832).
+            assert fresh is False
 
         monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
         monkeypatch.setattr(catalog_mod, "add_files", _fake_add)

--- a/tests/unit/extract/common/test_orchestrator_base.py
+++ b/tests/unit/extract/common/test_orchestrator_base.py
@@ -156,6 +156,41 @@ class TestInitExtractedCatalog:
         result = init_extracted_catalog(tmp_path, report, title=None, description=None)
         assert result == [tmp_path / "a/a.parquet"]
 
+    def test_adds_to_existing_catalog_without_init(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A directory that is already a Portolan catalog (issue #767). detect_state
+        # reads config.yaml alone to return MANAGED.
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text("# Portolan configuration\n")
+
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+        events: list[str] = []
+
+        import portolan_cli.catalog as catalog_mod
+
+        def _fake_init(*_a: object, **_k: object) -> None:
+            events.append("init")
+
+        def _fake_add(*, paths: list[Path], catalog_root: Path) -> None:
+            events.append("add")
+
+        def _post_init(_out: Path, files: list[Path]) -> None:
+            events.append("post_init")
+            assert files == [tmp_path / "a/a.parquet"]
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
+        monkeypatch.setattr(catalog_mod, "add_files", _fake_add)
+
+        result = init_extracted_catalog(
+            tmp_path, report, title="t", description="d", post_init=_post_init
+        )
+
+        assert result == [tmp_path / "a/a.parquet"]
+        # init_catalog is skipped for an existing catalog; the new collection is
+        # added instead of the run aborting.
+        assert events == ["post_init", "add"]
+
 
 class TestAddSourceLinks:
     def test_adds_link_only_for_successful_with_collection_json(


### PR DESCRIPTION
## What changed

`portolan extract` now adds new collections to a catalog that already exists,
rather than abort after it writes the data. This resolves #767.

Before, an extraction into a directory that was already a Portolan catalog
downloaded the data, wrote the Parquet and the `styles/` and `legends/` files,
then failed:

```
✗ Extraction failed: [PRTLN-CAT001] Catalog already exists at staging/maps
```

The `collection.json` was never written, so the data on disk had no STAC that
pointed at it.

The shared post-extraction path `init_extracted_catalog` called `init_catalog`
unconditionally. `init_catalog` raises `CatalogAlreadyExistsError` on a MANAGED
directory. The guard fired after the download. Now the code checks the catalog
state first. When the directory is already a MANAGED catalog, it skips
`init_catalog` and adds the extracted layers as new collections.

## Why

A caller who runs `extract` into a directory they already extracted into wants
the new layers added. The issue reporter split a 132-layer workspace into one
process per layer, all writing to the same output directory. The first layer
created the catalog. Every layer after it downloaded, wrote data, printed
`✓ Success`, then aborted before `collection.json`. Fifteen layers of data ended
up with nothing referencing them.

The fix covers all three extractors that share `init_extracted_catalog`: WFS,
ArcGIS, and Carto. The catalog already carries a license, so the `add` license
gate (issue #686) still passes. The Carto tabular-support step still runs in
`post_init`, so non-geo outputs still add correctly. Catalog-level metadata
seeding stays a safe no-op because it uses `O_EXCL` and does not overwrite the
existing `metadata.yaml`.

## Verification

The new integration test reproduces the issue. It extracts one layer, then a
second layer into the same catalog, and asserts the second `collection.json`
exists and the root catalog links to both collections. The test fails on the
old code with the exact issue error, and passes now.

Failing behavior on the pre-fix code:

```
$ git stash push portolan_cli/extract/common/orchestrator_base.py
$ uv run pytest "tests/integration/extract/test_extract_auto_init.py::TestAutoInitCatalog::test_second_extraction_adds_collection_to_existing_catalog" -q --no-cov
portolan_cli/catalog.py:458: in init_catalog
    raise CatalogAlreadyExistsError(str(path))
E   portolan_cli.errors.CatalogAlreadyExistsError: [PRTLN-CAT001] Catalog already exists at .../shared_catalog
FAILED ... test_second_extraction_adds_collection_to_existing_catalog
1 failed
```

Passing behavior with the fix:

```
$ uv run pytest tests/unit/extract/common/test_orchestrator_base.py \
    tests/integration/extract/test_extract_auto_init.py -q --no-cov
23 passed
```

This reads the `tests/fixtures/simple.parquet` fixture.

Closes #767

---
*Automated by agent-farm.*