### PR TITLE
init: add --id to set the catalog id

### DIFF
--- a/examples/philadelphia-housing/01-create-catalog.sh
+++ b/examples/philadelphia-housing/01-create-catalog.sh
@@ -7,6 +7,7 @@ set -eu
 arcgis_url=${PORTOLAN_PHL_ARCGIS_URL:-https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services}
 
 portolan extract arcgis "$arcgis_url" "$CATALOG_DIR" \
+    --id philadelphia-housing \
     --services "AffordableHousingProduction,Council_Districts_2024" \
     --workers 2 \
     --retries 3 \

--- a/examples/philadelphia-housing/README.md
+++ b/examples/philadelphia-housing/README.md
@@ -53,6 +53,7 @@ set -eu
 arcgis_url=${PORTOLAN_PHL_ARCGIS_URL:-https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services}
 
 portolan extract arcgis "$arcgis_url" "$CATALOG_DIR" \
+    --id philadelphia-housing \
     --services "AffordableHousingProduction,Council_Districts_2024" \
     --workers 2 \
     --retries 3 \
@@ -70,6 +71,10 @@ uv run ./examples/philadelphia-housing/01-create-catalog.sh
 Portolan searches Philadelphia's ArcGIS services and selects the two named services.
 It downloads every page, retries temporary failures, and converts each layer to GeoParquet.
 It also preserves the map style from each source layer.
+
+The `--id` flag names the catalog. Without it, Portolan derives the id from
+the output directory name. That id is the catalog's public STAC identity, so
+a scratch directory makes a poor one.
 
 The output shows this work as it happens:
 

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -238,7 +238,11 @@ def _sanitize_id(name: str) -> str:
 # Directory names that name a step in someone's workflow rather than the data
 # itself. `init` inside one of these silently published a catalog whose id was
 # "publish" (issue #821). Every entry is a valid STAC id, so no syntactic check
-# catches it. Only the meaning is wrong. The comparison ignores case.
+# catches it. Only the meaning is wrong.
+#
+# The last group is the output directory `extract` picks when the caller names
+# none. Those are the ids the tool produces on its own, so they reach a
+# published catalog most easily of all.
 _TOOLING_ARTIFACT_IDS = frozenset(
     {
         "build",
@@ -252,8 +256,28 @@ _TOOLING_ARTIFACT_IDS = frozenset(
         "temp",
         "tmp",
         "untitled",
+        "extract",
+        "arcgis-extract",
+        "carto-extract",
+        "services-extract",
+        "wfs-extract",
     }
 )
+
+
+def _is_tooling_artifact_id(catalog_id: str) -> bool:
+    """Report whether an id names a workflow step rather than the data.
+
+    Case and the choice of hyphen or underscore carry no meaning here, so
+    "WFS_Extract" and "wfs-extract" both match.
+
+    Args:
+        catalog_id: The candidate catalog id.
+
+    Returns:
+        True when the id names a tooling artifact.
+    """
+    return catalog_id.lower().replace("_", "-") in _TOOLING_ARTIFACT_IDS
 
 
 @overload
@@ -426,7 +450,7 @@ def _resolve_catalog_identity(
     # A derived id that names a workflow step rather than the data is the failure
     # in issue #821. Warn only when the id was derived. An explicit id is the
     # caller's decision.
-    if derived_id and catalog_id.lower() in _TOOLING_ARTIFACT_IDS:
+    if derived_id and _is_tooling_artifact_id(catalog_id):
         warnings.append(
             f"Derived catalog id '{catalog_id}' from the directory name. "
             "It looks like a tooling artifact, not the name of the data. "
@@ -485,6 +509,9 @@ def init_catalog(
         path: Directory path for the catalog. Will be created if doesn't exist.
             Resolved before use, so a relative path such as the CLI's "." default
             is interpreted against the working directory exactly once.
+        catalog_id: Catalog id. None derives one from the directory name, which
+            is the behavior before issue #821. A supplied id is validated and
+            rejected when invalid, rather than coerced.
         title: Optional catalog title.
         description: Optional catalog description.
         backend: Versioning backend name.
@@ -502,6 +529,9 @@ def init_catalog(
         can read it back without matching the working directory init ran in.
 
     Raises:
+        InputValidationError: If ``catalog_id`` is not a valid STAC identifier.
+            Raised before the directory is created, so a rejected id leaves no
+            trace on disk (issue #821).
         CatalogAlreadyExistsError: If directory is in MANAGED state.
         UnmanagedStacCatalogError: If directory is in UNMANAGED_STAC state.
         CatalogInitError: If filesystem operations fail.
@@ -521,6 +551,11 @@ def init_catalog(
     # parent. Resolving here keeps the trailing slash meaningful and gives the
     # caller an absolute path to read back (issue #731).
     path = Path(path).resolve()
+
+    # Resolve the identity before anything touches the filesystem. A rejected
+    # --id must leave no directory behind for the caller to clean up (issue #821).
+    catalog_id, title, identity_warnings = _resolve_catalog_identity(path, catalog_id, title)
+
     try:
         path.mkdir(parents=True, exist_ok=True)
     except OSError as e:
@@ -550,10 +585,7 @@ def init_catalog(
         except ValueError as e:
             raise CatalogInitError(str(e)) from e
 
-    warnings: list[str] = []
-
-    catalog_id, title, identity_warnings = _resolve_catalog_identity(path, catalog_id, title)
-    warnings.extend(identity_warnings)
+    warnings: list[str] = list(identity_warnings)
 
     if description is None:
         description = "A Portolan-managed STAC catalog"

--- a/portolan_cli/catalog.py
+++ b/portolan_cli/catalog.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, overload
 from portolan_cli.agents_md import visible_stac_files
 from portolan_cli.errors import CatalogAlreadyExistsError
 from portolan_cli.humanize import humanize_slug
+from portolan_cli.input_hardening import validate_catalog_id
 from portolan_cli.json_io import write_json_atomic, write_text_atomic
 from portolan_cli.models.catalog import CatalogModel
 from portolan_cli.utils import href_root, relative_href
@@ -234,6 +235,27 @@ def _sanitize_id(name: str) -> str:
     return sanitized
 
 
+# Directory names that name a step in someone's workflow rather than the data
+# itself. `init` inside one of these silently published a catalog whose id was
+# "publish" (issue #821). Every entry is a valid STAC id, so no syntactic check
+# catches it. Only the meaning is wrong. The comparison ignores case.
+_TOOLING_ARTIFACT_IDS = frozenset(
+    {
+        "build",
+        "data",
+        "dist",
+        "new",
+        "out",
+        "output",
+        "publish",
+        "staging",
+        "temp",
+        "tmp",
+        "untitled",
+    }
+)
+
+
 @overload
 def create_catalog(
     path: Path,
@@ -370,9 +392,61 @@ def _seed_root_metadata(
     return []
 
 
+def _resolve_catalog_identity(
+    path: Path, catalog_id: str | None, title: str | None
+) -> tuple[str, str, list[str]]:
+    """Decide the catalog's id and title, and report what had to be guessed.
+
+    The caller may name the catalog outright. Otherwise the id comes from the
+    directory name, which is what every catalog did before issue #821.
+    ``_sanitize_id`` coerces a derived id. A supplied id goes through
+    ``validate_catalog_id``, which rejects a bad value rather than rewrite it,
+    because the caller typed that value deliberately.
+
+    Args:
+        path: The resolved catalog directory, whose name seeds a derived id.
+        catalog_id: The id the caller supplied, or None to derive one.
+        title: The title the caller supplied, or None to derive one.
+
+    Returns:
+        A tuple of the catalog id, the title, and the warnings to report.
+
+    Raises:
+        InputValidationError: If a supplied id is not a valid STAC identifier.
+    """
+    warnings: list[str] = []
+    derived_id = catalog_id is None
+
+    if catalog_id is None:
+        # path is already resolved, so path.name is the real directory name.
+        catalog_id = _sanitize_id(path.name)
+    else:
+        catalog_id = validate_catalog_id(catalog_id)
+
+    # A derived id that names a workflow step rather than the data is the failure
+    # in issue #821. Warn only when the id was derived. An explicit id is the
+    # caller's decision.
+    if derived_id and catalog_id.lower() in _TOOLING_ARTIFACT_IDS:
+        warnings.append(
+            f"Derived catalog id '{catalog_id}' from the directory name. "
+            "It looks like a tooling artifact, not the name of the data. "
+            "Pass --id to set the catalog identity."
+        )
+
+    # Issue #502: a title is mandatory and must be human-readable, so derive one
+    # from the id instead of leaving it empty.
+    if not title:
+        title = humanize_slug(catalog_id)
+        source = "directory name" if derived_id else "catalog id"
+        warnings.append(f"Derived catalog title '{title}' from {source}")
+
+    return catalog_id, title, warnings
+
+
 def init_catalog(
     path: Path,
     *,
+    catalog_id: str | None = None,
     title: str | None = None,
     description: str | None = None,
     backend: str = "file",
@@ -478,14 +552,8 @@ def init_catalog(
 
     warnings: list[str] = []
 
-    # Auto-extract id from directory name (path is already resolved)
-    catalog_id = _sanitize_id(path.name)
-
-    # Set defaults. Issue #502: title is mandatory and must be human-readable,
-    # so derive one from the directory name instead of leaving it empty.
-    if not title:
-        title = humanize_slug(catalog_id)
-        warnings.append(f"Derived catalog title '{title}' from directory name")
+    catalog_id, title, identity_warnings = _resolve_catalog_identity(path, catalog_id, title)
+    warnings.extend(identity_warnings)
 
     if description is None:
         description = "A Portolan-managed STAC catalog"

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -81,6 +81,7 @@ from portolan_cli.validation import (
     build_fix_payload,
     remediation_for,
     run_check,
+    validate_catalog_id,
     validate_safe_path,
 )
 
@@ -6413,6 +6414,46 @@ def _output_extract_error(
         error(message)
 
 
+def _check_extract_catalog_id(
+    catalog_id: str | None,
+    *,
+    raw: bool,
+    url: str,
+    command: str,
+    use_json: bool,
+) -> None:
+    """Check ``--id`` before the extraction starts.
+
+    ``init_catalog`` validates the id, but extract calls it after the whole
+    download. A rejected id would cost the harvest and leave data on disk with
+    no catalog.json. This check fails on the first line instead. ``--raw``
+    writes no catalog at all, so the flag does nothing and says so (issue #821).
+
+    Args:
+        catalog_id: The id the caller supplied, or None.
+        raw: True when ``--raw`` suppresses catalog creation.
+        url: The service URL, for the JSON error envelope.
+        command: The command name for the JSON error envelope.
+        use_json: True when the command emits JSON.
+
+    Raises:
+        SystemExit: If the id is not a valid STAC identifier.
+    """
+    if catalog_id is None:
+        return
+
+    from portolan_cli.output import warn
+
+    try:
+        validate_catalog_id(catalog_id)
+    except InputValidationError as err:
+        _output_extract_error(use_json, "InputValidationError", str(err), url, command=command)
+        raise SystemExit(1) from None
+
+    if raw:
+        warn(f"Ignored --id '{catalog_id}'. --raw writes no catalog.")
+
+
 def _resolve_arcgis_token(
     *,
     url: str,
@@ -6872,6 +6913,16 @@ def extract_arcgis_cmd(
         _output_extract_error(use_json, "InvalidURLError", str(e), url)
         raise SystemExit(1) from None
 
+    # The ImageServer path always writes a catalog, so --raw does not suppress
+    # one there and --id still applies.
+    _check_extract_catalog_id(
+        catalog_id,
+        raw=raw and parsed.url_type != ArcGISURLType.IMAGE_SERVER,
+        url=url,
+        command="extract-arcgis",
+        use_json=use_json,
+    )
+
     resolved_token = _resolve_arcgis_token(
         url=url,
         token=token,
@@ -7204,6 +7255,10 @@ def extract_wfs_cmd(
 
     use_json = should_output_json(ctx, json_output)
 
+    _check_extract_catalog_id(
+        catalog_id, raw=raw, url=url, command="extract-wfs", use_json=use_json
+    )
+
     # Default output directory
     if output_dir is None:
         output_dir = Path("wfs_extract")
@@ -7478,6 +7533,10 @@ def extract_carto_cmd(
     from portolan_cli.output import detail, info, warn
 
     use_json = should_output_json(ctx, json_output)
+
+    _check_extract_catalog_id(
+        catalog_id, raw=raw, url=url, command="extract-carto", use_json=use_json
+    )
 
     if output_dir is None:
         output_dir = Path("carto_extract")

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -385,6 +385,13 @@ def cli(ctx: click.Context, output_format: str) -> None:
     help="Skip interactive prompts and use auto-extracted/default values.",
 )
 @click.option(
+    "--id",
+    "catalog_id",
+    type=str,
+    default=None,
+    help="Catalog id. Defaults to the sanitized directory name.",
+)
+@click.option(
     "--title",
     "-t",
     type=str,
@@ -435,6 +442,7 @@ def init(
     path: Path,
     json_output: bool,
     auto_mode: bool,
+    catalog_id: str | None,
     title: str | None,
     description: str | None,
     backend: str,
@@ -449,7 +457,9 @@ def init(
     management files (config.yaml, metadata.yaml). Also creates versions.json at
     the root.
 
-    Auto-extracts the catalog ID from the directory name.
+    Derives the catalog ID from the directory name. Pass --id to set it
+    yourself. The ID is the catalog's public STAC identity, so a directory
+    named for a step in your workflow makes a poor one.
 
     PATH is the directory where the catalog should be created (default: current directory).
 
@@ -458,8 +468,8 @@ def init(
     Pass an SPDX identifier, or 'other' with --license-url when the license has no
     identifier. Without --auto or --json you are prompted for it.
 
-    Use --auto to skip all prompts and use default values. Use --title and
-    --description to set catalog metadata directly.
+    Use --auto to skip all prompts and use default values. Use --id, --title,
+    and --description to set catalog metadata directly.
 
     A logo is optional. Pass --logo with a local image to copy it into _assets/
     and publish it as a rel="icon" link, or add one later with 'portolan logo'.
@@ -469,6 +479,7 @@ def init(
         portolan init                            # Prompts for the license
         portolan init --auto --license CC-BY-4.0 # Skip prompts
         portolan init --title "My Catalog" --license MIT
+        portolan init --id phl-housing --license CC-BY-4.0
         portolan init --license other --license-url https://x.org/terms
         portolan init --backend iceberg --license CC0-1.0
         portolan init --auto --license CC-BY-4.0 --logo brand.png
@@ -515,6 +526,7 @@ def init(
     try:
         catalog_file, warnings = init_catalog(
             path,
+            catalog_id=catalog_id,
             title=title,
             description=description,
             backend=backend,
@@ -547,6 +559,11 @@ def init(
             for w in warnings:
                 warn(w)
 
+    except InputValidationError as err:
+        # A bad --id fails before init_catalog writes anything, so the directory
+        # is untouched and the caller can retry with a valid id (issue #821).
+        emit_error("init", "InputValidationError", str(err), use_json=use_json)
+        raise SystemExit(1) from err
     except LogoError as err:
         emit_error("init", type(err).__name__, str(err), use_json=use_json, code=err.code)
         raise SystemExit(1) from err
@@ -6259,6 +6276,7 @@ def _handle_imageserver_extraction(
     ctx: click.Context,
     url: str,
     output_dir: Path,
+    catalog_id: str | None,
     tile_size: int,
     bbox: str | None,
     bbox_crs: str | None,
@@ -6328,6 +6346,7 @@ def _handle_imageserver_extraction(
 
     # Build options
     options = ImageServerCLIOptions(
+        catalog_id=catalog_id,
         tile_size=tile_size,
         max_concurrent=max_concurrent,
         dry_run=dry_run,
@@ -6730,6 +6749,13 @@ def extract() -> None:
     help="[ImageServer] Name for the collection (default: 'tiles').",
 )
 @click.option(
+    "--id",
+    "catalog_id",
+    type=str,
+    default=None,
+    help="Catalog id. Defaults to the sanitized directory name.",
+)
+@click.option(
     "--license",
     "license_id",
     type=str,
@@ -6746,6 +6772,7 @@ def extract() -> None:
 @click.pass_context
 def extract_arcgis_cmd(
     ctx: click.Context,
+    catalog_id: str | None,
     license_id: str | None,
     license_url: str | None,
     url: str,
@@ -6783,6 +6810,9 @@ def extract_arcgis_cmd(
 
     URL is the ArcGIS service URL (FeatureServer, MapServer, ImageServer, or services root).
     OUTPUT_DIR is the directory to write extracted data (default: inferred from service name).
+
+    The catalog id comes from the output directory name. Pass --id to set it
+    yourself, because that id is the catalog's public STAC identity.
 
     \b
     URL Types:
@@ -6891,6 +6921,7 @@ def extract_arcgis_cmd(
             ctx=ctx,
             url=url,
             output_dir=output_dir,
+            catalog_id=catalog_id,
             tile_size=tile_size,
             bbox=bbox,
             bbox_crs=bbox_crs,
@@ -6915,6 +6946,7 @@ def extract_arcgis_cmd(
 
     # Build options
     options = ExtractionOptions(
+        catalog_id=catalog_id,
         workers=workers,
         retries=retries,
         timeout=timeout,
@@ -7080,6 +7112,13 @@ def extract_arcgis_cmd(
     help="Skip auto-init: create only extraction files, no STAC catalog.",
 )
 @click.option(
+    "--id",
+    "catalog_id",
+    type=str,
+    default=None,
+    help="Catalog id. Defaults to the sanitized directory name.",
+)
+@click.option(
     "--license",
     "license_id",
     type=str,
@@ -7096,6 +7135,7 @@ def extract_arcgis_cmd(
 @click.pass_context
 def extract_wfs_cmd(
     ctx: click.Context,
+    catalog_id: str | None,
     license_id: str | None,
     license_url: str | None,
     url: str,
@@ -7124,6 +7164,9 @@ def extract_wfs_cmd(
 
     URL is the WFS service endpoint URL.
     OUTPUT_DIR is the directory to write extracted data (default: 'wfs_extract').
+
+    The catalog id comes from the output directory name. Pass --id to set it
+    yourself, because that id is the catalog's public STAC identity.
 
     \b
     WFS Versions:
@@ -7190,6 +7233,7 @@ def extract_wfs_cmd(
 
     # Build options
     options = ExtractionOptions(
+        catalog_id=catalog_id,
         workers=workers,
         retries=retries,
         timeout=timeout,
@@ -7353,6 +7397,13 @@ def extract_wfs_cmd(
     help="Skip auto-init: create only extraction files, no STAC catalog.",
 )
 @click.option(
+    "--id",
+    "catalog_id",
+    type=str,
+    default=None,
+    help="Catalog id. Defaults to the sanitized directory name.",
+)
+@click.option(
     "--license",
     "license_id",
     type=str,
@@ -7369,6 +7420,7 @@ def extract_wfs_cmd(
 @click.pass_context
 def extract_carto_cmd(
     ctx: click.Context,
+    catalog_id: str | None,
     license_id: str | None,
     license_url: str | None,
     url: str,
@@ -7400,6 +7452,9 @@ def extract_carto_cmd(
     URL is the Carto SQL API endpoint or account domain
     (e.g. https://phl.carto.com or https://phl.carto.com/api/v2/sql).
     OUTPUT_DIR is the directory to write extracted data (default: 'carto_extract').
+
+    The catalog id comes from the output directory name. Pass --id to set it
+    yourself, because that id is the catalog's public STAC identity.
 
     \b
     Examples:
@@ -7451,6 +7506,7 @@ def extract_carto_cmd(
     table_exclude = _parse_filter_patterns(exclude_tables)
 
     options = ExtractionOptions(
+        catalog_id=catalog_id,
         workers=workers,
         retries=retries,
         timeout=timeout,

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -866,6 +866,13 @@ def _auto_init_catalog(
         )
         for message in init_warnings:
             warn(message)
+    elif catalog_id is not None:
+        # The catalog already exists and keeps the id it was created with. Say so,
+        # rather than accept the flag and change nothing (issue #821).
+        warn(
+            f"Ignored --id '{catalog_id}'. {output_dir} is already a Portolan "
+            "catalog and keeps the id it was created with."
+        )
 
     # Add all COG files - this creates items per raster
     add_files(

--- a/portolan_cli/extract/arcgis/imageserver/extractor.py
+++ b/portolan_cli/extract/arcgis/imageserver/extractor.py
@@ -130,6 +130,8 @@ class ExtractionConfig:
         timeout: HTTP request timeout in seconds.
         max_concurrent: Maximum concurrent tile downloads.
         rate_limit_delay: Minimum delay between requests per slot (seconds).
+        catalog_id: Catalog id for the created catalog. None derives it from
+            the output directory name, which is the behavior before issue #821.
     """
 
     tile_size: int = 4096
@@ -140,6 +142,7 @@ class ExtractionConfig:
     timeout: float = 120.0
     max_concurrent: int = 4
     rate_limit_delay: float = DEFAULT_RATE_LIMIT_DELAY
+    catalog_id: str | None = None
 
     # Legacy compatibility: accept compression directly
     compression: str | None = None
@@ -820,6 +823,7 @@ def _auto_init_catalog(
     output_dir: Path,
     service_name: str | None = None,
     collection_name: str = "tiles",
+    catalog_id: str | None = None,
 ) -> bool:
     """Initialize a Portolan catalog and add extracted COG files.
 
@@ -831,6 +835,8 @@ def _auto_init_catalog(
         output_dir: Directory containing extracted COG files.
         service_name: Optional name for the catalog.
         collection_name: Name for the collection directory (default: 'tiles').
+        catalog_id: Catalog id for the created catalog. None derives it from
+            the output directory name, which is the behavior before issue #821.
 
     Returns:
         True if catalog was initialized, False if no files to add.
@@ -852,7 +858,14 @@ def _auto_init_catalog(
     if detect_state(output_dir) is not CatalogState.MANAGED:
         # Initialize the catalog. license_id=None because the ImageServer path seeds
         # metadata.yaml from the harvested service licenseInfo (issue #686).
-        init_catalog(output_dir, title=service_name, license_id=None)
+        # Print what init_catalog had to guess, the way `init` does, so a derived
+        # id that names a tooling artifact does not reach a published catalog
+        # unflagged (issue #821).
+        _, init_warnings = init_catalog(
+            output_dir, catalog_id=catalog_id, title=service_name, license_id=None
+        )
+        for message in init_warnings:
+            warn(message)
 
     # Add all COG files - this creates items per raster
     add_files(
@@ -1226,7 +1239,9 @@ async def extract_imageserver(
     catalog_initialized = False
     if not config.raw:
         info("Initializing Portolan catalog...")
-        catalog_initialized = _auto_init_catalog(output_dir, metadata.name, collection_name)
+        catalog_initialized = _auto_init_catalog(
+            output_dir, metadata.name, collection_name, config.catalog_id
+        )
         if catalog_initialized:
             success("Catalog initialized with STAC metadata")
         else:

--- a/portolan_cli/extract/arcgis/imageserver/orchestrator.py
+++ b/portolan_cli/extract/arcgis/imageserver/orchestrator.py
@@ -58,6 +58,8 @@ class ImageServerCLIOptions:
         compression: COG compression method ("DEFLATE" or "JPEG").
         use_json: If True, suppress progress output (for JSON mode).
         collection_name: Optional name for the collection (default: 'tiles').
+        catalog_id: Catalog id for the created catalog. None derives it from
+            the output directory name, which is the behavior before issue #821.
     """
 
     tile_size: int = 4096
@@ -71,6 +73,7 @@ class ImageServerCLIOptions:
     compression: str = "DEFLATE"
     use_json: bool = False
     collection_name: str | None = None
+    catalog_id: str | None = None
 
 
 def _create_progress_callback(
@@ -139,6 +142,7 @@ async def run_imageserver_extraction(
 
     # Build extraction config from CLI options
     config = ExtractionConfig(
+        catalog_id=options.catalog_id,
         tile_size=options.tile_size,
         max_concurrent=options.max_concurrent,
         dry_run=options.dry_run,

--- a/portolan_cli/extract/arcgis/orchestrator.py
+++ b/portolan_cli/extract/arcgis/orchestrator.py
@@ -258,6 +258,8 @@ class ExtractionOptions:
         output_crs: CRS for the extracted GeoParquet. "native" keeps the
             service's source CRS (default). An EPSG code (e.g. "EPSG:4326")
             reprojects the coordinates to that CRS (issue #802).
+        catalog_id: Catalog id for the created catalog. None derives it from
+            the output directory name, which is the behavior before issue #821.
     """
 
     workers: int = 3
@@ -273,6 +275,7 @@ class ExtractionOptions:
     license: str | None = None
     license_url: str | None = None
     output_crs: str = "native"
+    catalog_id: str | None = None
 
 
 def _is_wgs84_crs(crs: dict[str, object]) -> bool:
@@ -716,13 +719,16 @@ def extract_arcgis_catalog(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report, resolved_license)
+        _auto_init_catalog(output_dir, report, resolved_license, options.catalog_id)
 
     return report
 
 
 def _auto_init_catalog(
-    output_dir: Path, report: ExtractionReport, resolved_license: ResolvedLicense | None = None
+    output_dir: Path,
+    report: ExtractionReport,
+    resolved_license: ResolvedLicense | None = None,
+    catalog_id: str | None = None,
 ) -> None:
     """Initialize a Portolan catalog and add extracted files.
 
@@ -757,6 +763,7 @@ def _auto_init_catalog(
     added = init_extracted_catalog(
         output_dir,
         report,
+        catalog_id=catalog_id,
         title=filtered_title,
         description=filtered_description,
         post_init=_post_init,
@@ -1280,7 +1287,7 @@ def _extract_services_root(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report, resolved_license)
+        _auto_init_catalog(output_dir, report, resolved_license, options.catalog_id)
 
     return report
 

--- a/portolan_cli/extract/carto/orchestrator.py
+++ b/portolan_cli/extract/carto/orchestrator.py
@@ -95,6 +95,8 @@ class ExtractionOptions:
             license_url. Carto exposes no license metadata, so this is the only
             source (issue #686).
         license_url: URL of the license text.
+        catalog_id: Catalog id for the created catalog. None derives it from
+            the output directory name, which is the behavior before issue #821.
     """
 
     workers: int = 1
@@ -111,6 +113,7 @@ class ExtractionOptions:
     api_key: str | None = None
     license: str | None = None
     license_url: str | None = None
+    catalog_id: str | None = None
 
 
 def _slug_for_table(name: str) -> str:
@@ -514,7 +517,7 @@ def extract_carto_catalog(
     save_report(report, report_path)
 
     if not options.raw:
-        _auto_init_catalog(output_dir, report, discovery, resolved_license)
+        _auto_init_catalog(output_dir, report, discovery, resolved_license, options.catalog_id)
 
     return report
 
@@ -524,6 +527,7 @@ def _auto_init_catalog(
     report: ExtractionReport,
     discovery: CartoDiscoveryResult,
     resolved_license: ResolvedLicense | None = None,
+    catalog_id: str | None = None,
 ) -> None:
     """Initialize a Portolan catalog and add extracted tables.
 
@@ -549,6 +553,7 @@ def _auto_init_catalog(
     added = init_extracted_catalog(
         output_dir,
         report,
+        catalog_id=catalog_id,
         title=discovery.account_name,
         description=None,
         post_init=_post_init,

--- a/portolan_cli/extract/common/orchestrator_base.py
+++ b/portolan_cli/extract/common/orchestrator_base.py
@@ -64,6 +64,7 @@ def init_extracted_catalog(
     output_dir: Path,
     report: ExtractionReport,
     *,
+    catalog_id: str | None = None,
     title: str | None,
     description: str | None,
     post_init: Callable[[Path, list[Path], bool], None] | None = None,
@@ -85,6 +86,8 @@ def init_extracted_catalog(
     Args:
         output_dir: The catalog output directory.
         report: The extraction report.
+        catalog_id: Catalog id for ``init_catalog``. None derives it from the
+            output directory name, which is the behavior before issue #821.
         title: Catalog title for ``init_catalog`` (already filtered by caller).
         description: Catalog description for ``init_catalog``.
         post_init: Optional hook called as
@@ -116,7 +119,31 @@ def init_extracted_catalog(
         # service metadata in post_init below. Writing a template here first would
         # make that seeder's O_EXCL create a no-op and drop everything harvested
         # (issue #686).
-        init_catalog(output_dir, title=title, description=description, license_id=None)
+        # init_catalog reports what it had to guess. `init` prints those warnings,
+        # so extract prints them too. Otherwise a derived id that names a tooling
+        # artifact reaches a published catalog unflagged (issue #821).
+        _, init_warnings = init_catalog(
+            output_dir,
+            catalog_id=catalog_id,
+            title=title,
+            description=description,
+            license_id=None,
+        )
+        if init_warnings:
+            from portolan_cli.output import warn
+
+            for message in init_warnings:
+                warn(message)
+
+    elif catalog_id is not None:
+        # The catalog already exists and keeps the id it was created with. Say so,
+        # rather than accept the flag and change nothing (issue #821).
+        from portolan_cli.output import warn
+
+        warn(
+            f"Ignored --id '{catalog_id}'. {output_dir} is already a Portolan "
+            "catalog and keeps the id it was created with."
+        )
 
     if post_init is not None:
         post_init(output_dir, parquet_files, fresh)

--- a/portolan_cli/extract/common/orchestrator_base.py
+++ b/portolan_cli/extract/common/orchestrator_base.py
@@ -102,6 +102,7 @@ def init_extracted_catalog(
         add (the caller should then stop — no catalog was created).
     """
     from portolan_cli.catalog import CatalogState, add_files, detect_state, init_catalog
+    from portolan_cli.output import warn
 
     parquet_files = collect_successful_parquet_files(output_dir, report)
     if not parquet_files:
@@ -129,17 +130,12 @@ def init_extracted_catalog(
             description=description,
             license_id=None,
         )
-        if init_warnings:
-            from portolan_cli.output import warn
-
-            for message in init_warnings:
-                warn(message)
+        for message in init_warnings:
+            warn(message)
 
     elif catalog_id is not None:
         # The catalog already exists and keeps the id it was created with. Say so,
         # rather than accept the flag and change nothing (issue #821).
-        from portolan_cli.output import warn
-
         warn(
             f"Ignored --id '{catalog_id}'. {output_dir} is already a Portolan "
             "catalog and keeps the id it was created with."

--- a/portolan_cli/extract/wfs/orchestrator.py
+++ b/portolan_cli/extract/wfs/orchestrator.py
@@ -96,6 +96,8 @@ class ExtractionOptions:
             license_url. Overrides any license URL found in the service's own
             license text (issue #686).
         license_url: URL of the license text.
+        catalog_id: Catalog id for the created catalog. None derives it from
+            the output directory name, which is the behavior before issue #821.
     """
 
     workers: int = 1
@@ -113,6 +115,7 @@ class ExtractionOptions:
     auto_tile: bool = True
     license: str | None = None
     license_url: str | None = None
+    catalog_id: str | None = None
 
 
 def _slugify(name: str, disambiguate: bool = False, unique_id: int | None = None) -> str:
@@ -787,7 +790,9 @@ def extract_wfs_catalog(
 
     # Auto-init catalog unless raw mode
     if not options.raw:
-        _auto_init_catalog(output_dir, report, discovery_result, resolved_license)
+        _auto_init_catalog(
+            output_dir, report, discovery_result, resolved_license, options.catalog_id
+        )
 
     return report
 
@@ -797,6 +802,7 @@ def _auto_init_catalog(
     report: ExtractionReport,
     discovery_result: WFSDiscoveryResult | None = None,
     resolved_license: ResolvedLicense | None = None,
+    catalog_id: str | None = None,
 ) -> None:
     """Initialize a Portolan catalog and add extracted files.
 
@@ -829,6 +835,7 @@ def _auto_init_catalog(
     added = init_extracted_catalog(
         output_dir,
         report,
+        catalog_id=catalog_id,
         title=filtered_title,
         description=filtered_description,
         post_init=_post_init,

--- a/portolan_cli/input_hardening.py
+++ b/portolan_cli/input_hardening.py
@@ -185,6 +185,11 @@ def validate_item_id(item_id: str) -> str:
 # versions.json, so it carries no dots or other punctuation (issue #821).
 _CATALOG_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
+#: Upper bound on a catalog ID. The ID reaches catalog.json, versions.json, and
+#: every href a consumer resolves, so it stays inside the 255-byte name limit
+#: that common filesystems and object stores impose.
+MAX_CATALOG_ID_LENGTH = 255
+
 
 def validate_catalog_id(catalog_id: str) -> str:
     """Validate a STAC catalog ID for safety and compliance.
@@ -193,6 +198,10 @@ def validate_catalog_id(catalog_id: str) -> str:
     directory name is not something the caller typed. An ID the caller supplies
     is a deliberate choice, so this function rejects a bad value instead of
     silently rewriting it (issue #821).
+
+    The pattern alone rejects control characters, path separators, traversals,
+    and URL punctuation, so this function states one rule rather than repeat
+    each class of bad input as its own check.
 
     Args:
         catalog_id: The catalog ID to validate.
@@ -206,17 +215,10 @@ def validate_catalog_id(catalog_id: str) -> str:
     if not catalog_id:
         raise InputValidationError("Catalog ID cannot be empty")
 
-    if any(ord(c) < 0x20 for c in catalog_id):
-        raise InputValidationError("Control characters not allowed in catalog ID")
-
-    if "?" in catalog_id or "#" in catalog_id:
-        raise InputValidationError("Query parameters/fragments not allowed in catalog ID")
-
-    if "%" in catalog_id:
-        raise InputValidationError("URL-encoded characters not allowed in catalog ID")
-
-    if ".." in catalog_id or "/" in catalog_id or "\\" in catalog_id:
-        raise InputValidationError("Path separators/traversals not allowed in catalog ID")
+    if len(catalog_id) > MAX_CATALOG_ID_LENGTH:
+        raise InputValidationError(
+            f"Catalog ID is too long: {len(catalog_id)} characters, limit {MAX_CATALOG_ID_LENGTH}"
+        )
 
     if not _CATALOG_ID_PATTERN.match(catalog_id):
         raise InputValidationError(

--- a/portolan_cli/input_hardening.py
+++ b/portolan_cli/input_hardening.py
@@ -180,6 +180,52 @@ def validate_item_id(item_id: str) -> str:
     return item_id
 
 
+# STAC identifiers match ^[a-zA-Z0-9_-]+$. A catalog ID is stricter than an item
+# ID. It names a directory-level identity that reaches catalog.json and
+# versions.json, so it carries no dots or other punctuation (issue #821).
+_CATALOG_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def validate_catalog_id(catalog_id: str) -> str:
+    """Validate a STAC catalog ID for safety and compliance.
+
+    ``init_catalog`` sanitizes a *derived* ID by coercing it, because the
+    directory name is not something the caller typed. An ID the caller supplies
+    is a deliberate choice, so this function rejects a bad value instead of
+    silently rewriting it (issue #821).
+
+    Args:
+        catalog_id: The catalog ID to validate.
+
+    Returns:
+        The validated catalog ID.
+
+    Raises:
+        InputValidationError: If validation fails.
+    """
+    if not catalog_id:
+        raise InputValidationError("Catalog ID cannot be empty")
+
+    if any(ord(c) < 0x20 for c in catalog_id):
+        raise InputValidationError("Control characters not allowed in catalog ID")
+
+    if "?" in catalog_id or "#" in catalog_id:
+        raise InputValidationError("Query parameters/fragments not allowed in catalog ID")
+
+    if "%" in catalog_id:
+        raise InputValidationError("URL-encoded characters not allowed in catalog ID")
+
+    if ".." in catalog_id or "/" in catalog_id or "\\" in catalog_id:
+        raise InputValidationError("Path separators/traversals not allowed in catalog ID")
+
+    if not _CATALOG_ID_PATTERN.match(catalog_id):
+        raise InputValidationError(
+            f"Invalid catalog ID {catalog_id!r}: use only letters, digits, hyphens, and underscores"
+        )
+
+    return catalog_id
+
+
 def validate_remote_url(url: str) -> str:
     """Validate a remote storage URL for push/pull/sync operations.
 

--- a/portolan_cli/validation/__init__.py
+++ b/portolan_cli/validation/__init__.py
@@ -24,6 +24,7 @@ arguments is not catalog validation. These names are re-exported for the
 existing ``from portolan_cli.validation import ...`` call sites:
 - InputValidationError: Exception for input validation failures
 - validate_safe_path(): Protect against path traversal attacks
+- validate_catalog_id(): Validate STAC catalog IDs
 - validate_collection_id(): Validate STAC collection IDs
 - validate_item_id(): Validate STAC item IDs
 - validate_remote_url(): Validate S3/GCS/Azure URLs
@@ -33,6 +34,7 @@ existing ``from portolan_cli.validation import ...`` call sites:
 
 from portolan_cli.input_hardening import (
     InputValidationError,
+    validate_catalog_id,
     validate_collection_id,
     validate_config_key,
     validate_config_value,
@@ -71,6 +73,7 @@ __all__ = [
     "build_fix_payload",
     "remediation_for",
     "run_check",
+    "validate_catalog_id",
     "validate_collection_id",
     "validate_config_key",
     "validate_config_value",

--- a/tests/integration/extract/test_extract_auto_init.py
+++ b/tests/integration/extract/test_extract_auto_init.py
@@ -130,6 +130,36 @@ class TestAutoInitCatalog:
         # Should have catalog.json at root
         assert (output_dir / "catalog.json").exists(), "catalog.json should be created"
 
+    def test_auto_init_uses_supplied_catalog_id(self, tmp_path: Path) -> None:
+        """extract --id names the catalog instead of the directory (issue #821)."""
+        import json
+
+        # A scratch directory name is exactly what produced the "publish" catalog
+        # in issue #821, so the derived id here differs from the supplied one.
+        output_dir = tmp_path / "publish"
+        output_dir.mkdir()
+
+        layer_dir = output_dir / "test_layer"
+        layer_dir.mkdir()
+        output_parquet = layer_dir / "data.parquet"
+        shutil.copy(FIXTURES_DIR / "simple.parquet", output_parquet)
+
+        report = make_report(
+            layers=[
+                make_layer_result(
+                    output_path="test_layer/data.parquet",
+                    size_bytes=output_parquet.stat().st_size,
+                )
+            ],
+        )
+
+        _auto_init_catalog(output_dir, report, TEST_LICENSE, "phl-housing")
+
+        catalog = json.loads((output_dir / "catalog.json").read_text(encoding="utf-8"))
+        versions = json.loads((output_dir / "versions.json").read_text(encoding="utf-8"))
+        assert catalog["id"] == "phl-housing"
+        assert versions["catalog_id"] == "phl-housing"
+
     def test_auto_init_creates_config_yaml(self, tmp_path: Path) -> None:
         """_auto_init_catalog creates .portolan/config.yaml sentinel."""
         output_dir = tmp_path / "test_catalog"

--- a/tests/integration/test_init_command.py
+++ b/tests/integration/test_init_command.py
@@ -61,6 +61,26 @@ class TestInitCommandAutoMode:
         assert data["id"] == "my-cool-catalog"
 
     @pytest.mark.integration
+    def test_id_flag_writes_catalog_json_and_versions_json(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """--id must reach both id write sites, so they cannot drift (issue #821)."""
+        catalog_dir = tmp_path / "publish"
+        catalog_dir.mkdir()
+
+        result = runner.invoke(
+            cli,
+            ["init", "--auto", str(catalog_dir), "--id", "phl-housing", "--license", "CC-BY-4.0"],
+        )
+
+        assert result.exit_code == 0
+        catalog = json.loads((catalog_dir / "catalog.json").read_text())
+        versions = json.loads((catalog_dir / "versions.json").read_text())
+
+        assert catalog["id"] == "phl-housing"
+        assert versions["catalog_id"] == "phl-housing"
+
+    @pytest.mark.integration
     def test_init_auto_emits_warnings(self, runner: CliRunner, tmp_path: Path) -> None:
         """portolan init --auto should emit warnings for missing best-practice fields."""
         with runner.isolated_filesystem(temp_dir=tmp_path):

--- a/tests/unit/extract/arcgis/imageserver/test_extractor.py
+++ b/tests/unit/extract/arcgis/imageserver/test_extractor.py
@@ -571,7 +571,11 @@ class TestAutoInitCatalogExistingCatalog:
         import portolan_cli.add as add_mod
         import portolan_cli.catalog as catalog_mod
 
-        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: events.append("init"))
+        def _fake_init(output_dir: Path, **kwargs: object) -> tuple[Path, list[str]]:
+            events.append("init")
+            return output_dir / "catalog.json", []
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
         monkeypatch.setattr(add_mod, "add_files", lambda **k: events.append("add"))
 
         result = _auto_init_catalog(tmp_path, service_name="svc")
@@ -602,7 +606,9 @@ class TestAutoInitCatalogExistingCatalog:
         import portolan_cli.add as add_mod
         import portolan_cli.catalog as catalog_mod
 
-        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: events.append("init"))
+        monkeypatch.setattr(
+            catalog_mod, "init_catalog", lambda *a, **k: (tmp_path / "catalog.json", [])
+        )
         monkeypatch.setattr(add_mod, "add_files", lambda **k: events.append("add"))
 
         result = _auto_init_catalog(tmp_path, service_name="svc", collection_name="naip-2024")
@@ -610,3 +616,42 @@ class TestAutoInitCatalogExistingCatalog:
         assert result is True
         # init_catalog is skipped for an existing catalog; the tiles are added.
         assert events == ["add"]
+
+    def test_reports_init_catalog_warnings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The raster path prints what init_catalog had to guess (issue #821)."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _auto_init_catalog
+
+        self._make_tile(tmp_path)
+
+        import portolan_cli.add as add_mod
+        import portolan_cli.catalog as catalog_mod
+
+        def _fake_init(output_dir: Path, **kwargs: object) -> tuple[Path, list[str]]:
+            return output_dir / "catalog.json", ["Derived catalog id 'publish'"]
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
+        monkeypatch.setattr(add_mod, "add_files", lambda **k: None)
+
+        _auto_init_catalog(tmp_path, service_name="svc")
+
+        assert "Derived catalog id 'publish'" in capsys.readouterr().err
+
+    def test_warns_when_id_cannot_apply_to_an_existing_catalog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An existing catalog keeps its id, so a passed --id must not go silent."""
+        from portolan_cli.extract.arcgis.imageserver.extractor import _auto_init_catalog
+
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text("# Portolan configuration\n")
+        self._make_tile(tmp_path)
+
+        import portolan_cli.add as add_mod
+
+        monkeypatch.setattr(add_mod, "add_files", lambda **k: None)
+
+        _auto_init_catalog(tmp_path, service_name="svc", catalog_id="phl-housing")
+
+        assert "Ignored --id 'phl-housing'" in capsys.readouterr().err

--- a/tests/unit/extract/common/test_orchestrator_base.py
+++ b/tests/unit/extract/common/test_orchestrator_base.py
@@ -120,14 +120,16 @@ class TestInitExtractedCatalog:
         def _fake_init(
             output_dir: Path,
             *,
+            catalog_id: str | None,
             title: str | None,
             description: str | None,
             license_id: str | None,
-        ) -> None:
+        ) -> tuple[Path, list[str]]:
             events.append("init")
             # Issue #686: extract seeds metadata.yaml itself, in post_init, so
             # init_catalog must not write a template over it.
             assert license_id is None
+            return output_dir / "catalog.json", []
 
         def _fake_add(*, paths: list[Path], catalog_root: Path) -> None:
             events.append("add")
@@ -153,11 +155,53 @@ class TestInitExtractedCatalog:
         report = _report([_layer(0, "a", output_path="a/a.parquet")])
         import portolan_cli.catalog as catalog_mod
 
-        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: None)
+        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: (Path("catalog.json"), []))
         monkeypatch.setattr(catalog_mod, "add_files", lambda *a, **k: None)
 
         result = init_extracted_catalog(tmp_path, report, title=None, description=None)
         assert result == [tmp_path / "a/a.parquet"]
+
+    def test_catalog_id_reaches_init_catalog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The shared seam forwards the caller's id to init_catalog (issue #821)."""
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+        seen: dict[str, object] = {}
+
+        import portolan_cli.catalog as catalog_mod
+
+        def _fake_init(output_dir: Path, **kwargs: object) -> tuple[Path, list[str]]:
+            seen["catalog_id"] = kwargs["catalog_id"]
+            return output_dir / "catalog.json", []
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
+        monkeypatch.setattr(catalog_mod, "add_files", lambda *a, **k: None)
+
+        init_extracted_catalog(
+            tmp_path, report, catalog_id="phl-housing", title=None, description=None
+        )
+
+        assert seen["catalog_id"] == "phl-housing"
+
+    def test_catalog_id_defaults_to_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without an id the seam keeps the directory-name derivation."""
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+        seen: dict[str, object] = {}
+
+        import portolan_cli.catalog as catalog_mod
+
+        def _fake_init(output_dir: Path, **kwargs: object) -> tuple[Path, list[str]]:
+            seen["catalog_id"] = kwargs["catalog_id"]
+            return output_dir / "catalog.json", []
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
+        monkeypatch.setattr(catalog_mod, "add_files", lambda *a, **k: None)
+
+        init_extracted_catalog(tmp_path, report, title=None, description=None)
+
+        assert seen["catalog_id"] is None
 
     def test_adds_to_existing_catalog_without_init(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -196,6 +240,44 @@ class TestInitExtractedCatalog:
         # init_catalog is skipped for an existing catalog; the new collection is
         # added instead of the run aborting.
         assert events == ["post_init", "add"]
+
+    def test_reports_init_catalog_warnings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """extract prints what init_catalog had to guess, the way `init` does (#821)."""
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+
+        import portolan_cli.catalog as catalog_mod
+
+        def _fake_init(output_dir: Path, **kwargs: object) -> tuple[Path, list[str]]:
+            return output_dir / "catalog.json", ["Derived catalog id 'publish'"]
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", _fake_init)
+        monkeypatch.setattr(catalog_mod, "add_files", lambda *a, **k: None)
+
+        init_extracted_catalog(tmp_path, report, title=None, description=None)
+
+        assert "Derived catalog id 'publish'" in capsys.readouterr().err
+
+    def test_warns_when_id_cannot_apply_to_an_existing_catalog(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An existing catalog keeps its id, so a passed --id must not go silent."""
+        (tmp_path / ".portolan").mkdir()
+        (tmp_path / ".portolan" / "config.yaml").write_text("# Portolan configuration\n")
+
+        report = _report([_layer(0, "a", output_path="a/a.parquet")])
+
+        import portolan_cli.catalog as catalog_mod
+
+        monkeypatch.setattr(catalog_mod, "init_catalog", lambda *a, **k: (Path("catalog.json"), []))
+        monkeypatch.setattr(catalog_mod, "add_files", lambda *a, **k: None)
+
+        init_extracted_catalog(
+            tmp_path, report, catalog_id="phl-housing", title=None, description=None
+        )
+
+        assert "phl-housing" in capsys.readouterr().err
 
 
 class TestAddSourceLinks:

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -243,3 +243,54 @@ def test_output_crs_threads_into_options(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     assert result.exit_code == 0, result.output
     assert captured["output_crs"] == "EPSG:28992"
+
+
+@pytest.mark.unit
+def test_catalog_id_threads_into_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--id reaches ExtractionOptions passed to extract_arcgis_catalog (issue #821)."""
+    from types import SimpleNamespace
+
+    from portolan_cli.extract.arcgis.orchestrator import ExtractionOptions
+
+    captured: dict[str, object] = {}
+
+    def fake_extract(**kwargs: object) -> SimpleNamespace:
+        options = kwargs["options"]
+        assert isinstance(options, ExtractionOptions)
+        captured["catalog_id"] = options.catalog_id
+        summary = SimpleNamespace(
+            total_layers=0,
+            succeeded=0,
+            failed=0,
+            skipped=0,
+            empty=0,
+            total_features=0,
+            total_size_bytes=0,
+        )
+        return SimpleNamespace(
+            source_url="https://x/rest/services/F/FeatureServer",
+            summary=summary,
+            layers=[],
+            folder_coverage=None,
+        )
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.extract_arcgis_catalog", fake_extract
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://x/rest/services/F/FeatureServer",
+            "./out",
+            "--id",
+            "phl-housing",
+            "--auto",
+            "--raw",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["catalog_id"] == "phl-housing"

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -323,3 +323,39 @@ def test_extract_arcgis_rejects_bad_id_before_extraction(monkeypatch: pytest.Mon
     assert result.exit_code == 1
     assert calls == []
     assert "Invalid catalog ID" in result.output
+
+
+@pytest.mark.unit
+def test_extract_arcgis_rejects_bad_id_before_imageserver_extraction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The raster path checks --id at the boundary too (issue #821).
+
+    An ImageServer URL dispatches to a different handler than the vector path,
+    so the check must sit before that branch, not inside it.
+    """
+    calls: list[str] = []
+
+    def _never_called(*args: object, **kwargs: object) -> None:
+        calls.append("imageserver")
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.imageserver.orchestrator.run_imageserver_extraction_sync",
+        _never_called,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://example.com/arcgis/rest/services/x/ImageServer",
+            "--id",
+            "bad id",
+            "--auto",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert calls == []
+    assert "Invalid catalog ID" in result.output

--- a/tests/unit/test_cli_extract_arcgis.py
+++ b/tests/unit/test_cli_extract_arcgis.py
@@ -294,3 +294,32 @@ def test_catalog_id_threads_into_options(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     assert result.exit_code == 0, result.output
     assert captured["catalog_id"] == "phl-housing"
+
+
+@pytest.mark.unit
+def test_extract_arcgis_rejects_bad_id_before_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bad --id fails before the download starts, not after it (issue #821)."""
+    calls: list[str] = []
+
+    def _never_called(*args: object, **kwargs: object) -> None:
+        calls.append("extract")
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.arcgis.orchestrator.extract_arcgis_catalog", _never_called
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "arcgis",
+            "https://example.com/arcgis/rest/services/x/FeatureServer",
+            "--id",
+            "bad id",
+            "--auto",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert calls == []
+    assert "Invalid catalog ID" in result.output

--- a/tests/unit/test_cli_extract_carto.py
+++ b/tests/unit/test_cli_extract_carto.py
@@ -35,6 +35,7 @@ def _make_capturing_fake(captured: dict[str, object]) -> Callable[..., Extractio
         captured["limit"] = options.limit
         captured["api_key"] = options.api_key
         captured["workers"] = options.workers
+        captured["catalog_id"] = options.catalog_id
         captured["layer_filter"] = layer_filter
         captured["layer_exclude"] = layer_exclude
         return _build_dry_run_report(url, [])
@@ -123,3 +124,19 @@ def test_extract_carto_rejects_bad_bbox(monkeypatch: pytest.MonkeyPatch) -> None
         ["extract", "carto", "https://phl.carto.com", "--bbox", "1,2,3", "--auto"],
     )
     assert result.exit_code == 1
+
+
+def test_extract_carto_id_threads_into_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--id threads catalog_id into ExtractionOptions (issue #821)."""
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "portolan_cli.extract.carto.orchestrator.extract_carto_catalog",
+        _make_capturing_fake(captured),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["extract", "carto", "https://phl.carto.com", "--id", "phl-housing", "--dry-run", "--auto"],
+    )
+    assert result.exit_code == 0
+    assert captured["catalog_id"] == "phl-housing"

--- a/tests/unit/test_cli_extract_carto.py
+++ b/tests/unit/test_cli_extract_carto.py
@@ -140,3 +140,23 @@ def test_extract_carto_id_threads_into_options(monkeypatch: pytest.MonkeyPatch) 
     )
     assert result.exit_code == 0
     assert captured["catalog_id"] == "phl-housing"
+
+
+def test_extract_carto_rejects_bad_id_before_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bad --id fails before the download starts, not after it (issue #821)."""
+    calls: list[str] = []
+
+    def _never_called(*args: object, **kwargs: object) -> None:
+        calls.append("extract")
+
+    monkeypatch.setattr(
+        "portolan_cli.extract.carto.orchestrator.extract_carto_catalog", _never_called
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["extract", "carto", "https://phl.carto.com", "--id", "bad id", "--auto"]
+    )
+
+    assert result.exit_code == 1
+    assert calls == []
+    assert "Invalid catalog ID" in result.output

--- a/tests/unit/test_cli_extract_wfs.py
+++ b/tests/unit/test_cli_extract_wfs.py
@@ -33,6 +33,7 @@ def _make_capturing_fake(
         assert options is not None
         captured["page_size"] = options.page_size
         captured["auto_tile"] = options.auto_tile
+        captured["catalog_id"] = options.catalog_id
         return _build_dry_run_report(url=url, layers=[], discovery_result=None)
 
     return fake_extract
@@ -79,3 +80,36 @@ def test_extract_wfs_no_auto_tile_threads_false(monkeypatch: pytest.MonkeyPatch)
     )
     assert result.exit_code == 0
     assert captured["auto_tile"] is False
+
+
+@pytest.mark.unit
+def test_extract_wfs_id_threads_into_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--id threads catalog_id into ExtractionOptions (issue #821)."""
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "portolan_cli.extract.wfs.orchestrator.extract_wfs_catalog",
+        _make_capturing_fake(captured),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["extract", "wfs", "https://example.com/wfs", "--id", "phl-housing", "--dry-run", "--auto"],
+    )
+    assert result.exit_code == 0
+    assert captured["catalog_id"] == "phl-housing"
+
+
+@pytest.mark.unit
+def test_extract_wfs_id_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without --id the orchestrator keeps deriving the id from the directory name."""
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "portolan_cli.extract.wfs.orchestrator.extract_wfs_catalog",
+        _make_capturing_fake(captured),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["extract", "wfs", "https://example.com/wfs", "--dry-run", "--auto"]
+    )
+    assert result.exit_code == 0
+    assert captured["catalog_id"] is None

--- a/tests/unit/test_cli_extract_wfs.py
+++ b/tests/unit/test_cli_extract_wfs.py
@@ -113,3 +113,49 @@ def test_extract_wfs_id_defaults_to_none(monkeypatch: pytest.MonkeyPatch) -> Non
     )
     assert result.exit_code == 0
     assert captured["catalog_id"] is None
+
+
+@pytest.mark.unit
+def test_extract_wfs_rejects_bad_id_before_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bad --id fails before the download starts, not after it (issue #821)."""
+    calls: list[str] = []
+
+    def _never_called(*args: object, **kwargs: object) -> None:
+        calls.append("extract")
+
+    monkeypatch.setattr("portolan_cli.extract.wfs.orchestrator.extract_wfs_catalog", _never_called)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["extract", "wfs", "https://example.com/wfs", "--id", "bad id", "--auto"]
+    )
+
+    assert result.exit_code == 1
+    assert calls == []
+    assert "Invalid catalog ID" in result.output
+
+
+@pytest.mark.unit
+def test_extract_wfs_warns_that_raw_ignores_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--raw writes no catalog, so --id does nothing and says so (issue #821)."""
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "portolan_cli.extract.wfs.orchestrator.extract_wfs_catalog",
+        _make_capturing_fake(captured),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "extract",
+            "wfs",
+            "https://example.com/wfs",
+            "--id",
+            "phl-housing",
+            "--raw",
+            "--dry-run",
+            "--auto",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Ignored --id 'phl-housing'" in result.output

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -159,6 +159,29 @@ class TestCliInit:
             assert not Path("catalog.json").exists()
 
     @pytest.mark.unit
+    def test_rejected_id_creates_no_directory(self, runner: CliRunner, tmp_path: Path) -> None:
+        """A rejected --id leaves no directory behind (issue #821)."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                cli, ["init", "newdir", "--auto", "--id", "bad id", "--license", "CC-BY-4.0"]
+            )
+
+            assert result.exit_code != 0
+            assert not Path("newdir").exists()
+
+    @pytest.mark.unit
+    def test_warns_when_derived_id_is_an_extract_output_directory(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """The output directory `extract` picks by itself warns like any artifact."""
+        target = tmp_path / "wfs_extract"
+        target.mkdir()
+        result = runner.invoke(cli, ["init", str(target), "--auto", "--license", "CC-BY-4.0"])
+
+        assert result.exit_code == 0
+        assert "tooling artifact" in result.output
+
+    @pytest.mark.unit
     def test_warns_when_derived_id_is_a_tooling_artifact(
         self, runner: CliRunner, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_cli_init.py
+++ b/tests/unit/test_cli_init.py
@@ -118,6 +118,73 @@ class TestCliInit:
             data = json.loads(Path("catalog.json").read_text())
             assert data.get("description") == "Test description"
 
+    @pytest.mark.unit
+    def test_init_with_id_flag(self, runner: CliRunner, tmp_path: Path) -> None:
+        """portolan init --id should set the catalog id."""
+        import json
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                cli, ["init", "--auto", "--id", "phl-housing", "--license", "CC-BY-4.0"]
+            )
+
+            assert result.exit_code == 0
+            data = json.loads(Path("catalog.json").read_text())
+            assert data.get("id") == "phl-housing"
+
+    @pytest.mark.unit
+    def test_id_flag_overrides_directory_name(self, runner: CliRunner, tmp_path: Path) -> None:
+        """--id wins over the directory name the id is otherwise derived from."""
+        import json
+
+        target = tmp_path / "publish"
+        target.mkdir()
+        result = runner.invoke(
+            cli, ["init", str(target), "--auto", "--id", "phl-housing", "--license", "CC-BY-4.0"]
+        )
+
+        assert result.exit_code == 0
+        data = json.loads((target / "catalog.json").read_text())
+        assert data.get("id") == "phl-housing"
+
+    @pytest.mark.unit
+    def test_invalid_id_is_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        """An --id outside the STAC identifier pattern fails instead of being coerced."""
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(
+                cli, ["init", "--auto", "--id", "my catalog", "--license", "CC-BY-4.0"]
+            )
+
+            assert result.exit_code != 0
+            assert not Path("catalog.json").exists()
+
+    @pytest.mark.unit
+    def test_warns_when_derived_id_is_a_tooling_artifact(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """A directory named 'publish' warns that the derived id names no data (#821)."""
+        target = tmp_path / "publish"
+        target.mkdir()
+        result = runner.invoke(cli, ["init", str(target), "--auto", "--license", "CC-BY-4.0"])
+
+        assert result.exit_code == 0
+        assert "tooling artifact" in result.output
+        assert "--id" in result.output
+
+    @pytest.mark.unit
+    def test_no_artifact_warning_when_id_is_explicit(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """An explicit --id is the caller's decision, so the artifact warning stays quiet."""
+        target = tmp_path / "publish"
+        target.mkdir()
+        result = runner.invoke(
+            cli, ["init", str(target), "--auto", "--id", "phl-housing", "--license", "CC-BY-4.0"]
+        )
+
+        assert result.exit_code == 0
+        assert "tooling artifact" not in result.output
+
 
 class TestCliInitInteractive:
     """Tests for interactive prompting in the init command."""

--- a/tests/unit/test_input_hardening.py
+++ b/tests/unit/test_input_hardening.py
@@ -12,6 +12,7 @@ import pytest
 
 from portolan_cli.input_hardening import (
     InputValidationError,
+    validate_catalog_id,
     validate_collection_id,
     validate_config_key,
     validate_config_value,
@@ -206,6 +207,50 @@ class TestValidateItemId:
             validate_item_id("../item")
         with pytest.raises(InputValidationError, match="Path separators"):
             validate_item_id("parent/child")
+
+
+@pytest.mark.unit
+class TestValidateCatalogId:
+    """Tests for catalog ID validation (issue #821)."""
+
+    def test_valid_catalog_id(self) -> None:
+        """Valid catalog IDs are accepted."""
+        assert validate_catalog_id("phl-housing") == "phl-housing"
+        assert validate_catalog_id("census_2020") == "census_2020"
+        assert validate_catalog_id("IGN-Argentina") == "IGN-Argentina"
+
+    def test_rejects_empty_id(self) -> None:
+        """Empty catalog ID is rejected."""
+        with pytest.raises(InputValidationError, match="cannot be empty"):
+            validate_catalog_id("")
+
+    def test_rejects_control_characters(self) -> None:
+        """Control characters are rejected."""
+        with pytest.raises(InputValidationError, match="Control characters"):
+            validate_catalog_id("catalog\x00data")
+
+    def test_rejects_query_parameters(self) -> None:
+        """Query parameters are rejected."""
+        with pytest.raises(InputValidationError, match="Query parameters"):
+            validate_catalog_id("catalog?fields=name")
+
+    def test_rejects_url_encoding(self) -> None:
+        """Pre-encoded strings are rejected."""
+        with pytest.raises(InputValidationError, match="URL-encoded"):
+            validate_catalog_id("catalog%20name")
+
+    def test_rejects_path_traversals(self) -> None:
+        """Path traversals are rejected."""
+        with pytest.raises(InputValidationError, match="Path separators"):
+            validate_catalog_id("../catalog")
+        with pytest.raises(InputValidationError, match="Path separators"):
+            validate_catalog_id("parent/child")
+
+    def test_rejects_characters_outside_stac_pattern(self) -> None:
+        """A catalog ID must match the STAC identifier pattern."""
+        for bad in ("my catalog", "catalog.v2", "catalog!", "\u65e5\u672c\u8a9e"):
+            with pytest.raises(InputValidationError, match="letters, digits"):
+                validate_catalog_id(bad)
 
 
 @pytest.mark.unit

--- a/tests/unit/test_input_hardening.py
+++ b/tests/unit/test_input_hardening.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from portolan_cli.input_hardening import (
+    MAX_CATALOG_ID_LENGTH,
     InputValidationError,
     validate_catalog_id,
     validate_collection_id,
@@ -224,31 +225,31 @@ class TestValidateCatalogId:
         with pytest.raises(InputValidationError, match="cannot be empty"):
             validate_catalog_id("")
 
-    def test_rejects_control_characters(self) -> None:
-        """Control characters are rejected."""
-        with pytest.raises(InputValidationError, match="Control characters"):
-            validate_catalog_id("catalog\x00data")
-
-    def test_rejects_query_parameters(self) -> None:
-        """Query parameters are rejected."""
-        with pytest.raises(InputValidationError, match="Query parameters"):
-            validate_catalog_id("catalog?fields=name")
-
-    def test_rejects_url_encoding(self) -> None:
-        """Pre-encoded strings are rejected."""
-        with pytest.raises(InputValidationError, match="URL-encoded"):
-            validate_catalog_id("catalog%20name")
-
-    def test_rejects_path_traversals(self) -> None:
-        """Path traversals are rejected."""
-        with pytest.raises(InputValidationError, match="Path separators"):
-            validate_catalog_id("../catalog")
-        with pytest.raises(InputValidationError, match="Path separators"):
-            validate_catalog_id("parent/child")
+    def test_rejects_id_over_the_length_limit(self) -> None:
+        """A catalog ID stays inside the 255-character name limit."""
+        assert validate_catalog_id("a" * MAX_CATALOG_ID_LENGTH)
+        with pytest.raises(InputValidationError, match="too long"):
+            validate_catalog_id("a" * (MAX_CATALOG_ID_LENGTH + 1))
 
     def test_rejects_characters_outside_stac_pattern(self) -> None:
-        """A catalog ID must match the STAC identifier pattern."""
-        for bad in ("my catalog", "catalog.v2", "catalog!", "\u65e5\u672c\u8a9e"):
+        """One rule rejects every class of bad input a shell can deliver.
+
+        A tab, a query string, a percent escape, and a path separator all reach
+        the CLI as ordinary argument text, so each must fail the pattern.
+        """
+        bad_ids = (
+            "my catalog",
+            "catalog.v2",
+            "catalog!",
+            "\u65e5\u672c\u8a9e",
+            "catalog\tdata",
+            "catalog?fields=name",
+            "catalog%20name",
+            "../catalog",
+            "parent/child",
+            "parent\\child",
+        )
+        for bad in bad_ids:
             with pytest.raises(InputValidationError, match="letters, digits"):
                 validate_catalog_id(bad)
 


### PR DESCRIPTION
## What changed

`portolan init` and the three `portolan extract` commands accept `--id`. The flag
sets the catalog id. Before this change the id always came from the output
directory name, and no flag could change it.

The commands also warn when a derived id names a tooling artifact. The list holds
`build`, `data`, `dist`, `new`, `out`, `output`, `publish`, `staging`, `temp`,
`tmp`, and `untitled`. It also holds the output directory names `extract` picks
when the caller names none: `arcgis-extract`, `carto-extract`, `services-extract`,
`wfs-extract`, and `extract`. The comparison ignores case. It treats a hyphen and
an underscore as the same character, so `wfs_extract` matches `wfs-extract`. An
explicit `--id` silences the warning, because the caller made that choice on
purpose.

Two smaller gaps come with it:

- `extract` now prints the warnings that `init_catalog` returns. It discarded them
  before, so a derived id reached a published catalog with nothing said about it.
- `extract` now reports when it ignores `--id`. That happens when the output
  directory already holds a Portolan catalog. Such a catalog keeps its original id.

Five code paths create a catalog. All five take `--id` now:

- `portolan init`
- `portolan extract arcgis`
- `portolan extract wfs`
- `portolan extract carto`
- the ArcGIS ImageServer raster path

The `clone` command does not take it. A clone must keep the id of the catalog it
copies.

Validation. A derived id passes through `_sanitize_id`, which coerces it. An id
the caller types passes through the new `validate_catalog_id`, which rejects a bad
value. `init_catalog` resolves the identity before it creates the directory, so a
rejected id leaves nothing on disk. `validate_catalog_id` states one rule. The
STAC identifier pattern already rejects control characters, path separators,
traversals, and URL punctuation. The function also bounds the id at 255
characters.

`extract` checks `--id` on the first line of the command, before it opens any
connection. `init_catalog` runs at the end of an extraction, so a check there cost
the caller the whole download. The run then left data on disk with no
`catalog.json`.

`--raw` writes no catalog, so `--id` with `--raw` reports that the flag does
nothing. The ArcGIS ImageServer path always writes a catalog, so the message stays
quiet for an ImageServer URL. That path also reports an ignored `--id` when the
output directory already holds a catalog, which matches the vector path.

Docs. The published CLI reference comes from mkdocs-click, so the new option
appears in the option table with no manual edit. The tutorial now passes
`--id philadelphia-housing`. That value equals the id the tutorial derived before,
so the catalog it builds does not change.

## Why

Resolves #821.

A published Source Cooperative catalog carries `"id": "publish"`. The publisher ran
`init` inside a scratch directory named `publish/`. The directory name became the
catalog identity. The root `versions.json` recorded `"catalog_id": "publish"` next
to it.

Nothing flagged it. Rule `PTL-CAT-001` does not constrain the id content. Rule
`PTL-COL-003` applies to collection ids, not catalog ids. The id `publish` passes
every syntactic check. It names a step in a workflow instead of the data.

A publisher could set `--title` and `--description` directly. Nobody could set the
id. The `init` command warned about a derived title. The code that derived the id
in silence sat a few lines away.

The issue asks for `--id` on `init`. The same defect lives in `extract`, which
calls the same `init_catalog` and passes a title but no id. The tutorial creates
its catalog with `extract`, not with `init`. So `extract` is the path the docs
teach, and it needs the flag too.

## Verification

Every command below reads the public City of Philadelphia ArcGIS services.
The source is https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services.
Each command writes into a directory named `publish`. That directory name produced
the catalog in #821.

`extract` reproduces the failure and now reports it:

```console
$ portolan extract arcgis <phl services root> "$W/publish" \
    --services Council_Districts_2024 --license other --license-url ... --auto
⚠ Derived catalog id 'publish' from the directory name. It looks like a tooling artifact, not the name of the data. Pass --id to set the catalog identity.
✓ Extracted 1/1 layers
$ jq -r .id "$W/publish/catalog.json"
publish
```

`extract --id` writes the supplied id to both places that record it:

```console
$ portolan extract arcgis https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services \
    "$W/publish" --id phl-housing --services Council_Districts_2024 \
    --license other --license-url https://metadata.phila.gov/ --auto
→ [1/1] Council_Districts_2024
Streaming features to temp file...
Fetching features 1-10 of 10...
Reading temp file...
Converted 10 features
    ✓ Success
→ Seeded metadata.yaml from arcgis_featureserver

✓ Extracted 1/1 layers
→ Output: /tmp/user/1000/tmp.5JHQHIpkuE/publish
→ Report: /tmp/user/1000/tmp.5JHQHIpkuE/publish/.portolan/extraction-report.json
→ Folders traversed: 0, skipped: 0, services found: 2269
$ jq -r .id "$W/publish/catalog.json"
phl-housing
$ jq -r .catalog_id "$W/publish/versions.json"
phl-housing
```

`init` behaves the same way. Without `--id` it warns:

```console
$ portolan init "$W/publish" --auto --license CC-BY-4.0
✓ Initialized Portolan catalog in /tmp/user/1000/tmp.1SLED3WVYy/publish
→ Catalog ID: publish
⚠ Derived catalog id 'publish' from the directory name. It looks like a tooling artifact, not the name of the data. Pass --id to set the catalog identity.
⚠ Derived catalog title 'Publish' from directory name
$ jq -r .id "$W/publish/catalog.json"
publish
```

With `--id` it uses the supplied value and drops the warning:

```console
$ portolan init "$W/publish" --id phl-housing --auto --license CC-BY-4.0
✓ Initialized Portolan catalog in /tmp/user/1000/tmp.9DjUgqgCkr/publish
→ Catalog ID: phl-housing
⚠ Derived catalog title 'Phl Housing' from catalog id
$ jq -r .id "$W/publish/catalog.json"
phl-housing
$ jq -r .catalog_id "$W/publish/versions.json"
phl-housing
```

`extract` rejects a bad `--id` before it downloads anything. The command reads a
real service and returns in about one second:

```console
$ time portolan extract arcgis \
    https://services.arcgis.com/fLeGjb7u4uXqeF9q/arcgis/rest/services/_Sharswood_Community_Landmarks/FeatureServer \
    out-bad --auto --id "bad id"
✗ Invalid catalog ID 'bad id': use only letters, digits, hyphens, and underscores
portolan  1.77s user 0.20s system 160% cpu 1.221 total
$ ls -A
wfs_extract
```

No `out-bad` directory exists, and no feature was read.

`extract --id` writes the id when the run completes:

```console
$ portolan extract arcgis \
    https://services.arcgis.com/fLeGjb7u4uXqeF9q/arcgis/rest/services/_Sharswood_Community_Landmarks/FeatureServer \
    publish --auto --id phl-landmarks --license CC-BY-4.0
⚠ Derived catalog title 'Phl Landmarks' from catalog id
→ Seeded metadata.yaml from arcgis_featureserver

✓ Extracted 1/1 layers
$ python3 -c "import json;print(json.load(open('publish/catalog.json'))['id'])"
phl-landmarks
```

A second extraction into that catalog reports the ignored flag:

```console
$ portolan extract arcgis \
    https://services.arcgis.com/fLeGjb7u4uXqeF9q/arcgis/rest/services/_Sharswood_Major_Streets/FeatureServer \
    publish --auto --id other-name --license CC-BY-4.0
⚠ Ignored --id 'other-name'. publish is already a Portolan catalog and keeps the id it was created with.
✓ Extracted 1/1 layers
```

The output directory name `extract` picks by itself now warns:

```console
$ portolan init wfs_extract --auto --license CC-BY-4.0
✓ Initialized Portolan catalog in .../wfs_extract
→ Catalog ID: wfs_extract
⚠ Derived catalog id 'wfs_extract' from the directory name. It looks like a tooling artifact, not the name of the data. Pass --id to set the catalog identity.
⚠ Derived catalog title 'Wfs Extract' from directory name
```

A bad `--id` fails and creates no directory:

```console
$ portolan init newdir --auto --id "bad id" --license CC-BY-4.0
✗ Invalid catalog ID 'bad id': use only letters, digits, hyphens, and underscores
$ ls -A
```

The same command on an existing directory leaves it untouched:

```console
$ portolan init "$W/c" --auto --id "my catalog" --license CC-BY-4.0
✗ Invalid catalog ID 'my catalog': use only letters, digits, hyphens, and underscores
$ ls -A "$W/c"
```

JSON mode carries both the warning and the error:

```console
$ portolan init "$W/publish" --auto --license CC-BY-4.0 --json | jq '.data.warnings'
[
  "Derived catalog id 'publish' from the directory name. It looks like a tooling artifact, not the name of the data. Pass --id to set the catalog identity.",
  "Derived catalog title 'Publish' from directory name"
]
$ portolan init "$W/p2" --auto --id "bad id" --license CC-BY-4.0 --json | jq '.errors'
[
  {
    "type": "InputValidationError",
    "message": "Invalid catalog ID 'bad id': use only letters, digits, hyphens, and underscores"
  }
]
```

The tutorial still builds and validates the same catalog after the script change:

```console
$ uv run pytest tests/docs -q
23 passed, 1 skipped in 15.44s
```

The unit and integration suites pass:

```console
$ uv run pytest tests/unit tests/integration -q -x -p no:randomly --no-cov -n 4
======== 7007 passed, 7 skipped, 220022 warnings in 1142.32s (0:19:02) =========
```

## Tests

New coverage:

- `tests/unit/test_input_hardening.py` covers `validate_catalog_id`.
- `tests/unit/test_cli_init.py` covers `--id`, the override, the rejection, and
  both sides of the artifact warning.
- `tests/integration/test_init_command.py` checks that `--id` reaches
  `catalog.json` and `versions.json` together.
- `tests/integration/extract/test_extract_auto_init.py` runs the real ArcGIS
  auto-init path into a directory named `publish` and asserts the supplied id.
- `tests/unit/extract/common/test_orchestrator_base.py` covers the shared seam,
  the warning relay, and the ignored-id report.
- `tests/unit/test_cli_extract_{arcgis,wfs,carto}.py` check that `--id` reaches
  each source's `ExtractionOptions`.

The fakes for `init_catalog` in `test_orchestrator_base.py` returned `None`. They
now return the real `tuple[Path, list[str]]`, which is what let the dropped
warnings go unnoticed. The same fake in
`tests/unit/extract/arcgis/imageserver/test_extractor.py` broke on the new return
value. It returns the tuple now.

Review coverage:

- `tests/unit/test_cli_extract_{arcgis,wfs,carto}.py` assert that a bad `--id`
  exits 1 and never calls the orchestrator.
- `tests/unit/test_cli_extract_wfs.py` covers the `--raw` message.
- `tests/unit/test_cli_init.py` asserts that a rejected id creates no directory,
  and that `wfs_extract` warns.
- `tests/unit/extract/arcgis/imageserver/test_extractor.py` covers the warning
  relay and the ignored-id report on the raster path.
- `tests/unit/test_input_hardening.py` covers the length limit and every class of
  bad input the pattern rejects.

## Follow-up

The `portolan-skills` repository documents `init` options by hand in
`skills/portolan-cli/SKILL.md`, `skills/portolan-bootstrap/SKILL.md`, and
`skills/sourcecoop/SKILL.md`. Those files need `--id` in a separate pull request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `--id` flag to catalog initialization and ArcGIS, WFS, Carto, and ImageServer extraction commands.
  * Catalog IDs are now written consistently across generated catalog metadata.
  * Added validation for catalog IDs, with clear errors for invalid values.
* **Bug Fixes**
  * Added warnings when IDs are derived from workflow or temporary directory names.
  * Preserved the existing catalog ID when adding assets to an existing catalog.
* **Documentation**
  * Updated the Philadelphia housing example to demonstrate setting a stable catalog ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
