### PR TITLE
feat(push): add --prune to delete orphaned remote objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions are recorded where they apply (see `.claude/rules/documentation.md`)
 - **NO** new dependencies without discussion
 
-<!-- freshness: last-verified: 2026-08-31 -->
+<!-- freshness: last-verified: 2026-09-05 -->
 ## Design Principles
 
 | Principle | Meaning |

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -3864,6 +3864,137 @@ def _prepare_push_concurrency(
     return effective_file, effective_chunk
 
 
+def _run_prune(
+    catalog_path: Path,
+    destination: str,
+    profile: str | None,
+    region: str | None,
+    *,
+    dry_run: bool,
+    skip_confirm: bool,
+    use_json: bool,
+) -> dict[str, Any]:
+    """Compute and, once confirmed, apply a --prune plan. Returns data for the JSON envelope."""
+    from portolan_cli.sync.prune import build_prune_plan, delete_prune_plan, print_prune_plan
+    from portolan_cli.sync.push import discover_collections
+    from portolan_cli.sync.upload import setup_store
+
+    local_collections = discover_collections(catalog_path)
+    if not local_collections:
+        message = "Refusing to prune: no local collections found under the catalog root."
+        if not use_json:
+            warn(message)
+        return {"would_prune": 0, "refused": 0, "pruned": 0, "skipped_reason": message}
+
+    store, prefix = setup_store(destination, profile=profile, region=region)
+    plan = build_prune_plan(store, prefix, catalog_path, local_collections)
+
+    if not use_json:
+        print_prune_plan(plan)
+
+    result: dict[str, Any] = {
+        "would_prune": plan.delete_count,
+        "refused": plan.refuse_count,
+        "pruned": 0,
+    }
+
+    if plan.delete_count == 0 or dry_run:
+        return result
+
+    if not skip_confirm:
+        if use_json or not click.confirm(
+            f"Delete {plan.delete_count} remote object(s)?", default=False
+        ):
+            if not use_json:
+                warn("Skipping deletion. Re-run with --yes to confirm non-interactively.")
+            result["skipped_reason"] = "confirmation required (use --yes)"
+            return result
+
+    deleted, errors = delete_prune_plan(store, plan)
+    result["pruned"] = deleted
+    if errors:
+        result["errors"] = errors
+        if not use_json:
+            for message in errors:
+                warn(message)
+    if not use_json:
+        success(f"Pruned {deleted} remote object(s)")
+    return result
+
+
+def _push_all_collections_command(
+    catalog_path: Path,
+    resolved_destination: str,
+    resolved_profile: str | None,
+    resolved_region: str | None,
+    *,
+    force: bool,
+    dry_run: bool,
+    workers: int | None,
+    effective_file_conc: int,
+    effective_chunk_conc: int,
+    max_connections: int | None,
+    adaptive: bool,
+    verbose: bool,
+    use_json: bool,
+    prune: bool,
+    prune_yes: bool,
+) -> None:
+    """Push every collection in the catalog, then apply --prune if requested."""
+    from portolan_cli.sync.push import push_all_collections
+
+    try:
+        all_result = push_all_collections(
+            catalog_root=catalog_path,
+            destination=resolved_destination,
+            force=force,
+            dry_run=dry_run,
+            profile=resolved_profile,
+            region=resolved_region,
+            workers=workers,
+            file_concurrency=effective_file_conc,
+            chunk_concurrency=effective_chunk_conc,
+            max_connections=max_connections,
+            adaptive=adaptive,
+            verbose=verbose,
+            json_mode=use_json,
+        )
+
+        envelope_data: dict[str, Any] = {
+            "total_collections": all_result.total_collections,
+            "successful_collections": all_result.successful_collections,
+            "failed_collections": all_result.failed_collections,
+            "total_files_uploaded": all_result.total_files_uploaded,
+            "total_versions_pushed": all_result.total_versions_pushed,
+            "dry_run": all_result.dry_run,
+            "total_would_push_files": all_result.total_would_push_files,
+            "total_would_push_versions": all_result.total_would_push_versions,
+            "collection_errors": all_result.collection_errors,
+        }
+        # Terminal output for the push itself is handled by push_all_collections()
+
+        if prune and all_result.success:
+            envelope_data["prune"] = _run_prune(
+                catalog_path,
+                resolved_destination,
+                resolved_profile,
+                resolved_region,
+                dry_run=dry_run,
+                skip_confirm=prune_yes,
+                use_json=use_json,
+            )
+
+        if use_json:
+            output_json_envelope(success_envelope("push", envelope_data))
+
+        if not all_result.success:
+            raise SystemExit(1)
+
+    except Exception as err:
+        emit_error("push", type(err).__name__, str(err), use_json=use_json)
+        raise SystemExit(1) from err
+
+
 @cli.command()
 @click.argument("destination", required=False, default=None)
 @click.option(
@@ -3881,7 +4012,23 @@ def _prepare_push_concurrency(
 @click.option(
     "--dry-run",
     is_flag=True,
-    help="Show what would be pushed without uploading. Note: skips remote state check (no network I/O), so conflicts won't be detected.",
+    help="Show what would be pushed without uploading. Skips the remote conflict "
+    "check, so a plain push does no network I/O and won't detect conflicts. "
+    "With --prune, this command still lists remote objects to preview deletions.",
+)
+@click.option(
+    "--prune",
+    is_flag=True,
+    help="After pushing, delete remote objects under collection prefixes no "
+    "longer present locally. Never deletes objects under a prefix still used "
+    "locally. Requires --collection to be omitted. See --yes.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "prune_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt before --prune deletes anything.",
 )
 @click.option(
     "--profile",
@@ -3950,6 +4097,8 @@ def push(
     collection: str | None,
     force: bool,
     dry_run: bool,
+    prune: bool,
+    prune_yes: bool,
     profile: str | None,
     catalog_path: Path | None,
     workers: int | None,
@@ -3982,12 +4131,24 @@ def push(
         # Push all collections
         portolan push s3://mybucket/catalog
         portolan push --dry-run  # Uses configured remote
+
+        # Push all collections, then delete orphaned remote objects
+        portolan push s3://mybucket/catalog --prune
     """
     import asyncio
 
-    from portolan_cli.sync.push import PushConflictError, push_all_collections, push_async
+    from portolan_cli.sync.push import PushConflictError, push_async
 
     use_json = should_output_json(ctx, json_output)
+
+    if prune and collection is not None:
+        emit_error(
+            "push",
+            "UsageError",
+            "--prune reconciles the whole catalog and cannot be combined with --collection.",
+            use_json=use_json,
+        )
+        raise SystemExit(1)
 
     # Git-style: find catalog root from anywhere within the catalog
     # Use explicit --catalog if provided, otherwise auto-detect
@@ -4021,49 +4182,24 @@ def push(
 
     # If no collection specified, push all collections
     if collection is None:
-        try:
-            all_result = push_all_collections(
-                catalog_root=catalog_path,
-                destination=resolved_destination,
-                force=force,
-                dry_run=dry_run,
-                profile=resolved_profile,
-                region=resolved_region,
-                workers=workers,
-                file_concurrency=effective_file_conc,
-                chunk_concurrency=effective_chunk_conc,
-                max_connections=max_connections,
-                adaptive=adaptive,
-                verbose=verbose,
-                json_mode=use_json,
-            )
-
-            if use_json:
-                envelope = success_envelope(
-                    "push",
-                    {
-                        "total_collections": all_result.total_collections,
-                        "successful_collections": all_result.successful_collections,
-                        "failed_collections": all_result.failed_collections,
-                        "total_files_uploaded": all_result.total_files_uploaded,
-                        "total_versions_pushed": all_result.total_versions_pushed,
-                        "dry_run": all_result.dry_run,
-                        "total_would_push_files": all_result.total_would_push_files,
-                        "total_would_push_versions": all_result.total_would_push_versions,
-                        "collection_errors": all_result.collection_errors,
-                    },
-                )
-                output_json_envelope(envelope)
-            # Terminal output is handled by push_all_collections()
-
-            if not all_result.success:
-                raise SystemExit(1)
-
-            return
-
-        except Exception as err:
-            emit_error("push", type(err).__name__, str(err), use_json=use_json)
-            raise SystemExit(1) from err
+        _push_all_collections_command(
+            catalog_path,
+            resolved_destination,
+            resolved_profile,
+            resolved_region,
+            force=force,
+            dry_run=dry_run,
+            workers=workers,
+            effective_file_conc=effective_file_conc,
+            effective_chunk_conc=effective_chunk_conc,
+            max_connections=max_connections,
+            adaptive=adaptive,
+            verbose=verbose,
+            use_json=use_json,
+            prune=prune,
+            prune_yes=prune_yes,
+        )
+        return
 
     try:
         # Use async push for single-collection push (concurrent uploads)

--- a/portolan_cli/sync/prune.py
+++ b/portolan_cli/sync/prune.py
@@ -1,0 +1,207 @@
+"""Remote object pruning for ``portolan push --prune`` (Issue #753)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import obstore as obs
+
+from portolan_cli.output import detail, info, warn
+from portolan_cli.sync.upload import ObjectStore
+
+# Regenerated on every push; never flagged as stale on its own.
+_METADATA_BASENAMES = frozenset(
+    {"versions.json", "collection.json", "catalog.json", "item.json", "README.md", "AGENTS.md"}
+)
+
+
+@dataclass
+class PruneGroup:
+    """Remote keys sharing one collection prefix."""
+
+    prefix: str
+    keys: list[str]
+
+
+@dataclass
+class PrunePlan:
+    """Delete/refuse groups from reconciling remote objects against local state."""
+
+    delete: list[PruneGroup] = field(default_factory=list)
+    refuse: list[PruneGroup] = field(default_factory=list)
+
+    @property
+    def delete_count(self) -> int:
+        """Total remote keys eligible for deletion."""
+        return sum(len(g.keys) for g in self.delete)
+
+    @property
+    def refuse_count(self) -> int:
+        """Total remote keys refused (reported, never deleted)."""
+        return sum(len(g.keys) for g in self.refuse)
+
+
+def _list_remote_keys(store: ObjectStore, prefix: str) -> list[str]:
+    """List every object key under a remote prefix."""
+    # A trailing "/" stops a bare prefix like "acme" from also matching
+    # an unrelated sibling such as "acme-archive".
+    list_prefix = f"{prefix}/" if prefix else prefix
+    keys: list[str] = []
+    for batch in obs.list(store, prefix=list_prefix):
+        for meta in batch:
+            keys.append(str(meta["path"]))
+    return keys
+
+
+def _remote_collection_prefixes(rel_keys: list[str]) -> set[str]:
+    """Return every dir (relative to the remote root) holding a versions.json.
+
+    A bare root versions.json is catalog-level state, not a collection prefix.
+    """
+    prefixes: set[str] = set()
+    for rel_key in rel_keys:
+        if rel_key.rsplit("/", 1)[-1] == "versions.json" and "/" in rel_key:
+            prefixes.add(rel_key.rsplit("/", 1)[0])
+    return prefixes
+
+
+def _local_structural_dirs(local_collections: list[str]) -> set[str]:
+    """Ancestor directories of every local collection, including the catalog root."""
+    dirs: set[str] = {""}
+    for collection in local_collections:
+        parts = collection.split("/")
+        for i in range(len(parts)):
+            dirs.add("/".join(parts[:i]))
+    return dirs
+
+
+def _matches_prefix(rel_key: str, prefix: str) -> bool:
+    """True if ``rel_key`` lives under ``prefix``. The root prefix "" matches everything."""
+    return prefix == "" or rel_key == prefix or rel_key.startswith(f"{prefix}/")
+
+
+def _owning_prefix(rel_key: str, prefixes: set[str]) -> str | None:
+    """Return the most specific collection prefix owning ``rel_key``, or None if untracked."""
+    matches = [prefix for prefix in prefixes if _matches_prefix(rel_key, prefix)]
+    if not matches:
+        return None
+    return max(matches, key=len)
+
+
+def _local_asset_hrefs(catalog_root: Path, collection: str) -> set[str]:
+    """Return every href tracked by any local version of ``collection``."""
+    from portolan_cli.sync.push import _read_local_versions
+
+    try:
+        data: dict[str, Any] = _read_local_versions(catalog_root, collection)
+    except (FileNotFoundError, ValueError):
+        return set()
+
+    hrefs: set[str] = set()
+    for version_entry in data.get("versions", []):
+        for asset_name, asset_data in version_entry.get("assets", {}).items():
+            href = asset_data.get("href", asset_name)
+            if href:
+                hrefs.add(href)
+    return hrefs
+
+
+def build_prune_plan(
+    store: ObjectStore,
+    remote_prefix: str,
+    catalog_root: Path,
+    local_collections: list[str],
+) -> PrunePlan:
+    """Reconcile remote objects under ``remote_prefix`` against the local catalog."""
+    # An empty local catalog is never a legitimate reason to prune everything remote.
+    if not local_collections:
+        return PrunePlan()
+
+    root = remote_prefix.strip("/")
+    remote_keys = _list_remote_keys(store, root)
+    rel_keys = [key[len(root) :].lstrip("/") if root else key for key in remote_keys]
+    local_set = set(local_collections)
+    # A collection still counts as "known" even before its own versions.json has
+    # reached the remote (push uploads it last), so it is never treated as orphaned.
+    known_prefixes = _remote_collection_prefixes(rel_keys) | local_set
+    structural_dirs = _local_structural_dirs(local_collections)
+
+    delete_by_prefix: dict[str, list[str]] = {}
+    refuse_by_prefix: dict[str, list[str]] = {}
+    hrefs_by_collection: dict[str, set[str]] = {}
+
+    for key, rel_key in zip(remote_keys, rel_keys, strict=True):
+        owner = _owning_prefix(rel_key, known_prefixes)
+
+        if owner is None:
+            basename = rel_key.rsplit("/", 1)[-1]
+            directory = rel_key.rsplit("/", 1)[0] if "/" in rel_key else ""
+            # Root/subcatalog metadata is regenerated by every push, not an orphaned collection.
+            if basename in _METADATA_BASENAMES and directory in structural_dirs:
+                continue
+            delete_by_prefix.setdefault("(unrecognized)", []).append(key)
+            continue
+
+        # Prefix unused locally: safe to delete (Issue #753's safety rule).
+        if owner not in local_set:
+            delete_by_prefix.setdefault(owner, []).append(key)
+            continue
+
+        # hrefs in versions.json are catalog-root-relative, same as rel_key.
+        basename = rel_key.rsplit("/", 1)[-1]
+        if basename in _METADATA_BASENAMES:
+            continue
+        if owner not in hrefs_by_collection:
+            hrefs_by_collection[owner] = _local_asset_hrefs(catalog_root, owner)
+        if rel_key in hrefs_by_collection[owner]:
+            continue
+        refuse_by_prefix.setdefault(owner, []).append(key)
+
+    plan = PrunePlan()
+    plan.delete = [
+        PruneGroup(prefix=p, keys=sorted(k)) for p, k in sorted(delete_by_prefix.items())
+    ]
+    plan.refuse = [
+        PruneGroup(prefix=p, keys=sorted(k)) for p, k in sorted(refuse_by_prefix.items())
+    ]
+    return plan
+
+
+def print_prune_plan(plan: PrunePlan) -> None:
+    """Print a PrunePlan grouped by prefix."""
+    if not plan.delete and not plan.refuse:
+        info("Nothing to prune: remote matches the local publication.")
+        return
+
+    if plan.delete:
+        warn(f"Would delete {plan.delete_count} remote object(s) under unused prefix(es):")
+        for group in plan.delete:
+            detail(f"  {group.prefix}/ ({len(group.keys)} object(s))")
+
+    if plan.refuse:
+        warn(
+            f"Refusing to delete {plan.refuse_count} remote object(s) under "
+            "prefix(es) still used locally (possible incomplete local build):"
+        )
+        for group in plan.refuse:
+            detail(f"  {group.prefix}/ ({len(group.keys)} object(s))")
+
+
+def delete_prune_plan(store: ObjectStore, plan: PrunePlan) -> tuple[int, list[str]]:
+    """Delete every key in ``plan.delete``. Never touches ``plan.refuse``.
+
+    Returns the number of keys deleted and any per-key error messages; the
+    caller decides how to surface those (styled text vs. a JSON envelope).
+    """
+    deleted = 0
+    errors: list[str] = []
+    for group in plan.delete:
+        for key in group.keys:
+            try:
+                obs.delete(store, key)
+                deleted += 1
+            except Exception as e:
+                errors.append(f"Failed to delete {key}: {e}")
+    return deleted, errors

--- a/tests/integration/test_prune_integration.py
+++ b/tests/integration/test_prune_integration.py
@@ -1,0 +1,85 @@
+"""Integration tests for portolan_cli.sync.prune against a real object store.
+
+Exercises build_prune_plan/delete_prune_plan against obstore's MemoryStore,
+not mocks, and the CLI-level --prune/--collection guard (Issue #753).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import obstore as obs
+import pytest
+from click.testing import CliRunner
+from obstore.store import MemoryStore
+
+from portolan_cli.cli import cli
+from portolan_cli.sync.prune import build_prune_plan, delete_prune_plan
+
+
+@pytest.mark.integration
+def test_build_and_delete_plan_against_memory_store(tmp_path: Path) -> None:
+    store = MemoryStore()
+
+    # A still-live collection: one tracked asset, plus one the local build
+    # never regenerated (missing/incomplete, must be refused not deleted).
+    live_dir = tmp_path / "live"
+    live_dir.mkdir()
+    (live_dir / "versions.json").write_text(
+        json.dumps(
+            {"versions": [{"version": "1.0.0", "assets": {"a": {"href": "live/a.parquet"}}}]}
+        )
+    )
+    obs.put(store, "cat/live/versions.json", b"{}")
+    obs.put(store, "cat/live/a.parquet", b"x")
+    obs.put(store, "cat/live/orphan_asset.parquet", b"x")
+
+    # A collection removed locally in full (e.g. via `portolan rm --force`).
+    obs.put(store, "cat/gone/versions.json", b"{}")
+    obs.put(store, "cat/gone/b.parquet", b"x")
+
+    plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+    assert plan.delete_count == 2
+    assert {g.prefix for g in plan.delete} == {"gone"}
+    assert plan.refuse_count == 1
+    assert plan.refuse[0].keys == ["cat/live/orphan_asset.parquet"]
+
+    deleted, errors = delete_prune_plan(store, plan)
+    assert deleted == 2
+    assert errors == []
+
+    remaining = {
+        str(meta["path"]) for batch in obs.list(store, prefix="cat") for meta in batch
+    }
+    assert remaining == {"cat/live/versions.json", "cat/live/a.parquet", "cat/live/orphan_asset.parquet"}
+
+
+@pytest.mark.integration
+class TestPruneCliGuard:
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    def test_prune_with_collection_is_rejected(self, runner: CliRunner, tmp_path: Path) -> None:
+        portolan_dir = tmp_path / ".portolan"
+        portolan_dir.mkdir()
+        (portolan_dir / "config.yaml").write_text("version: '1.0'\n")
+
+        result = runner.invoke(
+            cli,
+            [
+                "push",
+                "s3://test/catalog",
+                "--collection",
+                "demographics",
+                "--prune",
+                "--catalog",
+                str(tmp_path),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "--prune" in result.output
+        assert "--collection" in result.output

--- a/tests/integration/test_prune_integration.py
+++ b/tests/integration/test_prune_integration.py
@@ -50,10 +50,12 @@ def test_build_and_delete_plan_against_memory_store(tmp_path: Path) -> None:
     assert deleted == 2
     assert errors == []
 
-    remaining = {
-        str(meta["path"]) for batch in obs.list(store, prefix="cat") for meta in batch
+    remaining = {str(meta["path"]) for batch in obs.list(store, prefix="cat") for meta in batch}
+    assert remaining == {
+        "cat/live/versions.json",
+        "cat/live/a.parquet",
+        "cat/live/orphan_asset.parquet",
     }
-    assert remaining == {"cat/live/versions.json", "cat/live/a.parquet", "cat/live/orphan_asset.parquet"}
 
 
 @pytest.mark.integration

--- a/tests/unit/test_cli_push_prune.py
+++ b/tests/unit/test_cli_push_prune.py
@@ -106,7 +106,7 @@ class TestPruneJsonOutputContract:
 
             assert result.exit_code == 0, f"Failed: {result.output}"
             assert "Would delete" not in result.output
-            # A second, unparseable envelope would raise json.JSONDecodeError here.
+            # A second, unparsable envelope would raise json.JSONDecodeError here.
             envelope = json.loads(result.output)
             assert envelope["success"] is True
             assert envelope["data"]["prune"]["pruned"] == 1

--- a/tests/unit/test_cli_push_prune.py
+++ b/tests/unit/test_cli_push_prune.py
@@ -1,0 +1,112 @@
+"""Tests for `portolan push --prune` safety guards and output contract (Issue #753)."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.sync.prune import PruneGroup, PrunePlan
+from portolan_cli.sync.push import PushAllResult
+
+TEST_REMOTE = "s3://test/catalog"
+
+
+def _setup_catalog(path: Path, collections: list[str]) -> None:
+    portolan_dir = path / ".portolan"
+    portolan_dir.mkdir(parents=True, exist_ok=True)
+    (portolan_dir / "config.yaml").write_text("version: '1.0'\n")
+    for name in collections:
+        coll_dir = path / name
+        coll_dir.mkdir()
+        (coll_dir / "versions.json").write_text(json.dumps({"versions": []}))
+
+
+def _successful_push(collections: int = 1) -> PushAllResult:
+    return PushAllResult(
+        success=True,
+        total_collections=collections,
+        successful_collections=collections,
+        failed_collections=0,
+        total_files_uploaded=collections,
+        total_versions_pushed=collections,
+    )
+
+
+class TestPruneEmptyLocalCollectionsGuard:
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    @pytest.mark.unit
+    @patch("portolan_cli.sync.upload.setup_store")
+    @patch("portolan_cli.sync.push.discover_collections")
+    @patch("portolan_cli.sync.push.push_all_collections")
+    def test_refuses_to_prune_with_zero_local_collections(
+        self,
+        mock_push_all: MagicMock,
+        mock_discover: MagicMock,
+        mock_setup_store: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _setup_catalog(Path("."), ["col1"])
+            mock_push_all.return_value = _successful_push()
+            mock_discover.return_value = []
+
+            with patch.dict(os.environ, {"PORTOLAN_REMOTE": TEST_REMOTE}):
+                result = runner.invoke(cli, ["push", "--catalog", ".", "--prune", "--yes"])
+
+            assert result.exit_code == 0, f"Failed: {result.output}"
+            mock_setup_store.assert_not_called()
+            assert "Refusing to prune" in result.output
+
+
+class TestPruneJsonOutputContract:
+    @pytest.fixture
+    def runner(self) -> CliRunner:
+        return CliRunner()
+
+    @pytest.mark.unit
+    @patch("portolan_cli.sync.prune.delete_prune_plan")
+    @patch("portolan_cli.sync.prune.build_prune_plan")
+    @patch("portolan_cli.sync.upload.setup_store")
+    @patch("portolan_cli.sync.push.discover_collections")
+    @patch("portolan_cli.sync.push.push_all_collections")
+    def test_json_mode_emits_one_envelope_with_no_styled_text(
+        self,
+        mock_push_all: MagicMock,
+        mock_discover: MagicMock,
+        mock_setup_store: MagicMock,
+        mock_build_plan: MagicMock,
+        mock_delete_plan: MagicMock,
+        runner: CliRunner,
+        tmp_path: Path,
+    ) -> None:
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _setup_catalog(Path("."), ["col1"])
+            mock_push_all.return_value = _successful_push()
+            mock_discover.return_value = ["col1"]
+            mock_setup_store.return_value = (MagicMock(), "cat")
+            mock_build_plan.return_value = PrunePlan(
+                delete=[PruneGroup(prefix="gone", keys=["cat/gone/a"])]
+            )
+            mock_delete_plan.return_value = (1, [])
+
+            with patch.dict(os.environ, {"PORTOLAN_REMOTE": TEST_REMOTE}):
+                result = runner.invoke(
+                    cli, ["push", "--catalog", ".", "--prune", "--yes", "--json"]
+                )
+
+            assert result.exit_code == 0, f"Failed: {result.output}"
+            assert "Would delete" not in result.output
+            # A second, unparseable envelope would raise json.JSONDecodeError here.
+            envelope = json.loads(result.output)
+            assert envelope["success"] is True
+            assert envelope["data"]["prune"]["pruned"] == 1

--- a/tests/unit/test_prune.py
+++ b/tests/unit/test_prune.py
@@ -1,0 +1,284 @@
+"""Unit tests for portolan_cli.sync.prune (Issue #753).
+
+TDD: written before the corresponding cli.py wiring was exercised end to end.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from portolan_cli.sync.prune import (
+    PrunePlan,
+    build_prune_plan,
+    delete_prune_plan,
+    print_prune_plan,
+)
+
+
+def _write_versions(catalog_root: Path, collection: str, hrefs: list[str]) -> None:
+    coll_dir = catalog_root / collection
+    coll_dir.mkdir(parents=True, exist_ok=True)
+    assets = {href.rsplit("/", 1)[-1]: {"href": href, "sha256": "x"} for href in hrefs}
+    (coll_dir / "versions.json").write_text(
+        json.dumps({"versions": [{"version": "1.0.0", "assets": assets}]})
+    )
+
+
+def _remote_meta(*paths: str) -> list[list[dict[str, object]]]:
+    return [[{"path": p, "size": 1} for p in paths]]
+
+
+@pytest.mark.unit
+class TestBuildPrunePlan:
+    def test_deletes_keys_under_unowned_prefix(self, tmp_path: Path) -> None:
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta("cat/stale/v1/versions.json", "cat/stale/v1/data.parquet"),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 2
+        assert plan.delete[0].prefix == "stale/v1"
+        assert plan.refuse_count == 0
+
+    def test_deletes_stray_key_under_no_known_collection(self, tmp_path: Path) -> None:
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta("cat/orphan.txt"),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 1
+        assert plan.delete[0].prefix == "(unrecognized)"
+
+    def test_refuses_key_missing_locally_under_live_collection(self, tmp_path: Path) -> None:
+        _write_versions(tmp_path, "live", ["live/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/live/versions.json", "cat/live/data.parquet", "cat/live/extra.parquet"
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 1
+        assert plan.refuse[0].keys == ["cat/live/extra.parquet"]
+
+    def test_ignores_metadata_basenames_under_live_collection(self, tmp_path: Path) -> None:
+        _write_versions(tmp_path, "live", ["live/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/live/data.parquet", "cat/live/versions.json", "cat/live/collection.json"
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+
+    def test_agents_md_is_a_metadata_basename(self, tmp_path: Path) -> None:
+        _write_versions(tmp_path, "live", ["live/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/live/data.parquet", "cat/live/versions.json", "cat/live/AGENTS.md"
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+
+    def test_nested_collection_never_matches_unrelated_sibling(self, tmp_path: Path) -> None:
+        # "live" must not match a remote key under "live-other/...".
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/live-other/versions.json", "cat/live-other/data.parquet"
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 2
+        assert plan.delete[0].prefix == "live-other"
+
+    def test_empty_local_collections_returns_empty_plan_without_listing(
+        self, tmp_path: Path
+    ) -> None:
+        store = MagicMock()
+        with patch("portolan_cli.sync.prune.obs.list") as mock_list:
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=[])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+        mock_list.assert_not_called()
+
+    def test_root_and_subcatalog_metadata_not_deleted(self, tmp_path: Path) -> None:
+        _write_versions(tmp_path, "region/live", ["region/live/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/catalog.json",
+                "cat/README.md",
+                "cat/region/catalog.json",
+                "cat/region/README.md",
+                "cat/region/live/versions.json",
+                "cat/region/live/data.parquet",
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["region/live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+
+    def test_root_metadata_survives_alongside_root_level_versions_json(
+        self, tmp_path: Path
+    ) -> None:
+        # A root versions.json is catalog-level state, not a collection prefix.
+        _write_versions(tmp_path, "region/live", ["region/live/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/AGENTS.md",
+                "cat/README.md",
+                "cat/catalog.json",
+                "cat/versions.json",
+                "cat/region/catalog.json",
+                "cat/region/README.md",
+                "cat/region/live/versions.json",
+                "cat/region/live/data.parquet",
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["region/live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+
+    def test_collection_missing_remote_versions_json_is_not_wiped(self, tmp_path: Path) -> None:
+        # push uploads versions.json last, so a live collection can have assets
+        # remote already with no remote versions.json yet.
+        _write_versions(tmp_path, "live", ["live/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta("cat/live/data.parquet"),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+
+    def test_nested_collection_prefix_matches_most_specific(self, tmp_path: Path) -> None:
+        _write_versions(tmp_path, "region/subregion", ["region/subregion/data.parquet"])
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta(
+                "cat/region/versions.json",
+                "cat/region/subregion/versions.json",
+                "cat/region/subregion/data.parquet",
+            ),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["region/subregion"])
+
+        assert plan.refuse_count == 0
+        assert plan.delete_count == 1
+        assert plan.delete[0].prefix == "region"
+
+    def test_local_versions_json_read_once_per_collection(self, tmp_path: Path) -> None:
+        _write_versions(tmp_path, "live", ["live/a.parquet", "live/b.parquet"])
+        store = MagicMock()
+        with (
+            patch(
+                "portolan_cli.sync.prune.obs.list",
+                return_value=_remote_meta(
+                    "cat/live/versions.json", "cat/live/a.parquet", "cat/live/b.parquet"
+                ),
+            ),
+            patch("portolan_cli.sync.prune._local_asset_hrefs") as mock_hrefs,
+        ):
+            mock_hrefs.return_value = {"live/a.parquet", "live/b.parquet"}
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 0
+        mock_hrefs.assert_called_once_with(tmp_path, "live")
+
+    def test_corrupted_local_versions_json_does_not_crash(self, tmp_path: Path) -> None:
+        coll_dir = tmp_path / "live"
+        coll_dir.mkdir()
+        (coll_dir / "versions.json").write_text("{not valid json")
+        store = MagicMock()
+        with patch(
+            "portolan_cli.sync.prune.obs.list",
+            return_value=_remote_meta("cat/live/versions.json", "cat/live/data.parquet"),
+        ):
+            plan = build_prune_plan(store, "cat", tmp_path, local_collections=["live"])
+
+        assert plan.delete_count == 0
+        assert plan.refuse_count == 1
+
+
+@pytest.mark.unit
+def test_list_remote_keys_uses_trailing_slash_boundary() -> None:
+    from portolan_cli.sync.prune import _list_remote_keys
+
+    store = MagicMock()
+    with patch("portolan_cli.sync.prune.obs.list", return_value=_remote_meta()) as mock_list:
+        _list_remote_keys(store, "acme")
+
+    assert mock_list.call_args.kwargs["prefix"] == "acme/"
+
+
+@pytest.mark.unit
+class TestDeletePrunePlan:
+    def test_deletes_only_delete_group(self) -> None:
+        store = MagicMock()
+        plan = PrunePlan()
+        from portolan_cli.sync.prune import PruneGroup
+
+        plan.delete = [PruneGroup(prefix="stale", keys=["cat/stale/a.parquet"])]
+        plan.refuse = [PruneGroup(prefix="live", keys=["cat/live/extra.parquet"])]
+
+        with patch("portolan_cli.sync.prune.obs.delete") as mock_delete:
+            deleted, errors = delete_prune_plan(store, plan)
+
+        assert deleted == 1
+        assert errors == []
+        mock_delete.assert_called_once_with(store, "cat/stale/a.parquet")
+
+    def test_continues_on_individual_delete_failure(self) -> None:
+        store = MagicMock()
+        plan = PrunePlan()
+        from portolan_cli.sync.prune import PruneGroup
+
+        plan.delete = [PruneGroup(prefix="stale", keys=["a", "b"])]
+
+        with patch("portolan_cli.sync.prune.obs.delete", side_effect=[Exception("boom"), None]):
+            deleted, errors = delete_prune_plan(store, plan)
+
+        assert deleted == 1
+        assert errors == ["Failed to delete a: boom"]
+
+
+@pytest.mark.unit
+def test_print_prune_plan_empty_reports_nothing_to_prune() -> None:
+    with patch("portolan_cli.sync.prune.info") as mock_info:
+        print_prune_plan(PrunePlan())
+
+    mock_info.assert_called_once()
+    assert "Nothing to prune" in mock_info.call_args[0][0]


### PR DESCRIPTION
## What changed

- `portolan push` accepts a new `--prune` flag.
- `--prune` deletes remote objects under a collection prefix missing from the local catalog.
- `--prune` never deletes objects under a prefix that still exists locally. It reports those objects as refused instead.
- Deletion needs `--prune` plus a second confirmation, or `--yes`.
- `--dry-run --prune` previews the plan. It still lists remote objects, because the preview needs that list.

## Why

Closes #753.

`portolan push` only adds and updates remote objects. When a user deletes a collection, or restructures the catalog into new prefixes, the old remote objects stay live forever.

## Verification

Local catalog at `/tmp/portolan-prune-test`, pushed to a local MinIO container (`s3://portolan-test/prune-test`, `localhost:9000`). Two collections, one nested under a subcatalog (`points/`, `region/polygons/`).

Removed `region/polygons` locally to test a catalog reorganization. Then ran the real command:

```
$ portolan push s3://portolan-test/prune-test --prune --yes
✓ Uploaded README.md
   Synced AGENTS.md
→ Synced 1 root metadata file(s)
✓ Uploaded catalog.json
✓ Uploaded versions.json
→
============================================================
✓ Pushed 1 collection(s), 0 version(s), 5 file(s)
⚠ Would delete 9 remote object(s) under unused prefix(es):
    (unrecognized)/ (2 object(s))
    region/polygons/ (7 object(s))
✓ Pruned 9 remote object(s)
```

Confirmed the remote state after, via `mc ls --recursive`:

```
AGENTS.md
README.md
catalog.json
points/AGENTS.md
points/README.md
points/collection.json
points/points.geojson
points/points.parquet
points/points.thumb.jpg
points/versions.json
versions.json
```

`region/` and its contents are gone. The root and `points/` metadata (`AGENTS.md`, `README.md`, `catalog.json`, `versions.json`) survive.

- [ ] This change does not alter behavior (docs, chore, or CI only).
- [ ] This pull request integrates changes already verified in their own pull requests (a release or integration branch).

## Implementation notes

Two review passes found issues before this commit. Real tests against MinIO found two more issues the reviews missed.

- A misconfigured `--catalog` path with zero local collections could wipe the whole remote catalog.
- The code now refuses to prune when the local catalog has zero collections.
- A bare-prefix match like `acme` also matched an unrelated catalog named `acme-archive`.
- The listing now uses a trailing slash boundary.
- The code deleted root and subcatalog metadata files as unrecognized objects.
- It now checks each file against the local structural directories first.
- Push writes a collection's `versions.json` last.
- The code treated a collection with no remote `versions.json` yet as orphaned.
- It now also treats the local collection list as known.
- The prefix match for nested collections was non-deterministic.
- It now picks the longest, most specific prefix.
- A corrupted local `versions.json` crashed the command.
- It now treats the collection as unreadable.
- It refuses to prune the collection's keys.
- The command printed styled text and a JSON envelope together under `--json`.
- It now emits one envelope only.
- `_local_asset_hrefs` read the same file once per remote asset.
- It now reads it once per collection.
- A root-level `versions.json` marks catalog state, not a collection.
- The code registered the root as a prunable prefix anyway.
- Real tests against MinIO found this bug.
- `AGENTS.md` was missing from the metadata basename set.
- Real tests against MinIO found this bug too.

## Related issues

None beyond #753.

<!-- ste-ok: GERUND required section heading from the org PR template -->
## Breaking Changes

None.

## Checklist

See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).

- [x] Tests written and exercise real behavior
- [x] Integration coverage where the change crosses layers
<!-- ste-ok: PASSIVE SEMICOLON required checklist line from the org PR template -->
- [x] `prek run --all-files` is green locally; all required CI checks pass
<!-- ste-ok: PASSIVE required checklist line from the org PR template -->
- [ ] Changed lines are covered (`codecov/patch`)
- [x] At least one adversarial review (actively tried to break it)
- [ ] CodeRabbit comments addressed
- [ ] Docs updated and, for non-obvious decisions, an ADR added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--prune` support to catalog-wide pushes, allowing remote objects from removed collections to be identified and deleted.
  * Added confirmation prompts, `--yes` automation, dry-run previews, and JSON output for pruning.
  * Preserves required metadata and refuses unsafe deletions, such as incomplete local collections.

* **Bug Fixes**
  * Added safeguards preventing pruning when used with a single collection or when no local collections are found.

* **Tests**
  * Added comprehensive coverage for pruning plans, safety checks, deletion failures, metadata preservation, and CLI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->