### PR TITLE
feat: add registry access and GeoServer server provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,7 @@ context/shared/plans/
 catalog.json
 !tests/fixtures/**/catalog.json
 versions.json
+registry_catalogs/
 
 # PyPI configuration file
 .pypirc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,7 +228,7 @@ Always research before implementing:
 - **ALL** non-obvious decisions are recorded where they apply (see `.claude/rules/documentation.md`)
 - **NO** new dependencies without discussion
 
-<!-- freshness: last-verified: 2026-08-31 -->
+<!-- freshness: last-verified: 2026-09-07 -->
 ## Design Principles
 
 | Principle | Meaning |

--- a/README.md
+++ b/README.md
@@ -21,11 +21,82 @@ It helps publishers:
 
 - Build [STAC](https://stacspec.org/en/) catalogs with [GeoParquet](https://geoparquet.org/) and [COG](https://cogeo.org/) assets.
 - Extract ArcGIS, WFS, and Carto sources.
+- Inspect and fetch published catalogs from the Portolan registry.
+- Plan and publish catalog resources to GeoServer.
 - Generate thumbnails, [PMTiles](https://docs.protomaps.com/pmtiles/), MapLibre styles, and STAC GeoParquet indexes.
 - Track collection versions and checksums without a database.
 - Validate catalog metadata, structure, and assets against the [Portolan specification](https://github.com/portolan-sdi/portolan-spec).
 - Push, pull, sync, and clone catalogs through S3, GCS, Azure, or S3-compatible storage.
 - Use structured JSON output, a typed Python API, or backend plugins.
+
+## Command Areas
+
+Portolan separates catalog publication from server publication.
+The core commands build and publish a static Portolan catalog:
+
+```sh
+portolan init ./catalog
+portolan add ./source-files --portolan-dir ./catalog
+portolan check ./catalog --strict
+portolan push s3://my-bucket/catalog --catalog ./catalog
+```
+
+The extraction commands turn service data into the same catalog shape:
+
+```sh
+portolan extract arcgis URL ./catalog --auto
+portolan extract wfs URL ./catalog --auto
+portolan extract carto URL ./catalog --auto
+```
+
+The registry commands read the published Portolan registry.
+They can list registered catalogs and fetch local snapshots for follow-on work:
+
+```sh
+portolan registry list
+portolan registry fetch CATALOG_ID --output ./catalogs
+```
+
+The server commands publish a Portolan catalog into a geospatial serving stack.
+GeoServer is the first provider:
+
+```sh
+portolan server geoserver plan ./catalog
+portolan server geoserver publish ./catalog
+portolan server geoserver sync ./catalog
+```
+
+`plan` is read-only.
+`publish` creates or updates GeoParquet and COG resources in GeoServer.
+`sync` currently matches idempotent publish behavior and does not prune server resources.
+
+## Extensibility Design
+
+The CLI is a thin Click layer over library modules.
+Command handlers resolve paths, credentials, and output mode, then delegate to
+typed orchestration code.
+This keeps the command surface stable while provider code evolves.
+
+Server publication uses a provider boundary under `portolan_cli/server/`.
+`server/model.py` defines provider-independent resource specs, plans, and
+results.
+`server/planner.py` reads a STAC catalog and selects publishable assets.
+`server/providers/base.py` defines the `ServerProvider` protocol with `plan`,
+`publish`, and `sync`.
+
+The GeoServer implementation lives under `server/providers/geoserver/`.
+It converts generic Portolan resources into GeoServer REST operations and
+stores `portolan.*` provenance metadata on created resources.
+That metadata lets a later plan detect whether a collection already exists,
+needs an update, or must be skipped.
+
+This boundary is intentionally provider-neutral.
+A MapServer, Esri, or other server provider can reuse the same catalog loader
+and planning model if it can map Portolan assets to that server's publishable
+resources.
+Provider-specific code should stay below `server/providers/<provider>/`, while
+shared catalog discovery stays in `server/planner.py`.
+The Portolan specification remains the source of truth for catalog conformance.
 
 ## Installation
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -31,8 +31,16 @@ This page is generated from the shipped Click command tree.
 - `portolan pull`
 - `portolan push`
 - `portolan readme`
+- `portolan registry`
+- `portolan registry fetch`
+- `portolan registry list`
 - `portolan rm`
 - `portolan scan`
+- `portolan server`
+- `portolan server geoserver`
+- `portolan server geoserver plan`
+- `portolan server geoserver publish`
+- `portolan server geoserver sync`
 - `portolan skills`
 - `portolan skills list`
 - `portolan skills show`

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,121 @@
+# Registry And Server Commands
+
+Portolan catalogs publish as static files first.
+That remains the canonical output.
+The registry and server commands add two follow-on workflows:
+
+- Find or fetch a published catalog from the Portolan registry.
+- Publish catalog resources into a geospatial server when an existing stack needs them.
+
+These commands do not change the Portolan catalog format.
+The Portolan specification remains the source of truth for catalog conformance.
+
+## Registry
+
+The registry commands read the public Portolan registry export.
+By default, they include only entries whose registry status is `valid`.
+
+List published catalog entries:
+
+```sh
+portolan registry list
+```
+
+Limit the list when you only need a small sample:
+
+```sh
+portolan registry list --limit 10
+```
+
+Fetch one catalog snapshot:
+
+```sh
+portolan registry fetch CATALOG_ID --output ./catalogs
+```
+
+Fetch all valid catalog snapshots:
+
+```sh
+portolan registry fetch --all --output ./catalogs
+```
+
+`registry fetch` writes a local copy of the STAC catalog documents.
+For collection assets, it rewrites relative asset `href` values to absolute URLs.
+That makes the snapshot useful for server commands without copying the data assets.
+
+Use `--registry-url` to read a different registry export.
+Use `--include-stale` when a workflow must inspect stale entries.
+Use `--json` for structured output.
+
+## GeoServer
+
+The `server geoserver` commands publish a Portolan catalog into GeoServer.
+They currently support GeoParquet vector resources and COG raster resources.
+PMTiles resources are detected by the generic planner, but the GeoServer provider skips them.
+
+Show the planned changes:
+
+```sh
+portolan server geoserver plan ./catalog
+```
+
+Publish supported resources:
+
+```sh
+portolan server geoserver publish ./catalog
+```
+
+Reconcile GeoServer with the current catalog:
+
+```sh
+portolan server geoserver sync ./catalog
+```
+
+`sync` currently matches idempotent publish behavior.
+It does not remove GeoServer resources that no longer appear in the catalog.
+
+### Credentials
+
+Pass GeoServer connection settings as flags:
+
+```sh
+portolan server geoserver plan ./catalog \
+  --url https://geoserver.example.org/geoserver/cloud \
+  --user admin \
+  --password "$GEOSERVER_PASSWORD" \
+  --workspace city-catalog
+```
+
+The same values can come from environment variables:
+
+```sh
+export PORTOLAN_GEOSERVER_URL=https://geoserver.example.org/geoserver/cloud
+export PORTOLAN_GEOSERVER_USER=admin
+export PORTOLAN_GEOSERVER_PASSWORD="$GEOSERVER_PASSWORD"
+export PORTOLAN_GEOSERVER_WORKSPACE=city-catalog
+
+portolan server geoserver plan ./catalog
+```
+
+Do not store credentials in `.portolan/config.yaml`.
+Use CLI flags, environment variables, or a catalog-local `.env` file.
+
+## Provider Design
+
+Server publication has a provider boundary.
+`portolan_cli/server/planner.py` reads the STAC catalog and emits generic
+resource candidates.
+Those candidates describe the desired state with a resource type, format,
+asset URL, metadata, and collection provenance.
+
+`portolan_cli/server/providers/base.py` defines the provider protocol.
+Each provider implements `plan`, `publish`, and `sync`.
+The GeoServer provider maps generic resources to GeoServer REST calls.
+It also writes `portolan.*` metadata to each created GeoServer resource.
+Later plans use that metadata to decide whether a resource already exists or
+needs an update.
+
+This structure lets another provider reuse the catalog loader and plan model.
+A MapServer or Esri provider would add code under `server/providers/<provider>/`
+and translate the same generic resources into that server's API or files.
+That provider can support only the resource formats that its target server can serve.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Examples: examples.md
+  - Registry And Server: server.md
   - Reference:
     - Overview: reference/index.md
     - CLI Reference: reference/cli.md

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -8604,3 +8604,357 @@ def skills_show_cmd(ctx: click.Context, name: str, json_output: bool) -> None:
         "skills show", {"name": name, "content": None, "url": SKILLS_REPO}, use_json=use_json
     ):
         click.echo(get_install_instructions())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Registry Commands
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@cli.group("registry")
+def registry_cmd() -> None:
+    """Inspect and fetch catalogs from the Portolan registry."""
+
+
+def _registry_catalog_entries(
+    registry_url: str | None,
+    catalog_id: tuple[str, ...],
+    include_stale: bool,
+    limit: int | None,
+) -> Any:
+    from portolan_cli.server.registry import DEFAULT_REGISTRY_URL, load_registry_entries
+
+    return load_registry_entries(
+        registry_url or DEFAULT_REGISTRY_URL,
+        catalog_ids=set(catalog_id) if catalog_id else None,
+        include_stale=include_stale,
+        limit=limit,
+    )
+
+
+@registry_cmd.command("list")
+@click.option("--registry-url", default=None, help="Portolan registry export URL.")
+@click.option("--catalog-id", multiple=True, help="Only show this registry catalog id.")
+@click.option("--include-stale", is_flag=True, help="Include stale registry entries.")
+@click.option("--limit", type=int, default=None, help="Maximum registry entries to show.")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def registry_list_cmd(
+    ctx: click.Context,
+    registry_url: str | None,
+    catalog_id: tuple[str, ...],
+    include_stale: bool,
+    limit: int | None,
+    json_output: bool,
+) -> None:
+    """List published catalog entries from the Portolan registry."""
+    use_json = should_output_json(ctx, json_output)
+    entries = _registry_catalog_entries(registry_url, catalog_id, include_stale, limit)
+    payload = [
+        {"id": entry.id, "url": entry.url, "title": entry.title, "status": entry.status}
+        for entry in entries
+    ]
+    if emit_success("registry list", {"catalogs": payload}, use_json=use_json):
+        return
+
+    click.echo(f"{'Catalog':<28} {'Status':<10} URL")
+    click.echo("-" * 88)
+    for entry in entries:
+        status = entry.status or "-"
+        click.echo(f"{entry.id:<28} {status:<10} {entry.url}")
+
+
+@registry_cmd.command("fetch")
+@click.argument("catalog_id", required=False)
+@click.option("--registry-url", default=None, help="Portolan registry export URL.")
+@click.option(
+    "--output",
+    "output_dir",
+    type=click.Path(path_type=Path),
+    default=Path("registry_catalogs"),
+    help="Directory that will receive the catalog snapshot.",
+)
+@click.option("--all", "fetch_all", is_flag=True, help="Fetch all registry catalog entries.")
+@click.option("--include-stale", is_flag=True, help="Allow stale registry entries.")
+@click.option("--path-only", is_flag=True, help="Print only the downloaded catalog path.")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def registry_fetch_cmd(
+    ctx: click.Context,
+    catalog_id: str | None,
+    registry_url: str | None,
+    output_dir: Path,
+    fetch_all: bool,
+    include_stale: bool,
+    path_only: bool,
+    json_output: bool,
+) -> None:
+    """Fetch registry catalogs for local server commands."""
+    from portolan_cli.server.registry import download_registry_catalog
+
+    use_json = should_output_json(ctx, json_output)
+    if fetch_all and catalog_id is not None:
+        raise click.ClickException("Use either CATALOG_ID or --all, not both.")
+    if not fetch_all and catalog_id is None:
+        raise click.ClickException("Provide CATALOG_ID or use --all.")
+    entries = _registry_catalog_entries(
+        registry_url,
+        () if fetch_all else (catalog_id,),
+        include_stale,
+        limit=None,
+    )
+    if not entries:
+        if fetch_all:
+            raise click.ClickException("No catalogs found in registry.")
+        raise click.ClickException(f"Catalog not found in registry: {catalog_id}")
+    fetched = [
+        (entry, download_registry_catalog(entry.url, output_dir))
+        for entry in entries
+    ]
+    if path_only:
+        for _entry, catalog_root in fetched:
+            click.echo(catalog_root)
+        return
+    if emit_success(
+        "registry fetch",
+        {
+            "catalogs": [
+                {
+                    "id": entry.id,
+                    "url": entry.url,
+                    "path": str(catalog_root),
+                }
+                for entry, catalog_root in fetched
+            ],
+        },
+        use_json=use_json,
+    ):
+        return
+    for entry, catalog_root in fetched:
+        success(f"Fetched {entry.id} to {catalog_root}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Server Commands
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@cli.group()
+def server() -> None:
+    """Publish a Portolan catalog to geospatial servers."""
+
+
+@server.group()
+def geoserver() -> None:
+    """Publish a Portolan catalog to GeoServer."""
+
+
+def _resolve_geoserver_provider(
+    catalog_root: Path | None,
+    url: str | None,
+    user: str | None,
+    password: str | None,
+    workspace: str | None,
+) -> Any:
+    """Build the GeoServer provider from CLI and environment settings."""
+    from portolan_cli.config import get_setting
+    from portolan_cli.server.providers.geoserver.client import GeoServerClient
+    from portolan_cli.server.providers.geoserver.planner import GeoServerProvider
+
+    resolved_url = get_setting("geoserver_url", cli_value=url, catalog_path=catalog_root)
+    resolved_user = get_setting("geoserver_user", cli_value=user, catalog_path=catalog_root)
+    resolved_password = get_setting(
+        "geoserver_password", cli_value=password, catalog_path=catalog_root
+    )
+    resolved_workspace = get_setting(
+        "geoserver_workspace", cli_value=workspace, catalog_path=catalog_root
+    )
+    missing = [
+        flag
+        for flag, value in (
+            ("--url", resolved_url),
+            ("--user", resolved_user),
+            ("--password", resolved_password),
+        )
+        if value is None
+    ]
+    if missing:
+        raise click.ClickException(f"Missing GeoServer connection option(s): {', '.join(missing)}")
+    client = GeoServerClient(str(resolved_url), str(resolved_user), str(resolved_password))
+    return GeoServerProvider(
+        client=client, workspace=str(resolved_workspace) if resolved_workspace else None
+    )
+
+
+def _resolve_geoserver_client(url: str | None, user: str | None, password: str | None) -> Any:
+    """Build a GeoServer client from CLI and environment settings."""
+    from portolan_cli.config import get_setting
+    from portolan_cli.server.providers.geoserver.client import GeoServerClient
+
+    resolved_url = get_setting("geoserver_url", cli_value=url)
+    resolved_user = get_setting("geoserver_user", cli_value=user)
+    resolved_password = get_setting("geoserver_password", cli_value=password)
+    missing = [
+        flag
+        for flag, value in (
+            ("--url", resolved_url),
+            ("--user", resolved_user),
+            ("--password", resolved_password),
+        )
+        if value is None
+    ]
+    if missing:
+        raise click.ClickException(f"Missing GeoServer connection option(s): {', '.join(missing)}")
+    return GeoServerClient(str(resolved_url), str(resolved_user), str(resolved_password))
+
+
+def _render_geoserver_plan(plan: Any) -> None:
+    """Render a GeoServer plan in text mode."""
+    click.echo("Portolan -> GeoServer plan")
+    click.echo("")
+    click.echo(f"Workspace: {plan.workspace}")
+    click.echo("")
+    click.echo(f"{'Collection':<28} {'Format':<12} Action")
+    click.echo("-" * 56)
+    for entry in plan.entries:
+        format_name = entry.format.value if entry.format else "-"
+        suffix = f" ({entry.reason})" if entry.reason else ""
+        click.echo(f"{entry.collection:<28} {format_name:<12} {entry.action.value}{suffix}")
+    click.echo("")
+    for action, count in plan.counts().items():
+        click.echo(f"{action:<12} {count}")
+
+
+@geoserver.command("plan")
+@click.argument("catalog_root_arg", required=False, type=click.Path(path_type=Path))
+@click.option("--url", default=None, help="GeoServer REST base URL.")
+@click.option("--user", default=None, help="GeoServer REST user.")
+@click.option("--password", default=None, help="GeoServer REST password.")
+@click.option("--workspace", default=None, help="GeoServer workspace name.")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def geoserver_plan_cmd(
+    ctx: click.Context,
+    catalog_root_arg: Path | None,
+    url: str | None,
+    user: str | None,
+    password: str | None,
+    workspace: str | None,
+    json_output: bool,
+) -> None:
+    """Show GeoServer resources that would be created."""
+    use_json = should_output_json(ctx, json_output)
+    catalog_root = catalog_root_arg or require_catalog_root(
+        use_json=use_json, command_name="server geoserver plan"
+    )
+    provider = _resolve_geoserver_provider(catalog_root, url, user, password, workspace)
+    plan = provider.plan(catalog_root)
+    if emit_success(
+        "server geoserver plan",
+        {
+            "workspace": plan.workspace,
+            "entries": [
+                {
+                    "collection": entry.collection,
+                    "format": entry.format.value if entry.format else None,
+                    "action": entry.action.value,
+                    "reason": entry.reason,
+                }
+                for entry in plan.entries
+            ],
+            "counts": plan.counts(),
+        },
+        use_json=use_json,
+    ):
+        return
+    _render_geoserver_plan(plan)
+
+
+@geoserver.command("publish")
+@click.argument("catalog_root_arg", required=False, type=click.Path(path_type=Path))
+@click.option("--url", default=None, help="GeoServer REST base URL.")
+@click.option("--user", default=None, help="GeoServer REST user.")
+@click.option("--password", default=None, help="GeoServer REST password.")
+@click.option("--workspace", default=None, help="GeoServer workspace name.")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def geoserver_publish_cmd(
+    ctx: click.Context,
+    catalog_root_arg: Path | None,
+    url: str | None,
+    user: str | None,
+    password: str | None,
+    workspace: str | None,
+    json_output: bool,
+) -> None:
+    """Publish GeoParquet and COG resources to GeoServer."""
+    use_json = should_output_json(ctx, json_output)
+    catalog_root = catalog_root_arg or require_catalog_root(
+        use_json=use_json, command_name="server geoserver publish"
+    )
+    provider = _resolve_geoserver_provider(catalog_root, url, user, password, workspace)
+    result = provider.publish(catalog_root)
+    if emit_success(
+        "server geoserver publish",
+        {
+            "workspace": result.workspace,
+            "published": result.published,
+            "skipped": result.skipped,
+            "errors": result.errors,
+        },
+        use_json=use_json,
+    ):
+        return
+    info_output("Publishing Portolan catalog to GeoServer")
+    info_output(f"Workspace: {result.workspace}")
+    success(f"Published {result.published} collections.")
+    if result.skipped:
+        warn(f"Skipped {result.skipped} collections.")
+    for err in result.errors:
+        error(err)
+    if result.errors:
+        raise SystemExit(1)
+
+
+@geoserver.command("sync")
+@click.argument("catalog_root_arg", required=False, type=click.Path(path_type=Path))
+@click.option("--url", default=None, help="GeoServer REST base URL.")
+@click.option("--user", default=None, help="GeoServer REST user.")
+@click.option("--password", default=None, help="GeoServer REST password.")
+@click.option("--workspace", default=None, help="GeoServer workspace name.")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def geoserver_sync_cmd(
+    ctx: click.Context,
+    catalog_root_arg: Path | None,
+    url: str | None,
+    user: str | None,
+    password: str | None,
+    workspace: str | None,
+    json_output: bool,
+) -> None:
+    """Reconcile GeoServer with the current catalog without pruning."""
+    use_json = should_output_json(ctx, json_output)
+    catalog_root = catalog_root_arg or require_catalog_root(
+        use_json=use_json, command_name="server geoserver sync"
+    )
+    provider = _resolve_geoserver_provider(catalog_root, url, user, password, workspace)
+    result = provider.sync(catalog_root)
+    if emit_success(
+        "server geoserver sync",
+        {
+            "workspace": result.workspace,
+            "published": result.published,
+            "skipped": result.skipped,
+            "errors": result.errors,
+        },
+        use_json=use_json,
+    ):
+        return
+    success(f"Synchronized {result.published} collections.")
+    if result.skipped:
+        warn(f"Skipped {result.skipped} collections.")
+    for err in result.errors:
+        error(err)
+    if result.errors:
+        raise SystemExit(1)

--- a/portolan_cli/cli.py
+++ b/portolan_cli/cli.py
@@ -8697,9 +8697,15 @@ def registry_fetch_cmd(
         raise click.ClickException("Use either CATALOG_ID or --all, not both.")
     if not fetch_all and catalog_id is None:
         raise click.ClickException("Provide CATALOG_ID or use --all.")
+    if fetch_all:
+        catalog_ids: tuple[str, ...] = ()
+    else:
+        if catalog_id is None:
+            raise click.ClickException("Provide CATALOG_ID or use --all.")
+        catalog_ids = (catalog_id,)
     entries = _registry_catalog_entries(
         registry_url,
-        () if fetch_all else (catalog_id,),
+        catalog_ids,
         include_stale,
         limit=None,
     )
@@ -8707,10 +8713,7 @@ def registry_fetch_cmd(
         if fetch_all:
             raise click.ClickException("No catalogs found in registry.")
         raise click.ClickException(f"Catalog not found in registry: {catalog_id}")
-    fetched = [
-        (entry, download_registry_catalog(entry.url, output_dir))
-        for entry in entries
-    ]
+    fetched = [(entry, download_registry_catalog(entry.url, output_dir)) for entry in entries]
     if path_only:
         for _entry, catalog_root in fetched:
             click.echo(catalog_root)

--- a/portolan_cli/config.py
+++ b/portolan_cli/config.py
@@ -41,6 +41,9 @@ SENSITIVE_SETTINGS: frozenset[str] = frozenset(
         "aws_profile",
         "profile",
         "region",
+        "geoserver_url",
+        "geoserver_user",
+        "geoserver_password",
         "s3_endpoint",
         "s3_use_ssl",
     }
@@ -72,6 +75,10 @@ KNOWN_SETTINGS: frozenset[str] = frozenset(
         "pmtiles.attribution",  # Attribution HTML for tiles
         "pmtiles.src_crs",  # Override source CRS if metadata is incorrect
         "push.exclude",  # Glob patterns to exclude from metadata sync (Issue #426)
+        "geoserver_url",  # GeoServer endpoint; sensitive, use env or CLI
+        "geoserver_user",  # GeoServer user; sensitive, use env or CLI
+        "geoserver_password",  # GeoServer password; sensitive, use env or CLI
+        "geoserver_workspace",  # GeoServer workspace name
         "tabular.enabled",  # Track non-geo tabular data as collection assets (Issue #432)
         "tabular.convert",  # Convert CSV/TSV/Excel to Parquet (default: true)
     }

--- a/portolan_cli/server/__init__.py
+++ b/portolan_cli/server/__init__.py
@@ -1,0 +1,1 @@
+"""Server publication support."""

--- a/portolan_cli/server/model.py
+++ b/portolan_cli/server/model.py
@@ -1,0 +1,120 @@
+"""Generic server publication model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class ResourceType(Enum):
+    """Generic server resource type."""
+
+    VECTOR = "VECTOR"
+    RASTER = "RASTER"
+    TILES = "TILES"
+
+
+class ResourceFormat(Enum):
+    """Generic cloud-native resource format."""
+
+    GEOPARQUET = "GeoParquet"
+    COG = "COG"
+    PMTILES = "PMTiles"
+
+
+class PlanAction(Enum):
+    """Action needed to align a server with the catalog."""
+
+    CREATE = "CREATE"
+    UPDATE = "UPDATE"
+    UNCHANGED = "UNCHANGED"
+    EXISTS = "EXISTS"
+    SKIP = "SKIP"
+    ERROR = "ERROR"
+    REMOVE_REQUIRED = "REMOVE_REQUIRED"
+
+
+@dataclass(frozen=True)
+class ServerResourceSpec:
+    """Provider-independent server resource desired state."""
+
+    id: str
+    resource_type: ResourceType
+    format: ResourceFormat
+    href: str
+    title: str | None
+    description: str | None
+    extent: dict[str, Any] | None
+    crs: str | None
+    primary_key: str | None
+    native_name: str | None
+    metadata: dict[str, object]
+    source_catalog: str | None
+    source_collection: str
+    source_asset: str
+
+
+@dataclass(frozen=True)
+class CollectionCandidate:
+    """A collection plus the resource it can publish, if any."""
+
+    collection: str
+    resource: ServerResourceSpec | None
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class PlanEntry:
+    """One line in a server publication plan."""
+
+    collection: str
+    format: ResourceFormat | None
+    action: PlanAction
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class PublishPlan:
+    """Computed server publication plan."""
+
+    workspace: str
+    entries: list[PlanEntry]
+
+    def counts(self) -> dict[str, int]:
+        """Return action counts by display value."""
+        counts: dict[str, int] = {}
+        for entry in self.entries:
+            counts[entry.action.value] = counts.get(entry.action.value, 0) + 1
+        return counts
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Result from applying a publication plan."""
+
+    workspace: str
+    published: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RegistryCatalogEntry:
+    """One catalog entry from a Portolan registry export."""
+
+    id: str
+    url: str
+    title: str | None = None
+    status: str | None = None
+
+
+@dataclass(frozen=True)
+class ServerCatalog:
+    """Loaded Portolan catalog data needed by server providers."""
+
+    root: Path | None
+    catalog_id: str
+    catalog_href: str
+    candidates: list[CollectionCandidate]

--- a/portolan_cli/server/planner.py
+++ b/portolan_cli/server/planner.py
@@ -214,9 +214,7 @@ def _primary_asset(assets: Any) -> tuple[str | None, dict[str, Any] | None]:
     return data_assets[0]
 
 
-def _native_name(
-    asset_key: str | None, href: str, resource_format: ResourceFormat
-) -> str | None:
+def _native_name(asset_key: str | None, href: str, resource_format: ResourceFormat) -> str | None:
     if resource_format == ResourceFormat.GEOPARQUET:
         stem = Path(urlparse(href).path).stem
         if stem:
@@ -330,8 +328,11 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 
 def _fetch_json(url: str) -> dict[str, Any]:
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Unsupported catalog URL scheme: {parsed.scheme or 'missing'}")
     request = Request(url, headers={"User-Agent": "portolan-cli/0.8"})
-    with urlopen(request, timeout=30) as response:
+    with urlopen(request, timeout=30) as response:  # nosec B310 - URL scheme checked above.
         data = json.loads(response.read().decode("utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"{url} must contain a JSON object")

--- a/portolan_cli/server/planner.py
+++ b/portolan_cli/server/planner.py
@@ -1,0 +1,338 @@
+"""Discover provider-independent server resources from a Portolan catalog."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+from portolan_cli.server.model import (
+    CollectionCandidate,
+    ResourceFormat,
+    ResourceType,
+    ServerCatalog,
+    ServerResourceSpec,
+)
+
+_GEOPARQUET_MEDIA_TYPES = frozenset({"application/vnd.apache.parquet"})
+_COG_MEDIA_TYPES = frozenset({"image/tiff; application=geotiff; profile=cloud-optimized"})
+_PMTILES_MEDIA_TYPES = frozenset({"application/vnd.pmtiles"})
+
+
+def load_server_catalog(catalog_root: Path) -> ServerCatalog:
+    """Load a Portolan catalog into generic server candidates."""
+    root = catalog_root.resolve()
+    catalog_path = root / "catalog.json"
+    catalog = _read_json(catalog_path)
+    catalog_id = str(catalog.get("id") or root.name or "portolan")
+    candidates = list(_walk_catalog(root, catalog_path, str(catalog_path)))
+    return ServerCatalog(
+        root=root,
+        catalog_id=catalog_id,
+        catalog_href=str(catalog_path),
+        candidates=candidates,
+    )
+
+
+def discover_server_resources(catalog_root: Path) -> list[ServerResourceSpec]:
+    """Return publishable server resources for a Portolan catalog."""
+    return [
+        candidate.resource
+        for candidate in load_server_catalog(catalog_root).candidates
+        if candidate.resource is not None
+    ]
+
+
+def load_server_catalog_url(
+    catalog_url: str,
+    *,
+    fetch_json: Callable[[str], dict[str, Any]] | None = None,
+) -> ServerCatalog:
+    """Load a published STAC catalog URL into generic server candidates."""
+    fetch = fetch_json or _fetch_json
+    catalog = fetch(catalog_url)
+    catalog_id = str(catalog.get("id") or "catalog")
+    candidates = list(_walk_catalog_url(catalog_url, catalog, catalog_url, fetch))
+    return ServerCatalog(
+        root=None,
+        catalog_id=catalog_id,
+        catalog_href=catalog_url,
+        candidates=candidates,
+    )
+
+
+def _walk_catalog(root: Path, catalog_path: Path, source_catalog: str) -> list[CollectionCandidate]:
+    data = _read_json(catalog_path)
+    candidates: list[CollectionCandidate] = []
+    for link in data.get("links", []):
+        if not isinstance(link, dict) or link.get("rel") != "child":
+            continue
+        href = link.get("href")
+        if not isinstance(href, str) or _is_remote_href(href):
+            continue
+        child_path = (catalog_path.parent / href).resolve()
+        if not _inside(child_path, root) or not child_path.exists():
+            continue
+        if child_path.name == "collection.json":
+            candidates.append(_collection_candidate(child_path, source_catalog))
+        elif child_path.name == "catalog.json":
+            candidates.extend(_walk_catalog(root, child_path, source_catalog))
+    return candidates
+
+
+def _walk_catalog_url(
+    catalog_url: str,
+    data: dict[str, Any],
+    source_catalog: str,
+    fetch_json: Callable[[str], dict[str, Any]],
+) -> list[CollectionCandidate]:
+    candidates: list[CollectionCandidate] = []
+    for link in data.get("links", []):
+        if not isinstance(link, dict) or link.get("rel") != "child":
+            continue
+        href = link.get("href")
+        if not isinstance(href, str):
+            continue
+        child_url = urljoin(catalog_url, href)
+        child = fetch_json(child_url)
+        child_type = child.get("type")
+        if child_type == "Collection":
+            candidates.append(_collection_candidate_url(child_url, child, source_catalog))
+        elif child_type == "Catalog":
+            candidates.extend(_walk_catalog_url(child_url, child, source_catalog, fetch_json))
+    return candidates
+
+
+def _collection_candidate(collection_path: Path, source_catalog: str) -> CollectionCandidate:
+    collection = _read_json(collection_path)
+    collection_id = str(collection["id"])
+    asset_key, asset = _primary_asset(collection.get("assets", {}))
+    if asset is None:
+        return CollectionCandidate(collection=collection_id, resource=None, reason="no data asset")
+
+    media_type = str(asset.get("type") or asset.get("media_type") or "")
+    if _is_parquet_asset(asset, media_type) and not _has_geometry(collection):
+        return CollectionCandidate(
+            collection=collection_id,
+            resource=None,
+            reason="non-spatial Parquet asset",
+        )
+    resource_type, resource_format = _classify_asset(collection, asset, media_type)
+    if resource_type is None or resource_format is None:
+        return CollectionCandidate(
+            collection=collection_id,
+            resource=None,
+            reason=f"unsupported media type: {media_type or 'unknown'}",
+        )
+
+    href = str(asset["href"])
+    metadata = _resource_metadata(collection, asset)
+    resolved_href = _resolve_asset_href(collection_path, href)
+    return CollectionCandidate(
+        collection=collection_id,
+        resource=ServerResourceSpec(
+            id=collection_id,
+            resource_type=resource_type,
+            format=resource_format,
+            href=resolved_href,
+            title=collection.get("title"),
+            description=collection.get("description"),
+            extent=collection.get("extent"),
+            crs=_crs(collection),
+            primary_key=_primary_key(collection),
+            native_name=_native_name(asset_key, resolved_href, resource_format),
+            metadata=metadata,
+            source_catalog=source_catalog,
+            source_collection=collection_id,
+            source_asset=str(asset_key),
+        ),
+    )
+
+
+def _collection_candidate_url(
+    collection_url: str, collection: dict[str, Any], source_catalog: str
+) -> CollectionCandidate:
+    collection_id = str(collection["id"])
+    asset_key, asset = _primary_asset(collection.get("assets", {}))
+    if asset is None:
+        return CollectionCandidate(collection=collection_id, resource=None, reason="no data asset")
+
+    media_type = str(asset.get("type") or asset.get("media_type") or "")
+    if _is_parquet_asset(asset, media_type) and not _has_geometry(collection):
+        return CollectionCandidate(
+            collection=collection_id,
+            resource=None,
+            reason="non-spatial Parquet asset",
+        )
+    resource_type, resource_format = _classify_asset(collection, asset, media_type)
+    if resource_type is None or resource_format is None:
+        return CollectionCandidate(
+            collection=collection_id,
+            resource=None,
+            reason=f"unsupported media type: {media_type or 'unknown'}",
+        )
+
+    href = str(asset["href"])
+    metadata = _resource_metadata(collection, asset)
+    resolved_href = urljoin(collection_url, href)
+    return CollectionCandidate(
+        collection=collection_id,
+        resource=ServerResourceSpec(
+            id=collection_id,
+            resource_type=resource_type,
+            format=resource_format,
+            href=resolved_href,
+            title=collection.get("title"),
+            description=collection.get("description"),
+            extent=collection.get("extent"),
+            crs=_crs(collection),
+            primary_key=_primary_key(collection),
+            native_name=_native_name(asset_key, resolved_href, resource_format),
+            metadata=metadata,
+            source_catalog=source_catalog,
+            source_collection=collection_id,
+            source_asset=str(asset_key),
+        ),
+    )
+
+
+def _primary_asset(assets: Any) -> tuple[str | None, dict[str, Any] | None]:
+    if not isinstance(assets, dict):
+        return None, None
+    data_assets = [
+        (key, asset)
+        for key, asset in assets.items()
+        if isinstance(asset, dict) and "data" in (asset.get("roles") or [])
+    ]
+    if not data_assets:
+        data_assets = [(key, asset) for key, asset in assets.items() if isinstance(asset, dict)]
+    if not data_assets:
+        return None, None
+    return data_assets[0]
+
+
+def _native_name(
+    asset_key: str | None, href: str, resource_format: ResourceFormat
+) -> str | None:
+    if resource_format == ResourceFormat.GEOPARQUET:
+        stem = Path(urlparse(href).path).stem
+        if stem:
+            return stem
+    return str(asset_key) if asset_key is not None else None
+
+
+def _classify_asset(
+    collection: dict[str, Any], asset: dict[str, Any], media_type: str
+) -> tuple[ResourceType | None, ResourceFormat | None]:
+    href = str(asset.get("href") or "").lower()
+    if _is_parquet_asset(asset, media_type):
+        return ResourceType.VECTOR, ResourceFormat.GEOPARQUET
+    if media_type in _COG_MEDIA_TYPES:
+        return ResourceType.RASTER, ResourceFormat.COG
+    if media_type in _PMTILES_MEDIA_TYPES or href.endswith(".pmtiles"):
+        return ResourceType.TILES, ResourceFormat.PMTILES
+    return None, None
+
+
+def _is_parquet_asset(asset: dict[str, Any], media_type: str) -> bool:
+    href = str(asset.get("href") or "").lower()
+    return media_type in _GEOPARQUET_MEDIA_TYPES or href.endswith(".parquet")
+
+
+def _has_geometry(collection: dict[str, Any]) -> bool:
+    if isinstance(collection.get("table:primary_geometry"), str):
+        return True
+    if collection.get("geoparquet:geometry_type") is not None:
+        return True
+    columns = collection.get("table:columns")
+    if not isinstance(columns, list):
+        return False
+    for column in columns:
+        if not isinstance(column, dict):
+            continue
+        name = column.get("name")
+        if name in {"geom", "geometry", "the_geom"}:
+            return True
+    return False
+
+
+def _resource_metadata(collection: dict[str, Any], asset: dict[str, Any]) -> dict[str, object]:
+    metadata: dict[str, object] = {}
+    for key in ("license", "providers", "keywords", "summaries"):
+        value = collection.get(key)
+        if value is not None:
+            metadata[key] = value
+    for key in ("file:checksum", "checksum:multihash", "type", "roles"):
+        value = asset.get(key)
+        if value is not None:
+            metadata[key] = value
+    return metadata
+
+
+def _crs(collection: dict[str, Any]) -> str | None:
+    summaries = collection.get("summaries")
+    if not isinstance(summaries, dict):
+        return None
+    epsg = summaries.get("proj:epsg")
+    if isinstance(epsg, list) and epsg:
+        return f"EPSG:{epsg[0]}"
+    if isinstance(epsg, int):
+        return f"EPSG:{epsg}"
+    return None
+
+
+def _primary_key(collection: dict[str, Any]) -> str | None:
+    columns = collection.get("table:columns")
+    if not isinstance(columns, list):
+        return None
+    names: list[str] = []
+    for column in columns:
+        if not isinstance(column, dict):
+            continue
+        name = column.get("name")
+        if isinstance(name, str):
+            names.append(name)
+    lowered = {name.lower(): name for name in names}
+    for candidate in ("id", "objectid", "_id", "fid", "ogc_fid", "gid"):
+        match = lowered.get(candidate)
+        if match is not None:
+            return match
+    return None
+
+
+def _resolve_asset_href(collection_path: Path, href: str) -> str:
+    if _is_remote_href(href):
+        return href
+    return str((collection_path.parent / href).resolve())
+
+
+def _is_remote_href(href: str) -> bool:
+    parsed = urlparse(href)
+    return bool(parsed.scheme and parsed.scheme != "file")
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def _fetch_json(url: str) -> dict[str, Any]:
+    request = Request(url, headers={"User-Agent": "portolan-cli/0.8"})
+    with urlopen(request, timeout=30) as response:
+        data = json.loads(response.read().decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{url} must contain a JSON object")
+    return data

--- a/portolan_cli/server/providers/__init__.py
+++ b/portolan_cli/server/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Server provider implementations."""

--- a/portolan_cli/server/providers/base.py
+++ b/portolan_cli/server/providers/base.py
@@ -1,0 +1,21 @@
+"""Server provider protocol."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from portolan_cli.server.model import PublishPlan, PublishResult
+
+
+class ServerProvider(Protocol):
+    """Protocol implemented by server providers."""
+
+    def plan(self, catalog_root: Path) -> PublishPlan:
+        """Plan changes for a Portolan catalog."""
+
+    def publish(self, catalog_root: Path) -> PublishResult:
+        """Publish a Portolan catalog."""
+
+    def sync(self, catalog_root: Path) -> PublishResult:
+        """Reconcile a Portolan catalog."""

--- a/portolan_cli/server/providers/geoserver/__init__.py
+++ b/portolan_cli/server/providers/geoserver/__init__.py
@@ -1,0 +1,5 @@
+"""GeoServer server provider."""
+
+from portolan_cli.server.providers.geoserver.planner import GeoServerProvider
+
+__all__ = ["GeoServerProvider"]

--- a/portolan_cli/server/providers/geoserver/client.py
+++ b/portolan_cli/server/providers/geoserver/client.py
@@ -1,0 +1,276 @@
+"""Thin wrapper around python-geoservercloud."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class GeoServerClientProtocol(Protocol):
+    """Protocol used by the GeoServer provider."""
+
+    def list_portolan_resources(self, workspace: str) -> dict[str, dict[str, Any]]:
+        """Return Portolan-managed resources keyed by collection id."""
+
+    def ensure_workspace(self, workspace: str) -> None:
+        """Create the workspace if needed."""
+
+    def publish_geoparquet(
+        self,
+        workspace: str,
+        name: str,
+        href: str,
+        metadata: dict[str, object],
+        primary_key: str | None = None,
+        native_name: str | None = None,
+    ) -> None:
+        """Publish a GeoParquet resource."""
+
+    def publish_cog(
+        self, workspace: str, name: str, href: str, metadata: dict[str, object]
+    ) -> None:
+        """Publish a COG resource."""
+
+
+class GeoServerClient:
+    """Wrap geoservercloud behind Portolan's provider boundary."""
+
+    def __init__(self, url: str, user: str, password: str, *, verifytls: bool = True) -> None:
+        try:
+            from geoservercloud import GeoServerCloud  # type: ignore[import-untyped]
+        except ImportError as exc:  # pragma: no cover - exercised only without optional dep
+            raise RuntimeError(
+                "GeoServer support requires the 'geoservercloud' package. "
+                "Install portolan-cli with GeoServer dependencies."
+            ) from exc
+
+        self._client: Any = GeoServerCloud(
+            url=url,
+            user=user,
+            password=password,
+            verifytls=verifytls,
+        )
+
+    def list_portolan_resources(self, workspace: str) -> dict[str, dict[str, Any]]:
+        """Read Portolan provenance from GeoServer ResourceInfo metadata."""
+        managed: dict[str, dict[str, Any]] = {}
+        datastores, datastore_status = self._client.get_datastores(workspace)
+        if datastore_status < 400 and isinstance(datastores, list):
+            for datastore in datastores:
+                name = datastore.get("name")
+                if isinstance(name, str):
+                    self._collect_feature_type(workspace, name, managed)
+
+        coverage_stores, coverage_store_status = self._coverage_stores(workspace)
+        if coverage_store_status < 400:
+            for store in coverage_stores:
+                self._collect_coverage(workspace, store, managed)
+        return managed
+
+    def ensure_workspace(self, workspace: str) -> None:
+        """Create or update the workspace."""
+        self._raise_on_error("create workspace", self._client.create_workspace(workspace))
+
+    def publish_geoparquet(
+        self,
+        workspace: str,
+        name: str,
+        href: str,
+        metadata: dict[str, object],
+        primary_key: str | None = None,
+        native_name: str | None = None,
+    ) -> None:
+        """Create a GeoParquet store and FeatureType with provenance metadata."""
+        self._raise_on_error(
+            "create GeoParquet datastore",
+            self._client.create_datastore(
+                workspace_name=workspace,
+                datastore_name=name,
+                datastore_type="GeoParquet",
+                connection_parameters=_geoparquet_connection_parameters(
+                    workspace, href, primary_key
+                ),
+                description=f"Portolan-managed GeoParquet resource {name}",
+            ),
+        )
+        self._raise_on_error(
+            "create FeatureType",
+            self._client.create_feature_type(
+                layer_name=name,
+                workspace_name=workspace,
+                datastore_name=name,
+                title=str(metadata.get("title") or name),
+                abstract=str(metadata.get("description") or ""),
+                keywords=_string_list(metadata.get("keywords")),
+                native_name=native_name or name,
+            ),
+        )
+        self._put_feature_type_metadata(workspace, name, name, metadata)
+
+    def publish_cog(
+        self, workspace: str, name: str, href: str, metadata: dict[str, object]
+    ) -> None:
+        """Create a COG coverage store and Coverage with provenance metadata."""
+        range_reader = "HTTP" if href.startswith(("http://", "https://")) else "FILE"
+        self._raise_on_error(
+            "create COG coverage store",
+            self._client.create_coverage_store(
+                workspace_name=workspace,
+                coveragestore_name=name,
+                url=f"cog://{href}",
+                type="GeoTIFF",
+                metadata={"cogSettings": {"rangeReaderSettings": range_reader}},
+            ),
+        )
+        self._raise_on_error(
+            "create Coverage",
+            self._client.create_coverage(
+                workspace_name=workspace,
+                coveragestore_name=name,
+                coverage_name=name,
+                title=str(metadata.get("title") or name),
+            ),
+        )
+        self._put_coverage_metadata(workspace, name, name, metadata)
+
+    def _collect_feature_type(
+        self, workspace: str, datastore: str, managed: dict[str, dict[str, Any]]
+    ) -> None:
+        rest_service = self._client.rest_service
+        path = rest_service.rest_endpoints.featuretype(workspace, datastore, datastore)
+        try:
+            response = rest_service.rest_client.get(path)
+        except Exception:
+            return
+        if response.status_code >= 400:
+            return
+        payload = response.json()
+        feature_type = payload.get("featureType", {})
+        if not isinstance(feature_type, dict):
+            return
+        metadata = _metadata_entries(feature_type.get("metadata"))
+        collection = metadata.get("portolan.collection")
+        if _is_managed(metadata.get("portolan.managed")) and isinstance(collection, str):
+            managed[collection] = metadata
+
+    def _collect_coverage(
+        self, workspace: str, coverage_store: str, managed: dict[str, dict[str, Any]]
+    ) -> None:
+        try:
+            coverage, status = self._client.get_coverage(workspace, coverage_store, coverage_store)
+        except Exception:
+            return
+        if status >= 400 or not isinstance(coverage, dict):
+            return
+        metadata = _metadata_entries(coverage.get("metadata"))
+        collection = metadata.get("portolan.collection")
+        if _is_managed(metadata.get("portolan.managed")) and isinstance(collection, str):
+            managed[collection] = metadata
+
+    def _coverage_stores(self, workspace: str) -> tuple[list[str], int]:
+        rest_service = self._client.rest_service
+        endpoints = rest_service.rest_endpoints
+        rest_client = rest_service.rest_client
+        response = rest_client.get(endpoints.coveragestores(workspace))
+        if response.status_code >= 400:
+            return [], response.status_code
+        payload = response.json()
+        return coverage_store_names(payload), response.status_code
+
+    def _put_feature_type_metadata(
+        self, workspace: str, datastore: str, name: str, metadata: dict[str, object]
+    ) -> None:
+        payload = {"featureType": {"name": name, "metadata": _metadata_payload(metadata)}}
+        rest_service = self._client.rest_service
+        path = rest_service.rest_endpoints.featuretype(workspace, datastore, name)
+        response = rest_service.rest_client.put(path, json=payload)
+        self._raise_on_error("write FeatureType provenance", ("", response.status_code))
+
+    def _put_coverage_metadata(
+        self, workspace: str, coverage_store: str, name: str, metadata: dict[str, object]
+    ) -> None:
+        payload = {"coverage": {"name": name, "metadata": _metadata_payload(metadata)}}
+        rest_service = self._client.rest_service
+        path = rest_service.rest_endpoints.coverage(workspace, coverage_store, name)
+        response = rest_service.rest_client.put(path, json=payload)
+        self._raise_on_error("write Coverage provenance", ("", response.status_code))
+
+    def _raise_on_error(self, operation: str, result: tuple[Any, int]) -> None:
+        content, status = result
+        if status >= 400:
+            raise RuntimeError(f"{operation} failed with HTTP {status}: {content}")
+
+
+def _metadata_payload(metadata: dict[str, object]) -> dict[str, object]:
+    return {
+        "entry": [
+            {"@key": key, "$": _metadata_value(value)}
+            for key, value in metadata.items()
+            if value is not None
+        ]
+    }
+
+
+def _geoparquet_connection_parameters(
+    workspace: str, href: str, primary_key: str | None
+) -> dict[str, object]:
+    parameters: dict[str, object] = {
+        "dbtype": "geoparquet",
+        "uri": href,
+        "namespace": f"http://{workspace}",
+    }
+    if primary_key is not None:
+        parameters["primary_key_id"] = primary_key
+    return parameters
+
+
+def _metadata_value(value: object) -> str:
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def coverage_store_names(payload: object) -> list[str]:
+    """Return coverage store names from GeoServer REST payload variants."""
+    if not isinstance(payload, dict):
+        return []
+    coverage_stores = payload.get("coverageStores", {})
+    if not isinstance(coverage_stores, dict):
+        return []
+    stores = coverage_stores.get("coverageStore", [])
+    if isinstance(stores, dict):
+        stores = [stores]
+    if not isinstance(stores, list):
+        return []
+    return [
+        store["name"]
+        for store in stores
+        if isinstance(store, dict) and isinstance(store.get("name"), str)
+    ]
+
+
+def _metadata_entries(metadata: object) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        return {}
+    entries = metadata.get("entry", [])
+    if isinstance(entries, dict):
+        return dict(entries)
+    result: dict[str, Any] = {}
+    if isinstance(entries, list):
+        for entry in entries:
+            if isinstance(entry, dict) and isinstance(entry.get("@key"), str):
+                result[entry["@key"]] = entry.get("$")
+    return result
+
+
+def _string_list(value: object) -> list[str] | None:
+    if isinstance(value, list):
+        return [str(item) for item in value]
+    return None
+
+
+def _is_managed(value: object) -> bool:
+    return value is True or (isinstance(value, str) and value.lower() == "true")

--- a/portolan_cli/server/providers/geoserver/planner.py
+++ b/portolan_cli/server/providers/geoserver/planner.py
@@ -1,0 +1,175 @@
+"""GeoServer provider plan and publish orchestration."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from pathlib import Path
+
+from portolan_cli.server.model import (
+    PlanAction,
+    PlanEntry,
+    PublishPlan,
+    PublishResult,
+    ResourceFormat,
+    ServerCatalog,
+    ServerResourceSpec,
+)
+from portolan_cli.server.planner import load_server_catalog
+from portolan_cli.server.providers.geoserver.client import GeoServerClientProtocol
+
+
+class GeoServerProvider:
+    """GeoServer implementation of Portolan's server provider protocol."""
+
+    def __init__(self, client: GeoServerClientProtocol, workspace: str | None = None) -> None:
+        self._client = client
+        self._workspace = workspace
+
+    def plan(self, catalog_root: Path) -> PublishPlan:
+        """Compute a read-only GeoServer publication plan."""
+        catalog = load_server_catalog(catalog_root)
+        return self.plan_catalog(catalog)
+
+    def plan_catalog(self, catalog: ServerCatalog) -> PublishPlan:
+        """Compute a read-only GeoServer publication plan for a loaded catalog."""
+        workspace = self._workspace or catalog.catalog_id
+        existing = self._client.list_portolan_resources(workspace)
+        entries: list[PlanEntry] = []
+        for candidate in catalog.candidates:
+            if candidate.resource is None:
+                entries.append(
+                    PlanEntry(
+                        collection=candidate.collection,
+                        format=None,
+                        action=PlanAction.SKIP,
+                        reason=candidate.reason,
+                    )
+                )
+                continue
+            if candidate.resource.format not in {
+                ResourceFormat.GEOPARQUET,
+                ResourceFormat.COG,
+            }:
+                entries.append(
+                    PlanEntry(
+                        collection=candidate.collection,
+                        format=candidate.resource.format,
+                        action=PlanAction.SKIP,
+                        reason="unsupported by GeoServer provider",
+                    )
+                )
+                continue
+            action = _action_for_existing(candidate.resource, existing.get(candidate.collection))
+            entries.append(
+                PlanEntry(
+                    collection=candidate.collection,
+                    format=candidate.resource.format,
+                    action=action,
+                )
+            )
+        return PublishPlan(workspace=workspace, entries=entries)
+
+    def publish(self, catalog_root: Path) -> PublishResult:
+        """Publish GeoParquet and COG resources to GeoServer."""
+        catalog = load_server_catalog(catalog_root)
+        return self.publish_catalog(catalog)
+
+    def publish_catalog(self, catalog: ServerCatalog) -> PublishResult:
+        """Publish a loaded catalog to GeoServer."""
+        workspace = self._workspace or catalog.catalog_id
+        self._client.ensure_workspace(workspace)
+        existing = self._client.list_portolan_resources(workspace)
+        published = 0
+        skipped = 0
+        errors: list[str] = []
+        for candidate in catalog.candidates:
+            if candidate.resource is None:
+                skipped += 1
+                continue
+            if (
+                _action_for_existing(candidate.resource, existing.get(candidate.collection))
+                == PlanAction.EXISTS
+            ):
+                skipped += 1
+                continue
+            resource = _with_provenance(candidate.resource, catalog.catalog_href)
+            server_name = geoserver_resource_name(resource.id)
+            resource = _with_geoserver_name(resource, server_name)
+            try:
+                if resource.format == ResourceFormat.GEOPARQUET:
+                    self._client.publish_geoparquet(
+                        workspace,
+                        server_name,
+                        resource.href,
+                        resource.metadata,
+                        resource.primary_key,
+                        resource.native_name,
+                    )
+                    published += 1
+                elif resource.format == ResourceFormat.COG:
+                    self._client.publish_cog(
+                        workspace, server_name, resource.href, resource.metadata
+                    )
+                    published += 1
+                else:
+                    skipped += 1
+            except Exception as exc:
+                errors.append(f"{candidate.collection}: {exc}")
+        return PublishResult(
+            workspace=workspace,
+            published=published,
+            skipped=skipped,
+            errors=errors,
+        )
+
+    def sync(self, catalog_root: Path) -> PublishResult:
+        """Initial sync behavior matches idempotent publish without pruning."""
+        return self.publish(catalog_root)
+
+
+def geoserver_resource_name(collection_id: str) -> str:
+    """Return a GeoServer-safe resource name for a STAC collection id."""
+    name = collection_id.replace("/", "__")
+    name = re.sub(r"[^A-Za-z0-9_.-]+", "_", name).strip("._-")
+    return name or "collection"
+
+
+def _with_geoserver_name(resource: ServerResourceSpec, server_name: str) -> ServerResourceSpec:
+    metadata = dict(resource.metadata)
+    metadata["portolan.geoserver_name"] = server_name
+    return replace(resource, metadata=metadata)
+
+
+def _with_provenance(resource: ServerResourceSpec, catalog_href: str) -> ServerResourceSpec:
+    metadata = dict(resource.metadata)
+    metadata["title"] = resource.title
+    metadata["description"] = resource.description
+    metadata["portolan.managed"] = True
+    metadata["portolan.catalog"] = catalog_href
+    metadata["portolan.collection"] = resource.source_collection
+    metadata["portolan.asset"] = resource.href
+    metadata["portolan.primary_key"] = resource.primary_key
+    metadata["portolan.native_name"] = resource.native_name
+    checksum = metadata.get("file:checksum") or metadata.get("checksum:multihash")
+    if checksum is not None:
+        metadata["portolan.checksum"] = checksum
+    return replace(resource, metadata=metadata)
+
+
+def _action_for_existing(
+    resource: ServerResourceSpec, existing_metadata: dict[str, object] | None
+) -> PlanAction:
+    if existing_metadata is None:
+        return PlanAction.CREATE
+    if existing_metadata.get("portolan.asset") != resource.href:
+        return PlanAction.UPDATE
+    if (
+        resource.primary_key is not None
+        and existing_metadata.get("portolan.primary_key") != resource.primary_key
+    ):
+        return PlanAction.UPDATE
+    checksum = resource.metadata.get("file:checksum") or resource.metadata.get("checksum:multihash")
+    if checksum is not None and existing_metadata.get("portolan.checksum") != checksum:
+        return PlanAction.UPDATE
+    return PlanAction.EXISTS

--- a/portolan_cli/server/registry.py
+++ b/portolan_cli/server/registry.py
@@ -1,0 +1,132 @@
+"""Load Portolan registry exports."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+from portolan_cli.server.model import RegistryCatalogEntry
+from portolan_cli.server.planner import _fetch_json
+
+DEFAULT_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/portolan-sdi/portolan-registry/"
+    "refs/heads/main/exports/catalogs.json"
+)
+
+
+def load_registry_entries(
+    registry_url: str = DEFAULT_REGISTRY_URL,
+    *,
+    fetch_json: Callable[[str], dict[str, Any]] | None = None,
+    catalog_ids: set[str] | None = None,
+    include_stale: bool = False,
+    limit: int | None = None,
+) -> list[RegistryCatalogEntry]:
+    """Load catalog entries from a Portolan registry export."""
+    fetch = fetch_json or _fetch_json
+    registry = fetch(registry_url)
+    entries: list[RegistryCatalogEntry] = []
+    for link in registry.get("links", []):
+        if not isinstance(link, dict) or link.get("rel") != "child":
+            continue
+        href = link.get("href")
+        registry_id = link.get("portolan_registry:id")
+        if not isinstance(href, str) or not isinstance(registry_id, str):
+            continue
+        status = link.get("portolan_registry:status")
+        if status != "valid" and not include_stale:
+            continue
+        if catalog_ids is not None and registry_id not in catalog_ids:
+            continue
+        title = link.get("title")
+        entries.append(
+            RegistryCatalogEntry(
+                id=registry_id,
+                url=href,
+                title=title if isinstance(title, str) else None,
+                status=status if isinstance(status, str) else None,
+            )
+        )
+        if limit is not None and len(entries) >= limit:
+            break
+    return entries
+
+
+def download_registry_catalog(
+    catalog_url: str,
+    output_dir: Path,
+    *,
+    fetch_json: Callable[[str], dict[str, Any]] | None = None,
+) -> Path:
+    """Download a published catalog snapshot for local server commands."""
+    fetch = fetch_json or _fetch_json
+    catalog = fetch(catalog_url)
+    catalog_id = str(catalog.get("id") or _fallback_catalog_id(catalog_url))
+    catalog_root = output_dir / catalog_id
+    _write_catalog_tree(catalog_url, catalog, catalog_url, catalog_root, fetch)
+    return catalog_root
+
+
+def _write_catalog_tree(
+    document_url: str,
+    document: dict[str, Any],
+    root_url: str,
+    output_root: Path,
+    fetch_json: Callable[[str], dict[str, Any]],
+) -> None:
+    relative_path = _relative_document_path(root_url, document_url)
+    target = output_root / relative_path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if document.get("type") == "Collection":
+        document = _with_absolute_asset_hrefs(document_url, document)
+    target.write_text(json.dumps(document, indent=2) + "\n", encoding="utf-8")
+
+    for link in document.get("links", []):
+        if not isinstance(link, dict) or link.get("rel") != "child":
+            continue
+        href = link.get("href")
+        if not isinstance(href, str):
+            continue
+        child_url = urljoin(document_url, href)
+        child = fetch_json(child_url)
+        if child.get("type") in {"Catalog", "Collection"}:
+            _write_catalog_tree(child_url, child, root_url, output_root, fetch_json)
+
+
+def _with_absolute_asset_hrefs(document_url: str, collection: dict[str, Any]) -> dict[str, Any]:
+    assets = collection.get("assets")
+    if not isinstance(assets, dict):
+        return collection
+    updated = dict(collection)
+    updated_assets: dict[str, Any] = {}
+    for key, asset in assets.items():
+        if not isinstance(asset, dict):
+            updated_assets[key] = asset
+            continue
+        href = asset.get("href")
+        if isinstance(href, str):
+            rewritten = dict(asset)
+            rewritten["href"] = urljoin(document_url, href)
+            updated_assets[key] = rewritten
+        else:
+            updated_assets[key] = asset
+    updated["assets"] = updated_assets
+    return updated
+
+
+def _relative_document_path(root_url: str, document_url: str) -> Path:
+    root_path = Path(urlparse(root_url).path).parent
+    document_path = Path(urlparse(document_url).path)
+    try:
+        relative = document_path.relative_to(root_path)
+    except ValueError:
+        return Path(document_path.name or "catalog.json")
+    return relative
+
+
+def _fallback_catalog_id(catalog_url: str) -> str:
+    parent = Path(urlparse(catalog_url).path).parent.name
+    return parent or "catalog"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -271,6 +271,7 @@ pytest_add_cli_args_test_selection = ["tests/"]
 # FileNotFoundError that fails the in-mutation pytest run and aborts the gate.
 also_copy = [
   "scripts/",
+  "docs/reference/",
   ".pip-audit-ignores",
   ".mutation-baseline",
   ".mutation-shards.json",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "defusedxml>=0.7.1", # Safe XML parsing (XXE protection) for CSW/ISO 19139 metadata
     "duckdb>=1.5.2,<1.5.6", # 1.5.5 segfaults in ST_Read_Meta on malformed input; see known-issues
     "geopandas>=0.14.0", # Reads GeoParquet for the thumbnail floor, which every collection needs (Issue #683)
+    "geoservercloud>=0.8.12", # GeoServer Cloud REST client for `portolan server geoserver`
     "geoparquet-io>=1.4.0", # Table API keeps the source CRS on write (gpio#625, Issue #810)
     "httpx>=0.27.0", # HTTP client for ArcGIS REST API discovery
     "matplotlib>=3.8.0", # Renders the deterministic thumbnail floor. Core, not optional: PTL-VIZ-001 is an ERROR, so a default install must be able to produce a conformant catalog (#518 Track 1, #683)

--- a/tests/unit/test_mutation_ci_config.py
+++ b/tests/unit/test_mutation_ci_config.py
@@ -69,3 +69,11 @@ def test_mutmut_excludes_static_source_scans() -> None:
 
     marker_expression = mutmut_args[mutmut_args.index("-m") + 1]
     assert "not source_scan" in marker_expression
+
+
+def test_mutmut_copies_checked_in_reference_pages() -> None:
+    """Reference freshness tests must see generated docs inside mutants/."""
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    also_copy = set(config["tool"]["mutmut"]["also_copy"])
+
+    assert "docs/reference/" in also_copy

--- a/tests/unit/test_server_geoserver.py
+++ b/tests/unit/test_server_geoserver.py
@@ -1,0 +1,657 @@
+"""GeoServer provider tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from portolan_cli.cli import cli
+from portolan_cli.server.model import (
+    CollectionCandidate,
+    PlanAction,
+    ResourceFormat,
+    ResourceType,
+    ServerCatalog,
+    ServerResourceSpec,
+)
+from portolan_cli.server.planner import discover_server_resources, load_server_catalog_url
+from portolan_cli.server.providers.geoserver.client import GeoServerClient, coverage_store_names
+from portolan_cli.server.providers.geoserver.planner import (
+    GeoServerProvider,
+    geoserver_resource_name,
+)
+from portolan_cli.server.registry import download_registry_catalog, load_registry_entries
+
+pytestmark = pytest.mark.unit
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _base_extent() -> dict[str, Any]:
+    return {
+        "spatial": {"bbox": [[-71.0, -35.0, -70.0, -34.0]]},
+        "temporal": {"interval": [[None, None]]},
+    }
+
+
+def _collection(
+    collection_id: str,
+    asset: dict[str, Any],
+    *,
+    title: str | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "type": "Collection",
+        "stac_version": "1.1.0",
+        "id": collection_id,
+        "description": f"{collection_id} description",
+        "license": "CC-BY-4.0",
+        "extent": _base_extent(),
+        "links": [],
+        "assets": {"data": asset},
+        "keywords": ["portolan", collection_id],
+    }
+    if str(asset.get("href", "")).lower().endswith(".parquet"):
+        data["table:primary_geometry"] = "geometry"
+    if title:
+        data["title"] = title
+    return data
+
+
+def _catalog(root: Path) -> None:
+    _write_json(
+        root / "catalog.json",
+        {
+            "type": "Catalog",
+            "stac_version": "1.1.0",
+            "id": "demo-catalog",
+            "description": "Demo catalog",
+            "links": [
+                {"rel": "child", "href": "./roads/collection.json", "type": "application/json"},
+                {"rel": "child", "href": "./elevation/collection.json", "type": "application/json"},
+                {"rel": "child", "href": "./basemap/collection.json", "type": "application/json"},
+                {"rel": "child", "href": "./notes/collection.json", "type": "application/json"},
+            ],
+        },
+    )
+    _write_json(root / ".portolan" / "config.yaml", {})
+    _write_json(
+        root / "roads" / "collection.json",
+        _collection(
+            "roads",
+            {
+                "href": "https://example.test/roads.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+                "file:checksum": "sha256:roads",
+            },
+            title="Roads",
+        ),
+    )
+    _write_json(
+        root / "elevation" / "collection.json",
+        _collection(
+            "elevation",
+            {
+                "href": "https://example.test/elevation.tif",
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "roles": ["data"],
+            },
+        ),
+    )
+    _write_json(
+        root / "basemap" / "collection.json",
+        _collection(
+            "basemap",
+            {
+                "href": "https://example.test/basemap.pmtiles",
+                "type": "application/vnd.pmtiles",
+                "roles": ["data"],
+            },
+        ),
+    )
+    _write_json(
+        root / "notes" / "collection.json",
+        _collection(
+            "notes",
+            {
+                "href": "https://example.test/notes.txt",
+                "type": "text/plain",
+                "roles": ["data"],
+            },
+        ),
+    )
+
+
+class RecordingGeoServerClient:
+    """Small fake for provider tests."""
+
+    def __init__(self, existing: dict[str, dict[str, Any]] | None = None) -> None:
+        self.existing = existing or {}
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    def list_portolan_resources(self, workspace: str) -> dict[str, dict[str, Any]]:
+        self.calls.append(("list_portolan_resources", (workspace,), {}))
+        return self.existing
+
+    def ensure_workspace(self, workspace: str) -> None:
+        self.calls.append(("ensure_workspace", (workspace,), {}))
+
+    def publish_geoparquet(
+        self,
+        workspace: str,
+        name: str,
+        href: str,
+        metadata: dict[str, object],
+        primary_key: str | None = None,
+        native_name: str | None = None,
+    ) -> None:
+        self.calls.append(
+            ("publish_geoparquet", (workspace, name, href, metadata, primary_key, native_name), {})
+        )
+
+    def publish_cog(
+        self, workspace: str, name: str, href: str, metadata: dict[str, object]
+    ) -> None:
+        self.calls.append(("publish_cog", (workspace, name, href, metadata), {}))
+
+
+class RaisingRestClient:
+    def get(self, path: str) -> Any:
+        raise RuntimeError(path)
+
+
+class RestEndpoints:
+    def featuretype(self, workspace: str, datastore: str, name: str) -> str:
+        return f"/{workspace}/{datastore}/{name}"
+
+
+class RestService:
+    rest_client = RaisingRestClient()
+    rest_endpoints = RestEndpoints()
+
+
+class BrokenGeoServerApi:
+    rest_service = RestService()
+
+    def get_datastores(self, workspace: str) -> tuple[list[dict[str, str]], int]:
+        return ([{"name": "broken"}], 200)
+
+
+def test_geoserver_client_ignores_unreadable_existing_feature_types() -> None:
+    client = GeoServerClient.__new__(GeoServerClient)
+    client._client = BrokenGeoServerApi()
+    client._coverage_stores = lambda workspace: ([], 404)  # type: ignore[method-assign]
+
+    assert client.list_portolan_resources("workspace") == {}
+
+
+def test_discovers_publishable_collection_assets(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+
+    resources = discover_server_resources(tmp_path)
+
+    assert [(r.id, r.resource_type, r.format) for r in resources] == [
+        ("roads", ResourceType.VECTOR, ResourceFormat.GEOPARQUET),
+        ("elevation", ResourceType.RASTER, ResourceFormat.COG),
+        ("basemap", ResourceType.TILES, ResourceFormat.PMTILES),
+    ]
+    assert resources[0].href == "https://example.test/roads.parquet"
+    assert resources[0].metadata["file:checksum"] == "sha256:roads"
+
+
+def test_skips_non_spatial_parquet_assets(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+    collection_path = tmp_path / "roads" / "collection.json"
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    collection.pop("table:primary_geometry")
+    collection["table:columns"] = [
+        {"name": "_id", "type": "int64"},
+        {"name": "name", "type": "string"},
+    ]
+    _write_json(collection_path, collection)
+
+    provider = GeoServerProvider(client=RecordingGeoServerClient(), workspace="portolan")
+
+    plan = provider.plan(tmp_path)
+
+    assert plan.entries[0].collection == "roads"
+    assert plan.entries[0].action == PlanAction.SKIP
+    assert plan.entries[0].reason == "non-spatial Parquet asset"
+
+
+def test_discovers_primary_key_hint_from_table_columns(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+    collection_path = tmp_path / "roads" / "collection.json"
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    collection["table:columns"] = [
+        {"name": "name", "type": "string"},
+        {"name": "objectid", "type": "int64"},
+        {"name": "geometry", "type": "binary"},
+    ]
+    _write_json(collection_path, collection)
+
+    resources = discover_server_resources(tmp_path)
+
+    assert resources[0].primary_key == "objectid"
+
+
+def test_discovers_uppercase_primary_key_hint_from_table_columns(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+    collection_path = tmp_path / "roads" / "collection.json"
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    collection["table:columns"] = [
+        {"name": "OGC_FID", "type": "int64"},
+        {"name": "geom", "type": "binary"},
+    ]
+    _write_json(collection_path, collection)
+
+    resources = discover_server_resources(tmp_path)
+
+    assert resources[0].primary_key == "OGC_FID"
+
+
+def test_geoparquet_native_name_comes_from_asset_href_stem(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+    collection_path = tmp_path / "roads" / "collection.json"
+    collection = json.loads(collection_path.read_text(encoding="utf-8"))
+    collection["assets"] = {
+        "data": {
+            "href": "https://example.test/brazil_car_area_imovel.parquet",
+            "type": "application/vnd.apache.parquet",
+            "roles": ["data"],
+        }
+    }
+    _write_json(collection_path, collection)
+
+    resources = discover_server_resources(tmp_path)
+
+    assert resources[0].source_asset == "data"
+    assert resources[0].native_name == "brazil_car_area_imovel"
+
+
+def test_geoserver_plan_marks_existing_and_skipped_resources(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+    client = RecordingGeoServerClient(
+        existing={
+            "roads": {
+                "portolan.asset": "https://example.test/roads.parquet",
+                "portolan.checksum": "sha256:roads",
+                "portolan.primary_key": "id",
+            }
+        }
+    )
+    provider = GeoServerProvider(client=client, workspace="portolan")
+
+    plan = provider.plan(tmp_path)
+
+    assert [(entry.collection, entry.format, entry.action) for entry in plan.entries] == [
+        ("roads", ResourceFormat.GEOPARQUET, PlanAction.EXISTS),
+        ("elevation", ResourceFormat.COG, PlanAction.CREATE),
+        ("basemap", ResourceFormat.PMTILES, PlanAction.SKIP),
+        ("notes", None, PlanAction.SKIP),
+    ]
+
+
+def test_geoserver_plan_marks_managed_resource_with_different_asset_as_update(
+    tmp_path: Path,
+) -> None:
+    _catalog(tmp_path)
+    client = RecordingGeoServerClient(existing={"roads": {"portolan.asset": "old.parquet"}})
+    provider = GeoServerProvider(client=client, workspace="portolan")
+
+    plan = provider.plan(tmp_path)
+
+    assert plan.entries[0].action == PlanAction.UPDATE
+
+
+def test_geoserver_publish_sends_resource_provenance(tmp_path: Path) -> None:
+    _catalog(tmp_path)
+    client = RecordingGeoServerClient()
+    provider = GeoServerProvider(client=client, workspace="portolan")
+
+    result = provider.publish(tmp_path)
+
+    assert result.published == 2
+    assert client.calls[0] == ("ensure_workspace", ("portolan",), {})
+    publish_calls = [call for call in client.calls if call[0].startswith("publish_")]
+    assert [call[0] for call in publish_calls] == ["publish_geoparquet", "publish_cog"]
+    metadata = publish_calls[0][1][3]
+    primary_key = publish_calls[0][1][4]
+    native_name = publish_calls[0][1][5]
+    assert metadata["portolan.managed"] is True
+    assert metadata["portolan.catalog"] == str(tmp_path / "catalog.json")
+    assert metadata["portolan.collection"] == "roads"
+    assert metadata["portolan.asset"] == "https://example.test/roads.parquet"
+    assert metadata["portolan.checksum"] == "sha256:roads"
+    assert metadata["portolan.primary_key"] is None
+    assert metadata["portolan.native_name"] == "roads"
+    assert primary_key is None
+    assert native_name == "roads"
+
+
+def test_geoserver_publish_uses_safe_name_for_nested_collection_id() -> None:
+    resource = ServerResourceSpec(
+        id="medio-ambiente/meteorologicos-diarios",
+        resource_type=ResourceType.VECTOR,
+        format=ResourceFormat.GEOPARQUET,
+        href="https://example.test/meteorologicos-diarios.parquet",
+        title="Meteorologicos Diarios",
+        description=None,
+        extent=None,
+        crs=None,
+        primary_key=None,
+        native_name="meteorologicos-diarios",
+        metadata={},
+        source_catalog=None,
+        source_collection="medio-ambiente/meteorologicos-diarios",
+        source_asset="data",
+    )
+    catalog = ServerCatalog(
+        root=None,
+        catalog_id="madrid-datos-abiertos",
+        catalog_href="https://example.test/catalog.json",
+        candidates=[
+            CollectionCandidate(
+                collection="medio-ambiente/meteorologicos-diarios",
+                resource=resource,
+            )
+        ],
+    )
+    client = RecordingGeoServerClient()
+    provider = GeoServerProvider(client=client)
+
+    result = provider.publish_catalog(catalog)
+
+    assert result.published == 1
+    publish_call = [call for call in client.calls if call[0] == "publish_geoparquet"][0]
+    assert publish_call[1][1] == "medio-ambiente__meteorologicos-diarios"
+    assert publish_call[1][5] == "meteorologicos-diarios"
+    assert publish_call[1][3]["portolan.collection"] == "medio-ambiente/meteorologicos-diarios"
+    assert publish_call[1][3]["portolan.geoserver_name"] == (
+        "medio-ambiente__meteorologicos-diarios"
+    )
+
+
+def test_geoserver_resource_name_replaces_url_path_separators() -> None:
+    assert (
+        geoserver_resource_name("medio-ambiente/meteorologicos-diarios")
+        == "medio-ambiente__meteorologicos-diarios"
+    )
+
+
+def test_cli_geoserver_plan_uses_env_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _catalog(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PORTOLAN_GEOSERVER_URL", "http://geoserver.test/geoserver/cloud")
+    monkeypatch.setenv("PORTOLAN_GEOSERVER_USER", "admin")
+    monkeypatch.setenv("PORTOLAN_GEOSERVER_PASSWORD", "secret")
+    monkeypatch.setattr(
+        "portolan_cli.server.providers.geoserver.client.GeoServerClient",
+        lambda url, user, password: RecordingGeoServerClient(),
+    )
+
+    result = CliRunner().invoke(cli, ["server", "geoserver", "plan"])
+
+    assert result.exit_code == 0, result.output
+    assert "Workspace: demo-catalog" in result.output
+    assert "roads" in result.output
+    assert "GeoParquet" in result.output
+    assert "elevation" in result.output
+    assert "COG" in result.output
+    assert "secret" not in result.output
+
+
+def test_cli_geoserver_plan_accepts_catalog_root_argument(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _catalog(tmp_path)
+    monkeypatch.setenv("PORTOLAN_GEOSERVER_URL", "http://geoserver.test/geoserver/cloud")
+    monkeypatch.setenv("PORTOLAN_GEOSERVER_USER", "admin")
+    monkeypatch.setenv("PORTOLAN_GEOSERVER_PASSWORD", "secret")
+    monkeypatch.setattr(
+        "portolan_cli.server.providers.geoserver.client.GeoServerClient",
+        lambda url, user, password: RecordingGeoServerClient(),
+    )
+
+    result = CliRunner().invoke(cli, ["server", "geoserver", "plan", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Workspace: demo-catalog" in result.output
+    assert "roads" in result.output
+
+
+def test_registry_entries_use_valid_child_links() -> None:
+    registry = {
+        "links": [
+            {
+                "rel": "child",
+                "href": "https://example.test/a/catalog.json",
+                "title": "A",
+                "portolan_registry:id": "catalog-a",
+                "portolan_registry:status": "valid",
+            },
+            {
+                "rel": "child",
+                "href": "https://example.test/b/catalog.json",
+                "portolan_registry:id": "catalog-b",
+                "portolan_registry:status": "stale",
+            },
+        ]
+    }
+
+    entries = load_registry_entries(
+        "https://registry.test/catalogs.json", fetch_json=lambda url: registry
+    )
+
+    assert [(entry.id, entry.url, entry.title, entry.status) for entry in entries] == [
+        ("catalog-a", "https://example.test/a/catalog.json", "A", "valid")
+    ]
+
+
+def test_download_registry_catalog_writes_local_snapshot_with_absolute_asset_hrefs(
+    tmp_path: Path,
+) -> None:
+    responses = {
+        "https://example.test/demo/catalog.json": {
+            "type": "Catalog",
+            "id": "demo",
+            "links": [
+                {"rel": "child", "href": "./roads/collection.json", "type": "application/json"}
+            ],
+        },
+        "https://example.test/demo/roads/collection.json": _collection(
+            "roads",
+            {
+                "href": "./roads.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+            },
+        ),
+    }
+
+    catalog_root = download_registry_catalog(
+        "https://example.test/demo/catalog.json",
+        tmp_path,
+        fetch_json=lambda url: responses[url],
+    )
+
+    assert catalog_root == tmp_path / "demo"
+    catalog = json.loads((catalog_root / "catalog.json").read_text(encoding="utf-8"))
+    collection = json.loads(
+        (catalog_root / "roads" / "collection.json").read_text(encoding="utf-8")
+    )
+    assert catalog["links"][0]["href"] == "./roads/collection.json"
+    assert (
+        collection["assets"]["data"]["href"]
+        == "https://example.test/demo/roads/roads.parquet"
+    )
+
+
+def test_cli_registry_list_outputs_online_catalogs(monkeypatch: pytest.MonkeyPatch) -> None:
+    from portolan_cli.server.model import RegistryCatalogEntry
+
+    monkeypatch.setattr(
+        "portolan_cli.server.registry.load_registry_entries",
+        lambda *args, **kwargs: [
+            RegistryCatalogEntry(
+                id="catalog-a",
+                url="https://example.test/a/catalog.json",
+                title="Catalog A",
+                status="valid",
+            )
+        ],
+    )
+
+    result = CliRunner().invoke(cli, ["registry", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "catalog-a" in result.output
+    assert "https://example.test/a/catalog.json" in result.output
+
+
+def test_cli_registry_fetch_outputs_catalog_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from portolan_cli.server.model import RegistryCatalogEntry
+
+    monkeypatch.setattr(
+        "portolan_cli.server.registry.load_registry_entries",
+        lambda *args, **kwargs: [
+            RegistryCatalogEntry(
+                id="catalog-a",
+                url="https://example.test/a/catalog.json",
+                title="Catalog A",
+                status="valid",
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "portolan_cli.server.registry.download_registry_catalog",
+        lambda catalog_url, output_dir: tmp_path / "catalog-a",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["registry", "fetch", "catalog-a", "--output", str(tmp_path), "--path-only"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == str(tmp_path / "catalog-a")
+
+
+def test_cli_registry_fetch_all_outputs_all_catalog_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from portolan_cli.server.model import RegistryCatalogEntry
+
+    entries = [
+        RegistryCatalogEntry(
+            id="catalog-a",
+            url="https://example.test/a/catalog.json",
+            title="Catalog A",
+            status="valid",
+        ),
+        RegistryCatalogEntry(
+            id="catalog-b",
+            url="https://example.test/b/catalog.json",
+            title="Catalog B",
+            status="valid",
+        ),
+    ]
+    monkeypatch.setattr(
+        "portolan_cli.server.registry.load_registry_entries",
+        lambda *args, **kwargs: entries,
+    )
+    monkeypatch.setattr(
+        "portolan_cli.server.registry.download_registry_catalog",
+        lambda catalog_url, output_dir: output_dir / catalog_url.split("/")[-2],
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["registry", "fetch", "--all", "--output", str(tmp_path), "--path-only"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.splitlines() == [
+        str(tmp_path / "a"),
+        str(tmp_path / "b"),
+    ]
+
+
+def test_load_server_catalog_url_resolves_remote_collection_assets() -> None:
+    responses = {
+        "https://example.test/demo/catalog.json": {
+            "type": "Catalog",
+            "id": "demo",
+            "links": [
+                {"rel": "child", "href": "./roads/collection.json", "type": "application/json"}
+            ],
+        },
+        "https://example.test/demo/roads/collection.json": _collection(
+            "roads",
+            {
+                "href": "./roads.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+            },
+        ),
+    }
+
+    catalog = load_server_catalog_url(
+        "https://example.test/demo/catalog.json",
+        fetch_json=lambda url: responses[url],
+    )
+
+    assert catalog.catalog_id == "demo"
+    assert catalog.catalog_href == "https://example.test/demo/catalog.json"
+    assert catalog.candidates[0].resource is not None
+    assert catalog.candidates[0].resource.href == "https://example.test/demo/roads/roads.parquet"
+
+
+def test_geoserver_provider_can_plan_loaded_registry_catalog() -> None:
+    responses = {
+        "https://example.test/demo/catalog.json": {
+            "type": "Catalog",
+            "id": "demo",
+            "links": [
+                {"rel": "child", "href": "./roads/collection.json", "type": "application/json"}
+            ],
+        },
+        "https://example.test/demo/roads/collection.json": _collection(
+            "roads",
+            {
+                "href": "https://example.test/demo/roads/roads.parquet",
+                "type": "application/vnd.apache.parquet",
+                "roles": ["data"],
+            },
+        ),
+    }
+    catalog = load_server_catalog_url(
+        "https://example.test/demo/catalog.json",
+        fetch_json=lambda url: responses[url],
+    )
+    provider = GeoServerProvider(client=RecordingGeoServerClient(), workspace="demo-workspace")
+
+    plan = provider.plan_catalog(catalog)
+
+    assert plan.workspace == "demo-workspace"
+    assert [(entry.collection, entry.action) for entry in plan.entries] == [
+        ("roads", PlanAction.CREATE)
+    ]
+
+
+def test_empty_geoserver_coverage_store_payload_returns_no_names() -> None:
+    payload = {"coverageStores": ""}
+
+    assert coverage_store_names(payload) == []

--- a/tests/unit/test_server_geoserver.py
+++ b/tests/unit/test_server_geoserver.py
@@ -18,7 +18,11 @@ from portolan_cli.server.model import (
     ServerCatalog,
     ServerResourceSpec,
 )
-from portolan_cli.server.planner import discover_server_resources, load_server_catalog_url
+from portolan_cli.server.planner import (
+    _fetch_json,
+    discover_server_resources,
+    load_server_catalog_url,
+)
 from portolan_cli.server.providers.geoserver.client import GeoServerClient, coverage_store_names
 from portolan_cli.server.providers.geoserver.planner import (
     GeoServerProvider,
@@ -491,10 +495,7 @@ def test_download_registry_catalog_writes_local_snapshot_with_absolute_asset_hre
         (catalog_root / "roads" / "collection.json").read_text(encoding="utf-8")
     )
     assert catalog["links"][0]["href"] == "./roads/collection.json"
-    assert (
-        collection["assets"]["data"]["href"]
-        == "https://example.test/demo/roads/roads.parquet"
-    )
+    assert collection["assets"]["data"]["href"] == "https://example.test/demo/roads/roads.parquet"
 
 
 def test_cli_registry_list_outputs_online_catalogs(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -617,6 +618,11 @@ def test_load_server_catalog_url_resolves_remote_collection_assets() -> None:
     assert catalog.catalog_href == "https://example.test/demo/catalog.json"
     assert catalog.candidates[0].resource is not None
     assert catalog.candidates[0].resource.href == "https://example.test/demo/roads/roads.parquet"
+
+
+def test_fetch_json_rejects_non_http_url() -> None:
+    with pytest.raises(ValueError, match="Unsupported catalog URL scheme: file"):
+        _fetch_json("file:///tmp/catalog.json")
 
 
 def test_geoserver_provider_can_plan_loaded_registry_catalog() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -856,7 +856,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
+    { name = "humanfriendly" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -915,7 +915,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -996,7 +996,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1421,7 +1421,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1858,6 +1858,23 @@ wheels = [
 ]
 
 [[package]]
+name = "geoservercloud"
+version = "0.8.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "owslib" },
+    { name = "psycopg2-binary" },
+    { name = "pytest" },
+    { name = "requests" },
+    { name = "sqlalchemy" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ab/3b684feefd19371d312592946084a974c086fcc0932d9ca4a9b47e0cb419/geoservercloud-0.8.12.tar.gz", hash = "sha256:b0ffdbd40330d0c8e195d8c7e0becaed9197c0c11370ba26386c278922e24f29", size = 16168885, upload-time = "2026-09-03T14:10:01.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/da/eacb7728b58d235d823756b3219db65bc64242413391dd816c7ced65535c/geoservercloud-0.8.12-py3-none-any.whl", hash = "sha256:49fb20337e7d6929083112814c63e8b96cf81bee009179d3a754df707963c363", size = 16209951, upload-time = "2026-09-03T14:09:59.661Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2170,7 +2187,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3350,9 +3367,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "attrs", marker = "python_full_version < '3.11'" },
-    { name = "pydantic", marker = "python_full_version < '3.11'" },
-    { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "attrs" },
+    { name = "pydantic" },
+    { name = "pyproj", version = "3.7.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/72/2d0e1f1e936538004581f792f8a2377831761fd12e4ed0a665abf768fc60/morecantile-6.2.0.tar.gz", hash = "sha256:65c7150ea68bbe16ee6f75f3f171ac1ae51ab26e7a77c92a768048f40f916412", size = 46317, upload-time = "2024-12-19T15:35:47.233Z" }
 wheels = [
@@ -3378,10 +3395,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "attrs", marker = "python_full_version >= '3.11'" },
-    { name = "click", marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "attrs" },
+    { name = "click" },
+    { name = "pydantic" },
+    { name = "pyproj", version = "3.7.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/44/fa4f0685481b51e5ce33089ca84e821453593d34f306738515a937934751/morecantile-7.0.3.tar.gz", hash = "sha256:b44419c83f310b411b1f547df2d07c115dc6d194ab7c8a4c318a154490e938c1", size = 43104, upload-time = "2026-02-04T23:03:26.423Z" }
 wheels = [
@@ -4023,12 +4040,12 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
-    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "protobuf", marker = "python_full_version < '3.11'" },
-    { name = "sympy", marker = "python_full_version < '3.11'" },
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -4074,11 +4091,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "protobuf", marker = "python_full_version >= '3.11'" },
-    { name = "sympy", marker = "python_full_version >= '3.11'" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2", size = 17332131, upload-time = "2026-03-17T22:05:49.005Z" },
@@ -4272,10 +4289,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4347,9 +4364,9 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
 wheels = [
@@ -4608,6 +4625,7 @@ dependencies = [
     { name = "duckdb" },
     { name = "geopandas" },
     { name = "geoparquet-io" },
+    { name = "geoservercloud" },
     { name = "httpx" },
     { name = "lxml" },
     { name = "matplotlib" },
@@ -4696,16 +4714,17 @@ requires-dist = [
     { name = "antimeridian", specifier = ">=0.3.11" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.3" },
     { name = "boto3", marker = "extra == 'e2e'", specifier = ">=1.35.0" },
-    { name = "click", specifier = ">=8.4,<8.5" },
+    { name = "click", specifier = ">=8.4,<8.6" },
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.4.1" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=4.13.4" },
     { name = "contextily", marker = "extra == 'thumbnails'", specifier = ">=1.5.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.25.1" },
-    { name = "duckdb", specifier = ">=1.5.2,<1.5.5" },
+    { name = "duckdb", specifier = ">=1.5.2,<1.5.6" },
     { name = "geopandas", specifier = ">=0.14.0" },
     { name = "geoparquet-io", specifier = ">=1.4.0" },
+    { name = "geoservercloud", specifier = ">=0.8.12" },
     { name = "gitingest", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.151.5" },
@@ -4934,6 +4953,69 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/80/49bacf9e51617d8309f6f0123e29edc793f6f5f6700c7d1f1b20782fbb37/psycopg2_binary-2.9.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b818ceff717f98851a64bffd4c5eb5b3059ae280276dcecc52ac658dcf006a4", size = 3712314, upload-time = "2026-04-20T23:33:31.363Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/98eeac7d60c43df9338287834edf9b3e69be68a2db78a57b1b81d705e735/psycopg2_binary-2.9.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d2fa0d7caca8635c56e373055094eeda3208d901d55dd0ff5abc1d4e47f82b56", size = 3822389, upload-time = "2026-04-20T23:33:34.178Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/30575e75f14d5351a56a1971bb43fe7f8bf7edf1b654fb1bec65c42a8812/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:864c261b3690e1207d14bbfe0a61e27567981b80c47a778561e49f676f7ce433", size = 4578448, upload-time = "2026-04-20T23:33:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/4df366d89f28c527dc39d0b6c98a5ca74e30d37ac097b73f3352147568ae/psycopg2_binary-2.9.12-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c5ee5213445dd45312459029b8c4c0a695461eb517b753d2582315bd07995f5e", size = 4273705, upload-time = "2026-04-20T23:33:39.291Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/8a/c566803818eb03161ba869b6ba612bf7ad56816d98b9e5121e0a22ad6b0b/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6f9cae1f848779b5b01f417e762c40d026ea93eb0648249a604728cda991dde3", size = 5893784, upload-time = "2026-04-20T23:33:41.658Z" },
+    { url = "https://files.pythonhosted.org/packages/63/fe/0dfa5797e0b229e0567bc378695224caf14d547f73b05be0c80549089772/psycopg2_binary-2.9.12-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:63a3ebbd543d3d1eda088ac99164e8c5bac15293ee91f20281fd17d050aee1c4", size = 4109306, upload-time = "2026-04-20T23:33:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/89/28063adf17a4ba501eedd9890feab0c649ee4d8bd0a97df0ff1e9584feab/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d6fcbba8c9fed08a73b8ac61ea79e4821e45b1e92bb466230c5e746bbf3d5256", size = 3654400, upload-time = "2026-04-20T23:33:46.115Z" },
+    { url = "https://files.pythonhosted.org/packages/84/94/5a01de0aa4ead0b8d8d1aa4ec18cec0bd36d03fa714eaa5bb8a0b1b50020/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:36512911ebb2b60a0c3e44d0bb5048c1980aced91235d133b7874f3d1d93487c", size = 3299215, upload-time = "2026-04-20T23:33:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/85/723bb085a61c6ac2dc0a0043f375f2fe7365363e27b073bad56ca5bda979/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:8ffdb59fe88f99589e34354a130217aa1fd2d615612402d6edc8b3dbc7a44463", size = 3047724, upload-time = "2026-04-20T23:33:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/67/4d8b1e0d2fc4166677380eac0edf9cdff91013aca2546e8ef7bc04b56158/psycopg2_binary-2.9.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a46fe069b65255df410f856d842bc235f90e22ffdf532dda625fd4213d3fd9b1", size = 3349183, upload-time = "2026-04-20T23:33:59.635Z" },
+    { url = "https://files.pythonhosted.org/packages/73/99/21af7a5498637ea4dc91a17c281a53bc1d632fbafe00f6689fbfb32a9fed/psycopg2_binary-2.9.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab29414b25dcb698bf26bf213e3348abdcd07bbd5de032a5bec15bd75b298b03", size = 2757036, upload-time = "2026-04-20T23:34:01.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/d4ce60954f3bb9d8e3bc5e5c4d1f2487de2d3851bf2391d54954c9df12a6/psycopg2_binary-2.9.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5c8ce6c61bd1b1f6b9c24ee32211599f6166af2c55abb19456090a21fd16554b", size = 3712338, upload-time = "2026-04-20T23:34:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/53/71/c85409ee0d78890f0660eff262e815e7dd2bb741a17611d82e9e8cd9dc5e/psycopg2_binary-2.9.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4a9eaa6e7f4ff91bec10aa3fb296878e75187bced5cc4bafe17dc40915e1326", size = 3822407, upload-time = "2026-04-20T23:34:05.977Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/60486c2c7f0d4d1ede2bfb1ed27e2498477ce646bc7f6b2759906303117e/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c6528cefc8e50fcc6f4a107e27a672058b36cc5736d665476aeb413ba88dbb06", size = 4578425, upload-time = "2026-04-20T23:34:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b9/656cb03fad9f4f49f2145c334b1126ee75189929ca4e6187d485a2d59951/psycopg2_binary-2.9.12-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e4e184b1fb6072bf05388aa41c697e1b2d01b3473f107e7ec44f186a32cfd0b8", size = 4273709, upload-time = "2026-04-20T23:34:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/99/66/08cf0da0e25cc6fb142c89be45fc8418792858f0c4cbff5e24530ff02cd6/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4766ab678563054d3f1d064a4db19cc4b5f9e3a8d9018592a8285cf200c248f3", size = 5893779, upload-time = "2026-04-20T23:34:13.905Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d7/eecd9ce8e146d3721115d82d3836efdbb712187e4590325df549989d18f4/psycopg2_binary-2.9.12-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5a0253224780c978746cb9be55a946bcdaf40fe3519c0f622924cdabdafe2c39", size = 4109308, upload-time = "2026-04-20T23:34:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2e/b1dc289b362cc8d45697b57eefbd673186f49a4ea0906928988e3affcc98/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0dc9228d47c46bda253d2ecd6bb93b56a9f2d7ad33b684a1fa3622bf74ffe30c", size = 3654405, upload-time = "2026-04-20T23:34:19.303Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/4c4aea6473214dbdbd0fbba11aa4691e76dc01722c55724c5951719865ff/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f921f3cd87035ef7df233383011d7a53ea1d346224752c1385f1edfd790ceb6a", size = 3299187, upload-time = "2026-04-20T23:34:21.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5d/b03b99986446a4f57b170ed9a2579fb7ff9783ca0fa5226b19db99737fee/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d999bd982a723113c1a45b55a7a6a90d64d0ed2278020ed625c490ff7bef96c", size = 3047716, upload-time = "2026-04-20T23:34:23.077Z" },
+    { url = "https://files.pythonhosted.org/packages/14/86/382ee4afbd1d97500c9d2862b20c2fdeddf4b7335e984df3fb4309f64108/psycopg2_binary-2.9.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29d4d134bd0ab46ffb04e94aa3c5fa3ef582e9026609165e2f758ff76fc3a3be", size = 3349237, upload-time = "2026-04-20T23:34:25.211Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/16/9a57c75ba1eda7165c017342f526810d5f5a12647dde749c99ae9a7141d7/psycopg2_binary-2.9.12-cp311-cp311-win_amd64.whl", hash = "sha256:cb4a1dacdd48077150dc762a9e5ddbf32c256d66cb46f80839391aa458774936", size = 2757036, upload-time = "2026-04-20T23:34:27.77Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
 ]
 
 [[package]]
@@ -5487,7 +5569,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/10/a8480ea27ea4bbe896c168808854d00f2a9b49f95c0319ddcbba693c8a90/pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47", size = 226339, upload-time = "2025-02-16T04:28:46.621Z" }
 wheels = [
@@ -5544,7 +5626,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
 wheels = [
@@ -5999,15 +6081,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "affine", marker = "python_full_version < '3.12'" },
-    { name = "attrs", marker = "python_full_version < '3.12'" },
-    { name = "certifi", marker = "python_full_version < '3.12'" },
-    { name = "click", marker = "python_full_version < '3.12'" },
-    { name = "click-plugins", marker = "python_full_version < '3.12'" },
-    { name = "cligj", marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "affine" },
+    { name = "attrs" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "click-plugins" },
+    { name = "cligj" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.11.*'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "pyparsing", marker = "python_full_version < '3.12'" },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fa/fce8dc9f09e5bc6520b6fc1b4ecfa510af9ca06eb42ad7bdff9c9b8989d0/rasterio-1.4.4.tar.gz", hash = "sha256:c95424e2c7f009b8f7df1095d645c52895cd332c0c2e1b4c2e073ea28b930320", size = 445004, upload-time = "2025-12-12T18:01:08.971Z" }
 wheels = [
@@ -6070,13 +6152,13 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "affine", marker = "python_full_version >= '3.12'" },
-    { name = "attrs", marker = "python_full_version >= '3.12'" },
-    { name = "certifi", marker = "python_full_version >= '3.12'" },
-    { name = "click", marker = "python_full_version >= '3.12'" },
-    { name = "cligj", marker = "python_full_version >= '3.12'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.12'" },
+    { name = "affine" },
+    { name = "attrs" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "cligj" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyparsing" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f6/88/edb4b66b6cb2c13f123af5a3896bf70c0cbe73ab3cd4243cb4eb0212a0f6/rasterio-1.5.0.tar.gz", hash = "sha256:1e0ea56b02eea4989b36edf8e58a5a3ef40e1b7edcb04def2603accd5ab3ee7b", size = 452184, upload-time = "2026-01-05T16:06:47.169Z" }
 wheels = [
@@ -6321,10 +6403,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.11'" },
-    { name = "morecantile", version = "6.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pydantic", marker = "python_full_version < '3.11'" },
-    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "click" },
+    { name = "morecantile", version = "6.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
+    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/14/1c00dc4795ac3ee6a040d79e215ad9f84e14ef04d04fd592fdd0f62504bb/rio_cogeo-6.0.0.tar.gz", hash = "sha256:d215904c3b348edda1e38340f0dfdda5ffdf865ab9871df1fc55b6142dd58bb3", size = 21189, upload-time = "2025-11-05T10:37:21.794Z" }
 wheels = [
@@ -6350,10 +6432,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "click", marker = "python_full_version >= '3.11'" },
-    { name = "morecantile", version = "7.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic", marker = "python_full_version >= '3.11'" },
-    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "click" },
+    { name = "morecantile", version = "7.0.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic" },
+    { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "rasterio", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/01/3b88154233db4cb29cc54df64006537fadb8d7c2ace872af985dac972fd3/rio_cogeo-7.0.2.tar.gz", hash = "sha256:1454ff94dca8652db68862d667bf47e54ecabfe8872c939f2c16ebb62d432f69", size = 19282, upload-time = "2026-03-27T08:25:27.554Z" }


### PR DESCRIPTION
<!-- ops-sync:begin — synced from portolan-sdi/portolan-ops. Edit there, not here. -->

<!-- Title in conventional-commit form: it becomes the squash commit message. -->

## What changed

<!-- What behaves differently once this merges. Write the outcome, not the
     work you did to reach it. Skip "first I tried X, then Y". -->

## Why

<!-- Reference the issue (#N) rather than restating it. CI requires the
     reference unless the waiver below is ticked. -->

## Verification

<!-- Re-run the reproduction from the linked issue. Paste the command and its
     output in a fenced block, and name the data it read: a URL or a catalog
     path. Show the reported behavior changed. Green tests are not
     verification. -->

<!-- Keep the checkbox wording intact: CI matches its exact phrase. Tick at
     most one. -->

- [ ] This change does not alter behavior (docs, chore, or CI only).
- [ ] This pull request integrates changes already verified in their own pull
      requests (a release or integration branch). List them under "What
      changed".

## Implementation notes

<!-- Optional. Files touched, design choices, edge cases, and anything a
     reviewer needs that does not belong in the opening. Length is fine
     here. -->

## Related issues

<!--
Write for two readers. A human reads the top and learns what changed, why it
matters, and that it works. A reviewer or agent reads on for evidence and
detail. There is no word limit. A long body is good when its opening makes
the outcome obvious.

Use short sentences and plain words. A hook checks the body when you run
`gh pr create`. See `.claude/hooks/writing_check.py --print-rules`.
-->

<!-- ops-sync:end -->

## Breaking Changes

<!-- What breaks, and how users migrate. Leave empty when nothing does. -->

## Checklist

See [what a finished PR looks like](https://github.com/portolan-sdi/portolan-cli/blob/main/docs/contributing.md#what-a-finished-pr-looks-like).

- [ ] Tests written **first** and exercise real behavior (TDD)
- [ ] Integration coverage where the change crosses layers
- [ ] `prek run --all-files` is green locally; all required CI checks pass
- [ ] Changed lines are covered (`codecov/patch`)
- [ ] At least one adversarial review (actively tried to break it)
- [ ] CodeRabbit comments addressed
- [ ] Docs updated and, for non-obvious decisions, an ADR added
