### PR TITLE
add overwrites each collection's title with the catalog root's, and rewrites stac_extensions to the bundled schema version

### DIFF
--- a/portolan_cli/add.py
+++ b/portolan_cli/add.py
@@ -81,6 +81,9 @@ from portolan_cli.finalization import (
     _update_catalog_links as _update_catalog_links,  # noqa: PLC0414
 )
 from portolan_cli.finalization import (
+    apply_human_metadata as apply_human_metadata,  # noqa: PLC0414
+)
+from portolan_cli.finalization import (
     finalize_items as finalize_items,  # noqa: PLC0414
 )
 from portolan_cli.formats import (
@@ -154,9 +157,6 @@ from portolan_cli.query import ItemInfo, get_item_info, is_current, list_items  
 from portolan_cli.remove import remove_files  # noqa: F401
 from portolan_cli.stac import (
     MergeStrategy,
-    apply_human_license,
-    apply_human_providers,
-    apply_provenance,
     create_collection,
     declare_file_extension,
     document_tabular_table,
@@ -546,12 +546,9 @@ def _ensure_tabular_collection(
     )
 
     # A tabular-only add never reaches finalize_items, so apply the same
-    # human-authored license, providers, and derived provenance metadata.yaml
-    # carries for geo collections (issue #654 / issue #684).
-    merged_metadata = load_merged_metadata(collection_dir, catalog_root)
-    apply_human_license(collection, merged_metadata)
-    apply_human_providers(collection, merged_metadata)
-    apply_provenance(collection, merged_metadata)
+    # human-authored title, license, providers, and derived provenance
+    # metadata.yaml carries for geo collections (issue #654 / issue #684 / #755).
+    apply_human_metadata(collection, collection_dir, catalog_root)
 
     # Save collection.json
     collection_dir.mkdir(parents=True, exist_ok=True)

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -893,6 +893,27 @@ def load_merged_metadata(
     return merged
 
 
+def load_own_metadata(path: Path) -> dict[str, Any]:
+    """Load only the metadata.yaml a directory owns, with no inheritance.
+
+    ``load_merged_metadata`` merges a collection's metadata.yaml with the ones its
+    ancestors own. This reads the single ``.portolan/metadata.yaml`` in ``path``
+    alone. A caller uses it to tell a value the collection declares from a value it
+    inherits (issue #755).
+
+    Args:
+        path: Directory that may own a ``.portolan/metadata.yaml``.
+
+    Returns:
+        The parsed metadata mapping, or an empty dict when the file is absent,
+        empty, or not a mapping.
+    """
+    file_path = path / ".portolan" / "metadata.yaml"
+    if not file_path.is_file():
+        return {}
+    return _load_validated_mapping(file_path) or {}
+
+
 # =============================================================================
 # .env file support (Issue #356)
 # =============================================================================

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -424,6 +424,11 @@ def apply_human_metadata(
     replaces a title, a license, or providers a maintainer set on this collection,
     and a catalog title never becomes a collection title (issue #755).
 
+    An own ``contact`` counts as an own providers declaration. It seeds the host
+    provider, so it regenerates the providers array even over one a maintainer
+    hand-edited into collection.json. Do not set both a hand-edited array and an
+    own ``contact`` unless you want the contact to win.
+
     Args:
         collection: The collection to update in place.
         collection_dir: The collection's directory under the catalog root.
@@ -445,8 +450,9 @@ def apply_human_metadata(
         # still resolve its link.
         apply_human_license(collection, own)
 
-    # Providers: the own declaration wins, and a host seeds from an inherited
-    # contact. An inherited array fills only a collection that declares none yet.
+    # Providers: an own providers array or an own contact rebuilds the array,
+    # because both are own declarations (an own contact seeds the host). An
+    # inherited array fills only a collection that declares none yet.
     if "providers" in own or "contact" in own or not collection.providers:
         apply_human_providers(collection, merged)
 

--- a/portolan_cli/finalization.py
+++ b/portolan_cli/finalization.py
@@ -30,7 +30,7 @@ from typing import Any
 import pystac
 from pystac.layout import AsIsLayoutStrategy
 
-from portolan_cli.config import load_merged_metadata
+from portolan_cli.config import load_merged_metadata, load_own_metadata
 from portolan_cli.formats import FormatType
 from portolan_cli.humanize import humanize_slug
 from portolan_cli.json_io import write_json_atomic
@@ -39,6 +39,7 @@ from portolan_cli.metadata.geoparquet import GeoParquetMetadata
 from portolan_cli.preparation import PreparedItem
 from portolan_cli.query import ItemInfo
 from portolan_cli.stac import (
+    DEFAULT_LICENSE,
     MergeStrategy,
     add_asset_to_collection,
     add_collection_extensions_from_summaries,
@@ -408,6 +409,50 @@ def _get_or_create_collection(
         title=title,
         bbox=initial_bbox,
     )
+
+
+def apply_human_metadata(
+    collection: pystac.Collection,
+    collection_dir: Path,
+    catalog_root: Path,
+) -> None:
+    """Write human-authored metadata onto a collection, own value over inherited.
+
+    A metadata.yaml the collection owns is authoritative. Portolan re-applies its
+    title, description, license, and providers on every add. A metadata.yaml an
+    ancestor owns only fills a field the collection still lacks. So a re-add never
+    replaces a title, a license, or providers a maintainer set on this collection,
+    and a catalog title never becomes a collection title (issue #755).
+
+    Args:
+        collection: The collection to update in place.
+        collection_dir: The collection's directory under the catalog root.
+        catalog_root: Root directory of the catalog.
+    """
+    own = load_own_metadata(collection_dir)
+    merged = load_merged_metadata(collection_dir, catalog_root)
+
+    # Title and description: only the collection's own declaration applies. An
+    # ancestor title names the catalog, not this collection, so it never inherits.
+    apply_human_titles(collection, own)
+
+    # License: the own declaration wins. An inherited license fills only a
+    # collection that still carries the placeholder default license.
+    if "license" in own or collection.license == DEFAULT_LICENSE:
+        apply_human_license(collection, merged)
+    else:
+        # Preserve the existing license, but let the collection's own license_url
+        # still resolve its link.
+        apply_human_license(collection, own)
+
+    # Providers: the own declaration wins, and a host seeds from an inherited
+    # contact. An inherited array fills only a collection that declares none yet.
+    if "providers" in own or "contact" in own or not collection.providers:
+        apply_human_providers(collection, merged)
+
+    # Provenance derives from the providers now on the collection and the source
+    # link the merged metadata declares.
+    apply_provenance(collection, merged)
 
 
 def _add_prepared_items_to_collection(
@@ -1038,16 +1083,10 @@ def _finalize_collection(
         initial_bbox=first_item.bbox,
     )
 
-    # Issue #502/#654: apply human title/description/license overrides from
-    # metadata.yaml (highest precedence over the auto-derived defaults).
-    merged_metadata = load_merged_metadata(collection_dir, catalog_root)
-    apply_human_titles(collection, merged_metadata)
-    apply_human_license(collection, merged_metadata)
-
-    # Issue #684: providers name who produced the data and who hosts this copy,
-    # and their relationship is what makes this collection official or a mirror.
-    apply_human_providers(collection, merged_metadata)
-    apply_provenance(collection, merged_metadata)
+    # Issue #502/#654/#684/#755: apply human title/description/license/providers
+    # from metadata.yaml. The collection's own metadata.yaml wins; inherited
+    # ancestor metadata only fills fields the collection still lacks.
+    apply_human_metadata(collection, collection_dir, catalog_root)
 
     # Add items or collection-level assets to collection (in memory)
     _add_prepared_items_to_collection(collection, items, merge_strategy)

--- a/portolan_cli/stac.py
+++ b/portolan_cli/stac.py
@@ -32,9 +32,19 @@ if TYPE_CHECKING:
 
 # Any versioned Portolan profile URI, not just the current one: matching the
 # whole family is what lets a stale claim be rewritten rather than duplicated.
+# The capture groups read the SemVer triple, so the stamper can compare versions
+# and keep the higher one (issue #755).
 PORTOLAN_SCHEMA_URI_PATTERN = re.compile(
-    r"^https://schemas\.portolan-sdi\.org/portolan/v\d+\.\d+\.\d+/schema\.json$"
+    r"^https://schemas\.portolan-sdi\.org/portolan/v(\d+)\.(\d+)\.(\d+)/schema\.json$"
 )
+
+
+def _profile_version(uri: str) -> tuple[int, int, int] | None:
+    """Return the SemVer triple of a Portolan profile URI, or None when it does not match."""
+    match = PORTOLAN_SCHEMA_URI_PATTERN.match(uri)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
 class MergeStrategy(Enum):
@@ -927,6 +937,10 @@ def ensure_portolan_schema_uri(document: dict[str, Any]) -> bool:
     upgrades it instead of accumulating claims. Other extension declarations keep
     their relative order.
 
+    The URI never moves down a version. A catalog that already declares a newer
+    spec release than the one the installed validator bundles keeps its version,
+    so ``add`` does not stamp an older schema over a newer one (issue #755).
+
     Args:
         document: Parsed ``catalog.json`` or ``collection.json``, mutated in place.
 
@@ -936,18 +950,30 @@ def ensure_portolan_schema_uri(document: dict[str, Any]) -> bool:
     existing = document.get("stac_extensions")
     declared: list[str] = list(existing) if isinstance(existing, list) else []
 
+    # Keep the highest version between what is declared and what this CLI stamps,
+    # so a re-add upgrades an older claim but never downgrades a newer one.
+    canonical = PORTOLAN_SCHEMA_URI
+    canonical_version = _profile_version(PORTOLAN_SCHEMA_URI)
+    for uri in declared:
+        if not isinstance(uri, str):
+            continue
+        version = _profile_version(uri)
+        if version is not None and canonical_version is not None and version > canonical_version:
+            canonical = uri
+            canonical_version = version
+
     kept: list[str] = []
     stamped = False
     for uri in declared:
         if isinstance(uri, str) and PORTOLAN_SCHEMA_URI_PATTERN.match(uri):
             # Collapse every profile claim (stale or duplicate) onto the first.
             if not stamped:
-                kept.append(PORTOLAN_SCHEMA_URI)
+                kept.append(canonical)
                 stamped = True
             continue
         kept.append(uri)
     if not stamped:
-        kept.append(PORTOLAN_SCHEMA_URI)
+        kept.append(canonical)
 
     if kept == declared and isinstance(existing, list):
         return False

--- a/tests/integration/test_readd_preserves_metadata.py
+++ b/tests/integration/test_readd_preserves_metadata.py
@@ -1,0 +1,107 @@
+"""Integration tests: a re-add preserves collection-specific metadata (issue #755).
+
+``portolan add`` regenerates ``collection.json`` on every run. It used to overwrite
+the collection title with the catalog root title, and it re-stamped the license and
+providers from metadata merged down the tree. A maintainer who fixed a collection by
+hand then lost the fix on the next add. These tests add a collection, edit it by hand,
+add again, and confirm the hand edits survive.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+
+pytestmark = pytest.mark.integration
+
+FIXTURE = Path(__file__).resolve().parents[1] / "fixtures" / "simple.parquet"
+
+
+def _init_catalog(root: Path) -> None:
+    """Init a catalog whose root metadata.yaml declares a title and a license."""
+    result = CliRunner().invoke(
+        cli,
+        ["init", str(root), "--auto", "--title", "Demo Catalog", "--license", "CC-BY-4.0"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    portolan_dir = root / ".portolan"
+    (portolan_dir / "metadata.yaml").write_text(
+        yaml.dump({"title": "Demo Catalog", "license": "CC-BY-4.0"}),
+        encoding="utf-8",
+    )
+
+
+def _add_collection(root: Path) -> Path:
+    collection_dir = root / "roads"
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    dest = collection_dir / "roads.parquet"
+    shutil.copy(FIXTURE, dest)
+    result = CliRunner().invoke(
+        cli,
+        ["add", "--portolan-dir", str(root), str(dest)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    return collection_dir
+
+
+def _readd(root: Path, dest: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        ["add", "--portolan-dir", str(root), "--force", str(dest)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_readd_keeps_the_hand_edited_collection_title(tmp_path: Path) -> None:
+    """The root title never overwrites a title a maintainer set on the collection."""
+    root = tmp_path / "catalog"
+    _init_catalog(root)
+    collection_dir = _add_collection(root)
+    collection_json = collection_dir / "collection.json"
+
+    # A maintainer fixes the title by hand.
+    data = json.loads(collection_json.read_text(encoding="utf-8"))
+    data["title"] = "Municipal Road Network"
+    collection_json.write_text(json.dumps(data), encoding="utf-8")
+
+    _readd(root, collection_dir / "roads.parquet")
+
+    reloaded = json.loads(collection_json.read_text(encoding="utf-8"))
+    assert reloaded["title"] == "Municipal Road Network"
+
+
+def test_first_add_does_not_inherit_the_root_title(tmp_path: Path) -> None:
+    """A fresh collection keeps its humanized slug title, not the catalog title."""
+    root = tmp_path / "catalog"
+    _init_catalog(root)
+    collection_dir = _add_collection(root)
+
+    data = json.loads((collection_dir / "collection.json").read_text(encoding="utf-8"))
+    assert data["title"] == "Roads"
+
+
+def test_readd_keeps_the_hand_edited_license(tmp_path: Path) -> None:
+    """An inherited license never overwrites a license a maintainer set by hand."""
+    root = tmp_path / "catalog"
+    _init_catalog(root)
+    collection_dir = _add_collection(root)
+    collection_json = collection_dir / "collection.json"
+
+    data = json.loads(collection_json.read_text(encoding="utf-8"))
+    data["license"] = "ODbL-1.0"
+    collection_json.write_text(json.dumps(data), encoding="utf-8")
+
+    _readd(root, collection_dir / "roads.parquet")
+
+    reloaded = json.loads(collection_json.read_text(encoding="utf-8"))
+    assert reloaded["license"] == "ODbL-1.0"

--- a/tests/unit/test_apply_human_metadata.py
+++ b/tests/unit/test_apply_human_metadata.py
@@ -1,0 +1,136 @@
+"""Unit tests for own-over-inherited metadata precedence (issue #755).
+
+``portolan add`` used to overwrite a collection's title, license, and providers
+with values merged down from the catalog root. ``apply_human_metadata`` fixes
+that: a value the collection owns wins, and an inherited value only fills a field
+the collection still lacks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from portolan_cli.finalization import apply_human_metadata
+from portolan_cli.stac import DEFAULT_LICENSE, create_collection
+
+pytestmark = pytest.mark.unit
+
+
+def _write_metadata(directory: Path, data: dict[str, object]) -> None:
+    portolan = directory / ".portolan"
+    portolan.mkdir(parents=True, exist_ok=True)
+    (portolan / "metadata.yaml").write_text(yaml.dump(data), encoding="utf-8")
+
+
+def _collection_dir(catalog_root: Path, collection_id: str = "roads") -> Path:
+    collection_dir = catalog_root / collection_id
+    collection_dir.mkdir(parents=True, exist_ok=True)
+    return collection_dir
+
+
+class TestTitlePrecedence:
+    def test_inherited_title_never_overwrites_a_collection_title(self, tmp_path: Path) -> None:
+        """The catalog title must not become the collection title (issue #755)."""
+        _write_metadata(tmp_path, {"title": "Root Catalog"})
+        collection_dir = _collection_dir(tmp_path)
+        collection = create_collection(collection_id="roads", description="Roads", title="Roads")
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.title == "Roads"
+
+    def test_own_title_wins(self, tmp_path: Path) -> None:
+        _write_metadata(tmp_path, {"title": "Root Catalog"})
+        collection_dir = _collection_dir(tmp_path)
+        _write_metadata(collection_dir, {"title": "City Roads"})
+        collection = create_collection(collection_id="roads", description="Roads", title="Roads")
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.title == "City Roads"
+
+
+class TestLicensePrecedence:
+    def test_inherited_license_fills_placeholder(self, tmp_path: Path) -> None:
+        _write_metadata(tmp_path, {"license": "CC-BY-4.0"})
+        collection_dir = _collection_dir(tmp_path)
+        collection = create_collection(collection_id="roads", description="Roads")
+        assert collection.license == DEFAULT_LICENSE
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.license == "CC-BY-4.0"
+
+    def test_inherited_license_does_not_overwrite_a_real_license(self, tmp_path: Path) -> None:
+        _write_metadata(tmp_path, {"license": "CC-BY-4.0"})
+        collection_dir = _collection_dir(tmp_path)
+        collection = create_collection(collection_id="roads", description="Roads", license="MIT")
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.license == "MIT"
+
+    def test_own_license_wins_over_inherited(self, tmp_path: Path) -> None:
+        _write_metadata(tmp_path, {"license": "CC-BY-4.0"})
+        collection_dir = _collection_dir(tmp_path)
+        _write_metadata(collection_dir, {"license": "ODbL-1.0"})
+        collection = create_collection(collection_id="roads", description="Roads", license="MIT")
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.license == "ODbL-1.0"
+
+
+class TestProvidersPrecedence:
+    def test_inherited_contact_fills_missing_providers(self, tmp_path: Path) -> None:
+        _write_metadata(
+            tmp_path,
+            {
+                "providers": [{"name": "City GIS", "roles": ["producer", "host"]}],
+            },
+        )
+        collection_dir = _collection_dir(tmp_path)
+        collection = create_collection(collection_id="roads", description="Roads")
+        assert not collection.providers
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        names = [provider.name for provider in collection.providers or []]
+        assert names == ["City GIS"]
+
+    def test_inherited_providers_do_not_overwrite_existing(self, tmp_path: Path) -> None:
+        """A maintainer's hand-edited providers survive a re-add (issue #755)."""
+        _write_metadata(
+            tmp_path,
+            {"providers": [{"name": "Root Org", "roles": ["producer", "host"]}]},
+        )
+        collection_dir = _collection_dir(tmp_path)
+        collection = create_collection(collection_id="roads", description="Roads")
+        # The collection already carries providers a human wrote by hand.
+        import pystac
+
+        collection.providers = [pystac.Provider(name="Hand Edited", roles=["producer", "host"])]
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        names = [provider.name for provider in collection.providers or []]
+        assert names == ["Hand Edited"]
+
+    def test_own_providers_win_over_existing(self, tmp_path: Path) -> None:
+        collection_dir = _collection_dir(tmp_path)
+        _write_metadata(
+            collection_dir,
+            {"providers": [{"name": "Own Org", "roles": ["producer", "host"]}]},
+        )
+        collection = create_collection(collection_id="roads", description="Roads")
+        import pystac
+
+        collection.providers = [pystac.Provider(name="Stale", roles=["producer", "host"])]
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        names = [provider.name for provider in collection.providers or []]
+        assert names == ["Own Org"]

--- a/tests/unit/test_apply_human_metadata.py
+++ b/tests/unit/test_apply_human_metadata.py
@@ -53,6 +53,32 @@ class TestTitlePrecedence:
         assert collection.title == "City Roads"
 
 
+class TestDescriptionPrecedence:
+    def test_inherited_description_never_overwrites_a_collection_description(
+        self, tmp_path: Path
+    ) -> None:
+        """An ancestor description must not become the collection description (issue #755)."""
+        _write_metadata(tmp_path, {"description": "Root catalog description"})
+        collection_dir = _collection_dir(tmp_path)
+        collection = create_collection(
+            collection_id="roads", description="Road network of the city"
+        )
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.description == "Road network of the city"
+
+    def test_own_description_wins(self, tmp_path: Path) -> None:
+        _write_metadata(tmp_path, {"description": "Root catalog description"})
+        collection_dir = _collection_dir(tmp_path)
+        _write_metadata(collection_dir, {"description": "City road network"})
+        collection = create_collection(collection_id="roads", description="Roads")
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        assert collection.description == "City road network"
+
+
 class TestLicensePrecedence:
     def test_inherited_license_fills_placeholder(self, tmp_path: Path) -> None:
         _write_metadata(tmp_path, {"license": "CC-BY-4.0"})
@@ -85,7 +111,7 @@ class TestLicensePrecedence:
 
 
 class TestProvidersPrecedence:
-    def test_inherited_contact_fills_missing_providers(self, tmp_path: Path) -> None:
+    def test_inherited_providers_fill_missing_providers(self, tmp_path: Path) -> None:
         _write_metadata(
             tmp_path,
             {
@@ -95,6 +121,27 @@ class TestProvidersPrecedence:
         collection_dir = _collection_dir(tmp_path)
         collection = create_collection(collection_id="roads", description="Roads")
         assert not collection.providers
+
+        apply_human_metadata(collection, collection_dir, tmp_path)
+
+        names = [provider.name for provider in collection.providers or []]
+        assert names == ["City GIS"]
+
+    def test_own_contact_regenerates_providers(self, tmp_path: Path) -> None:
+        """An owned contact rebuilds providers, even over a hand-edited array.
+
+        A collection's own metadata.yaml is authoritative. A contact it declares
+        seeds the host provider, so the resolved providers replace the array.
+        """
+        collection_dir = _collection_dir(tmp_path)
+        _write_metadata(
+            collection_dir,
+            {"contact": {"name": "City GIS", "email": "gis@city.example"}},
+        )
+        collection = create_collection(collection_id="roads", description="Roads")
+        import pystac
+
+        collection.providers = [pystac.Provider(name="Hand Edited", roles=["producer", "host"])]
 
         apply_human_metadata(collection, collection_dir, tmp_path)
 

--- a/tests/unit/test_schema_uri.py
+++ b/tests/unit/test_schema_uri.py
@@ -82,3 +82,27 @@ class TestEnsurePortolanSchemaUri:
 
         assert ensure_portolan_schema_uri(doc) is True
         assert doc["stac_extensions"] == [PORTOLAN_SCHEMA_URI]
+
+    def test_keeps_a_newer_profile_version(self) -> None:
+        """A re-add must not stamp the bundled version over a newer release (issue #755)."""
+        newer = _bumped_minor(PORTOLAN_SCHEMA_URI)
+        doc: dict[str, object] = {"stac_extensions": [newer]}
+
+        assert ensure_portolan_schema_uri(doc) is False
+        assert doc["stac_extensions"] == [newer]
+
+    def test_keeps_a_newer_profile_version_and_collapses_duplicates(self) -> None:
+        newer = _bumped_minor(PORTOLAN_SCHEMA_URI)
+        other = "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+        doc: dict[str, object] = {"stac_extensions": [newer, other, PORTOLAN_SCHEMA_URI]}
+
+        assert ensure_portolan_schema_uri(doc) is True
+        assert doc["stac_extensions"] == [newer, other]
+
+
+def _bumped_minor(uri: str) -> str:
+    """Return the profile URI one minor version above the given one."""
+    match = re.search(r"/v(\d+)\.(\d+)\.(\d+)/", uri)
+    assert match is not None
+    major, minor, patch = (int(match.group(i)) for i in (1, 2, 3))
+    return re.sub(r"/v\d+\.\d+\.\d+/", f"/v{major}.{minor + 1}.{patch}/", uri)


### PR DESCRIPTION
## What changed

`portolan add` no longer overwrites collection metadata that a maintainer set by
hand. It also no longer stamps an older schema version over a newer one. This
resolves #755.

A new function `apply_human_metadata` in `finalization.py` applies human-authored
title, description, license, and providers with clear precedence:

- The collection's own `.portolan/metadata.yaml` always wins.
- An ancestor `metadata.yaml` only fills a field the collection still lacks.
- A catalog title never becomes a collection title.

`config.load_own_metadata` reads a single directory's `metadata.yaml` with no
inheritance. `apply_human_metadata` uses it to tell an owned value from an
inherited value. Both the geospatial path (`finalization._finalize_collection`)
and the tabular path (`add.py`) call the new function.

`stac.ensure_portolan_schema_uri` now keeps the higher of the declared version and
the bundled version. So a re-add upgrades an older profile URI but never downgrades
a newer one. The URI pattern gained capture groups, and a helper `_profile_version`
reads the SemVer triple for the comparison.

## Why

`add` regenerates `collection.json` on every run. It merged the catalog root
metadata down the tree and wrote the merged value onto the collection without a
guard. A collection lost its own title to the root title. A hand-fixed license or
providers array reverted on the next add. The 183-collection migration had to rerun
`tools/generate/apply_metadata.py` after every add. Separately, the bundled
validator reports `v0.1.0`, so `add` stamped `v0.1.0` over a `v0.1.1` catalog.

## Verification

The new integration test adds a collection, edits its title and license by hand,
runs `add --force` again, and confirms the hand edits survive. It reads
`tests/fixtures/simple.parquet`.

```
$ uv run pytest tests/integration/test_readd_preserves_metadata.py \
    tests/unit/test_apply_human_metadata.py tests/unit/test_schema_uri.py -q
22 passed in 8.25s
```

The full fast gate stays green.

```
$ uv run ruff format --check .
573 files already formatted
$ uv run ruff check .
All checks passed!
$ uv run mypy portolan_cli
Success: no issues found in 159 source files
$ uv run pytest tests/ --ignore=tests/iceberg/ -m 'not network and not slow and not benchmark' -n 2 -q
6935 passed, 8 skipped, 65 warnings in 469.52s
```

Closes #755

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-adding collections now preserves manually edited titles, descriptions, licenses, providers, and provenance.
  * Collection metadata correctly takes precedence over inherited catalog metadata.
  * New collections no longer incorrectly inherit the catalog title.

* **Improvements**
  * Portolan schema version handling now preserves newer versions, upgrades older declarations, and removes duplicates.

* **Tests**
  * Added coverage for metadata preservation, inheritance rules, and schema version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->