### PR TITLE
perf(ci): halve the CI test-matrix wall time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        exclude:
-          # Reduce matrix size - test older Python only on Linux
-          - os: macos-latest
-            python-version: '3.10'
-          - os: windows-latest
-            python-version: '3.10'
+        # Anchor cells (suite: full) run the whole suite on every event: the
+        # newest interpreter on each OS, plus the ubuntu-3.11 coverage cell.
+        # The other cells run the unit lane on pull requests and the full
+        # suite on push to main, so an interpreter-specific integration break
+        # surfaces at merge instead of never. 3.10 runs on Linux only, as
+        # before.
+        include:
+          - {os: ubuntu-latest, python-version: '3.11', suite: full}
+          - {os: ubuntu-latest, python-version: '3.13', suite: full}
+          - {os: windows-latest, python-version: '3.13', suite: full}
+          - {os: macos-latest, python-version: '3.13', suite: full}
+          - {os: ubuntu-latest, python-version: '3.10', suite: unit}
+          - {os: ubuntu-latest, python-version: '3.12', suite: unit}
+          - {os: windows-latest, python-version: '3.11', suite: unit}
+          - {os: windows-latest, python-version: '3.12', suite: unit}
+          - {os: macos-latest, python-version: '3.11', suite: unit}
+          - {os: macos-latest, python-version: '3.12', suite: unit}
     env:
       # Prevent obstore from attempting EC2 metadata service calls
       # GitHub Actions runners aren't EC2 instances, so IMDS requests fail
@@ -209,14 +218,19 @@ jobs:
           HYPOTHESIS_PROFILE: ci
           MATRIX_OS: ${{ matrix.os }}
           MATRIX_PY: ${{ matrix.python-version }}
+          MATRIX_SUITE: ${{ matrix.suite }}
         shell: bash
         run: |
           cov_args=()
           if [ "$MATRIX_OS" = "ubuntu-latest" ] && [ "$MATRIX_PY" = "3.11" ]; then
             cov_args=(--cov=portolan_cli --cov-report=term-missing --cov-report=xml)
           fi
+          marker="not network and not slow and not benchmark"
+          if [ "$MATRIX_SUITE" = "unit" ] && [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            marker="unit and not network and not slow and not benchmark"
+          fi
           uv run pytest tests/ --ignore=tests/iceberg/ --tb=short \
-            -m "not network and not slow and not benchmark" \
+            -m "$marker" \
             -n logical --dist loadscope \
             --durations=25 --durations-min=1.0 \
             "${cov_args[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,31 @@ jobs:
           command: uv sync --all-extras
 
       - name: Run tests (unit + integration, no network, no iceberg)
-        run: uv run pytest tests/ --ignore=tests/iceberg/ -v --tb=short -m "not network and not slow and not benchmark" -n auto --dist loadscope --cov=portolan_cli --cov-report=term-missing --cov-report=xml
+        # Speed decisions (see context/shared/documentation/ci.md):
+        # - `-n logical`: `-n auto` counts physical cores and started only 2
+        #   workers on the 4-vCPU ubuntu/windows runners. Logical count starts 4.
+        # - Coverage only on the one cell that uploads to Codecov. Branch
+        #   coverage on the other 9 cells cost 20-40% wall time and was
+        #   discarded.
+        # - HYPOTHESIS_PROFILE=ci selects the reduced deterministic profile
+        #   from tests/conftest.py. Nightly keeps the full default profile.
+        # - --durations=25 records the slowest tests so a slow-test regression
+        #   is visible in the log.
+        env:
+          HYPOTHESIS_PROFILE: ci
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_PY: ${{ matrix.python-version }}
+        shell: bash
+        run: |
+          cov_args=()
+          if [ "$MATRIX_OS" = "ubuntu-latest" ] && [ "$MATRIX_PY" = "3.11" ]; then
+            cov_args=(--cov=portolan_cli --cov-report=term-missing --cov-report=xml)
+          fi
+          uv run pytest tests/ --ignore=tests/iceberg/ --tb=short \
+            -m "not network and not slow and not benchmark" \
+            -n logical --dist loadscope \
+            --durations=25 --durations-min=1.0 \
+            "${cov_args[@]}"
 
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -16,7 +16,7 @@ AI agents write most of the code. Human review doesn't scale to match AI output 
 | Tier | Trigger | Duration | Purpose |
 |------|---------|----------|---------|
 | **Tier 1** | prek hook | < 30s | Fast feedback loop for developers |
-| **Tier 2** | PR / push to main | 2-5 min | Comprehensive quality gates |
+| **Tier 2** | PR / push to main | 5-10 min | Comprehensive quality gates |
 | **Tier 3** | Nightly schedule | 10-30 min | Expensive checks, trend tracking |
 
 ---
@@ -79,8 +79,18 @@ non-deterministic in CI — drift is still caught by the non-mutating
 - Python versions: 3.10, 3.11, 3.12, 3.13
 - Operating systems: Ubuntu, macOS, Windows
 - Excludes network, slow, and benchmark tests
-- Coverage reporting to Codecov (the `codecov/patch` changed-line gate is a
-  required check — see [Branch protection](#branch-protection))
+- Runs pytest with `-n logical`. The 4-vCPU runners report 2 physical cores,
+  so `-n auto` started only 2 workers. The logical count starts 4.
+- Coverage runs only on the ubuntu-3.11 cell. That is the one cell that
+  uploads to Codecov (the `codecov/patch` changed-line gate is a required
+  check — see [Branch protection](#branch-protection)). The other 9 cells
+  skip coverage measurement, so platform-specific branches are not counted.
+- Hypothesis runs the reduced deterministic `ci` profile (25 examples,
+  derandomized), selected with `HYPOTHESIS_PROFILE=ci` and registered in
+  `tests/conftest.py`. Nightly runs the default profile with 100 randomized
+  examples, so example exploration continues there.
+- `--durations=25` prints the slowest tests in every run, so a slow-test
+  regression is visible in the log.
 
 #### `docs` — Documentation Build
 

--- a/context/shared/documentation/ci.md
+++ b/context/shared/documentation/ci.md
@@ -79,6 +79,11 @@ non-deterministic in CI — drift is still caught by the non-mutating
 - Python versions: 3.10, 3.11, 3.12, 3.13
 - Operating systems: Ubuntu, macOS, Windows
 - Excludes network, slow, and benchmark tests
+- Four anchor cells run the full suite on every event: ubuntu-3.11 (the
+  coverage cell), ubuntu-3.13, windows-3.13, and macos-3.13. The other six
+  cells run only unit tests on pull requests. Every cell runs the full suite
+  on push to main, so an interpreter-specific integration break surfaces at
+  merge.
 - Runs pytest with `-n logical`. The 4-vCPU runners report 2 physical cores,
   so `-n auto` started only 2 workers. The logical count starts 4.
 - Coverage runs only on the ubuntu-3.11 cell. That is the one cell that

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ asyncio_default_fixture_loop_scope = "function"
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-v --tb=short --cov=portolan_cli --cov-report=term-missing --cov-fail-under=0"
+addopts = "--tb=short"
 markers = [
     "unit: Fast, isolated, no I/O (< 100ms each)",
     "integration: Multi-component, may touch filesystem",
@@ -272,8 +272,8 @@ also_copy = [
   ".mutation-shards.json",
 ]
 # The stats/baseline run must mirror the fast CI test job, not the whole suite:
-# - --no-cov: pyproject's addopts inject --cov, whose instrumentation conflicts
-# with mutmut's; without this the stats phase is unreliable.
+# - --no-cov: keeps coverage instrumentation off even when a caller or config
+# adds --cov (it conflicts with mutmut's); addopts no longer injects it.
 # - --tb=short: a stats-phase failure must show WHERE it broke.
 # - marker filter: exclude network/slow/benchmark/e2e (mutation of portolan_cli
 # is validated by the fast, offline suite; e2e needs Docker, network needs a

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,23 @@ if _MUTMUT_ENV_KEY in os.environ:
     _root_logger.setLevel(_logging.WARNING)
 
 
+# CI selects a reduced, deterministic Hypothesis profile with
+# HYPOTHESIS_PROFILE=ci (set in .github/workflows/ci.yml). A PR run gets a fast
+# reproducible check. Nightly does not set the variable, so it keeps the
+# default profile with 100 randomized examples, and example exploration is not
+# lost. A test's own @settings(...) overrides these values.
+if _MUTMUT_ENV_KEY not in os.environ and os.environ.get("HYPOTHESIS_PROFILE") == "ci":
+    from hypothesis import settings as _ci_hypothesis_settings
+
+    _ci_hypothesis_settings.register_profile(
+        "ci",
+        max_examples=25,
+        derandomize=True,
+        print_blob=True,
+    )
+    _ci_hypothesis_settings.load_profile("ci")
+
+
 @contextmanager
 def cleared_environ(**overrides: str) -> Iterator[None]:
     """Clear os.environ for the block, preserving mutmut's bookkeeping var.

--- a/tests/integration/test_add_spatial_optimization.py
+++ b/tests/integration/test_add_spatial_optimization.py
@@ -748,7 +748,6 @@ class TestAWgs84FileGainsItsCoveringColumn:
         """
         import geopandas as gpd
         import numpy as np
-        from shapely.geometry import Point
 
         root = tmp_path / "catalog"
         collection = root / "points"
@@ -756,12 +755,10 @@ class TestAWgs84FileGainsItsCoveringColumn:
         target = collection / "points.parquet"
         rng = np.random.default_rng(0)
         n = 100_000  # 512 partitions need 100 rows each to clear gpio's floor
+        # Vectorized: a Python loop of Point objects took tens of seconds.
         gpd.GeoDataFrame(
             {"id": range(n)},
-            geometry=[
-                Point(x, y)
-                for x, y in zip(rng.uniform(-180, 180, n), rng.uniform(-90, 90, n), strict=True)
-            ],
+            geometry=gpd.points_from_xy(rng.uniform(-180, 180, n), rng.uniform(-90, 90, n)),
             crs="EPSG:4326",
         ).to_parquet(target)
         _init(root)

--- a/tests/integration/test_partition_paths.py
+++ b/tests/integration/test_partition_paths.py
@@ -8,6 +8,11 @@ Per Issue #349/#399: Partitioned GeoParquet files should:
 These tests verify the fix for the path mismatch bug where:
 - versions.json recorded "data_XXXX/XXXX.parquet"
 - But actual files were "kdtree_cell=XXXX/XXXX.parquet"
+
+The tests are module-level functions, not class methods, on purpose.
+`--dist loadscope` groups class methods per class, so two classes land on two
+xdist workers and each worker builds the module-scoped catalog again. Module-
+level functions group per module, so one worker builds the catalog one time.
 """
 
 from __future__ import annotations
@@ -19,6 +24,8 @@ import pytest
 from click.testing import CliRunner
 
 from portolan_cli.cli import cli
+
+pytestmark = pytest.mark.integration
 
 
 def _set_partitioning_config(catalog_root: Path, threshold_gb: float = 0.00001) -> None:
@@ -37,9 +44,7 @@ def partitioned_catalog(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path,
 
     The build partitions the data into 512+ Hive directories and costs tens of
     seconds. Every test in this module reads the result and does not change it,
-    so the fixture is module-scoped and the build runs one time. The CI runner
-    uses `--dist loadscope`, which keeps the module on one xdist worker, so the
-    fixture does not rebuild across workers.
+    so the fixture is module-scoped and the build runs one time.
 
     Returns (catalog_root, collection_dir).
     """
@@ -80,161 +85,155 @@ def partitioned_catalog(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path,
     return catalog_root, collection_dir
 
 
-@pytest.mark.integration
-class TestPartitionPathConsistency:
-    """Tests for partition path consistency between filesystem and versions.json."""
+def test_versions_json_paths_match_hive_structure(
+    partitioned_catalog: tuple[Path, Path],
+) -> None:
+    """versions.json paths should match actual Hive-style directory structure."""
+    _catalog_root, collection_dir = partitioned_catalog
 
-    def test_versions_json_paths_match_hive_structure(
-        self, partitioned_catalog: tuple[Path, Path]
-    ) -> None:
-        """versions.json paths should match actual Hive-style directory structure."""
-        _catalog_root, collection_dir = partitioned_catalog
+    versions_path = collection_dir / "versions.json"
+    assert versions_path.exists(), "versions.json not created"
 
-        versions_path = collection_dir / "versions.json"
-        assert versions_path.exists(), "versions.json not created"
+    versions_data = json.loads(versions_path.read_text())
+    assets = versions_data["versions"][0]["assets"]
 
-        versions_data = json.loads(versions_path.read_text())
-        assets = versions_data["versions"][0]["assets"]
+    # Get actual partition directories
+    partition_dirs = list(collection_dir.glob("kdtree_cell=*"))
+    assert len(partition_dirs) > 0, "No partition directories created"
 
-        # Get actual partition directories
-        partition_dirs = list(collection_dir.glob("kdtree_cell=*"))
-        assert len(partition_dirs) > 0, "No partition directories created"
+    # Verify each partition directory has a corresponding entry in versions.json
+    for partition_dir in partition_dirs:
+        dir_name = partition_dir.name  # e.g., "kdtree_cell=0000000000"
+        parquet_files = list(partition_dir.glob("*.parquet"))
+        assert len(parquet_files) == 1, f"Expected 1 parquet in {dir_name}"
 
-        # Verify each partition directory has a corresponding entry in versions.json
-        for partition_dir in partition_dirs:
-            dir_name = partition_dir.name  # e.g., "kdtree_cell=0000000000"
-            parquet_files = list(partition_dir.glob("*.parquet"))
-            assert len(parquet_files) == 1, f"Expected 1 parquet in {dir_name}"
+        filename = parquet_files[0].name
+        expected_key = f"{dir_name}/{filename}"
 
-            filename = parquet_files[0].name
-            expected_key = f"{dir_name}/{filename}"
+        assert expected_key in assets, (
+            f"versions.json missing entry for {expected_key}. Keys: {list(assets.keys())[:5]}..."
+        )
 
-            assert expected_key in assets, (
-                f"versions.json missing entry for {expected_key}. "
-                f"Keys: {list(assets.keys())[:5]}..."
-            )
 
-    def test_glob_pattern_matches_actual_files(
-        self, partitioned_catalog: tuple[Path, Path]
-    ) -> None:
-        """Glob pattern in collection.json should match actual partition files."""
-        _catalog_root, collection_dir = partitioned_catalog
+def test_glob_pattern_matches_actual_files(
+    partitioned_catalog: tuple[Path, Path],
+) -> None:
+    """Glob pattern in collection.json should match actual partition files."""
+    _catalog_root, collection_dir = partitioned_catalog
 
-        # Check collection.json for glob asset
-        collection_path = collection_dir / "collection.json"
-        collection_data = json.loads(collection_path.read_text())
+    # Check collection.json for glob asset
+    collection_path = collection_dir / "collection.json"
+    collection_data = json.loads(collection_path.read_text())
 
-        # Find glob asset
-        glob_asset = None
-        for _key, asset in collection_data.get("assets", {}).items():
-            if "*" in asset.get("href", ""):
-                glob_asset = asset
-                break
+    # Find glob asset
+    glob_asset = None
+    for _key, asset in collection_data.get("assets", {}).items():
+        if "*" in asset.get("href", ""):
+            glob_asset = asset
+            break
 
-        assert glob_asset is not None, "No glob asset found in collection.json"
+    assert glob_asset is not None, "No glob asset found in collection.json"
 
-        # Extract glob pattern and verify structure (not exact match - allows strategy changes)
-        href = glob_asset["href"]  # e.g., "./kdtree_cell=*/*.parquet"
-        assert href.startswith("./"), f"Glob should be relative: {href}"
-        assert "*" in href, f"Glob should contain wildcard: {href}"
-        assert href.endswith("/*.parquet"), f"Glob should match parquet files: {href}"
+    # Extract glob pattern and verify structure (not exact match - allows strategy changes)
+    href = glob_asset["href"]  # e.g., "./kdtree_cell=*/*.parquet"
+    assert href.startswith("./"), f"Glob should be relative: {href}"
+    assert "*" in href, f"Glob should contain wildcard: {href}"
+    assert href.endswith("/*.parquet"), f"Glob should match parquet files: {href}"
 
-        # Verify glob actually matches files
-        pattern = href.lstrip("./")  # "kdtree_cell=*/*.parquet"
+    # Verify glob actually matches files
+    pattern = href.lstrip("./")  # "kdtree_cell=*/*.parquet"
+    matched_files = list(collection_dir.glob(pattern))
+
+    assert len(matched_files) > 0, f"Glob pattern {pattern} matched no files"
+
+
+def test_glob_excludes_non_parquet_files(
+    partitioned_catalog: tuple[Path, Path],
+) -> None:
+    """Glob pattern should NOT match non-parquet files in partition directories."""
+    _catalog_root, collection_dir = partitioned_catalog
+
+    # Add a non-parquet file to a partition directory
+    partition_dirs = list(collection_dir.glob("kdtree_cell=*"))
+    assert len(partition_dirs) > 0
+    decoy_file = partition_dirs[0] / "metadata.json"
+    decoy_file.write_text('{"decoy": true}')
+
+    try:
+        # Get glob pattern and verify it doesn't match the decoy
+        pattern = "kdtree_cell=*/*.parquet"
         matched_files = list(collection_dir.glob(pattern))
 
-        assert len(matched_files) > 0, f"Glob pattern {pattern} matched no files"
+        # Verify decoy is NOT in matches
+        matched_names = [f.name for f in matched_files]
+        assert "metadata.json" not in matched_names, "Glob incorrectly matched non-parquet file"
 
-    def test_glob_excludes_non_parquet_files(self, partitioned_catalog: tuple[Path, Path]) -> None:
-        """Glob pattern should NOT match non-parquet files in partition directories."""
-        _catalog_root, collection_dir = partitioned_catalog
-
-        # Add a non-parquet file to a partition directory
-        partition_dirs = list(collection_dir.glob("kdtree_cell=*"))
-        assert len(partition_dirs) > 0
-        decoy_file = partition_dirs[0] / "metadata.json"
-        decoy_file.write_text('{"decoy": true}')
-
-        try:
-            # Get glob pattern and verify it doesn't match the decoy
-            pattern = "kdtree_cell=*/*.parquet"
-            matched_files = list(collection_dir.glob(pattern))
-
-            # Verify decoy is NOT in matches
-            matched_names = [f.name for f in matched_files]
-            assert "metadata.json" not in matched_names, "Glob incorrectly matched non-parquet file"
-
-            # All matches should be .parquet
-            for f in matched_files:
-                assert f.suffix == ".parquet", f"Non-parquet file matched: {f}"
-        finally:
-            # The catalog fixture is module-scoped and shared. Remove the decoy
-            # so later tests see the exact `add` output.
-            decoy_file.unlink()
-
-    def test_duckdb_can_read_via_glob(self, partitioned_catalog: tuple[Path, Path]) -> None:
-        """DuckDB should be able to read partitioned data via glob pattern."""
-        pytest.importorskip("duckdb")
-        import duckdb
-
-        _catalog_root, collection_dir = partitioned_catalog
-
-        # Read collection.json to get glob pattern
-        collection_path = collection_dir / "collection.json"
-        collection_data = json.loads(collection_path.read_text())
-
-        # Find glob asset
-        glob_href = None
-        for asset in collection_data.get("assets", {}).values():
-            if "*" in asset.get("href", ""):
-                glob_href = asset["href"]
-                break
-
-        assert glob_href is not None, "No glob asset found"
-
-        # Convert to absolute path for DuckDB
-        glob_path = str(collection_dir / glob_href.lstrip("./"))
-
-        # Query via DuckDB
-        result = duckdb.sql(f"SELECT count(*) as cnt FROM '{glob_path}'").fetchone()
-        assert result is not None
-        row_count = result[0]
-
-        # Should have all 100k rows
-        assert row_count == 100_000, f"Expected 100000 rows, got {row_count}"
+        # All matches should be .parquet
+        for f in matched_files:
+            assert f.suffix == ".parquet", f"Non-parquet file matched: {f}"
+    finally:
+        # The catalog fixture is module-scoped and shared. Remove the decoy
+        # so later tests see the exact `add` output.
+        decoy_file.unlink()
 
 
-@pytest.mark.integration
-class TestPushGlobTransformation:
-    """Tests for partition:glob field transformation during push."""
+def test_duckdb_can_read_via_glob(partitioned_catalog: tuple[Path, Path]) -> None:
+    """DuckDB should be able to read partitioned data via glob pattern."""
+    pytest.importorskip("duckdb")
+    import duckdb
 
-    def test_push_dryrun_shows_correct_glob_url(
-        self, partitioned_catalog: tuple[Path, Path]
-    ) -> None:
-        """Push dry-run should show correct glob URL transformation."""
-        _catalog_root, collection_dir = partitioned_catalog
+    _catalog_root, collection_dir = partitioned_catalog
 
-        # Verify transformation function works correctly
-        from portolan_cli.sync.push import _transform_collection_glob_assets
+    # Read collection.json to get glob pattern
+    collection_path = collection_dir / "collection.json"
+    collection_data = json.loads(collection_path.read_text())
 
-        collection_path = collection_dir / "collection.json"
-        content = collection_path.read_bytes()
+    # Find glob asset
+    glob_href = None
+    for asset in collection_data.get("assets", {}).values():
+        if "*" in asset.get("href", ""):
+            glob_href = asset["href"]
+            break
 
-        transformed = _transform_collection_glob_assets(content, "s3://bucket/catalog", "points")
-        transformed_data = json.loads(transformed)
+    assert glob_href is not None, "No glob asset found"
 
-        # Find glob asset and verify partition:glob structure (not exact match)
-        for asset in transformed_data.get("assets", {}).values():
-            if "*" in asset.get("href", ""):
-                assert "partition:glob" in asset, "partition:glob not added"
-                assert "portolan:glob" not in asset, "the removed legacy field is back"
-                glob_url = asset["partition:glob"]
-                # Verify URL structure without hardcoding exact pattern
-                assert glob_url.startswith("s3://bucket/catalog/points/"), (
-                    f"Wrong base URL: {glob_url}"
-                )
-                assert "*" in glob_url, f"Missing wildcard in glob URL: {glob_url}"
-                assert glob_url.endswith("/*.parquet"), f"Wrong suffix: {glob_url}"
-                break
-        else:
-            pytest.fail("No glob asset found in transformed collection")
+    # Convert to absolute path for DuckDB
+    glob_path = str(collection_dir / glob_href.lstrip("./"))
+
+    # Query via DuckDB
+    result = duckdb.sql(f"SELECT count(*) as cnt FROM '{glob_path}'").fetchone()
+    assert result is not None
+    row_count = result[0]
+
+    # Should have all 100k rows
+    assert row_count == 100_000, f"Expected 100000 rows, got {row_count}"
+
+
+def test_push_dryrun_shows_correct_glob_url(
+    partitioned_catalog: tuple[Path, Path],
+) -> None:
+    """Push dry-run should show correct glob URL transformation."""
+    _catalog_root, collection_dir = partitioned_catalog
+
+    # Verify transformation function works correctly
+    from portolan_cli.sync.push import _transform_collection_glob_assets
+
+    collection_path = collection_dir / "collection.json"
+    content = collection_path.read_bytes()
+
+    transformed = _transform_collection_glob_assets(content, "s3://bucket/catalog", "points")
+    transformed_data = json.loads(transformed)
+
+    # Find glob asset and verify partition:glob structure (not exact match)
+    for asset in transformed_data.get("assets", {}).values():
+        if "*" in asset.get("href", ""):
+            assert "partition:glob" in asset, "partition:glob not added"
+            assert "portolan:glob" not in asset, "the removed legacy field is back"
+            glob_url = asset["partition:glob"]
+            # Verify URL structure without hardcoding exact pattern
+            assert glob_url.startswith("s3://bucket/catalog/points/"), f"Wrong base URL: {glob_url}"
+            assert "*" in glob_url, f"Missing wildcard in glob URL: {glob_url}"
+            assert glob_url.endswith("/*.parquet"), f"Wrong suffix: {glob_url}"
+            break
+    else:
+        pytest.fail("No glob asset found in transformed collection")

--- a/tests/integration/test_partition_paths.py
+++ b/tests/integration/test_partition_paths.py
@@ -21,44 +21,6 @@ from click.testing import CliRunner
 from portolan_cli.cli import cli
 
 
-@pytest.fixture
-def runner() -> CliRunner:
-    """Create a CLI test runner."""
-    return CliRunner()
-
-
-@pytest.fixture
-def initialized_catalog(tmp_path: Path) -> Path:
-    """Create an initialized Portolan catalog using CLI."""
-    result = CliRunner().invoke(cli, ["init", str(tmp_path), "--auto", "--license", "CC-BY-4.0"])
-    assert result.exit_code == 0, f"Init failed: {result.output}"
-    return tmp_path
-
-
-@pytest.fixture
-def large_geoparquet(initialized_catalog: Path) -> Path:
-    """Create a GeoParquet file large enough to trigger partitioning."""
-    import geopandas as gpd
-    import numpy as np
-    from shapely.geometry import Point
-
-    collection_dir = initialized_catalog / "points"
-    collection_dir.mkdir()
-
-    # Create 100k points - exceeds minimum (512 partitions * 100 rows = 51,200 minimum)
-    n = 100_000
-    gdf = gpd.GeoDataFrame(
-        {"id": range(n), "val": np.random.rand(n)},
-        geometry=[
-            Point(np.random.uniform(-180, 180), np.random.uniform(-90, 90)) for _ in range(n)
-        ],
-        crs="EPSG:4326",
-    )
-    parquet_path = collection_dir / "data.parquet"
-    gdf.to_parquet(parquet_path)
-    return parquet_path
-
-
 def _set_partitioning_config(catalog_root: Path, threshold_gb: float = 0.00001) -> None:
     """Enable partitioning with low threshold via direct config file manipulation."""
     config_path = catalog_root / ".portolan" / "config.yaml"
@@ -69,41 +31,73 @@ partitioning.threshold_gb: {threshold_gb}
     config_path.write_text(config_content)
 
 
+@pytest.fixture(scope="module")
+def partitioned_catalog(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Initialize a catalog, write 100k points, and run one partitioning `add`.
+
+    The build partitions the data into 512+ Hive directories and costs tens of
+    seconds. Every test in this module reads the result and does not change it,
+    so the fixture is module-scoped and the build runs one time. The CI runner
+    uses `--dist loadscope`, which keeps the module on one xdist worker, so the
+    fixture does not rebuild across workers.
+
+    Returns (catalog_root, collection_dir).
+    """
+    import geopandas as gpd
+    import numpy as np
+
+    catalog_root = tmp_path_factory.mktemp("partition-catalog")
+    result = CliRunner().invoke(
+        cli, ["init", str(catalog_root), "--auto", "--license", "CC-BY-4.0"]
+    )
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+
+    collection_dir = catalog_root / "points"
+    collection_dir.mkdir()
+
+    # 100k points exceeds the partitioning minimum
+    # (512 partitions * 100 rows = 51,200). Vectorized construction with
+    # points_from_xy: a Python loop of shapely Point objects took tens of
+    # seconds per build.
+    n = 100_000
+    rng = np.random.default_rng(42)
+    gdf = gpd.GeoDataFrame(
+        {"id": range(n), "val": rng.random(n)},
+        geometry=gpd.points_from_xy(rng.uniform(-180, 180, n), rng.uniform(-90, 90, n)),
+        crs="EPSG:4326",
+    )
+    gdf.to_parquet(collection_dir / "data.parquet")
+
+    _set_partitioning_config(catalog_root)
+
+    result = CliRunner().invoke(
+        cli,
+        ["add", "--force", "--portolan-dir", str(catalog_root), str(collection_dir)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, f"Add failed: {result.output}"
+    assert "Added" in result.output
+    return catalog_root, collection_dir
+
+
 @pytest.mark.integration
 class TestPartitionPathConsistency:
     """Tests for partition path consistency between filesystem and versions.json."""
 
     def test_versions_json_paths_match_hive_structure(
-        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+        self, partitioned_catalog: tuple[Path, Path]
     ) -> None:
         """versions.json paths should match actual Hive-style directory structure."""
-        # Enable partitioning with very low threshold via direct config
-        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
+        _catalog_root, collection_dir = partitioned_catalog
 
-        # Add the file (should trigger partitioning)
-        result = runner.invoke(
-            cli,
-            [
-                "add",
-                "--force",
-                "--portolan-dir",
-                str(initialized_catalog),
-                str(large_geoparquet.parent),
-            ],
-            catch_exceptions=False,
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
-        assert "Added" in result.output
-
-        # Check versions.json
-        versions_path = large_geoparquet.parent / "versions.json"
+        versions_path = collection_dir / "versions.json"
         assert versions_path.exists(), "versions.json not created"
 
         versions_data = json.loads(versions_path.read_text())
         assets = versions_data["versions"][0]["assets"]
 
         # Get actual partition directories
-        partition_dirs = list(large_geoparquet.parent.glob("kdtree_cell=*"))
+        partition_dirs = list(collection_dir.glob("kdtree_cell=*"))
         assert len(partition_dirs) > 0, "No partition directories created"
 
         # Verify each partition directory has a corresponding entry in versions.json
@@ -121,27 +115,13 @@ class TestPartitionPathConsistency:
             )
 
     def test_glob_pattern_matches_actual_files(
-        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+        self, partitioned_catalog: tuple[Path, Path]
     ) -> None:
         """Glob pattern in collection.json should match actual partition files."""
-        # Enable partitioning via direct config
-        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
-
-        # Add the file
-        result = runner.invoke(
-            cli,
-            [
-                "add",
-                "--force",
-                "--portolan-dir",
-                str(initialized_catalog),
-                str(large_geoparquet.parent),
-            ],
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
+        _catalog_root, collection_dir = partitioned_catalog
 
         # Check collection.json for glob asset
-        collection_path = large_geoparquet.parent / "collection.json"
+        collection_path = collection_dir / "collection.json"
         collection_data = json.loads(collection_path.read_text())
 
         # Find glob asset
@@ -160,78 +140,47 @@ class TestPartitionPathConsistency:
         assert href.endswith("/*.parquet"), f"Glob should match parquet files: {href}"
 
         # Verify glob actually matches files
-
-        collection_dir = large_geoparquet.parent
-        # Convert glob pattern to pathlib pattern
         pattern = href.lstrip("./")  # "kdtree_cell=*/*.parquet"
         matched_files = list(collection_dir.glob(pattern))
 
         assert len(matched_files) > 0, f"Glob pattern {pattern} matched no files"
 
-    def test_glob_excludes_non_parquet_files(
-        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
-    ) -> None:
+    def test_glob_excludes_non_parquet_files(self, partitioned_catalog: tuple[Path, Path]) -> None:
         """Glob pattern should NOT match non-parquet files in partition directories."""
-        # Enable partitioning via direct config
-        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
-
-        # Add the file
-        result = runner.invoke(
-            cli,
-            [
-                "add",
-                "--force",
-                "--portolan-dir",
-                str(initialized_catalog),
-                str(large_geoparquet.parent),
-            ],
-        )
-        assert result.exit_code == 0
+        _catalog_root, collection_dir = partitioned_catalog
 
         # Add a non-parquet file to a partition directory
-        partition_dirs = list(large_geoparquet.parent.glob("kdtree_cell=*"))
+        partition_dirs = list(collection_dir.glob("kdtree_cell=*"))
         assert len(partition_dirs) > 0
         decoy_file = partition_dirs[0] / "metadata.json"
         decoy_file.write_text('{"decoy": true}')
 
-        # Get glob pattern and verify it doesn't match the decoy
-        collection_dir = large_geoparquet.parent
-        pattern = "kdtree_cell=*/*.parquet"
-        matched_files = list(collection_dir.glob(pattern))
+        try:
+            # Get glob pattern and verify it doesn't match the decoy
+            pattern = "kdtree_cell=*/*.parquet"
+            matched_files = list(collection_dir.glob(pattern))
 
-        # Verify decoy is NOT in matches
-        matched_names = [f.name for f in matched_files]
-        assert "metadata.json" not in matched_names, "Glob incorrectly matched non-parquet file"
+            # Verify decoy is NOT in matches
+            matched_names = [f.name for f in matched_files]
+            assert "metadata.json" not in matched_names, "Glob incorrectly matched non-parquet file"
 
-        # All matches should be .parquet
-        for f in matched_files:
-            assert f.suffix == ".parquet", f"Non-parquet file matched: {f}"
+            # All matches should be .parquet
+            for f in matched_files:
+                assert f.suffix == ".parquet", f"Non-parquet file matched: {f}"
+        finally:
+            # The catalog fixture is module-scoped and shared. Remove the decoy
+            # so later tests see the exact `add` output.
+            decoy_file.unlink()
 
-    def test_duckdb_can_read_via_glob(
-        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
-    ) -> None:
+    def test_duckdb_can_read_via_glob(self, partitioned_catalog: tuple[Path, Path]) -> None:
         """DuckDB should be able to read partitioned data via glob pattern."""
         pytest.importorskip("duckdb")
         import duckdb
 
-        # Enable partitioning via direct config
-        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
-
-        # Add the file
-        result = runner.invoke(
-            cli,
-            [
-                "add",
-                "--force",
-                "--portolan-dir",
-                str(initialized_catalog),
-                str(large_geoparquet.parent),
-            ],
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
+        _catalog_root, collection_dir = partitioned_catalog
 
         # Read collection.json to get glob pattern
-        collection_path = large_geoparquet.parent / "collection.json"
+        collection_path = collection_dir / "collection.json"
         collection_data = json.loads(collection_path.read_text())
 
         # Find glob asset
@@ -244,7 +193,6 @@ class TestPartitionPathConsistency:
         assert glob_href is not None, "No glob asset found"
 
         # Convert to absolute path for DuckDB
-        collection_dir = large_geoparquet.parent
         glob_path = str(collection_dir / glob_href.lstrip("./"))
 
         # Query via DuckDB
@@ -261,29 +209,15 @@ class TestPushGlobTransformation:
     """Tests for partition:glob field transformation during push."""
 
     def test_push_dryrun_shows_correct_glob_url(
-        self, runner: CliRunner, initialized_catalog: Path, large_geoparquet: Path
+        self, partitioned_catalog: tuple[Path, Path]
     ) -> None:
         """Push dry-run should show correct glob URL transformation."""
-        # Enable partitioning via direct config
-        _set_partitioning_config(initialized_catalog, threshold_gb=0.00001)
-
-        # Add the file
-        result = runner.invoke(
-            cli,
-            [
-                "add",
-                "--force",
-                "--portolan-dir",
-                str(initialized_catalog),
-                str(large_geoparquet.parent),
-            ],
-        )
-        assert result.exit_code == 0
+        _catalog_root, collection_dir = partitioned_catalog
 
         # Verify transformation function works correctly
         from portolan_cli.sync.push import _transform_collection_glob_assets
 
-        collection_path = large_geoparquet.parent / "collection.json"
+        collection_path = collection_dir / "collection.json"
         content = collection_path.read_bytes()
 
         transformed = _transform_collection_glob_assets(content, "s3://bucket/catalog", "points")

--- a/tests/integration/test_push_integration.py
+++ b/tests/integration/test_push_integration.py
@@ -1226,7 +1226,7 @@ class TestPushOutputInvariants:
         versions_pushed=st.integers(min_value=0, max_value=100),
     )
     @settings(
-        max_examples=50,
+        max_examples=25,
         suppress_health_check=[
             HealthCheck.function_scoped_fixture,
             HealthCheck.differing_executors,

--- a/tests/integration/test_versioning_stress.py
+++ b/tests/integration/test_versioning_stress.py
@@ -18,7 +18,7 @@ import json
 import os
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -152,62 +152,60 @@ def s3_bucket(moto_server: str) -> Generator[tuple[str, str], None, None]:
 # =============================================================================
 
 
+@pytest.fixture(scope="module")
+def single_file_add_versions(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> dict[str, Any]:
+    """Run one `add` of one file and return the parsed versions.json.
+
+    The `add` conversion dominates this module's runtime. The four tests in
+    TestAddPopulatesVersions assert different keys of the same result and do
+    not change it, so one CLI invocation serves all of them. The CI runner
+    uses `--dist loadscope`, which keeps the module on one xdist worker.
+    """
+    catalog_root = tmp_path_factory.mktemp("single-add-catalog")
+    result = CliRunner().invoke(
+        cli, ["init", str(catalog_root), "--auto", "--license", "CC-BY-4.0"]
+    )
+    assert result.exit_code == 0, f"Init failed: {result.output}"
+
+    collection_dir = catalog_root / "test-collection"
+    collection_dir.mkdir()
+    single_file = collection_dir / "file_0.geojson"
+    single_file.write_text(create_geojson(coords=(0.0, 0.0), props={"id": 0}))
+
+    result = CliRunner().invoke(cli, ["add", "--portolan-dir", str(catalog_root), str(single_file)])
+    assert result.exit_code == 0, f"Add failed: {result.output}"
+
+    versions_path = collection_dir / "versions.json"
+    assert versions_path.exists(), f"versions.json not created at {versions_path}"
+    data: dict[str, Any] = json.loads(versions_path.read_text())
+    return data
+
+
 class TestAddPopulatesVersions:
     """Verify `portolan add` creates properly-structured collection-level versions.json."""
 
     @pytest.mark.integration
     def test_add_single_file_creates_versions_json(
-        self, catalog_with_source_files: tuple[Path, Path], runner: CliRunner
+        self, single_file_add_versions: dict[str, Any]
     ) -> None:
         """versions.json exists after add (add.py:1174)."""
-        catalog_root, collection_dir = catalog_with_source_files
-        single_file = collection_dir / "file_0.geojson"
-
-        result = runner.invoke(
-            cli,
-            ["add", "--portolan-dir", str(catalog_root), str(single_file)],
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
-
-        versions_path = collection_dir / "versions.json"
-        assert versions_path.exists(), f"versions.json not created at {versions_path}"
+        # The shared fixture asserts existence; a parsed document proves it.
+        assert single_file_add_versions is not None
 
     @pytest.mark.integration
-    def test_add_populates_versions_array(
-        self, catalog_with_source_files: tuple[Path, Path], runner: CliRunner
-    ) -> None:
+    def test_add_populates_versions_array(self, single_file_add_versions: dict[str, Any]) -> None:
         """versions array is non-empty after add (add.py:1216)."""
-        catalog_root, collection_dir = catalog_with_source_files
-        single_file = collection_dir / "file_0.geojson"
-
-        result = runner.invoke(
-            cli,
-            ["add", "--portolan-dir", str(catalog_root), str(single_file)],
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
-
-        versions_path = collection_dir / "versions.json"
-        versions_data = json.loads(versions_path.read_text())
+        versions_data = single_file_add_versions
 
         assert "versions" in versions_data, "Missing 'versions' key"
         assert len(versions_data["versions"]) > 0, "versions array is empty"
 
     @pytest.mark.integration
-    def test_add_sets_current_version(
-        self, catalog_with_source_files: tuple[Path, Path], runner: CliRunner
-    ) -> None:
+    def test_add_sets_current_version(self, single_file_add_versions: dict[str, Any]) -> None:
         """current_version field is set (add.py:1187-1192)."""
-        catalog_root, collection_dir = catalog_with_source_files
-        single_file = collection_dir / "file_0.geojson"
-
-        result = runner.invoke(
-            cli,
-            ["add", "--portolan-dir", str(catalog_root), str(single_file)],
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
-
-        versions_path = collection_dir / "versions.json"
-        versions_data = json.loads(versions_path.read_text())
+        versions_data = single_file_add_versions
 
         assert versions_data.get("current_version") is not None, "current_version not set"
         assert versions_data["current_version"] == versions_data["versions"][-1]["version"], (
@@ -215,21 +213,9 @@ class TestAddPopulatesVersions:
         )
 
     @pytest.mark.integration
-    def test_add_includes_asset_metadata(
-        self, catalog_with_source_files: tuple[Path, Path], runner: CliRunner
-    ) -> None:
+    def test_add_includes_asset_metadata(self, single_file_add_versions: dict[str, Any]) -> None:
         """Assets have sha256, size_bytes, href (add.py:1208-1213)."""
-        catalog_root, collection_dir = catalog_with_source_files
-        single_file = collection_dir / "file_0.geojson"
-
-        result = runner.invoke(
-            cli,
-            ["add", "--portolan-dir", str(catalog_root), str(single_file)],
-        )
-        assert result.exit_code == 0, f"Add failed: {result.output}"
-
-        versions_path = collection_dir / "versions.json"
-        versions_data = json.loads(versions_path.read_text())
+        versions_data = single_file_add_versions
 
         latest_version = versions_data["versions"][-1]
         assert "assets" in latest_version, "Missing 'assets' in version"
@@ -246,10 +232,16 @@ class TestAddPopulatesVersions:
             )
 
     @pytest.mark.integration
+    @pytest.mark.slow
     def test_add_100_files_accumulates(
         self, catalog_with_many_files: tuple[Path, Path], runner: CliRunner
     ) -> None:
-        """Scale test: many files in one add (Issue #339 scenario)."""
+        """Scale test: many files in one add (Issue #339 scenario).
+
+        Marked slow: 100 conversions cost the most worker time in the PR test
+        job. The nightly slow tier runs it. The 10-file test below keeps the
+        accumulation path covered on every PR.
+        """
         catalog_root, collection_dir = catalog_with_many_files
 
         result = runner.invoke(
@@ -265,6 +257,29 @@ class TestAddPopulatesVersions:
         latest_version = versions_data["versions"][-1]
         asset_count = len(latest_version["assets"])
         assert asset_count >= 100, f"Only {asset_count} assets tracked, expected >= 100"
+
+    @pytest.mark.integration
+    def test_add_10_files_accumulates(self, initialized_catalog: Path, runner: CliRunner) -> None:
+        """PR-lane smoke test for multi-file accumulation (Issue #339 scenario)."""
+        collection_dir = initialized_catalog / "scale-smoke"
+        collection_dir.mkdir()
+        for i in range(10):
+            (collection_dir / f"file_{i:02d}.geojson").write_text(
+                create_geojson(coords=(float(i), float(i)), props={"id": i})
+            )
+
+        result = runner.invoke(
+            cli,
+            ["add", "--portolan-dir", str(initialized_catalog), str(collection_dir)],
+        )
+        assert result.exit_code == 0, f"Add failed: {result.output}"
+
+        versions_path = collection_dir / "versions.json"
+        versions_data = json.loads(versions_path.read_text())
+
+        latest_version = versions_data["versions"][-1]
+        asset_count = len(latest_version["assets"])
+        assert asset_count >= 10, f"Only {asset_count} assets tracked, expected >= 10"
 
 
 # =============================================================================

--- a/tests/unit/test_scan_bounded_465.py
+++ b/tests/unit/test_scan_bounded_465.py
@@ -53,11 +53,11 @@ def test_collection_level_scan_is_bounded_not_quadratic(
     """Adding N collection-level vectors must NOT re-checksum every sibling.
 
     Pre-fix, each file's scan re-checksums all N siblings, so `compute_checksum`
-    is called on the order of N·(N+1)/2 times (≈820 for N=40). Post-fix each file
+    is called on the order of N·(N+1)/2 times (≈210 for N=20). Post-fix each file
     checksums only itself (+ its own sidecars), so the count is O(N). The bound
-    3*N (120) sits far below the quadratic value and above the true linear count.
+    3*N (60) sits far below the quadratic value and above the true linear count.
     """
-    n = 40
+    n = 20
     collection_dir = initialized_catalog / "many"
     collection_dir.mkdir()
     fixture_bytes = (fixtures_dir / "simple.parquet").read_bytes()
@@ -81,7 +81,7 @@ def test_collection_level_scan_is_bounded_not_quadratic(
 
     assert not failures, f"unexpected failures: {failures}"
 
-    # Bound: linear, not quadratic. Pre-fix ≈ n*(n+1)/2 = 820 ≫ 120.
+    # Bound: linear, not quadratic. Pre-fix ≈ n*(n+1)/2 = 210 ≫ 60.
     assert call_count <= 3 * n, (
         f"compute_checksum called {call_count} times for {n} files "
         f"(expected O(n) <= {3 * n}; quadratic would be ~{n * (n + 1) // 2}). "


### PR DESCRIPTION
## What changed

CI test jobs run 35-45% shorter. Four config changes, three test changes, and one matrix change cause this.

Config changes in `.github/workflows/ci.yml`, `pyproject.toml`, and `tests/conftest.py`:

- The test job starts pytest with `-n logical` and gets 4 xdist workers per runner.
- `-n auto` counted 2 physical cores on the 4-vCPU runners and started only 2 workers.
- Coverage runs only on the ubuntu-3.11 cell, which uploads to Codecov.
- `addopts` no longer injects `--cov` into every local pytest run.
- Hypothesis loads a 25-example deterministic profile in CI through `HYPOTHESIS_PROFILE=ci`.
- Nightly keeps the default profile with 100 randomized examples.
- The test command drops `-v` and adds `--durations=25`, so each run reports its slowest tests.

Test changes:

- `tests/integration/test_partition_paths.py` builds its 100k-point partitioned catalog one time per module.
- The old function-scoped fixture rebuilt that catalog for each of 5 tests.
- The build now uses vectorized `points_from_xy` instead of a Python loop of `Point` objects.
- The partition tests are module-level functions, because `--dist loadscope` groups class methods per class and built the module fixture twice.
- `tests/integration/test_versioning_stress.py` runs one `add` for the four read-only assertions in `TestAddPopulatesVersions`.
- `test_add_100_files_accumulates` carries `@pytest.mark.slow` and moves to the nightly tier.
- A new 10-file test keeps the accumulation path covered on every PR.
- `test_collection_level_scan_is_bounded_not_quadratic` proves its linear bound with 20 files instead of 40.
- The `test_push_integration.py` property test drops from 50 to 25 examples.

Matrix change:

- Four anchor cells run the full suite on every event: ubuntu-3.11, ubuntu-3.13, windows-3.13, and macos-3.13.
- The other six cells run only unit tests on pull requests.
- Every cell runs the full suite on push to main, so an interpreter-specific integration break surfaces at merge.
- The job list, the `ci-success` aggregation, and the branch protection contexts do not change.

`context/shared/documentation/ci.md` records the new worker, coverage, Hypothesis, and matrix policy.

## Why

Resolves #844.

The test matrix took 18m15s on Windows, 13m50s on Ubuntu, and 10m19s on macOS (run 33391230419). The documented Tier 2 budget was 2-5 min. The run logs show three causes:

- Only 2 xdist workers ran on Ubuntu and Windows, and worker count tracked wall time.
- All 10 matrix cells measured branch coverage that only one cell uploads.
- A few integration modules rebuilt an expensive catalog per test.

## Verification

Baseline: run 33391230419 (main). Comparison: run 33395302484 (this branch, workflow_dispatch, full suite on all 10 cells). All 29 checks pass on the comparison run. No xdist worker crashed.

| Job | Baseline | Run 33395302484 |
|-----|----------|-----------------|
| Test (3.11 / ubuntu, coverage cell) | ~14m | 8m07s |
| Test (3.13 / ubuntu) | 13m50s | 10m19s |
| Test (3.13 / windows) | 15m52s | 11m36s |
| Test (3.12 / windows) | 18m15s | 14m23s |
| Test (3.11 / windows) | 18m51s | 14m07s |
| Test (3.12 / macos) | 10m44s | 9m29s |
| Test (3.13 / macos) | 10m19s | 13m02s |

The pytest step on ubuntu-3.13 dropped from 830s to 580s with 4 workers confirmed in the log: `4 workers [7139 items]`. The macos-3.13 cell was slower in that run. The runner has 3 cores and `-n logical` starts 4 workers there.

Validation run 33397081385 repeats the full-suite measurement after the tail fixes. All 29 checks pass. The job times are:

| Job | Baseline | Run 33397081385 |
|-----|----------|-----------------|
| Test (3.11 / ubuntu, coverage cell) | ~14m | 11m02s |
| Test (3.13 / ubuntu) | 13m50s | 9m52s |
| Test (3.13 / windows) | 15m52s | 13m11s |
| Test (3.12 / windows) | 18m15s | 13m38s |
| Test (3.11 / windows) | 18m51s | 10m48s |
| Test (3.12 / macos) | 10m44s | 8m42s |
| Test (3.13 / macos) | 10m19s | 9m45s |

The macos-3.13 cell reads 9m45s here, so the 13m02s in the first run was runner variance and not worker contention.

Run 33398684794 is this pull request's own run and the first with the anchor matrix. All 29 checks pass. The full-suite anchor cells and the unit-lane cells read:

| Job | Lane | Baseline | Run 33398684794 |
|-----|------|----------|-----------------|
| Test (3.13 / windows) | full | 15m52s | 11m44s |
| Test (3.13 / ubuntu) | full | 13m50s | 8m35s |
| Test (3.11 / ubuntu, coverage) | full | ~14m | 11m21s |
| Test (3.13 / macos) | full | 10m19s | 9m48s |
| Test (3.11 / windows) | unit | 18m51s | 4m20s |
| Test (3.12 / windows) | unit | 18m15s | 5m06s |
| Test (3.10 / ubuntu) | unit | ~14m | 3m03s |
| Test (3.12 / ubuntu) | unit | ~15m | 3m06s |
| Test (3.11 / macos) | unit | ~11m | 4m09s |
| Test (3.12 / macos) | unit | ~11m | 3m23s |

The slowest cell gates the pull request. It was 18m51s and is 11m44s now.

The `--durations=25` output of run 33395302484 exposed the tail. The later commits removed it. The tail held a 52s duplicate catalog build in `test_partition_paths.py`, a 54s `Point`-loop test, and an 88s quadratic-bound test.

The refactored modules pass locally and keep their assertions:

```
$ uv run pytest tests/integration/test_partition_paths.py \
    tests/integration/test_versioning_stress.py \
    -m "not network and not slow and not benchmark" -q --no-cov
30 passed, 6 deselected in 33.98s
```

The partition tests read the 100k-point GeoDataFrame from the module fixture under `tmp_path_factory.mktemp("partition-catalog")`. The fixture partitions it into `kdtree_cell=*` Hive directories.
