### PR TITLE
extract arcgis silently reprojects the source CRS to WGS84 and writes crs: null

### DIFF
--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -6639,6 +6639,13 @@ def extract() -> None:
     help="Do not traverse folders for services-root URLs (default: recurse).",
 )
 @click.option(
+    "--output-crs",
+    type=str,
+    default="native",
+    help="CRS for extracted GeoParquet. 'native' keeps the service's source CRS "
+    "(default). Pass an EPSG code (e.g. EPSG:4326) to reproject.",
+)
+@click.option(
     "--workers",
     type=click.IntRange(min=1),
     default=3,
@@ -6750,6 +6757,7 @@ def extract_arcgis_cmd(
     username: str | None,
     password: str | None,
     no_recurse: bool,
+    output_crs: str,
     workers: int,
     retries: int,
     timeout: float,
@@ -6804,6 +6812,9 @@ def extract_arcgis_cmd(
 
         # Dry run to see what would be extracted
         portolan extract arcgis URL --dry-run
+
+        # Reproject the output to WGS84 instead of keeping the source CRS
+        portolan extract arcgis URL --output-crs EPSG:4326
 
         # Extract raw files only (no STAC catalog auto-init)
         portolan extract arcgis URL --raw
@@ -6911,6 +6922,7 @@ def extract_arcgis_cmd(
         recurse=not no_recurse,
         license=license_id,
         license_url=license_url,
+        output_crs=output_crs,
     )
 
     # Progress callback for text output

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -255,6 +255,9 @@ class ExtractionOptions:
             license_url. Overrides any license URL found in the source's own
             license text (issue #686).
         license_url: URL of the license text.
+        output_crs: CRS for the extracted GeoParquet. "native" keeps the
+            service's source CRS (default). An EPSG code (e.g. "EPSG:4326")
+            reprojects the coordinates to that CRS (issue #802).
     """
 
     workers: int = 3
@@ -269,6 +272,68 @@ class ExtractionOptions:
     recurse: bool = True
     license: str | None = None
     license_url: str | None = None
+    output_crs: str = "native"
+
+
+def _is_wgs84_crs(crs: dict[str, object]) -> bool:
+    """Return True when the PROJJSON CRS is WGS84 (EPSG:4326 or OGC:CRS84).
+
+    A null CRS in GeoParquet already means CRS84, so a WGS84 output needs no
+    explicit CRS tag (issue #802).
+    """
+    from pyproj import CRS
+    from pyproj.exceptions import CRSError
+
+    try:
+        return CRS.from_json_dict(crs).to_epsg() == 4326
+    except (CRSError, KeyError, TypeError, ValueError):
+        # An unparseable CRS is not WGS84, so tag it rather than assume CRS84.
+        return False
+
+
+def _ensure_geoparquet_crs(output_path: Path, source_crs: dict[str, object] | None) -> None:
+    """Write the source CRS into the GeoParquet metadata when the writer drops it.
+
+    gpio.Table.write() emits ``crs: null`` even for a native extraction, so a file
+    with projected coordinates would claim WGS84 (issue #802). This restamps the
+    primary geometry column with ``source_crs`` and preserves the row groups.
+
+    Args:
+        output_path: The written GeoParquet file.
+        source_crs: PROJJSON CRS the extractor detected, or None when unknown.
+    """
+    if source_crs is None or _is_wgs84_crs(source_crs):
+        # No CRS to preserve, or WGS84 where the null tag is already correct.
+        return
+
+    import json
+
+    import pyarrow.parquet as pq
+
+    parquet_file = pq.ParquetFile(output_path)
+    schema = parquet_file.schema_arrow
+    metadata = schema.metadata or {}
+    geo_bytes = metadata.get(b"geo")
+    if geo_bytes is None:
+        return
+
+    geo = json.loads(geo_bytes)
+    primary = geo.get("primary_column")
+    column = geo.get("columns", {}).get(primary)
+    if column is None or column.get("crs") == source_crs:
+        # Already tagged with the source CRS; nothing to rewrite.
+        return
+
+    column["crs"] = source_crs
+    new_schema = schema.with_metadata({**metadata, b"geo": json.dumps(geo).encode("utf-8")})
+
+    # Parquet keeps its CRS in the footer, so a rewrite is the only way to change
+    # it. Copy the row groups verbatim to keep the covering statistics intact.
+    temp_path = output_path.with_suffix(output_path.suffix + ".tmp")
+    with pq.ParquetWriter(temp_path, new_schema, compression="zstd") as writer:
+        for row_group in range(parquet_file.num_row_groups):
+            writer.write_table(parquet_file.read_row_group(row_group))
+    temp_path.replace(output_path)
 
 
 def _extract_single_layer(
@@ -306,7 +371,24 @@ def _extract_single_layer(
         kwargs["max_workers"] = options.workers
     if options.token and "token" in sig.parameters:
         kwargs["token"] = options.token
+    # Keep the service's source CRS instead of the silent WGS84 reprojection that
+    # the GeoJSON path forces (issue #802). Older gpio versions without output_crs
+    # cannot preserve the CRS, so warn that the output stays WGS84.
+    if "output_crs" in sig.parameters:
+        kwargs["output_crs"] = options.output_crs
+    else:
+        from portolan_cli.output import warn
+
+        warn(
+            "Installed geoparquet-io does not support output CRS selection. "
+            f"Output uses WGS84 (EPSG:4326), not '{options.output_crs}'."
+        )
     table = gpio.extract_arcgis(layer_url, **kwargs)
+
+    # Capture the CRS the extractor detected before the write drops it. gpio.Table
+    # tags the native SR on the table but its writer emits crs: null, so a native
+    # extraction would declare WGS84 over projected coordinates (issue #802).
+    source_crs = getattr(table, "crs", None)
 
     # Apply Hilbert sorting if requested
     if options.sort_hilbert:
@@ -322,6 +404,9 @@ def _extract_single_layer(
 
     # Write to parquet
     table.write(str(output_path))
+
+    # Restore the source CRS that gpio's writer discarded (issue #802).
+    _ensure_geoparquet_crs(output_path, source_crs)
 
     duration = time.monotonic() - start_time
     # gpio.Table uses num_rows property instead of __len__

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -288,7 +288,7 @@ def _is_wgs84_crs(crs: dict[str, object]) -> bool:
     try:
         parsed = CRS.from_json_dict(crs)
     except (CRSError, KeyError, TypeError, ValueError):
-        # An unparseable CRS is not WGS84, so tag it rather than assume CRS84.
+        # An unparsable CRS is not WGS84, so tag it rather than assume CRS84.
         return False
     return parsed.to_epsg() == 4326 or parsed == CRS("OGC:CRS84")
 
@@ -312,29 +312,33 @@ def _ensure_geoparquet_crs(output_path: Path, source_crs: dict[str, object] | No
 
     import pyarrow.parquet as pq
 
-    parquet_file = pq.ParquetFile(output_path)
-    schema = parquet_file.schema_arrow
-    metadata = schema.metadata or {}
-    geo_bytes = metadata.get(b"geo")
-    if geo_bytes is None:
-        return
-
-    geo = json.loads(geo_bytes)
-    primary = geo.get("primary_column")
-    column = geo.get("columns", {}).get(primary)
-    if column is None or column.get("crs") == source_crs:
-        # Already tagged with the source CRS; nothing to rewrite.
-        return
-
-    column["crs"] = source_crs
-    new_schema = schema.with_metadata({**metadata, b"geo": json.dumps(geo).encode("utf-8")})
-
-    # Parquet keeps its CRS in the footer, so a rewrite is the only way to change
-    # it. Copy the row groups verbatim to keep the covering statistics intact.
     temp_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    with pq.ParquetWriter(temp_path, new_schema, compression="zstd") as writer:
-        for row_group in range(parquet_file.num_row_groups):
-            writer.write_table(parquet_file.read_row_group(row_group))
+    with pq.ParquetFile(output_path) as parquet_file:
+        schema = parquet_file.schema_arrow
+        metadata = schema.metadata or {}
+        geo_bytes = metadata.get(b"geo")
+        if geo_bytes is None:
+            return
+
+        geo = json.loads(geo_bytes)
+        primary = geo.get("primary_column")
+        column = geo.get("columns", {}).get(primary)
+        if column is None or column.get("crs") == source_crs:
+            # Already tagged with the source CRS; nothing to rewrite.
+            return
+
+        column["crs"] = source_crs
+        new_schema = schema.with_metadata({**metadata, b"geo": json.dumps(geo).encode("utf-8")})
+
+        # Parquet keeps its CRS in the footer, so a rewrite is the only way to
+        # change it. Copy the row groups verbatim to keep the covering
+        # statistics intact.
+        with pq.ParquetWriter(temp_path, new_schema, compression="zstd") as writer:
+            for row_group in range(parquet_file.num_row_groups):
+                writer.write_table(parquet_file.read_row_group(row_group))
+
+    # Windows refuses to replace a file while a reader still holds it open. The
+    # rename runs after the ParquetFile closes.
     temp_path.replace(output_path)
 
 

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -279,16 +279,18 @@ def _is_wgs84_crs(crs: dict[str, object]) -> bool:
     """Return True when the PROJJSON CRS is WGS84 (EPSG:4326 or OGC:CRS84).
 
     A null CRS in GeoParquet already means CRS84, so a WGS84 output needs no
-    explicit CRS tag (issue #802).
+    explicit CRS tag (issue #802). gpio tags a native-4326 GeoJSON extraction as
+    OGC:CRS84, whose ``to_epsg()`` is None, so this matches CRS84 as well.
     """
     from pyproj import CRS
     from pyproj.exceptions import CRSError
 
     try:
-        return CRS.from_json_dict(crs).to_epsg() == 4326
+        parsed = CRS.from_json_dict(crs)
     except (CRSError, KeyError, TypeError, ValueError):
         # An unparseable CRS is not WGS84, so tag it rather than assume CRS84.
         return False
+    return parsed.to_epsg() == 4326 or parsed == CRS("OGC:CRS84")
 
 
 def _ensure_geoparquet_crs(output_path: Path, source_crs: dict[str, object] | None) -> None:
@@ -388,7 +390,10 @@ def _extract_single_layer(
     # Capture the CRS the extractor detected before the write drops it. gpio.Table
     # tags the native SR on the table but its writer emits crs: null, so a native
     # extraction would declare WGS84 over projected coordinates (issue #802).
-    source_crs = getattr(table, "crs", None)
+    # gpio.Table.crs may return a dict, a string, or None. Only a PROJJSON dict
+    # restamps a valid CRS, so ignore the other forms.
+    captured_crs = getattr(table, "crs", None)
+    source_crs = captured_crs if isinstance(captured_crs, dict) else None
 
     # Apply Hilbert sorting if requested
     if options.sort_hilbert:

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -24,6 +24,7 @@ from portolan_cli.extract.arcgis.orchestrator import (
     ExtractionProgress,
     ServicesRootDiscoveryResult,
     _discover_and_filter_services,
+    _ensure_geoparquet_crs,
     _extract_single_layer,
     _service_output_dir,
     _slugify,
@@ -1440,3 +1441,176 @@ def test_extract_single_layer_passes_token(monkeypatch: pytest.MonkeyPatch, tmp_
     )
     assert captured["token"] == "TKN"
     assert captured["bbox"] is True
+
+
+# =============================================================================
+# _extract_single_layer output-CRS forwarding tests (issue #802)
+# =============================================================================
+
+
+def _fake_gpio_capturing(captured: dict[str, object]) -> types.ModuleType:
+    """Build a fake geoparquet_io whose extract_arcgis records output_crs."""
+
+    def fake_extract_arcgis(
+        url: str, max_workers: int | None = None, output_crs: str | None = None
+    ) -> object:
+        captured["output_crs"] = output_crs
+
+        class _T:
+            num_rows = 1
+
+            def add_bbox(self) -> _T:
+                return self
+
+            def write(self, path: str) -> None:
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_bytes(b"PAR1")
+
+        return _T()
+
+    fake_gpio = types.ModuleType("geoparquet_io")
+    fake_gpio.extract_arcgis = fake_extract_arcgis  # type: ignore[attr-defined]
+    return fake_gpio
+
+
+def test_output_crs_defaults_to_native() -> None:
+    """ExtractionOptions must preserve the source CRS by default (issue #802)."""
+    assert ExtractionOptions().output_crs == "native"
+
+
+def test_extract_single_layer_forwards_native_output_crs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The default keeps the service CRS by passing output_crs='native' to gpio."""
+    captured: dict[str, object] = {}
+    monkeypatch.setitem(sys.modules, "geoparquet_io", _fake_gpio_capturing(captured))
+
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        tmp_path / "out.parquet",
+        ExtractionOptions(sort_hilbert=False),
+    )
+    assert captured["output_crs"] == "native"
+
+
+def test_extract_single_layer_forwards_explicit_output_crs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An explicit --output-crs value reaches gpio.extract_arcgis unchanged."""
+    captured: dict[str, object] = {}
+    monkeypatch.setitem(sys.modules, "geoparquet_io", _fake_gpio_capturing(captured))
+
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        tmp_path / "out.parquet",
+        ExtractionOptions(output_crs="EPSG:28992", sort_hilbert=False),
+    )
+    assert captured["output_crs"] == "EPSG:28992"
+
+
+def test_extract_single_layer_warns_when_gpio_lacks_output_crs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An older gpio without output_crs must warn that it reprojects to WGS84."""
+
+    def fake_extract_arcgis(url: str, max_workers: int | None = None) -> object:
+        class _T:
+            num_rows = 1
+
+            def add_bbox(self) -> _T:
+                return self
+
+            def write(self, path: str) -> None:
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_bytes(b"PAR1")
+
+        return _T()
+
+    fake_gpio = types.ModuleType("geoparquet_io")
+    fake_gpio.extract_arcgis = fake_extract_arcgis  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "geoparquet_io", fake_gpio)
+
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        tmp_path / "out.parquet",
+        ExtractionOptions(sort_hilbert=False),
+    )
+    assert "WGS84" in capsys.readouterr().err
+
+
+# =============================================================================
+# _ensure_geoparquet_crs tests (issue #802)
+# =============================================================================
+
+
+def _write_geoparquet_with_null_crs(path: Path) -> None:
+    """Write a minimal GeoParquet whose primary column declares crs: null."""
+    import json
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    from shapely import Point, to_wkb
+
+    geo = {
+        "version": "1.1.0",
+        "primary_column": "geometry",
+        "columns": {"geometry": {"encoding": "WKB", "crs": None, "geometry_types": ["Point"]}},
+    }
+    table = pa.table({"geometry": pa.array([to_wkb(Point(155000.0, 463000.0))])})
+    table = table.replace_schema_metadata({"geo": json.dumps(geo)})
+    pq.write_table(table, path)
+
+
+def _read_crs(path: Path) -> object:
+    """Return the PROJJSON CRS of the primary geometry column."""
+    import json
+
+    import pyarrow.parquet as pq
+
+    geo = json.loads(pq.ParquetFile(path).metadata.metadata[b"geo"])
+    return geo["columns"][geo["primary_column"]].get("crs")
+
+
+def test_ensure_geoparquet_crs_stamps_projected_crs(tmp_path: Path) -> None:
+    """A projected source CRS must replace the null tag gpio wrote (issue #802)."""
+    from pyproj import CRS
+
+    path = tmp_path / "rd.parquet"
+    _write_geoparquet_with_null_crs(path)
+    assert _read_crs(path) is None
+
+    rd_new = CRS.from_epsg(28992).to_json_dict()
+    _ensure_geoparquet_crs(path, rd_new)
+
+    stamped = _read_crs(path)
+    assert isinstance(stamped, dict)
+    assert stamped["id"] == {"authority": "EPSG", "code": 28992}
+
+
+def test_ensure_geoparquet_crs_leaves_wgs84_null(tmp_path: Path) -> None:
+    """A WGS84 source CRS keeps the null tag, which already means CRS84."""
+    from pyproj import CRS
+
+    path = tmp_path / "wgs84.parquet"
+    _write_geoparquet_with_null_crs(path)
+
+    _ensure_geoparquet_crs(path, CRS.from_epsg(4326).to_json_dict())
+
+    assert _read_crs(path) is None
+
+
+def test_ensure_geoparquet_crs_ignores_missing_crs(tmp_path: Path) -> None:
+    """A None source CRS must not rewrite the file."""
+    path = tmp_path / "none.parquet"
+    _write_geoparquet_with_null_crs(path)
+    before = path.read_bytes()
+
+    _ensure_geoparquet_crs(path, None)
+
+    assert path.read_bytes() == before

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -26,6 +26,7 @@ from portolan_cli.extract.arcgis.orchestrator import (
     _discover_and_filter_services,
     _ensure_geoparquet_crs,
     _extract_single_layer,
+    _is_wgs84_crs,
     _service_output_dir,
     _slugify,
     extract_arcgis_catalog,
@@ -1544,6 +1545,91 @@ def test_extract_single_layer_warns_when_gpio_lacks_output_crs(
     assert "WGS84" in capsys.readouterr().err
 
 
+def test_extract_single_layer_restamps_projected_source_crs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A native extraction with a projected table CRS ends up tagged with it.
+
+    This covers the capture-write-restamp chain in _extract_single_layer, not
+    the isolated helpers (issue #802).
+    """
+    from pyproj import CRS
+
+    rd_new = CRS.from_epsg(28992).to_json_dict()
+
+    def fake_extract_arcgis(
+        url: str, max_workers: int | None = None, output_crs: str | None = None
+    ) -> object:
+        class _T:
+            num_rows = 1
+            crs = rd_new
+
+            def add_bbox(self) -> _T:
+                return self
+
+            def write(self, path: str) -> None:
+                _write_geoparquet_with_null_crs(Path(path))
+
+        return _T()
+
+    fake_gpio = types.ModuleType("geoparquet_io")
+    fake_gpio.extract_arcgis = fake_extract_arcgis  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "geoparquet_io", fake_gpio)
+
+    out = tmp_path / "out.parquet"
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        out,
+        ExtractionOptions(sort_hilbert=False),
+    )
+
+    stamped = _read_crs(out)
+    assert isinstance(stamped, dict)
+    assert stamped["id"] == {"authority": "EPSG", "code": 28992}
+
+
+def test_extract_single_layer_ignores_string_source_crs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A string table CRS must not reach the metadata, which needs PROJJSON.
+
+    gpio.Table.crs may return a string. A string CRS is not a valid PROJJSON
+    dict, so the writer's null tag stays (issue #802).
+    """
+
+    def fake_extract_arcgis(
+        url: str, max_workers: int | None = None, output_crs: str | None = None
+    ) -> object:
+        class _T:
+            num_rows = 1
+            crs = "EPSG:28992"
+
+            def add_bbox(self) -> _T:
+                return self
+
+            def write(self, path: str) -> None:
+                _write_geoparquet_with_null_crs(Path(path))
+
+        return _T()
+
+    fake_gpio = types.ModuleType("geoparquet_io")
+    fake_gpio.extract_arcgis = fake_extract_arcgis  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "geoparquet_io", fake_gpio)
+
+    out = tmp_path / "out.parquet"
+    layer = LayerInfo(id=0, name="L", layer_type="Feature Layer")
+    _extract_single_layer(
+        "https://x/rest/services/F/FeatureServer",
+        layer,
+        out,
+        ExtractionOptions(sort_hilbert=False),
+    )
+
+    assert _read_crs(out) is None
+
+
 # =============================================================================
 # _ensure_geoparquet_crs tests (issue #802)
 # =============================================================================
@@ -1614,3 +1700,36 @@ def test_ensure_geoparquet_crs_ignores_missing_crs(tmp_path: Path) -> None:
     _ensure_geoparquet_crs(path, None)
 
     assert path.read_bytes() == before
+
+
+def test_ensure_geoparquet_crs_leaves_crs84_null(tmp_path: Path) -> None:
+    """An OGC:CRS84 source CRS keeps the null tag, which already means CRS84."""
+    from pyproj import CRS
+
+    path = tmp_path / "crs84.parquet"
+    _write_geoparquet_with_null_crs(path)
+
+    _ensure_geoparquet_crs(path, CRS("OGC:CRS84").to_json_dict())
+
+    assert _read_crs(path) is None
+
+
+def test_is_wgs84_crs_matches_epsg_4326() -> None:
+    """_is_wgs84_crs must treat EPSG:4326 as the null-equivalent CRS."""
+    from pyproj import CRS
+
+    assert _is_wgs84_crs(CRS.from_epsg(4326).to_json_dict()) is True
+
+
+def test_is_wgs84_crs_matches_ogc_crs84() -> None:
+    """_is_wgs84_crs must treat OGC:CRS84 as the null-equivalent CRS."""
+    from pyproj import CRS
+
+    assert _is_wgs84_crs(CRS("OGC:CRS84").to_json_dict()) is True
+
+
+def test_is_wgs84_crs_rejects_projected_crs() -> None:
+    """_is_wgs84_crs must return False for a projected CRS."""
+    from pyproj import CRS
+
+    assert _is_wgs84_crs(CRS.from_epsg(28992).to_json_dict()) is False

--- a/tests/unit/extract/arcgis/test_orchestrator.py
+++ b/tests/unit/extract/arcgis/test_orchestrator.py
@@ -1659,7 +1659,10 @@ def _read_crs(path: Path) -> object:
 
     import pyarrow.parquet as pq
 
-    geo = json.loads(pq.ParquetFile(path).metadata.metadata[b"geo"])
+    # Close the reader before returning. Windows blocks a replace on the file
+    # while a handle stays open.
+    with pq.ParquetFile(path) as parquet_file:
+        geo = json.loads(parquet_file.metadata.metadata[b"geo"])
     return geo["columns"][geo["primary_column"]].get("crs")
 
 

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -182,3 +182,64 @@ def test_imageserver_rejects_auth_flags() -> None:
     )
     assert result.exit_code == 1
     assert "ImageServer" in result.output
+
+
+@pytest.mark.unit
+def test_extract_arcgis_has_output_crs_flag() -> None:
+    """The --output-crs flag must appear in help (issue #802)."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["extract", "arcgis", "--help"])
+    assert result.exit_code == 0
+    assert "--output-crs" in result.output
+    assert "native" in result.output
+
+
+@pytest.mark.unit
+def test_output_crs_threads_into_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--output-crs reaches ExtractionOptions passed to extract_arcgis_catalog (issue #802)."""
+    from types import SimpleNamespace
+
+    from portolan_cli.extract.arcgis.orchestrator import ExtractionOptions
+
+    captured: dict[str, object] = {}
+
+    def fake_extract(**kwargs: object) -> SimpleNamespace:
+        options = kwargs["options"]
+        assert isinstance(options, ExtractionOptions)
+        captured["output_crs"] = options.output_crs
+        summary = SimpleNamespace(
+            total_layers=0,
+            succeeded=0,
+            failed=0,
+            skipped=0,
+            empty=0,
+            total_features=0,
+            total_size_bytes=0,
+        )
+        return SimpleNamespace(
+            source_url="https://x/rest/services/F/FeatureServer",
+            summary=summary,
+            layers=[],
+            folder_coverage=None,
+        )
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.extract_arcgis_catalog", fake_extract
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://x/rest/services/F/FeatureServer",
+            "./out",
+            "--output-crs",
+            "EPSG:28992",
+            "--auto",
+            "--raw",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["output_crs"] == "EPSG:28992"


### PR DESCRIPTION
## What changed

`portolan extract arcgis` now keeps the service's source CRS in the GeoParquet
output. Before this change the command reprojected every layer to WGS84 and wrote
`crs: null`. No flag asked for the reprojection and no warning appeared.

The change has two parts.

- The extractor now asks geoparquet-io for the native CRS by default. A new
  `--output-crs` option controls this. `native` keeps the source CRS. An EPSG
  code (for example `EPSG:4326`) reprojects the coordinates.
- The extractor restamps the GeoParquet metadata after the write. geoparquet-io
  returns native coordinates but its writer still emits `crs: null`. Without the
  restamp a file with projected coordinates would declare WGS84. This is the
  cause of issue #802.

## Why

The bootstrap skill contract says to keep GeoParquet in the source CRS.
Reprojection belongs in PMTiles. Dutch government data uses EPSG:28992 (RD New)
end to end. A silent 28992 to 4326 round trip loses precision. A consumer that
needs native coordinates cannot recover them. See #802.

## Key implementation notes

- `ExtractionOptions.output_crs` defaults to `"native"`. The CLI threads
  `--output-crs` into it.
- `_extract_single_layer` reads `table.crs` before the write, then calls
  `_ensure_geoparquet_crs` after the write.
- `_ensure_geoparquet_crs` leaves the file unchanged for WGS84 or an absent CRS,
  because a null tag already means CRS84. For a projected CRS it rewrites the
  file with the correct `crs` and copies the row groups verbatim to keep the
  covering statistics.
- An older geoparquet-io without the `output_crs` parameter cannot preserve the
  CRS. The command warns that the output stays WGS84.
- The STAC extent still uses WGS84. The catalog build transforms the projected
  bounding box to WGS84 through the existing CRS path.

## Verification

Ran the failing command from the issue against the same service (layer 3, 3,851
features):
`https://services-eu1.arcgis.com/4D1GBrbE6xp1T4YG/arcgis/rest/services/Inweva2025/FeatureServer`

```
$ portolan extract arcgis "https://services-eu1.arcgis.com/4D1GBrbE6xp1T4YG/arcgis/rest/services/Inweva2025/FeatureServer" ./crstest --layers "Werkdag gemiddelde intensiteiten in 2025" --auto --raw
✓ Extracted 1/1 layers

$ python -c "import pyarrow.parquet as pq, json, shapely.wkb as wkb; \
geo=json.loads(pq.ParquetFile('crstest/werkdag_gemiddelde_intensiteiten_in_2025/werkdag_gemiddelde_intensiteiten_in_2025.parquet').metadata.metadata[b'geo']); \
c=geo['columns'][geo['primary_column']]['crs']; print('declared CRS:', c['id']); \
t=pq.read_table('crstest/.../*.parquet'); g=wkb.loads(t.column('geometry')[0].as_py()); \
print('first coord:', list(g.geoms[0].coords)[0])"
declared CRS: {'authority': 'EPSG', 'code': 28992}
first coord: (31194.5020000003, 371150.818)
```

The declared CRS is EPSG:28992. The coordinates are RD meters. They match.

Gate:

```
$ uv run ruff format --check .
571 files already formatted
$ uv run ruff check .
All checks passed!
$ uv run mypy portolan_cli
Success: no issues found in 159 source files
$ uv run pytest tests/ --ignore=tests/iceberg/ -m 'not network and not slow and not benchmark' -n 2 -q
6931 passed, 8 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #802

---
*Automated by agent-farm.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--output-crs` option to ArcGIS extraction.
  * Preserve the source coordinate reference system by default.
  * Support reprojection using an EPSG code, such as `EPSG:28992`.
  * Preserve projected CRS metadata in GeoParquet output where supported.
* **Documentation**
  * Added CLI help and a reprojection example.
* **Compatibility**
  * Older GeoParquet tooling continues to work with a warning and WGS84 output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->