### PR TITLE
push --dry-run reports "0 version(s), 0 file(s)" for collections it would fully upload

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -4026,6 +4026,9 @@ def push(
                         "failed_collections": all_result.failed_collections,
                         "total_files_uploaded": all_result.total_files_uploaded,
                         "total_versions_pushed": all_result.total_versions_pushed,
+                        "dry_run": all_result.dry_run,
+                        "total_would_push_files": all_result.total_would_push_files,
+                        "total_would_push_versions": all_result.total_would_push_versions,
                         "collection_errors": all_result.collection_errors,
                     },
                 )

--- a/portolan_cli/sync/push.py
+++ b/portolan_cli/sync/push.py
@@ -2232,6 +2232,11 @@ class PushAllResult:
         failed_collections: Number of collections that failed to push.
         total_files_uploaded: Aggregate count of files uploaded across all collections.
         total_versions_pushed: Aggregate count of versions pushed across all collections.
+        dry_run: True if this was a dry-run operation (no network calls made).
+        total_would_push_files: In dry-run mode, max asset files that would be uploaded
+            (upper bound; actual count depends on remote state).
+        total_would_push_versions: In dry-run mode, max versions that would be pushed
+            (upper bound; actual count depends on remote state).
         collection_errors: Dict mapping collection name to error messages.
     """
 
@@ -2241,6 +2246,9 @@ class PushAllResult:
     failed_collections: int
     total_files_uploaded: int
     total_versions_pushed: int
+    dry_run: bool = False
+    total_would_push_files: int = 0
+    total_would_push_versions: int = 0
     collection_errors: dict[str, list[str]] = field(default_factory=dict)
 
 
@@ -2331,9 +2339,10 @@ def _push_all_process_result(
             stats["failed"] += 1
             stats["errors"][coll] = [err_msg]
         elif result and result.success:
-            # Dry-run does no remote check, so report the local upper-bound estimate.
-            # Reporting the real 0/0 counts here contradicts the "Would push up to N"
-            # estimate that push() prints and misleads an operator (Issue #804).
+            # A dry-run does no remote check, so the terminal line reports the local
+            # upper-bound estimate. The estimate goes to the would-push stats, not the
+            # uploaded stats. The uploaded stats stay at 0 to keep the JSON envelope
+            # side-effect-honest and consistent with the single-collection path.
             if result.dry_run:
                 v = result.would_push_versions
                 f = result.would_push_files
@@ -2341,13 +2350,15 @@ def _push_all_process_result(
                     f"[{current_completed}/{total}] {coll}: "
                     f"would push up to {v} version(s), {f} file(s)"
                 )
+                stats["total_would_push_files"] += f
+                stats["total_would_push_versions"] += v
             else:
                 v = result.versions_pushed
                 f = result.files_uploaded
                 success(f"[{current_completed}/{total}] {coll}: {v} version(s), {f} file(s)")
+                stats["total_files"] += f
+                stats["total_versions"] += v
             stats["successful"] += 1
-            stats["total_files"] += f
-            stats["total_versions"] += v
             if result.metrics:
                 stats["metrics"].merge(result.metrics)
         elif result:
@@ -2595,6 +2606,7 @@ async def push_all_collections_async(
             failed_collections=0,
             total_files_uploaded=0,
             total_versions_pushed=0,
+            dry_run=dry_run,
         )
 
     info(f"Found {total} collection(s) to push")
@@ -2605,6 +2617,8 @@ async def push_all_collections_async(
         "failed": 0,
         "total_files": 0,
         "total_versions": 0,
+        "total_would_push_files": 0,
+        "total_would_push_versions": 0,
         "metrics": UploadMetrics(),
         "errors": {},
     }
@@ -2667,8 +2681,10 @@ async def push_all_collections_async(
         info(f"\n{'=' * 60}")
         if overall_success:
             if dry_run:
+                wv = stats["total_would_push_versions"]
+                wf = stats["total_would_push_files"]
                 msg = f"[DRY RUN] Would push {stats['successful']} collection(s), "
-                msg += f"{stats['total_versions']} version(s), {stats['total_files']} file(s)"
+                msg += f"{wv} version(s), {wf} file(s)"
             else:
                 msg = f"Pushed {stats['successful']} collection(s), "
                 msg += f"{stats['total_versions']} version(s), {stats['total_files']} file(s)"
@@ -2691,6 +2707,9 @@ async def push_all_collections_async(
         failed_collections=stats["failed"],
         total_files_uploaded=stats["total_files"],
         total_versions_pushed=stats["total_versions"],
+        dry_run=dry_run,
+        total_would_push_files=stats["total_would_push_files"],
+        total_would_push_versions=stats["total_would_push_versions"],
         collection_errors=stats["errors"],
     )
 

--- a/portolan_cli/sync/push.py
+++ b/portolan_cli/sync/push.py
@@ -104,6 +104,8 @@ class PushResult:
         dry_run: True if this was a dry-run operation (no network calls made).
         would_push_versions: In dry-run mode, max versions that would be pushed
             (upper bound; actual count depends on remote state).
+        would_push_files: In dry-run mode, max asset files that would be uploaded
+            (upper bound; actual count depends on remote state).
         metrics: Upload performance metrics (bytes, duration, speed).
     """
 
@@ -115,6 +117,7 @@ class PushResult:
     metadata_errors: list[str] = field(default_factory=list)
     dry_run: bool = False
     would_push_versions: int = 0
+    would_push_files: int = 0
     metrics: UploadMetrics | None = None
 
     @property
@@ -1283,6 +1286,7 @@ def _handle_push_dry_run(
         errors=missing_assets,
         dry_run=True,
         would_push_versions=len(local_versions),
+        would_push_files=asset_count,
     )
 
 
@@ -2327,9 +2331,20 @@ def _push_all_process_result(
             stats["failed"] += 1
             stats["errors"][coll] = [err_msg]
         elif result and result.success:
-            v = result.versions_pushed
-            f = result.files_uploaded
-            success(f"[{current_completed}/{total}] {coll}: {v} version(s), {f} file(s)")
+            # Dry-run does no remote check, so report the local upper-bound estimate.
+            # Reporting the real 0/0 counts here contradicts the "Would push up to N"
+            # estimate that push() prints and misleads an operator (Issue #804).
+            if result.dry_run:
+                v = result.would_push_versions
+                f = result.would_push_files
+                success(
+                    f"[{current_completed}/{total}] {coll}: "
+                    f"would push up to {v} version(s), {f} file(s)"
+                )
+            else:
+                v = result.versions_pushed
+                f = result.files_uploaded
+                success(f"[{current_completed}/{total}] {coll}: {v} version(s), {f} file(s)")
             stats["successful"] += 1
             stats["total_files"] += f
             stats["total_versions"] += v
@@ -2651,12 +2666,16 @@ async def push_all_collections_async(
     with output_section():
         info(f"\n{'=' * 60}")
         if overall_success:
-            msg = f"Pushed {stats['successful']} collection(s), "
-            msg += f"{stats['total_versions']} version(s), {stats['total_files']} file(s)"
-            if stats["metrics"].total_bytes > 0:
-                size = format_file_size(stats["metrics"].total_bytes)
-                speed = format_speed(stats["metrics"].average_speed)
-                msg += f" ({size}, avg {speed})"
+            if dry_run:
+                msg = f"[DRY RUN] Would push {stats['successful']} collection(s), "
+                msg += f"{stats['total_versions']} version(s), {stats['total_files']} file(s)"
+            else:
+                msg = f"Pushed {stats['successful']} collection(s), "
+                msg += f"{stats['total_versions']} version(s), {stats['total_files']} file(s)"
+                if stats["metrics"].total_bytes > 0:
+                    size = format_file_size(stats["metrics"].total_bytes)
+                    speed = format_speed(stats["metrics"].average_speed)
+                    msg += f" ({size}, avg {speed})"
             success(msg)
         else:
             warn(

--- a/tests/unit/test_push.py
+++ b/tests/unit/test_push.py
@@ -2384,6 +2384,7 @@ class TestDryRunNetworkIsolation:
         assert result.files_uploaded == 0  # dry-run never uploads
         assert result.dry_run is True  # H3: result must indicate dry-run mode
         assert result.would_push_versions > 0  # H3: should show how many would push
+        assert result.would_push_files > 0  # Issue #804: also show file estimate
 
     @pytest.mark.unit
     def test_push_dry_run_does_not_call_upload_assets(self, local_catalog: Path) -> None:

--- a/tests/unit/test_push_catalog_wide.py
+++ b/tests/unit/test_push_catalog_wide.py
@@ -333,3 +333,48 @@ class TestPushAllCollections:
         assert call_kwargs["dry_run"] is True
         assert call_kwargs["collection"] == "col1"
         assert call_kwargs["include_catalog"] is False
+
+    @patch("portolan_cli.sync.push.push_async", new_callable=AsyncMock)
+    def test_dry_run_reports_would_push_estimate(
+        self, mock_push: MagicMock, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Dry-run per-collection and summary counts use the would-push estimate.
+
+        Regression for Issue #804. A dry-run does no remote check, so push()
+        returns files_uploaded=0 and versions_pushed=0. The catalog-wide report
+        must show the local upper-bound estimate instead of 0/0, which otherwise
+        contradicts the "Would push up to N" line and misleads an operator.
+        """
+        _setup_valid_catalog(tmp_path)
+
+        (tmp_path / "col1").mkdir()
+        (tmp_path / "col1" / "versions.json").write_text(json.dumps({"versions": []}))
+
+        mock_push.return_value = PushResult(
+            success=True,
+            files_uploaded=0,
+            versions_pushed=0,
+            conflicts=[],
+            errors=[],
+            dry_run=True,
+            would_push_versions=2,
+            would_push_files=3,
+        )
+
+        result = push_all_collections(
+            catalog_root=tmp_path,
+            destination="s3://bucket/catalog",
+            force=False,
+            dry_run=True,
+            profile=None,
+        )
+
+        # Aggregate result carries the estimate, not the real 0/0 counts.
+        assert result.total_versions_pushed == 2
+        assert result.total_files_uploaded == 3
+
+        # Terminal output must not report the contradictory "0 version(s), 0 file(s)".
+        out = capsys.readouterr().out
+        assert "col1: would push up to 2 version(s), 3 file(s)" in out
+        assert "[DRY RUN] Would push 1 collection(s), 2 version(s), 3 file(s)" in out
+        assert "0 version(s), 0 file(s)" not in out

--- a/tests/unit/test_push_catalog_wide.py
+++ b/tests/unit/test_push_catalog_wide.py
@@ -12,8 +12,11 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
+from portolan_cli.cli import cli
 from portolan_cli.sync.push import (
+    PushAllResult,
     PushResult,
     discover_collections,
     push_all_collections,
@@ -369,12 +372,66 @@ class TestPushAllCollections:
             profile=None,
         )
 
-        # Aggregate result carries the estimate, not the real 0/0 counts.
-        assert result.total_versions_pushed == 2
-        assert result.total_files_uploaded == 3
+        # The uploaded counts stay at 0 because a dry-run uploads nothing.
+        # The estimate goes to the separate would-push fields.
+        assert result.dry_run is True
+        assert result.total_versions_pushed == 0
+        assert result.total_files_uploaded == 0
+        assert result.total_would_push_versions == 2
+        assert result.total_would_push_files == 3
 
         # Terminal output must not report the contradictory "0 version(s), 0 file(s)".
         out = capsys.readouterr().out
         assert "col1: would push up to 2 version(s), 3 file(s)" in out
         assert "[DRY RUN] Would push 1 collection(s), 2 version(s), 3 file(s)" in out
         assert "0 version(s), 0 file(s)" not in out
+
+
+class TestCatalogWideDryRunJson:
+    """The catalog-wide --json dry-run envelope must be side-effect-honest."""
+
+    @patch("portolan_cli.sync.push.push_all_collections")
+    def test_dry_run_json_reports_zero_uploaded(
+        self, mock_push_all: MagicMock, tmp_path: Path
+    ) -> None:
+        """A dry-run uploads nothing, so the JSON envelope reports 0 uploaded.
+
+        Regression for Issue #833. The estimate belongs in the would-push fields.
+        The total_files_uploaded and total_versions_pushed fields stay at 0. An
+        agent that reads total_files_uploaded must not see the estimate there.
+        """
+        _setup_valid_catalog(tmp_path)
+
+        mock_push_all.return_value = PushAllResult(
+            success=True,
+            total_collections=1,
+            successful_collections=1,
+            failed_collections=0,
+            total_files_uploaded=0,
+            total_versions_pushed=0,
+            dry_run=True,
+            total_would_push_files=3,
+            total_would_push_versions=2,
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "push",
+                "s3://bucket/catalog",
+                "--dry-run",
+                "--json",
+                "--catalog",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 0
+        envelope = json.loads(result.output)
+        data = envelope["data"]
+        assert data["total_files_uploaded"] == 0
+        assert data["total_versions_pushed"] == 0
+        assert data["dry_run"] is True
+        assert data["total_would_push_files"] == 3
+        assert data["total_would_push_versions"] == 2


### PR DESCRIPTION
## What changed

`portolan push --dry-run` now reports the same estimate in every line. The
per-collection line and the final summary show the local upper-bound counts.
Before this change, they printed `0 version(s), 0 file(s)` and contradicted the
`Would push up to N version(s) / M asset file(s)` estimate above them.

- `PushResult` gets a new `would_push_files` field. `_handle_push_dry_run` sets
  it to the asset count.
- `_push_all_process_result` reads `would_push_versions` and `would_push_files`
  for a dry-run result. It prints `would push up to N version(s), M file(s)` and
  aggregates the estimate.
- The catalog-wide summary prints `[DRY RUN] Would push K collection(s), N
  version(s), M file(s)` in dry-run mode.

The real `files_uploaded` and `versions_pushed` counts stay `0` in dry-run. A
dry-run does no work. The dry-run does no remote check, so the reported counts
are an upper bound, not the exact push count.

## Why

A dry-run reads no remote state. The per-collection tally counted work done,
which is `0` in a dry-run. The `Would push` estimate reads the local ledger. The
two code paths disagreed in one report. An operator reads "nothing to upload"
and then a real `push` transfers many gigabytes. An agent that gates an
expensive step on the dry-run output gets the wrong answer. This resolves #804.

## Verification

The gate passes:

```
$ uv run pytest tests/unit/test_push_catalog_wide.py::TestPushAllCollections::test_dry_run_reports_would_push_estimate -q
.                                                                        [100%]
1 passed
```

```
$ uv run ruff format --check . && uv run ruff check . && uv run mypy portolan_cli
571 files already formatted
All checks passed!
Success: no issues found in 159 source files
```

The new test drives `push_all_collections` in dry-run mode. It asserts the
report shows `col1: would push up to 2 version(s), 3 file(s)` and `[DRY RUN]
Would push 1 collection(s), 2 version(s), 3 file(s)`. It asserts the report
never shows `0 version(s), 0 file(s)`. Data read: an in-memory catalog fixture
with one collection and a mocked `push_async`.

Closes #804

---
*Automated by agent-farm.*