### PR TITLE
docs(readme): install the beta by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,18 @@ It helps publishers:
 
 ## Installation
 
+*Portolan CLI is currently in a beta release, as breaking changes are expected for the time being.*
+
+Pass the prerelease flag so the installer selects the beta:
+
 ```sh
-uv tool install portolan-cli
+uv tool install portolan-cli --prerelease allow
 ```
 
 Or with pip:
 
 ```sh
-pip install portolan-cli
+pip install --pre portolan-cli
 ```
 
 ## Documentation


### PR DESCRIPTION
## What changed

The README install commands now select the beta. `uv tool install` gains
`--prerelease allow`. `pip install` gains `--pre`. The section also states
that the CLI is in a beta release, and that breaking changes are expected.

## Why

The old commands installed version 0.7.0, published on 2026-05-07. That
version predates the move to rashid and the spec release `v0.1.0`. Its
`check --json` output still uses the old `results` shape.

PEP 440 excludes a prerelease from default version resolution. PyPI holds
`1.0.0b0`, but a bare `pip install portolan-cli` skips it and selects the
newest final version. A flag on the install command is the only way to reach
the beta. No PyPI or GitHub setting changes this.

## Verification

Each documented command installs `1.0.0b0` from PyPI. Both runs use a clean
throwaway environment.

```
$ python3 -m venv v1
$ ./v1/bin/pip install --pre portolan-cli
$ ./v1/bin/portolan --version
portolan, version 1.0.0b0

$ uv venv v2
$ VIRTUAL_ENV=v2 uv pip install --prerelease allow portolan-cli
$ ./v2/bin/portolan --version
portolan, version 1.0.0b0
```

The old command selects the stale version:

```
$ uvx --from portolan-cli portolan --version
portolan, version 0.7.0
```

The data read is the PyPI index for `portolan-cli`, at
https://pypi.org/project/portolan-cli/.

- [x] This change does not alter behavior (docs, chore, or CI only).

## Implementation notes

`uv tool install` takes `--prerelease allow`. The verification uses
`uv pip install` with the same flag, because `uv tool install` writes to the
user tool directory. Both commands share one resolver.

The GitHub release keeps `prerelease=false`. That flag controls the "Latest"
badge on the releases page and the `/releases/latest` endpoint. It does not
affect pip. The beta stays badged as the latest release on purpose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the beta release of Portolan CLI.
  * Added a notice that breaking changes may occur during the beta period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->