### PR TITLE
Benchmark tests fail on main because their fixture declares no license

### DIFF
--- a/tests/benchmark/test_batch_versioning_benchmark.py
+++ b/tests/benchmark/test_batch_versioning_benchmark.py
@@ -22,6 +22,8 @@ def benchmark_catalog(tmp_path: Path) -> Path:
     portolan_dir = tmp_path / ".portolan"
     portolan_dir.mkdir()
     (portolan_dir / "config.yaml").write_text("version: 1\n")
+    # add_files rejects a collection with no license (issue #842).
+    (portolan_dir / "metadata.yaml").write_text('license: "CC-BY-4.0"\n')
 
     catalog_data = {
         "type": "Catalog",


### PR DESCRIPTION
## What changed

The `benchmark_catalog` fixture in `tests/benchmark/test_batch_versioning_benchmark.py` now writes `.portolan/metadata.yaml` with a license. The fixture already writes `.portolan/config.yaml` and `catalog.json` by hand. It did not declare a license.

## Why

Two benchmark tests failed on `main`. The fixture built a collection with no license. `add_files` calls `_require_licenses` and rejects that collection. The product behavior is correct. The fixture was stale.

Release v1.0.0b0 (`d0bc747`) added `add._require_licenses`. That change did not update fixtures that build `.portolan/` by hand. This closes #842.

Pull request CI does not run the benchmark marker. `ci.yml` excludes it with `-m "not network and not slow and not benchmark"`. Only `nightly.yml` runs `-m benchmark`. The nightly workflow failed on every run from 2026-08-26 through 2026-08-30 for this reason.

## Verification

Before the change, the two tests fail on the missing license:

```console
$ uv run pytest tests/benchmark/test_batch_versioning_benchmark.py -q --no-cov
portolan_cli/add.py:1252: in _require_licenses
    raise MissingLicenseError(f"collection '{coll_id}'", gap)
E   portolan_cli.errors.MissingLicenseError: [PRTLN-VAL004] No usable license for collection 'test-collection': no license is declared
========================= 2 failed, 1 passed in 8.13s ==========================
```

After the change, the full benchmark file passes:

```console
$ uv run pytest tests/benchmark/test_batch_versioning_benchmark.py -q --no-cov
tests/benchmark/test_batch_versioning_benchmark.py ...                   [100%]
============================== 3 passed in 25.37s ==============================
```

The fast test gate stays green:

```console
$ uv run pytest tests/ --ignore=tests/iceberg/ -m 'not network and not slow and not benchmark' -n 8 -q --tb=short
===== 7130 passed, 8 skipped, 1 xfailed, 79 warnings in 364.98s (0:06:04) ======
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #842

---
*Automated by agent-farm.*