### PR TITLE
fix(ci): bump pypi-publish to v1.14.2 for core metadata 2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.release_check.outputs.release_exists == 'false'
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true
 


### PR DESCRIPTION
## What changed

The release workflow now publishes to PyPI again. It pins
`pypa/gh-action-pypi-publish` at v1.14.2 instead of v1.14.1. That version
bundles Twine 7, which accepts core metadata 2.5. The pin stays a commit SHA,
as the repository requires.

## Why

Issue #847. The release run 33403181495 pushed the tag `v1.0.0b0`. It then
failed at the `Publish to PyPI` step. `hatchling` writes
`Metadata-Version: 2.5`, and the Twine 6.2.0 inside v1.14.1 rejects that
value before the upload starts.

## Verification

The failure and the fix both reproduce on the real `v1.0.0b0` artifacts.
Build the package, then check it with each Twine version:

```
$ uv build
Successfully built dist/portolan_cli-1.0.0b0.tar.gz
Successfully built dist/portolan_cli-1.0.0b0-py3-none-any.whl

$ python3 -c "import zipfile,glob; z=zipfile.ZipFile(glob.glob('dist/*.whl')[0]); \
print(z.read([n for n in z.namelist() if n.endswith('.dist-info/METADATA')][0]).decode().splitlines()[0])"
Metadata-Version: 2.5

$ uvx twine==6.2.0 check dist/*
Checking dist/portolan_cli-1.0.0b0-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a
valid metadata version

$ uvx twine==7.0.0 check dist/*
Checking dist/portolan_cli-1.0.0b0-py3-none-any.whl: PASSED
Checking dist/portolan_cli-1.0.0b0.tar.gz: PASSED
```

Twine 6.2.0 ships in v1.14.1. Twine 7 ships in v1.14.2. The artifacts read are
the local build of this repository at version 1.0.0b0.

The pinned SHA matches the tag:

```
$ gh api repos/pypa/gh-action-pypi-publish/commits/v1.14.2 --jq .sha
dc37677b2e1c63e2034f94d8a5b11f265b73ba33
```

## Implementation notes

The tag `v1.0.0b0` exists at `bdfe893`. PyPI holds no `1.0.0b0` release.
The workflow reads the version from `pyproject.toml`. It detects this state as
recovery mode. It skips the tag creation step. It runs the build, the publish,
and the release steps.

Run this after the merge to finish the v1.0.0b0 release:

```
gh workflow run release.yml --ref main
```

The merge itself does not start the workflow, because the squash commit does
not start with `bump:`.

## Related issues

Closes #847.
